### PR TITLE
Added support for reading file lists from stdin

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -45,11 +45,21 @@ static void AddFilesToList(const std::string& FileList, std::vector<std::string>
     // xml is a bonus then, since we can easily extend it
     // we need a good parser then -> suggestion : TinyXml
     // drawback : creates a dependency
-    std::ifstream Files(FileList.c_str());
+    std::istream *Files;
+    std::ifstream Infile;
+    if (FileList.compare("-") == 0) // read from stdin
+    {
+        Files = &std::cin;
+    }
+    else
+    {
+        Infile.open(FileList.c_str());
+        Files = &Infile;
+    }
     if (Files)
     {
-        std::string FileName;
-        while (std::getline(Files, FileName)) // next line
+        std::cout << "Program is here" << std::endl;
+        while (std::getline(*Files, FileName)) // next line
         {
             if (!FileName.empty())
             {


### PR DESCRIPTION
I changed the command line parser so that when the argument for "--file-list=" is a hyphen, it reads from stdin. This is useful because it allows you to write a command like this (I have it in a script called gitcheck):

git status -s | grep '^[AM][ M]' | awk 'NF{print $2}' | cppcheck --file-list=- 2>&1

With my commit, this command grabs all of the files that you've added or modified and then checks them using cppcheck. This is a real time saver if you're working on a large project with a lot of files. It makes no sense to cppcheck files that you've already checked but haven't changed. Also, this command can easily be changed to work with svn by changing "git status -s" to "svn status".
