### PR TITLE
Bug #2679: Determination of rule support in CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,12 @@ cmake_minimum_required (VERSION 2.6)
 PROJECT(CPPCHECK)
 
 set(CMAKE_MODULE_PATH "${CPPCHECK_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
+find_package(PCRE)
+
+if(NOT PCRE_FOUND)
+   message("User-defined rules are disabled since required PCRE libraries were not found.
+If you want to enable the rules, then configure the PCRE paths for CMake.")
+endif()
 
 # Building lib as static library is disabled due to bug
 # #1299 CMake: The CheckClass is not used

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,5 +1,11 @@
 # Minimal CMake build file to build cppcheck command line executable
 
+if(PCRE_FOUND)
+   add_definitions(-DHAVE_RULES)
+   include_directories("${PCRE_INCLUDE_DIR}")
+   set(CHECK_LIBS ${PCRE_LIBRARIES})
+endif()
+
 set(TINYXML_INCLUDE_DIR "${CPPCHECK_SOURCE_DIR}/externals/tinyxml/")
 
 SET(CHECKCLI_SRCS

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,11 @@
 # - tests
 # - Qt GUI
 
+if(PCRE_FOUND)
+   add_definitions(-DHAVE_RULES)
+   include_directories("${PCRE_INCLUDE_DIR}")
+endif()
+
 set(CPPCHECK_LIB_DIR "")
 include("library_sources.cmake")
 
@@ -12,3 +17,7 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 add_library(checklib STATIC ${CPPCHECK_LIB_SOURCES})
+
+if(PCRE_FOUND)
+   target_link_libraries(checklib ${PCRE_LIBRARIES})
+endif()


### PR DESCRIPTION
Would you like to [accept](https://github.com/danmar/cppcheck/pull/22#issuecomment-948536) this update variant where PCRE settings are omitted for the gui and test directory?
