### PR TITLE
Unify enabling style checks in Settings-class.

### DIFF
--- a/lib/check64bit.cpp
+++ b/lib/check64bit.cpp
@@ -46,7 +46,7 @@ static bool isint(const Variable *var)
 
 void Check64BitPortability::pointerassignment()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())

--- a/lib/checkassignif.cpp
+++ b/lib/checkassignif.cpp
@@ -34,7 +34,7 @@ CheckAssignIf instance;
 
 void CheckAssignIf::assignIf()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -84,7 +84,7 @@ void CheckAssignIf::assignIfError(const Token *tok, bool result)
 
 void CheckAssignIf::comparison()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -140,7 +140,7 @@ void CheckAssignIf::comparisonError(const Token *tok, bool result)
 
 void CheckAssignIf::multiCondition()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -115,7 +115,7 @@ void CheckBufferOverrun::bufferOverrun(const Token *tok, const std::string &varn
 
 void CheckBufferOverrun::strncatUsage(const Token *tok)
 {
-    if (_settings && !_settings->_checkCodingStyle)
+    if (_settings && !_settings->isEnabled("style"))
         return;
 
     reportError(tok, Severity::warning, "strncatUsage",
@@ -137,7 +137,7 @@ void CheckBufferOverrun::pointerOutOfBounds(const Token *tok, const std::string 
 
 void CheckBufferOverrun::sizeArgumentAsChar(const Token *tok)
 {
-    if (_settings && !_settings->_checkCodingStyle)
+    if (_settings && !_settings->isEnabled("style"))
         return;
     reportError(tok, Severity::warning, "sizeArgumentAsChar", "The size argument is given as a char constant");
 }
@@ -1017,7 +1017,7 @@ void CheckBufferOverrun::checkScope(const Token *tok, const std::vector<std::str
         if (varid && Token::Match(tok, "= %varid% + %num% ;", varid))
         {
             const MathLib::bigint index = MathLib::toLongNumber(tok->strAt(3));
-            if (index > size && _settings->_checkCodingStyle)
+            if (index > size && _settings->isEnabled("style"))
                 pointerOutOfBounds(tok->next(), "buffer");
             if (index >= size && Token::Match(tok->tokAt(-2), "[;{}] %varid% =", varid))
                 pointerIsOutOfBounds = true;
@@ -1127,7 +1127,7 @@ void CheckBufferOverrun::checkScope(const Token *tok, const ArrayInfo &arrayInfo
             checkFunctionCall(tok, arrayInfo);
         }
 
-        if (_settings->_checkCodingStyle)
+        if (_settings->isEnabled("style"))
         {
             // check for strncpy which is not terminated
             if ((Token::Match(tok, "strncpy ( %varid% , %var% , %num% )", arrayInfo.varid())))
@@ -1217,7 +1217,7 @@ void CheckBufferOverrun::checkScope(const Token *tok, const ArrayInfo &arrayInfo
         }
 
         // undefined behaviour: result of pointer arithmetic is out of bounds
-        if (_settings->_checkCodingStyle && Token::Match(tok, "= %varid% + %num% ;", arrayInfo.varid()))
+        if (_settings->isEnabled("style") && Token::Match(tok, "= %varid% + %num% ;", arrayInfo.varid()))
         {
             const MathLib::bigint index = MathLib::toLongNumber(tok->strAt(3));
             if (index < 0 || index > arrayInfo.num(0))
@@ -2186,7 +2186,7 @@ void CheckBufferOverrun::executionPaths()
 
 void CheckBufferOverrun::arrayIndexThenCheck()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -63,7 +63,7 @@ void CheckClass::createSymbolDatabase()
 
 void CheckClass::constructors()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     createSymbolDatabase();
@@ -570,7 +570,7 @@ void CheckClass::operatorEqVarError(const Token *tok, const std::string &classna
 
 void CheckClass::privateFunctions()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // don't check code that contains templates. Templates that are
@@ -802,7 +802,7 @@ void CheckClass::memsetError(const Token *tok, const std::string &memfunc, const
 
 void CheckClass::operatorEq()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     createSymbolDatabase();
@@ -841,7 +841,7 @@ void CheckClass::operatorEqReturnError(const Token *tok, const std::string &clas
 
 void CheckClass::operatorEqRetRefThis()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     createSymbolDatabase();
@@ -957,7 +957,7 @@ void CheckClass::operatorEqRetRefThisError(const Token *tok)
 
 void CheckClass::operatorEqToSelf()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     createSymbolDatabase();
@@ -1251,7 +1251,7 @@ void CheckClass::virtualDestructorError(const Token *tok, const std::string &Bas
 
 void CheckClass::thisSubtraction()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const Token *tok = _tokenizer->tokens();

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -35,7 +35,7 @@ CheckExceptionSafety instance;
 void CheckExceptionSafety::destructors()
 {
     // This is a style error..
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // Perform check..
@@ -175,7 +175,7 @@ void CheckExceptionSafety::deallocThrow()
 //---------------------------------------------------------------------------
 void CheckExceptionSafety::checkRethrowCopy()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     const char catchPattern[] = "catch ( const| %type% &|*| %var% ) { %any%";
 

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2910,7 +2910,7 @@ void CheckMemoryLeakInClass::checkPublicFunctions(const Scope *scope, const Toke
     // Check that public functions deallocate the pointers that they allocate.
     // There is no checking how these functions are used and therefore it
     // isn't established if there is real leaks or not.
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const unsigned int varid = classtok->varId();

--- a/lib/checknonreentrantfunctions.cpp
+++ b/lib/checknonreentrantfunctions.cpp
@@ -33,7 +33,7 @@ CheckNonReentrantFunctions instance;
 
 void CheckNonReentrantFunctions::nonReentrantFunctions()
 {
-    if (!_settings->isEnabled("posix") || !_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("posix") || !_settings->isEnabled("style"))
         return;
 
     // Don't check C# and Java code

--- a/lib/checkobsoletefunctions.cpp
+++ b/lib/checkobsoletefunctions.cpp
@@ -33,7 +33,7 @@ CheckObsoleteFunctions instance;
 
 void CheckObsoleteFunctions::obsoleteFunctions()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // Don't check C# and Java code

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -37,7 +37,7 @@ CheckOther instance;
 
 void CheckOther::checkIncrementBoolean()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -70,7 +70,7 @@ void CheckOther::incrementBooleanError(const Token *tok)
 
 void CheckOther::clarifyCalculation()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -136,7 +136,7 @@ void CheckOther::clarifyCalculationError(const Token *tok, const std::string &op
 // Clarify condition '(x = a < 0)' into '((x = a) < 0)' or '(x = (a < 0))'
 void CheckOther::clarifyCondition()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -170,7 +170,7 @@ void CheckOther::clarifyConditionError(const Token *tok)
 
 void CheckOther::warningOldStylePointerCast()
 {
-    if (!_settings->_checkCodingStyle ||
+    if (!_settings->isEnabled("style") ||
         (_tokenizer->tokens() && _tokenizer->fileLine(_tokenizer->tokens()).find(".cpp") == std::string::npos))
         return;
 
@@ -368,7 +368,7 @@ void CheckOther::checkRedundantAssignmentInSwitch()
 
 void CheckOther::checkSwitchCaseFallThrough()
 {
-    if (!(_settings->_checkCodingStyle && _settings->experimental))
+    if (!(_settings->isEnabled("style") && _settings->experimental))
         return;
 
     const char switchPattern[] = "switch (";
@@ -544,7 +544,7 @@ void CheckOther::checkSwitchCaseFallThrough()
 //---------------------------------------------------------------------------
 void CheckOther::checkSelfAssignment()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // POD variables..
@@ -576,7 +576,7 @@ void CheckOther::checkSelfAssignment()
 //---------------------------------------------------------------------------
 void CheckOther::checkAssignmentInAssert()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const char assertPattern[] = "assert ( %any%";
@@ -608,7 +608,7 @@ void CheckOther::checkAssignmentInAssert()
 //---------------------------------------------------------------------------
 void CheckOther::checkIncorrectLogicOperator()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const char conditionPattern[] = "if|while (";
@@ -796,7 +796,7 @@ void CheckOther::checkIncorrectLogicOperator()
 //---------------------------------------------------------------------------
 void CheckOther::checkCatchExceptionByValue()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const char catchPattern[] = "} catch (";
@@ -903,7 +903,7 @@ void CheckOther::invalidFunctionUsage()
 
 void CheckOther::invalidScanf()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -946,7 +946,7 @@ void CheckOther::invalidScanf()
 //---------------------------------------------------------------------------
 void CheckOther::checkComparisonOfBoolWithInt()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -983,7 +983,7 @@ void CheckOther::checkComparisonOfBoolWithInt()
 //---------------------------------------------------------------------------
 void CheckOther::checkDuplicateBreak()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const char breakPattern[] = "break|continue ; break|continue ;";
@@ -1058,7 +1058,7 @@ void CheckOther::invalidScanfError(const Token *tok)
 
 void CheckOther::checkUnsignedDivision()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // Check for "ivar / uvar" and "uvar / ivar"
@@ -1809,7 +1809,7 @@ bool CheckOther::isRecordTypeWithoutSideEffects(const Token *tok)
 
 void CheckOther::functionVariableUsage()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // Parse all executing scopes..
@@ -2711,7 +2711,7 @@ void CheckOther::lookupVar(const Token *tok1, const std::string &varname)
 
 void CheckOther::checkConstantFunctionParameter()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const SymbolDatabase * const symbolDatabase = _tokenizer->getSymbolDatabase();
@@ -2777,7 +2777,7 @@ void CheckOther::checkConstantFunctionParameter()
 
 void CheckOther::checkStructMemberUsage()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     std::string structname;
@@ -2878,7 +2878,7 @@ void CheckOther::checkStructMemberUsage()
 
 void CheckOther::checkCharVariable()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -2978,7 +2978,7 @@ void CheckOther::checkCharVariable()
 
 void CheckOther::checkIncompleteStatement()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -3328,7 +3328,7 @@ static bool expressionHasSideEffects(const Token *first, const Token *last)
 
 void CheckOther::checkDuplicateIf()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();
@@ -3409,7 +3409,7 @@ void CheckOther::duplicateIfError(const Token *tok1, const Token *tok2)
 
 void CheckOther::checkDuplicateBranch()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     if (!_settings->inconclusive)
@@ -3471,7 +3471,7 @@ void CheckOther::duplicateBranchError(const Token *tok1, const Token *tok2)
 
 void CheckOther::checkDuplicateExpression()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     // Parse all executing scopes..
@@ -3532,7 +3532,7 @@ void CheckOther::duplicateExpressionError(const Token *tok1, const Token *tok2, 
 
 void CheckOther::checkAlwaysTrueOrFalseStringCompare()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const char pattern1[] = "strcmp|stricmp|strcmpi|strcasecmp|wcscmp ( %str% , %str% )";
@@ -3709,7 +3709,7 @@ void CheckOther::fflushOnInputStreamError(const Token *tok, const std::string &v
 
 void CheckOther::sizeofsizeof()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -3732,7 +3732,7 @@ void CheckOther::sizeofsizeofError(const Token *tok)
 
 void CheckOther::sizeofCalculation()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -3873,7 +3873,7 @@ void CheckOther::assignBoolToPointerError(const Token *tok)
 
 void CheckOther::checkSignOfUnsignedVariable()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();

--- a/lib/checkpostfixoperator.cpp
+++ b/lib/checkpostfixoperator.cpp
@@ -35,7 +35,7 @@ CheckPostfixOperator instance;
 
 void CheckPostfixOperator::postfixOperator()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     const Token *tok = _tokenizer->tokens();

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -744,7 +744,7 @@ void CheckStl::stlBoundriesError(const Token *tok, const std::string &container_
 
 void CheckStl::if_find()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
     {
@@ -844,7 +844,7 @@ bool CheckStl::isStlContainer(unsigned int varid)
 
 void CheckStl::size()
 {
-    if (!_settings->_checkCodingStyle)
+    if (!_settings->isEnabled("style"))
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next())
@@ -1169,7 +1169,7 @@ void CheckStl::checkAutoPointer()
         {
             if (Token::Match(tok, "%var% = %var% ;"))
             {
-                if (_settings->_checkCodingStyle)
+                if (_settings->isEnabled("style"))
                 {
                     iter = autoPtrVarId.find(tok->next()->next()->varId());
                     if (iter != autoPtrVarId.end())

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -506,7 +506,7 @@ std::string Preprocessor::removeComments(const std::string &str, const std::stri
 
                 // First check for a "fall through" comment match, but only
                 // add a suppression if the next token is 'case' or 'default'
-                if (_settings->_checkCodingStyle && _settings->experimental && fallThroughComment)
+                if (_settings->isEnabled("style") && _settings->experimental && fallThroughComment)
                 {
                     std::string::size_type j = str.find_first_not_of("abcdefghijklmnopqrstuvwxyz", i);
                     std::string tok = str.substr(i, j - i);

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -31,7 +31,6 @@
 Settings::Settings()
 {
     debug = debugwarnings = false;
-    _checkCodingStyle = false;
     _errorsOnly = false;
     _inlineSuppressions = false;
     _verbose = false;
@@ -389,12 +388,8 @@ std::string Settings::addEnabled(const std::string &str)
 
     bool handled = false;
 
-    if (str == "all")
-        handled = _checkCodingStyle = true;
-    else if (str == "style")
-        handled = _checkCodingStyle = true;
-
     std::set<std::string> id;
+    id.insert("style");
     id.insert("missingInclude");
     id.insert("unusedFunction");
     id.insert("information");

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -66,9 +66,6 @@ public:
      */
     bool experimental;
 
-    /** @brief Is --style given? */
-    bool _checkCodingStyle;
-
     /** @brief Is --quiet given? */
     bool _errorsOnly;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -509,7 +509,7 @@ void Tokenizer::createTokens(std::istream &code)
 
 void Tokenizer::duplicateTypedefError(const Token *tok1, const Token *tok2, const std::string &type)
 {
-    if (tok1 && !(_settings->_checkCodingStyle))
+    if (tok1 && !(_settings->isEnabled("style")))
         return;
 
     std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;
@@ -543,7 +543,7 @@ void Tokenizer::duplicateTypedefError(const Token *tok1, const Token *tok2, cons
 
 void Tokenizer::duplicateDeclarationError(const Token *tok1, const Token *tok2, const std::string &type)
 {
-    if (tok1 && !(_settings->_checkCodingStyle))
+    if (tok1 && !(_settings->isEnabled("style")))
         return;
 
     std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;
@@ -8054,7 +8054,7 @@ void Tokenizer::simplifyNestedStrcat()
 
 void Tokenizer::duplicateEnumError(const Token * tok1, const Token * tok2, const std::string & type)
 {
-    if (tok1 && !(_settings->_checkCodingStyle))
+    if (tok1 && !(_settings->isEnabled("style")))
         return;
 
     std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -47,7 +47,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testassignif.cpp
+++ b/test/testassignif.cpp
@@ -46,7 +46,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -43,7 +43,7 @@ private:
 
         Settings settings;
         settings.experimental = experimental;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -50,7 +50,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -206,7 +206,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -309,7 +309,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -550,7 +550,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -1641,7 +1641,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -3038,7 +3038,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -3098,7 +3098,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -3516,7 +3516,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -390,7 +390,7 @@ private:
         Settings settings;
         CmdLineParser parser(&settings);
         ASSERT(parser.ParseFromArgs(3, argv));
-        ASSERT(settings._checkCodingStyle);
+        ASSERT(settings.isEnabled("style"));
         ASSERT(settings.isEnabled("unusedFunction"));
         ASSERT(settings.isEnabled("missingInclude"));
     }
@@ -402,7 +402,7 @@ private:
         Settings settings;
         CmdLineParser parser(&settings);
         ASSERT(parser.ParseFromArgs(3, argv));
-        ASSERT(settings._checkCodingStyle);
+        ASSERT(settings.isEnabled("style"));
     }
 
     void enabledUnusedFunction()

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -41,7 +41,7 @@ private:
 
         Settings settings;
         settings.inconclusive = showAll;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testdivision.cpp
+++ b/test/testdivision.cpp
@@ -42,7 +42,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = style;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -42,7 +42,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -3839,7 +3839,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testnonreentrantfunctions.cpp
+++ b/test/testnonreentrantfunctions.cpp
@@ -47,7 +47,7 @@ private:
         Settings settings;
         settings.addEnabled("posix");
         settings.inconclusive = true;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -59,7 +59,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testobsoletefunctions.cpp
+++ b/test/testobsoletefunctions.cpp
@@ -57,7 +57,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         settings.addEnabled("posix");
 
         // Tokenize..

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -136,7 +136,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         settings.inconclusive = true;
 
         // Tokenize..
@@ -206,7 +206,7 @@ private:
             filename = "test.cpp";
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         settings.experimental = true;
 
         // Preprocess file..
@@ -726,7 +726,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizerCpp(&settings, this);
@@ -825,7 +825,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -2896,7 +2896,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -41,7 +41,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         settings.inconclusive = true;
 
         // Tokenize..

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -3976,7 +3976,7 @@ private:
         // Tokenize..
         Settings settings;
         settings.inconclusive = true;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         settings.debugwarnings = true;   // show warnings about unhandled typedef
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -6400,7 +6400,7 @@ private:
         // Tokenize..
         Settings settings;
         settings.inconclusive = true;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -119,7 +119,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5013,7 +5013,7 @@ private:
         // Tokenize..
         Settings settings;
         settings.inconclusive = true;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         errout.str("");

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -55,7 +55,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -79,7 +79,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -131,7 +131,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
@@ -368,7 +368,7 @@ private:
         errout.str("");
 
         Settings settings;
-        settings._checkCodingStyle = true;
+        settings.addEnabled("style");
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);


### PR DESCRIPTION
I noticed all other _enable_-options from CLI are handled as "enable-list" in `Settings` class. But style checks have their own boolean attribute. So instead of this:
`settings->_checkCodingStyle = true;
settings->addEnabled("information");
`
it is cleaner and more consistent to have this:
`settings->addEnabled("style");
settings->addEnabled("information");
`

Admittedly this is very noisy change and not something everybody likes. Hence the pull request for others to comment..
