### PR TITLE
Avoid clang warning.

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -33,7 +33,7 @@
 #include "pathmatch.h"
 
 CppCheckExecutor::CppCheckExecutor()
-    : time1(0), errorlist(false), _settings(0)
+    : _settings(0), time1(0), errorlist(false)
 {
 }
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -39,7 +39,7 @@ static const char ExtraVersion[] = "";
 static TimerResults S_timerResults;
 
 CppCheck::CppCheck(ErrorLogger &errorLogger, bool useGlobalSuppressions)
-    : _useGlobalSuppressions(useGlobalSuppressions), _errorLogger(errorLogger), exitcode(0)
+    : exitcode(0), _useGlobalSuppressions(useGlobalSuppressions), _errorLogger(errorLogger)
 {
 }
 


### PR DESCRIPTION
Hello,

This PR makes the build warning free when using clang.

Thanks to consider it,
  Simon
