### PR TITLE
Ticket 3059: Report the correct line number in unused functions warnings

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -74,7 +74,7 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer)
                     ! Token::simpleMatch(tok2, ") const {") &&
                     ! Token::simpleMatch(tok2, ") const throw ( ) {") &&
                     ! Token::simpleMatch(tok2, ") throw ( ) {"))
-                    funcname = NULL;
+                    funcname = 0;
                 break;
             }
         }
@@ -83,10 +83,14 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer)
         {
             FunctionUsage &func = _functions[ funcname->str()];
 
+            if(!func.lineNumber)
+                func.lineNumber = funcname->linenr();
+
             // No filename set yet..
             if (func.filename.empty())
+            {
                 func.filename = tokenizer.getFiles()->at(0);
-
+            }
             // Multiple files => filename = "+"
             else if (func.filename != tokenizer.getFiles()->at(0))
             {
@@ -141,7 +145,6 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer)
 
             if (func.filename.empty() || func.filename == "+")
                 func.usedOtherFile = true;
-
             else
                 func.usedSameFile = true;
         }
@@ -167,7 +170,7 @@ void CheckUnusedFunctions::check(ErrorLogger * const errorLogger)
                 filename = "";
             else
                 filename = func.filename;
-            unusedFunctionError(errorLogger, filename, it->first);
+            unusedFunctionError(errorLogger, filename, func.lineNumber, it->first);
         }
         else if (! func.usedOtherFile)
         {
@@ -181,14 +184,16 @@ void CheckUnusedFunctions::check(ErrorLogger * const errorLogger)
     }
 }
 
-void CheckUnusedFunctions::unusedFunctionError(ErrorLogger * const errorLogger, const std::string &filename, const std::string &funcname)
+void CheckUnusedFunctions::unusedFunctionError(ErrorLogger * const errorLogger,
+                                               const std::string &filename, unsigned int lineNumber,
+                                               const std::string &funcname)
 {
     std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;
     if (!filename.empty())
     {
         ErrorLogger::ErrorMessage::FileLocation fileLoc;
         fileLoc.setfile(filename);
-        fileLoc.line = 1;
+        fileLoc.line = lineNumber;
         locationList.push_back(fileLoc);
     }
 

--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -53,13 +53,15 @@ private:
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings)
     {
         CheckUnusedFunctions c(0, settings, errorLogger);
-        c.unusedFunctionError(errorLogger, "", "funcName");
+        c.unusedFunctionError(errorLogger, "", 0, "funcName");
     }
 
     /**
      * Dummy implementation, just to provide error for --errorlist
      */
-    void unusedFunctionError(ErrorLogger * const errorLogger, const std::string &filename, const std::string &funcname);
+    void unusedFunctionError(ErrorLogger * const errorLogger,
+                             const std::string &filename, unsigned int lineNumber,
+                             const std::string &funcname);
 
     /**
      * Dummy implementation, just to provide error for --errorlist
@@ -82,10 +84,11 @@ private:
     class FunctionUsage
     {
     public:
-        FunctionUsage() : usedSameFile(false), usedOtherFile(false)
+        FunctionUsage() : lineNumber(0), usedSameFile(false), usedOtherFile(false)
         { }
 
         std::string filename;
+        unsigned int lineNumber;
         bool   usedSameFile;
         bool   usedOtherFile;
     };

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -47,6 +47,8 @@ private:
         TEST_CASE(initializationIsNotAFunction);
 
         TEST_CASE(multipleFiles);   // same function name in multiple files
+
+        TEST_CASE(lineNumber); // Ticket 3059
     }
 
     void check(const char code[])
@@ -215,6 +217,15 @@ private:
         c.check(this);
 
         ASSERT_EQUALS("[test1.cpp:1]: (style) The function 'f' is never used\n",errout.str());
+    }
+
+    void lineNumber()
+    {
+        check("void foo() {}\n"
+              "void bar() {}\n"
+              "int main()\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) The function 'bar' is never used\n"
+                      "[test.cpp:1]: (style) The function 'foo' is never used\n", errout.str());
     }
 };
 


### PR DESCRIPTION
Hello,

This is a patch to fix the issue that the unused function warning always shows 1 as line number, reported in
  https://sourceforge.net/apps/trac/cppcheck/ticket/3059

Best regards,
  Simon
