### PR TITLE
Check mutex is unlocked before returning from method

### DIFF
--- a/lib/checkthreadsafety.cpp
+++ b/lib/checkthreadsafety.cpp
@@ -1,0 +1,177 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2012 Daniel Marjamäki and Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+//---------------------------------------------------------------------------
+// Check Thread safety 
+// - find non reentrant functions
+// - mutex should get unlocked before returning from method in which its locked
+//---------------------------------------------------------------------------
+
+#include "checkthreadsafety.h"
+
+//---------------------------------------------------------------------------
+
+// Register this check class (by creating a static instance of it)
+namespace {
+    CheckThreadSafety instance;
+}
+
+typedef std::map<std::string, bool>::iterator Iter;
+
+void CheckThreadSafety::nonReentrantFunctions()
+{
+    if (!_settings->standards.posix || !_settings->isEnabled("portability"))
+        return;
+
+    std::map<std::string,std::string>::const_iterator nonReentrant_end = _nonReentrantFunctions.end();
+    for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next()) {
+        // Look for function invocations
+        if (!tok->isName() || tok->strAt(1) != "(" || tok->varId() != 0)
+            continue;
+
+        // Check for non-reentrant function name
+        std::map<std::string,std::string>::const_iterator it = _nonReentrantFunctions.find(tok->str());
+        if (it == nonReentrant_end)
+            continue;
+
+        const Token *prev = tok->previous();
+        if (prev) {
+            // Ignore function definitions, class members or class definitions
+            if (prev->isName() || Token::Match(prev, ".|:"))
+                continue;
+
+            // Check for "std" or global namespace, ignore other namespaces
+            if (prev->str() == "::" && prev->previous() && prev->previous()->str() != "std" && prev->previous()->isName())
+                continue;
+        }
+
+        // Only affecting multi threaded code, therefore this is "portability"
+        reportError(tok, Severity::portability, "nonreentrantFunctions"+it->first, it->second);
+    }
+}
+//---------------------------------------------------------------------------
+
+//#include "tokenize.h"
+//#include "token.h"
+//#include "errorlogger.h"
+#include "symboldatabase.h"
+
+//#include <cctype>
+//#include <cstdlib>
+//#include <stdio.h>
+//#include <map>
+//---------------------------------------------------------------------------
+
+
+std::string CheckThreadSafety::getMutexVariable(const Token * tok4) {
+    std::string mutexVariable ;
+    Token *tok4Link = tok4->link() ;
+    for ( tok4 = tok4->next(); tok4 != tok4Link ; tok4 = tok4->next() )   {
+         mutexVariable +=  tok4->str() ;
+    }
+    return mutexVariable ;
+}
+
+void CheckThreadSafety::checkMutexState(std::map<std::string, bool>& mutexToState, 
+            const Token * locationTok, Token *functionName) {
+   for (Iter i = mutexToState.begin() ; i != mutexToState.end() ; i++ ) {
+       if (i->second == true)    {
+           checkMutexUsageError(locationTok, i->first, functionName->str()) ;
+       }
+   }
+}
+            
+void CheckThreadSafety::setAllMutexState(std::map<std::string, bool>& mutexToState, bool value) {
+   for (Iter i = mutexToState.begin() ; i != mutexToState.end() ; i++ ) {
+       i->second = value ;
+   }
+}
+
+void CheckThreadSafety::checkFunction(const Token *tok)	{
+      // map mutex to its state i.e. its locked(true) or unlocked(false) 
+      std::map<std::string, bool> mutexToState ; 
+      bool lastReturnExists = false;
+
+      Token * functionName = tok->link()->tokAt(-1)->link()->tokAt(-1);
+      const Token *tok2 = NULL ;
+      for ( tok2 = tok->link() ; tok2 && tok2 != tok; tok2 = tok2->next() ) {
+         if ( tok2->str() ==  "pthread_mutex_lock" ) 	{
+            const Token *tok4 = tok2->next() ; 
+            if (tok4->str() != "(" ) { // make sure this is a function call
+                  continue ;  
+            }
+            // set this mutex state to lock  
+            mutexToState[getMutexVariable(tok4)] = true ; 
+
+         } else if ( tok2->str() == "pthread_mutex_unlock" ) {
+            const Token *tok4 = tok2->next() ; 
+            if (tok4->str() != "(" ) { // make sure this is a function call
+                  continue ;  
+            }  
+            // set this mutex state to unlock  
+            mutexToState[getMutexVariable(tok4)] = false ;
+ 
+         } else if ( tok2->str() == "return" ) {
+           
+            // check if its an interm return in the method by going to the ";"
+            // token and comparing next token with tok. If its an interm return
+            // then check mutex states and then set all mutexes as locked again
+            const Token * tok3 = NULL ;
+            for (tok3 = tok2->next(); tok3 ; tok3 = tok3->next() )   {
+                if (tok3->str() == ";" ) { break ; }
+            }    
+            if ( tok3->next() && (tok3->next() != tok) ) { //interim return
+                // check state of all mutexes 
+                checkMutexState(mutexToState, tok2, functionName);  
+                setAllMutexState(mutexToState, true); 
+            } else { // last return. check and break from loop
+                checkMutexState(mutexToState, tok2, functionName);
+                lastReturnExists = true;
+                break ;  
+            }
+         } // "return" 
+
+      } // for loop
+   
+     // taking care of functions which return void and hence may not have a return statement
+     if (!lastReturnExists) { 
+          checkMutexState(mutexToState, tok, functionName);
+     }
+}
+
+void CheckThreadSafety::checkMutexUsageError(const Token *tok, const std::string mutex, 
+					const std::string & functionName) {
+    reportError(tok, Severity::error, "pthreadLockUnlockMismatch", "A pthread_mutex_lock call on mutex "
+             +mutex+" doesn't have a related unlock call in function "+ functionName + ".");
+}
+
+void CheckThreadSafety::checkMutexUsage()
+{
+    const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase() ;
+    std::list<Scope>::const_iterator scope;
+
+    for (scope = symbolDatabase->scopeList.begin() ; scope != symbolDatabase->scopeList.end(); ++scope) {
+        
+         if (scope->type != Scope::eFunction) // check only functions
+             continue ;
+   
+         const Token *tok = scope->classEnd;
+         checkFunction(tok);    
+   } 
+}
+

