### PR TITLE
Bug #2390: Enclose the output of a variable name with quotes in "CheckOther::variableScopeError"

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2657,8 +2657,8 @@ void CheckOther::variableScopeError(const Token *tok, const std::string &varname
     reportError(tok,
                 Severity::information,
                 "variableScope",
-                "The scope of the variable " + varname + " can be reduced\n"
-                "The scope of the variable " + varname + " can be reduced. Warning: It can be unsafe "
+                "The scope of the variable '" + varname + "' can be reduced\n"
+                "The scope of the variable '" + varname + "' can be reduced. Warning: It can be unsafe "
                 "to fix this message. Be careful. Especially when there are inner loops. Here is an "
                 "example where cppcheck will write that the scope for 'i' can be reduced:\n"
                 "void f(int x)\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -465,7 +465,7 @@ private:
                  "        for ( ; i < 10; ++i) ;\n"
                  "    }\n"
                  "}\n");
-        ASSERT_EQUALS("[test.cpp:3]: (information) The scope of the variable i can be reduced\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (information) The scope of the variable 'i' can be reduced\n", errout.str());
 
         varScope("void f(int x)\n"
                  "{\n"
@@ -475,7 +475,7 @@ private:
                  "        for ( ; i < 10; ++i) ;\n"
                  "    }\n"
                  "}\n");
-        ASSERT_EQUALS("[test.cpp:3]: (information) The scope of the variable i can be reduced\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (information) The scope of the variable 'i' can be reduced\n", errout.str());
     }
 
     void varScope6()
@@ -541,7 +541,7 @@ private:
                  "        edgeResistance = (edge+1) / 2.0;\n"
                  "    }\n"
                  "}\n");
-        ASSERT_EQUALS("[test.cpp:2]: (information) The scope of the variable edgeResistance can be reduced\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (information) The scope of the variable 'edgeResistance' can be reduced\n", errout.str());
     }
 
     void varScope9()


### PR DESCRIPTION
Would you like to integrate [this update suggestion](https://sourceforge.net/apps/trac/cppcheck/ticket/2390#comment:7) into your source code repository?
