### PR TITLE
Added to check to detect the use of memset on non-dynamic variables

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -175,6 +175,13 @@ void CheckBufferOverrun::bufferNotZeroTerminatedError(const Token *tok, const st
     reportInconclusiveError(tok, Severity::warning, "bufferNotZeroTerminated", errmsg);
 }
 
+void CheckBufferOverrun::memoryAllocationToNormalVariablesError(const Token *tok)
+{
+    reportError(tok, Severity::warning ,
+                "MemoryAllocationToNormalVariablesError",
+                "memset allocating memory to non-dynamic variable.");
+}
+
 //---------------------------------------------------------------------------
 
 
@@ -1557,6 +1564,7 @@ void CheckBufferOverrun::bufferOverrun()
     checkStructVariable();
     checkBufferAllocatedWithStrlen();
     checkInsecureCmdLineArgs();
+    checkMemoryAllocationToNormalVariables();
 }
 //---------------------------------------------------------------------------
 
@@ -1857,6 +1865,19 @@ void CheckBufferOverrun::negativeIndex()
     }
 }
 
+void CheckBufferOverrun::checkMemoryAllocationToNormalVariables()
+{
+    for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next()) {
+        if (Token::Match(tok, "memset ( & %any%")) {
+            const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();
+            const Variable *var(symbolDatabase->getVariableFromVarId(tok->tokAt(3)->varId()));
+
+            if (var && !(var->isPointer() || var->isArray())) {
+                memoryAllocationToNormalVariablesError(tok);
+            }
+        }
+    }
+}
 
 
 

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -108,6 +108,9 @@ public:
     /** Check for negative index */
     void negativeIndex();
 
+    /** Check for memset being used on non-pointer variable */
+    void checkMemoryAllocationToNormalVariables();
+
     /** Information about N-dimensional array */
     class ArrayInfo {
     private:
@@ -230,6 +233,7 @@ public:
     void arrayIndexThenCheckError(const Token *tok, const std::string &indexName);
     void possibleBufferOverrunError(const Token *tok, const std::string &src, const std::string &dst, bool cat);
     void possibleReadlinkBufferOverrunError(const Token *tok, const std::string &funcname, const std::string &varname);
+    void memoryAllocationToNormalVariablesError(const Token *tok);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) {
         CheckBufferOverrun c(0, settings, errorLogger);

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -205,6 +205,8 @@ private:
 
         TEST_CASE(memset1);
         TEST_CASE(memset2);
+        TEST_CASE(memset3);
+
         TEST_CASE(counter_test);
         TEST_CASE(strncpy1);
         TEST_CASE(unknownType);
@@ -3020,6 +3022,15 @@ private:
               "    memset(array, 0, sizeof(array));\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void memset3() {
+        check("void f()\n"
+              "{\n"
+              "    int i = 10;\n"
+              "    memset(&i, 0, 10);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) memset allocating memory to non-dynamic variable.\n", errout.str());
     }
 
     void counter_test() {


### PR DESCRIPTION
Detecting this will avoid the risk of buffer overruns.
