### PR TITLE
Make the build warning clean with clang++

### DIFF
--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -75,7 +75,7 @@ private:
         TEST_CASE(jobs);
         TEST_CASE(jobsMissingCount);
         TEST_CASE(jobsInvalid);
-        TEST_CASE(reportprogress);
+        TEST_CASE(reportProgressTest); // "Test" suffix to avoid hiding the parent's reportProgress
         TEST_CASE(stdposix);
         TEST_CASE(suppressionsOld); // TODO: Create and test real suppression file
         TEST_CASE(suppressions);
@@ -570,7 +570,7 @@ private:
         ASSERT_EQUALS(false, parser.ParseFromArgs(4, argv));
     }
 
-    void reportprogress()
+    void reportProgressTest()
     {
         REDIRECT;
         const char *argv[] = {"cppcheck", "--report-progress", "file.cpp"};


### PR DESCRIPTION
Hello,

This patch gets rid of the following warning when building with clang++:

test/testcmdlineparser.cpp:573:10: warning: 'TestCmdlineParser::reportProgress' hides overloaded virtual function [-Woverloaded-virtual]
    void reportProgress()
         ^
lib/errorlogger.h:282:18: note: hidden overloaded virtual function 'ErrorLogger::reportProgress' declared here
    virtual void reportProgress(const std::string &filename, const char stage[], const unsigned int value)
                 ^
1 warning generated.

Best regards,
  Simon
