### PR TITLE
Fix for #3317 - same expression on both side of '&&' false positives

### DIFF
--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -26,6 +26,7 @@
 #include "settings.h"
 
 class Token;
+class Function;
 
 /// @addtogroup Checks
 /// @{
@@ -434,8 +435,13 @@ private:
         return varname;
     }
 
-    void checkExpressionRange(const Token *start, const Token *end, const std::string &toCheck);
-    void complexDuplicateExpressionCheck(const Token *classStart,
+    void checkExpressionRange(const std::list<Function> &constFunctions,
+                              const Token *start,
+                              const Token *end,
+                              const std::string &toCheck);
+
+    void complexDuplicateExpressionCheck(const std::list<Function> &constFunctions,
+                                         const Token *classStart,
                                          const std::string &toCheck,
                                          const std::string &alt);
 };


### PR DESCRIPTION
The first patch fixes regular false positives due to a logic bug.

The other 2 fix the issue (and add tests) in a way that I think is not going to give false positives and actually show up real bugs.
