### PR TITLE
Add general PRO file for console builds.

### DIFF
--- a/cli/cli.pro
+++ b/cli/cli.pro
@@ -6,6 +6,8 @@ OBJECTS_DIR = temp
 CONFIG += warn_on
 CONFIG -= qt app_bundle
 
+include(../console_common.pri)
+
 BASEPATH = ../externals/tinyxml/
 include($$PWD/../externals/tinyxml/tinyxml.pri)
 BASEPATH = ../lib/
@@ -24,30 +26,15 @@ HEADERS += cppcheckexecutor.h \
            pathmatch.h \
            threadexecutor.h
 
-CONFIG(release, debug|release) {
-	DEFINES += NDEBUG
-}
-
 win32 {
-    CONFIG += embed_manifest_exe console
-    DEFINES += _CRT_SECURE_NO_WARNINGS
     RC_FILE = cppcheck.rc
     HEADERS += resource.h
-    LIBS += -lshlwapi
 }
 
-# Add more strict compiling flags for GCC
+# Enable STL checking in GCC debug builds
 contains(QMAKE_CXX, g++) {
-    QMAKE_CXXFLAGS_WARN_ON += -Wextra -pedantic -Wfloat-equal -Wcast-qual -Wlogical-op -Wno-long-long
-
     CONFIG(debug, debug|release) {
         # checked STL
         DEFINES += _GLIBCXX_DEBUG
     }
-}
-
-# Change Visual Studio compiler (CL) warning level to W4
-contains(QMAKE_CXX, cl) {
-    QMAKE_CXXFLAGS_WARN_ON -= -W3
-    QMAKE_CXXFLAGS_WARN_ON += -W4
 }

--- a/console_common.pri
+++ b/console_common.pri
@@ -1,0 +1,23 @@
+# console_common.pri
+# These are common definitions for console builds.
+
+win32 {
+    CONFIG += embed_manifest_exe console
+    DEFINES += _CRT_SECURE_NO_WARNINGS
+    LIBS += -lshlwapi
+}
+
+# Add more strict compiling flags for GCC
+contains(QMAKE_CXX, g++) {
+    QMAKE_CXXFLAGS_WARN_ON += -Wextra -pedantic -Wfloat-equal -Wcast-qual -Wlogical-op -Wno-long-long
+}
+
+# Change Visual Studio compiler (CL) warning level to W4
+contains(QMAKE_CXX, cl) {
+    QMAKE_CXXFLAGS_WARN_ON -= -W3
+    QMAKE_CXXFLAGS_WARN_ON += -W4
+}
+
+CONFIG(release, debug|release) {
+	DEFINES += NDEBUG
+}

--- a/test/test.pro
+++ b/test/test.pro
@@ -6,9 +6,8 @@ INCLUDEPATH += . ../cli ../lib
 OBJECTS_DIR = temp
 CONFIG += warn_on console
 CONFIG -= qt app_bundle
-win32 {
-    LIBS += -lshlwapi
-}
+
+include(../console_common.pri)
 
 BASEPATH = ../externals/tinyxml/
 include(../externals/tinyxml/tinyxml.pri)
@@ -30,14 +29,5 @@ HEADERS += ../cli/cmdlineparser.h \
            ../cli/pathmatch.h \
            ../cli/threadexecutor.h
 
-# test/*
-
 HEADERS += options.h redirect.h testsuite.h
 SOURCES += options.cpp
-
-# Change Visual Studio compiler (CL) warning level to W4
-contains(QMAKE_CXX, cl) {
-    QMAKE_CXXFLAGS_WARN_ON -= -W3
-    QMAKE_CXXFLAGS_WARN_ON += -W4
-    DEFINES += _CRT_SECURE_NO_WARNINGS
-}

--- a/tools/tools.pro
+++ b/tools/tools.pro
@@ -6,35 +6,11 @@ OBJECTS_DIR = temp
 CONFIG += warn_on
 CONFIG -= qt app_bundle
 
+include(../console_common.pri)
+
 SOURCES += dmake.cpp \
            ../cli/filelister.cpp \
            ../lib/path.cpp
 
 HEADERS += ../cli/filelister.h \
            ../lib/path.h
-
-CONFIG(release, debug|release) {
-	DEFINES += NDEBUG
-}
-
-win32 {
-    CONFIG += embed_manifest_exe console
-    DEFINES += _CRT_SECURE_NO_WARNINGS
-    LIBS += -lshlwapi
-}
-
-# Add more strict compiling flags for GCC
-contains(QMAKE_CXX, g++) {
-    QMAKE_CXXFLAGS_WARN_ON += -Wextra -pedantic -Wfloat-equal -Wcast-qual -Wlogical-op -Wno-long-long
-
-    CONFIG(debug, debug|release) {
-        # checked STL
-        DEFINES += _GLIBCXX_DEBUG
-    }
-}
-
-# Change Visual Studio compiler (CL) warning level to W4
-contains(QMAKE_CXX, cl) {
-    QMAKE_CXXFLAGS_WARN_ON -= -W3
-    QMAKE_CXXFLAGS_WARN_ON += -W4
-}


### PR DESCRIPTION
It is easier to maintain PRO files when we keep all the console-
build specific general options in one file. For example changes to
compiler options affect to all console builds.
