### PR TITLE
checkunusedvar: std::tolower() needs <cctype> included

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -21,6 +21,7 @@
 #include "checkunusedvar.h"
 #include "symboldatabase.h"
 #include <algorithm>
+#include <cctype>
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)


### PR DESCRIPTION
Signed-off-by: Stefan Naewe stefan.naewe@googlemail.com
