### PR TITLE
GUI: Fix bug in severity filtering.

### DIFF
--- a/gui/showtypes.cpp
+++ b/gui/showtypes.cpp
@@ -47,9 +47,9 @@ ShowTypes::ShowType ShowTypes::SeverityToShowType(Severity::SeverityType severit
     case Severity::portability:
         return ShowTypes::ShowPortability;
     case Severity::information:
-        return ShowTypes::ShowPortability;
+        return ShowTypes::ShowInformation;
     default:
-        return ShowTypes::ShowPortability;
+        return ShowTypes::ShowNone;
     }
 
     return ShowTypes::ShowNone;


### PR DESCRIPTION
There was (obviously) a copy-paste bug in code converting severities
to GUI's show types. This caused some severities not being
filtered correctly when severity selection in GUI was changed.

Fixes ticket: #3242 (GUI: Unmatched suppression: message in wrong category)
