### PR TITLE
Extra check for auto_ptr new[]

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1101,6 +1101,10 @@ void CheckStl::checkAutoPointer()
                 while (tok2) {
                     if (Token::Match(tok2, "> %var%")) {
                         const Token *tok3 = tok2->next()->next();
+                        if (Token::Match(tok3, "( new %type% [")) {
+                            autoPointerArrayError(tok2->next());
+                            break;
+                        }
                         while (tok3 && tok3->str() != ";") {
                             tok3 = tok3->next();
                         }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -1435,6 +1435,12 @@ private:
 
         check("void f() \n"
               "{\n"
+              "    auto_ptr<T> p2( new T[5] );\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. You should not use 'auto_ptr' for pointers obtained with operator 'new[]'.\n", errout.str());
+
+        check("void f() \n"
+              "{\n"
               "    auto_ptr<T> p2;\n"
               "    p2.reset( new T[] );\n"
               "}\n");


### PR DESCRIPTION
This fixes cases like this:

   auto_ptr<foo> bar(new foo[10]);

which previously did not work correctly.