--- a/lib/checkthreadsafety.h
+++ b/lib/checkthreadsafety.h
@@ -1,0 +1,134 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2012 Daniel Marjamäki and Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+//---------------------------------------------------------------------------
+#ifndef CheckThreadSafetyH
+#define CheckThreadSafetyH
+//---------------------------------------------------------------------------
+
+#include "config.h"
+#include "check.h"
+#include <string>
+#include <map>
+
+
+/// @addtogroup Checks
+/// @{
+
+/**
+ * @brief
+ * - Using non reentrant functions that can be replaced by their reentrant versions
+ * - Check that within a function each mutex which is locked is also
+ *   unlocked before returning from the function.
+ *   The code checks the above for pthread mutexes (i.e. functions  pthread_mutex_lock
+ *   and pthread_mutex_unlock)
+ */
+
+class CPPCHECKLIB CheckThreadSafety : public Check {
+public:
+    /** This constructor is used when registering the CheckThreadSafety */
+    CheckThreadSafety() : Check(myName()) {
+        initNonReentrantFunctions();
+    }
+
+    /** This constructor is used when running checks. */
+    CheckThreadSafety(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
+        : Check(myName(), tokenizer, settings, errorLogger) {
+        initNonReentrantFunctions();
+    }
+
+    void runSimplifiedChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) {
+        CheckThreadSafety checkThreadSafety(tokenizer, settings, errorLogger);
+        checkThreadSafety.nonReentrantFunctions();
+        checkThreadSafety.checkMutexUsage();
+    }
+
+    /** Check for non reentrant functions */
+    void nonReentrantFunctions();
+
+    /** @brief %Check usage of pthread_mutex_lock and pthread_mutex_unlock */
+    void checkMutexUsage();
+
+private:
+    
+    /* function name / error message */
+    std::map<std::string,std::string> _nonReentrantFunctions;
+
+    /** init nonreentrant functions list ' */
+    void initNonReentrantFunctions() {
+        static const char * const non_reentrant_functions_list[] = {
+            "localtime", "gmtime", "strtok", "gethostbyname", "gethostbyaddr", "getservbyname"
+            , "getservbyport", "crypt", "ttyname", "gethostbyname2"
+            , "getprotobyname", "getnetbyname", "getnetbyaddr", "getrpcbyname", "getrpcbynumber", "getrpcent"
+            , "ctermid", "readdir", "getlogin", "getpwent", "getpwnam", "getpwuid", "getspent"
+            , "fgetspent", "getspnam", "getgrnam", "getgrgid", "getnetgrent", "tempnam", "fgetpwent"
+            , "fgetgrent", "ecvt", "gcvt", "getservent", "gethostent", "getgrent", "fcvt"
+        };
+
+        // generate messages
+        for (unsigned int i = 0; i < (sizeof(non_reentrant_functions_list) / sizeof(char *)); ++i) {
+            std::string strMsg("Non reentrant function '");
+            strMsg+=non_reentrant_functions_list[i];
+            strMsg+= "' called. For threadsafe applications it is recommended to use the reentrant replacement function '";
+            strMsg+=non_reentrant_functions_list[i];
+            strMsg+="_r'.";
+            _nonReentrantFunctions[non_reentrant_functions_list[i]] = strMsg;
+        }
+    }
+
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
+        CheckThreadSafety c(0, settings, errorLogger);
+
+        std::map<std::string,std::string>::const_iterator it(_nonReentrantFunctions.begin()), itend(_nonReentrantFunctions.end());
+        for (; it!=itend; ++it) {
+            c.reportError(0, Severity::portability, "nonreentrantFunctions"+it->first, it->second);
+        }
+    }
+    //void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
+    //    CheckMutex c(0, settings, errorLogger);
+    //}
+
+    static std::string myName() {
+        return "Thread Safety";
+    }
+
+    std::string classInfo() const {
+        std::string info = "Warn if a mutex locked in a method remains locked when control exists the method.\n";
+         info += "Check pthread_mutex locking.\n"
+                 "* Each pthread_mutex_lock call should have a corresponding pthread_mutex_unlock call\n"
+                 "  before returning from method\n";
+        info += "Warn if any of these non reentrant functions are used:\n";
+        std::map<std::string,std::string>::const_iterator it(_nonReentrantFunctions.begin()), itend(_nonReentrantFunctions.end());
+        for (; it!=itend; ++it) {
+            info += "* " + it->first + "\n";
+        }
+        return info;
+    }
+
+    void checkFunction(const Token* tok);
+    std::string getMutexVariable(const Token * tok4);
+    void setAllMutexState(std::map<std::string, bool>& mutexToState, bool value);
+    void checkMutexState(std::map<std::string, bool>& mutexToState, 
+            const Token * locationTok, Token *functionName); 
+    // Reporting errors..
+    void checkMutexUsageError(const Token* tok, std::string, const std::string& functionName);
+};
+/// @}
+//---------------------------------------------------------------------------
+#endif

