### PR TITLE
GUI: Remove empty/space-only items from MRU list.

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1014,6 +1014,20 @@ void MainWindow::UpdateMRUMenuItems()
     }
 
     QStringList projects = mSettings->value(SETTINGS_MRU_PROJECTS).toStringList();
+
+    // Do a sanity check - remove duplicates and empty or space only items
+    int removed = projects.removeDuplicates();
+    for (int i = projects.size() - 1; i >= 0; i--) {
+        QString text = projects[i].trimmed();
+        if (text.isEmpty()) {
+            projects.removeAt(i);
+            removed++;
+        }
+    }
+
+    if (removed)
+        mSettings->setValue(SETTINGS_MRU_PROJECTS, projects);
+
     const int numRecentProjects = qMin(projects.size(), (int)MaxRecentProjects);
     for (int i = 0; i < numRecentProjects; i++) {
         const QString filename = QFileInfo(projects[i]).fileName();


### PR DESCRIPTION
For some reason I got an empty item to my GUI's MRU list. This should not happen in normal conditions, perhaps this was left-over of some of my earlier debugging or something. But anyway it was such annoying I decided to add a fix for removing such items.

This patch adds simple sanity check for MRU menu construction so that empty items or items consisting only whitespace are removed from the list and not added to the menu.
