### PR TITLE
Generate version information by git tags. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,9 @@ endif
 
 EXTOBJ += $(TINYXML)
 
+### set version
+CXXFLAGS += -DCPPCHECK_VERSION=$(shell git describe --tags)
+
 ###### Targets
 
 cppcheck: $(LIBOBJ) $(CLIOBJ) $(EXTOBJ)

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -34,7 +34,14 @@
 #include <pcre.h>
 #endif
 
-static const char Version[] = "1.58 dev";
+#ifdef CPPCHECK_VERSION
+    #define STRINGIFY(x) #x
+    #define AS_STRING(x) STRINGIFY(x)
+    static const char Version[] = AS_STRING(CPPCHECK_VERSION);
+#else
+    static const char Version[] = "unknown version (later than 1.57)";
+#endif
+
 static const char ExtraVersion[] = "";
 
 static TimerResults S_timerResults;

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -326,6 +326,9 @@ int main(int argc, char **argv)
 
     makeExtObj(fout, externalfiles);
 
+    fout << std::endl << "### set version" << std::endl;
+    fout << "CXXFLAGS += -DCPPCHECK_VERSION=$(shell git describe --tags)" << std::endl;
+
     fout << "\n###### Targets\n\n";
     fout << "cppcheck: $(LIBOBJ) $(CLIOBJ) $(EXTOBJ)\n";
     fout << "\t$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o cppcheck $(CLIOBJ) $(LIBOBJ) $(EXTOBJ) $(LIBS) $(LDFLAGS)\n\n";


### PR DESCRIPTION
This removes the step to manually adapt the version information in
lib/cppcheck.cpp but at compiletime the Makefile calls `git describe --tags` which yields
the version currently being used.
