### PR TITLE
Improve for same expression on both sides of operator

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2337,7 +2337,7 @@ void CheckOther::checkDuplicateExpression()
             continue;
 
         for (const Token *tok = scope->classStart; tok && tok != scope->classStart->link(); tok = tok->next()) {
-            if (Token::Match(tok, "(|&&|%oror% %var% &&|%oror%|==|!=|<=|>=|<|>|-|%or% %var% )|&&|%oror%") &&
+            if (Token::Match(tok, "return|(|&&|%oror% %var% &&|%oror%|==|!=|<=|>=|<|>|-|%or% %var% )|&&|%oror%|;") &&
                 tok->strAt(1) == tok->strAt(3)) {
                 // float == float and float != float are valid NaN checks
                 if (Token::Match(tok->tokAt(2), "==|!=") && tok->next()->varId()) {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3408,6 +3408,11 @@ private:
                       "[test.cpp:4] -> [test.cpp:4]: (style) Same expression on both sides of '-'.\n"
                       "[test.cpp:5] -> [test.cpp:5]: (style) Same expression on both sides of '>'.\n"
                       "[test.cpp:6] -> [test.cpp:6]: (style) Same expression on both sides of '<'.\n", errout.str());
+
+        check("void foo() {\n"
+              "    return a && a;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (style) Same expression on both sides of '&&'.\n", errout.str());
     }
 
     void duplicateExpression2() { // ticket #2730


### PR DESCRIPTION
Previously on a && a was detected if it had parenthesis. Return from a function is also a common use case error.

Not sure if the other Match in CheckOther::checkDuplicateExpression needs updating, I couldn't tell what it was for exactly?
