### PR TITLE
version-protect a qt 4.7 feature

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -63,7 +63,9 @@ MainWindow::MainWindow() :
 
     // "Filter" toolbar
     mLineEditFilter = new QLineEdit(mUI.mToolBarFilter);
+#if QT_VERSION >= QT_VERSION_CHECK(4, 7, 0)
     mLineEditFilter->setPlaceholderText(tr("Quick Filter:"));
+#endif
     mUI.mToolBarFilter->addWidget(mLineEditFilter);
     connect(mLineEditFilter, SIGNAL(textChanged(const QString&)), mFilterTimer, SLOT(start()));
     connect(mLineEditFilter, SIGNAL(returnPressed()), this, SLOT(FilterResults()));


### PR DESCRIPTION
There's one line in mainwindow.cpp that uses a Qt 4.7 feature - everything else works on 4.6. I've put it in a #if guard. Tested on Qt 4.6.3 on Windows (VC 2008)
