### PR TITLE
Remove 'help' from qmake profile

### DIFF
--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -1,6 +1,6 @@
 TEMPLATE = app
 TARGET = cppcheck-gui
-CONFIG += warn_on help
+CONFIG += warn_on
 DEPENDPATH += . \
     ../lib
 INCLUDEPATH += . \


### PR DESCRIPTION
Supports cross-build using mingw-cross-env