--- a/test/testthreadsafety.cpp
+++ b/test/testthreadsafety.cpp
@@ -1,0 +1,187 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2012 Daniel Marjamäki and Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "tokenize.h"
+#include "checkthreadsafety.h"
+#include "testsuite.h"
+
+#include <sstream>
+
+extern std::ostringstream errout;
+
+class TestThreadSafety : public TestFixture {
+public:
+    TestThreadSafety() : TestFixture("TestThreadSafety")
+    { }
+
+private:
+
+    void run() {
+        TEST_CASE(test_crypt);
+        TEST_CASE(test_namespace_handling);
+        TEST_CASE(MutexSimplePass)
+        TEST_CASE(MutexSimpleFail)
+        TEST_CASE(MutexComplexPass)
+        TEST_CASE(MutexComplexFail)
+    }
+
+    void check(const char code[]) {
+        // Clear the error buffer..
+        errout.str("");
+
+        Settings settings;
+        settings.standards.posix = true;
+        settings.addEnabled("portability");
+
+        // Tokenize..
+        Tokenizer tokenizer(&settings, this);
+        std::istringstream istr(code);
+        tokenizer.tokenize(istr, "test.cpp");
+        tokenizer.simplifyTokenList();
+
+        // Check for non reentrant functions..
+        CheckThreadSafety checkThreadSafety(&tokenizer, &settings, this);
+        checkThreadSafety.nonReentrantFunctions();
+        checkThreadSafety.checkMutexUsage();
+    }
+
+    void test_crypt() {
+        check("void f(char *pwd)\n"
+              "{\n"
+              "    char *cpwd;"
+              "    crypt(pwd, cpwd);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    char *pwd = getpass(\"Password:\");"
+              "    char *cpwd;"
+              "    crypt(pwd, cpwd);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'crypt' called. For threadsafe applications it is recommended to use the reentrant replacement function 'crypt_r'.\n", errout.str());
+
+        check("int f()\n"
+              "{\n"
+              "    int crypt = 0;"
+              "    return crypt;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void test_namespace_handling() {
+        check("int f()\n"
+              "{\n"
+              "    time_t t = 0;"
+              "    std::localtime(&t);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'localtime' called. For threadsafe applications it is recommended to use the reentrant replacement function 'localtime_r'.\n", errout.str());
+
+        // Passed as function argument
+        check("int f()\n"
+              "{\n"
+              "    printf(\"Magic guess: %d\n\", getpwent());\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.\n", errout.str());
+
+        // Pass return value
+        check("int f()\n"
+              "{\n"
+              "    time_t t = 0;"
+              "    struct tm *foo = localtime(&t);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'localtime' called. For threadsafe applications it is recommended to use the reentrant replacement function 'localtime_r'.\n", errout.str());
+
+        // Access via global namespace
+        check("int f()\n"
+              "{\n"
+              "    ::getpwent();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (portability) Non reentrant function 'getpwent' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getpwent_r'.\n", errout.str());
+
+        // Be quiet on function definitions
+        check("int getpwent()\n"
+              "{\n"
+              "    return 123;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        // Be quiet on other namespaces
+        check("int f()\n"
+              "{\n"
+              "    foobar::getpwent();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        // Be quiet on class member functions
+        check("int f()\n"
+              "{\n"
+              "    foobar.getpwent();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void MutexSimplePass() {
+        check("void f() {\n"
+              "    pthread_mutex_lock(m);\n"
+              "    functionCall() ;\n" 
+              "    pthread_mutex_unlock(m) ;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+    void MutexSimpleFail() {
+        check("void f() {\n"
+              "    pthread_mutex_lock(m);\n"
+              "    functionCall() ;\n"
+              "    return ;\n" 
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) A pthread_mutex_lock call on mutex m doesn't have a related unlock call in function f.\n",
+           errout.str());
+    }
+    void MutexComplexPass() {
+        check("int f() {\n"
+              "    pthread_mutex_lock(m);\n"
+              "    if (n) {\n"
+              "      functionCall() ;" 
+              "      pthread_mutex_unlock(m) ;\n"
+              "      return 10; }  \n"
+              "    pthread_mutex_unlock(m)\n"
+              "    return 23;  \n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+    void MutexComplexFail() {
+        check("void f() {\n"
+              "    pthread_mutex_lock(m);\n"
+              "    if (m) { \n" 
+              "       functionCall1() ; \n"
+              "       pthread_mutex_unlock(m);\n"
+              "       return ; \n"
+              "    } else { \n" 
+              "       functionCall2(); \n"
+              "    }\n" 
+              "}");
+        ASSERT_EQUALS("[test.cpp:10]: (error) A pthread_mutex_lock call on mutex m doesn't have a related unlock call in function f.\n",
+           errout.str());
+    }
+
+};
+
+REGISTER_TEST(TestThreadSafety)
+


### PR DESCRIPTION
It makes sure that if a mutex is locked in a function, it gets unlocked before control returns from that function. See http://lars-lab.jpl.nasa.gov/JPL_Coding_Standard_C.pdf - Rule 9 (semaphores and locking) - ...Unlock operations shall always appear within the body of the same function that performs the matching lock operation.

Currently it does this by checking for pthread mutex methods, pthread_mutex_lock() and pthread_mutex_unlock()

Also see last response from PKEuS and adityanaidu here:https://github.com/danmar/cppcheck/pull/107
