### PR TITLE
Refactoring information messages.

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -207,7 +207,7 @@ int CppCheckExecutor::check(int argc, const char* const argv[])
                                           "--check-config.",
                                           "missingInclude",
                                           false);
-            reportErr(msg);
+            reportInfo(msg);
         }
     }
 
@@ -263,6 +263,11 @@ void CppCheckExecutor::reportProgress(const std::string &filename, const char st
         // Report progress message
         reportOut(ostr.str());
     }
+}
+
+void CppCheckExecutor::reportInfo(const ErrorLogger::ErrorMessage &msg)
+{
+    reportOut(msg.toXML(false, _settings._xml_version));
 }
 
 void CppCheckExecutor::reportStatus(size_t fileindex, size_t filecount, size_t sizedone, size_t sizetotal)

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -73,6 +73,11 @@ public:
     void reportProgress(const std::string &filename, const char stage[], const unsigned int value);
 
     /**
+     * Output information messages.
+     */
+    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg);
+
+    /**
      * Information about how many files have been checked
      *
      * @param fileindex This many files have been checked.

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -290,6 +290,11 @@ void ThreadExecutor::reportErr(const ErrorLogger::ErrorMessage &msg)
     writeToPipe(REPORT_ERROR, msg.serialize());
 }
 
+void ThreadExecutor::reportInfo(const ErrorLogger::ErrorMessage &msg)
+{
+    writeToPipe(REPORT_OUT, msg.serialize());
+}
+
 #else
 
 void ThreadExecutor::addFileContent(const std::string &/*path*/, const std::string &/*content*/)
@@ -307,6 +312,11 @@ void ThreadExecutor::reportOut(const std::string &/*outmsg*/)
 
 }
 void ThreadExecutor::reportErr(const ErrorLogger::ErrorMessage &/*msg*/)
+{
+
+}
+
+void ThreadExecutor::reportInfo(const ErrorLogger::ErrorMessage &msg)
 {
 
 }

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -44,6 +44,7 @@ public:
     unsigned int check();
     virtual void reportOut(const std::string &outmsg);
     virtual void reportErr(const ErrorLogger::ErrorMessage &msg);
+    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg);
 
     /**
      * @brief Add content to a file, to be used in unit testing.

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -209,8 +209,7 @@ unsigned int CppCheck::processFile(const std::string& filename)
                                                  "toomanyconfigs",
                                                  false);
 
-                reportErr(errmsg);
-
+                reportInfo(errmsg);
                 break;
             }
 
@@ -510,6 +509,11 @@ void CppCheck::reportOut(const std::string &outmsg)
 void CppCheck::reportProgress(const std::string &filename, const char stage[], const unsigned int value)
 {
     _errorLogger.reportProgress(filename, stage, value);
+}
+
+void CppCheck::reportInfo(const ErrorLogger::ErrorMessage &msg)
+{
+    _errorLogger.reportInfo(msg);
 }
 
 void CppCheck::reportStatus(unsigned int /*fileindex*/, unsigned int /*filecount*/, size_t /*sizedone*/, size_t /*sizetotal*/)

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -175,6 +175,11 @@ private:
 
     void reportProgress(const std::string &filename, const char stage[], const unsigned int value);
 
+    /**
+     * Output information messages.
+     */
+    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg);
+
     CheckUnusedFunctions _checkUnusedFunctions;
     ErrorLogger &_errorLogger;
 

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -266,8 +266,7 @@ public:
      * Information about found errors and warnings is directed
      * here. Override this to receive the errormessages.
      *
-     * @param msg Location and other information about the found.
-     * error
+     * @param msg Location and other information about the found error.
      */
     virtual void reportErr(const ErrorLogger::ErrorMessage &msg) = 0;
 
@@ -282,6 +281,12 @@ public:
         (void)stage;
         (void)value;
     }
+
+    /**
+     * Output information messages.
+     * @param msg Location and other information about the found error.
+     */
+    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg) = 0;
 
     /**
      * Report list of unmatched suppressions

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -2100,7 +2100,7 @@ void Preprocessor::missingInclude(const std::string &filename, unsigned int line
     const std::string id = userheader ? "missingInclude" : "debug";
     ErrorLogger::ErrorMessage errmsg(locationList, severity, "Include file: \"" + header + "\" not found.", id, false);
     errmsg.file0 = file0;
-    _errorLogger->reportErr(errmsg);
+    errorLogger->reportInfo(errmsg);
 }
 
 /**


### PR DESCRIPTION
Currently the information severity messages are outputted as error
messages with Severity::Information. This causes constant confusion
as people think it as mildest error severity (and rightfully so).
When it was meant to be for printing messages about the checking
procedure itself (like missing header files etc).

So I'm adding a new function for the ErrorLogger for printing these
informative messages. This makes clear the distinction of errors
found from the code and messages related to the checking itself.
It also makes it easier for clients to handle these separately.

**NOTE** This commit is not yet for integrating, this is proof of the concept commit for discussion.
