### PR TITLE
Add a GUI command line parameter for opening a results file

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -76,7 +76,9 @@ void ShowUsage()
         "    cppcheck-gui [OPTIONS] [files or paths]\n\n"
         "Options:\n"
         "    -h, --help    Print this help\n"
-        "    -p <file>     Open given project file and start checking it\n";
+        "    -p <file>      Open given project file and start checking it\n"
+        "    -l <file>      Open given results file\n"
+        "    -d <directory> Specify the directory that was checked to generate the results specified with -x\n";
 #if defined(_WIN32)
     QMessageBox msgBox(QMessageBox::Information,
                        "Cppcheck GUI",

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -78,7 +78,7 @@ MainWindow::MainWindow() :
     connect(mUI.mActionCheckDirectory, SIGNAL(triggered()), this, SLOT(CheckDirectory()));
     connect(mUI.mActionSettings, SIGNAL(triggered()), this, SLOT(ProgramSettings()));
     connect(mUI.mActionClearResults, SIGNAL(triggered()), this, SLOT(ClearResults()));
-    connect(mUI.mActionOpenXML, SIGNAL(triggered()), this, SLOT(OpenXML()));
+    connect(mUI.mActionOpenXML, SIGNAL(triggered()), this, SLOT(OpenResults()));
 
     connect(mUI.mActionShowStyle, SIGNAL(toggled(bool)), this, SLOT(ShowStyle(bool)));
     connect(mUI.mActionShowErrors, SIGNAL(toggled(bool)), this, SLOT(ShowErrors(bool)));
@@ -194,6 +194,24 @@ void MainWindow::HandleCLIParams(const QStringList &params)
             projFile = params[ind + 1];
 
         LoadProjectFile(projFile);
+    } else if (params.contains("-l")) {
+        QString logFile;
+        const int ind = params.indexOf("-l");
+        if ((ind + 1) < params.length())
+            logFile = params[ind + 1];
+
+        if (params.contains("-d")) {
+            QString checkedDir;
+            const int ind = params.indexOf("-d");
+            if ((ind + 1) < params.length())
+                checkedDir = params[ind + 1];
+
+            LoadResults(logFile, checkedDir);
+        }
+        else
+        {
+            LoadResults(logFile);
+        }
     } else
         DoCheckFiles(params);
 }
@@ -609,7 +627,7 @@ void MainWindow::ClearResults()
     mUI.mActionSave->setEnabled(false);
 }
 
-void MainWindow::OpenXML()
+void MainWindow::OpenResults()
 {
     if (mUI.mResults->HasResults()) {
         QMessageBox msgBox(this);
@@ -637,9 +655,22 @@ void MainWindow::OpenXML()
                            &selectedFilter);
 
     if (!selectedFile.isEmpty()) {
+        LoadResults(selectedFile);
+    }
+}
+
+void MainWindow::LoadResults(const QString selectedFile)
+{
+    if (!selectedFile.isEmpty()) {
         mUI.mResults->Clear(true);
         mUI.mResults->ReadErrorsXml(selectedFile);
     }
+}
+
+void MainWindow::LoadResults(const QString selectedFile, const QString sourceDirectory)
+{
+    LoadResults(selectedFile);
+    mUI.mResults->SetCheckDirectory(sourceDirectory);
 }
 
 void MainWindow::EnableCheckButtons(bool enable)

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -85,7 +85,7 @@ public slots:
     * @brief Slot to open XML report file
     *
     */
-    void OpenXML();
+    void OpenResults();
 
     /**
     * @brief Show errors with type "style"
@@ -389,6 +389,19 @@ protected:
     * @param params List of string given to command line.
     */
     void HandleCLIParams(const QStringList &params);
+    
+    /**
+    * @brief Load XML file to the GUI.
+    * @param file Filename (inc. path) of XML file to load.
+    */
+    void LoadResults(const QString file);
+
+    /**
+    * @brief Load XML file to the GUI.
+    * @param file Filename (inc. path) of XML file to load.
+    * @param checkedDirectory Path to the directory that the results were generated for.
+    */
+    void LoadResults(const QString file, const QString checkedDirectory);
 
     /**
     * @brief Load project file to the GUI.


### PR DESCRIPTION
This change allows you to pass '-l' on the command line to cause the GUI to open a previously generated results file. You can also specify '-d' to specify which directory the results were generated for (so that you don't have to browser to source when you double click on an error)
