### PR TITLE
Fix compiler warnings and comment/string typos

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -210,7 +210,7 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
         }
 
         // Filter errors
-        // This is deprecated, see --supressions-list above
+        // This is deprecated, see --suppressions-list above
         else if (std::strcmp(argv[i], "--suppressions") == 0) {
             ++i;
 

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -186,7 +186,7 @@ unsigned int ThreadExecutor::check()
                 fileChecker.settings() = _settings;
                 unsigned int resultOfCheck = 0;
 
-                if (_fileContents.size() > 0 && _fileContents.find(i->first) != _fileContents.end()) {
+                if (!_fileContents.empty() && _fileContents.find(i->first) != _fileContents.end()) {
                     // File content was given as a string
                     resultOfCheck = fileChecker.check(i->first, _fileContents[ i->first ]);
                 } else {

--- a/gui/scratchpad.cpp
+++ b/gui/scratchpad.cpp
@@ -32,7 +32,7 @@ ScratchPad::ScratchPad(MainWindow& mainWindow)
 void ScratchPad::CheckButtonClicked()
 {
     QString filename = mUI.lineEdit->text();
-    if (filename.size() == 0)
+    if (filename.isEmpty())
         filename = "test.cpp";
     mMainWindow.CheckCode(mUI.plainTextEdit->toPlainText(), filename);
 }

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -242,7 +242,7 @@ void SettingsDialog::EditApplication()
 void SettingsDialog::DefaultApplication()
 {
     QList<QListWidgetItem *> selected = mUI.mListWidget->selectedItems();
-    if (selected.size() > 0) {
+    if (!selected.isEmpty()) {
         int index = mUI.mListWidget->row(selected[0]);
         mTempApplications->SetDefault(index);
         mUI.mListWidget->clear();

--- a/gui/test/data/benchmark/simple.cpp
+++ b/gui/test/data/benchmark/simple.cpp
@@ -532,7 +532,7 @@ void CheckOther::checkIncorrectLogicOperator()
     const Token *endTok = tok ? tok->next()->link() : NULL;
 
     while (tok && endTok) {
-        // Find a pair of OR'd terms, with or without parenthesis
+        // Find a pair of OR'd terms, with or without parentheses
         // e.g. if (x != 3 || x != 4)
         const Token *logicTok = NULL, *term1Tok = NULL, *term2Tok = NULL;
         const Token *op1Tok = NULL, *op2Tok = NULL, *op3Tok = NULL, *nextTok = NULL;
@@ -2772,7 +2772,7 @@ void CheckOther::checkMathFunctions()
                  MathLib::toLongNumber(tok->tokAt(2)->str()) <= 0) {
             mathfunctionCallError(tok);
         }
-        // acos( x ), asin( x )  where x is defined for intervall [-1,+1], but not beyound
+        // acos( x ), asin( x )  where x is defined for interval [-1,+1], but not beyond
         else if (tok->varId() == 0 &&
                  Token::Match(tok, "acos|asin ( %num% )") &&
                  std::fabs(MathLib::toDoubleNumber(tok->tokAt(2)->str())) > 1.0) {
@@ -3508,6 +3508,6 @@ void CheckOther::unsignedPositive(const Token *tok, const std::string &varname)
 {
     reportError(tok, Severity::style, "unsignedPositive",
                 "Checking if unsigned variable '" + varname + "' is positive is always true.\n"
-                "An unsigned variable will never alwayw be positive so it is either pointless or "
+                "An unsigned variable can't be negative so it is either pointless or "
                 "an error to check if it is.");
 }

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -175,10 +175,7 @@ void ThreadHandler::SaveSettings(QSettings &settings) const
 
 bool ThreadHandler::HasPreviousFiles() const
 {
-    if (mLastFiles.size() > 0)
-        return true;
-
-    return false;
+    return !mLastFiles.isEmpty();
 }
 
 int ThreadHandler::GetPreviousFilesCount() const

--- a/gui/threadresult.cpp
+++ b/gui/threadresult.cpp
@@ -91,7 +91,7 @@ void ThreadResult::reportErr(const ErrorLogger::ErrorMessage &msg)
 QString ThreadResult::GetNextFile()
 {
     QMutexLocker locker(&mutex);
-    if (mFiles.size() == 0) {
+    if (mFiles.isEmpty()) {
         return "";
     }
 

--- a/gui/txtreport.cpp
+++ b/gui/txtreport.cpp
@@ -59,7 +59,7 @@ void TxtReport::WriteError(const ErrorItem &error)
     for (int i = 0; i < error.lines.size(); i++) {
         const QString file = QDir::toNativeSeparators(error.files[i]);
         line += QString("[%1:%2]").arg(file).arg(error.lines[i]);
-        if (i < error.lines.size() - 1 && error.lines.size() > 0) {
+        if (i < error.lines.size() - 1 && !error.lines.isEmpty()) {
             line += " -> ";
         }
 

--- a/gui/xmlreportv1.cpp
+++ b/gui/xmlreportv1.cpp
@@ -162,7 +162,7 @@ ErrorItem XmlReportV1::ReadError(QXmlStreamReader *reader)
         item.errorId = attribs.value("", IdAttribute).toString();
         item.severity = GuiSeverity::fromString(attribs.value("", SeverityAttribute).toString());
 
-        // NOTE: This dublicates the message to Summary-field. But since
+        // NOTE: This duplicates the message to Summary-field. But since
         // old XML format doesn't have separate summary and verbose messages
         // we must add same message to both data so it shows up in GUI.
         // Check if there is full stop and cut the summary to it.

--- a/lib/check64bit.cpp
+++ b/lib/check64bit.cpp
@@ -75,7 +75,7 @@ void Check64BitPortability::pointerassignment()
         }
     }
 
-    // Check assignements
+    // Check assignments
     for (std::size_t i = 0; i < functions; ++i) {
         const Scope * scope = symbolDatabase->functionScopes[i];
         for (const Token *tok = scope->classStart; tok && tok != scope->classEnd; tok = tok->next()) {

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -825,7 +825,7 @@ void CheckBufferOverrun::checkScopeForBody(const Token *tok, const ArrayInfo &ar
     if (Token::Match(tok2->next(), "%var% =") && MathLib::toLongNumber(max_counter_value) < size)
         condition_out_of_bounds = false;
 
-    // Goto the end parenthesis of the for-statement: "for (x; y; z)" ..
+    // Goto the end parentheses of the for-statement: "for (x; y; z)" ..
     tok2 = tok->next()->link();
     if (!tok2 || !tok2->tokAt(5)) {
         bailout = true;

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -771,7 +771,7 @@ void CheckClass::privateFunctions()
             }
         }
 
-        // Bailout for overriden virtual functions of base classes
+        // Bailout for overridden virtual functions of base classes
         if (!scope->derivedFrom.empty()) {
             // Check virtual functions
             for (std::list<const Function*>::iterator it = FuncList.begin(); it != FuncList.end();) {
@@ -1108,7 +1108,7 @@ bool CheckClass::hasAllocation(const Function *func, const Scope* scope)
             var = tok->tokAt(3);
         else if (Token::Match(tok, "delete %var%"))
             var = tok->next();
-        // Check for assignement to the deleted pointer (only if its a member of the class)
+        // Check for assignment to the deleted pointer (only if its a member of the class)
         if (var && isMemberVar(scope, var)) {
             for (const Token *tok1 = var->next(); tok1 && (tok1 != last); tok1 = tok1->next()) {
                 if (Token::Match(tok1, "%var% =")) {

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -115,7 +115,7 @@ void CheckExceptionSafety::deallocThrow()
 
                 // Variable is assigned -> Bail out
                 else if (Token::Match(tok2, "%varid% =", varid)) {
-                    if (ThrowToken) // For non-inconclusive checking, wait until we find an assignement to it. Otherwise we assume it is safe to leave a dead pointer.
+                    if (ThrowToken) // For non-inconclusive checking, wait until we find an assignment to it. Otherwise we assume it is safe to leave a dead pointer.
                         deallocThrowError(ThrowToken, tok2->str());
                     break;
                 }

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -92,9 +92,14 @@ static const char * const call_func_white_list[] = {
     , "vscanf", "vsnprintf", "vsprintf", "vsscanf", "while", "wordexp","write", "writev"
 };
 
-static int call_func_white_list_compare(const void *a, const void *b)
+extern "C"
 {
-    return std::strcmp((const char *)a, *(const char * const *)b);
+    int call_func_white_list_compare(const void *a, const void *b);
+
+    int call_func_white_list_compare(const void *a, const void *b)
+    {
+        return std::strcmp((const char *)a, *(const char * const *)b);
+    }
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -358,7 +358,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Sym
     // streams dereference nullpointers
     if (Token::Match(tok->previous(), "<<|>> %var%")) {
         const Variable* var = symbolDatabase->getVariableFromVarId(tok->varId());
-        if (var && var->isPointer() && Token::Match(var->typeStartToken(), "char|wchar_t")) { // Only outputing or reading to char* can cause problems
+        if (var && var->isPointer() && Token::Match(var->typeStartToken(), "char|wchar_t")) { // Only outputting or reading to char* can cause problems
             const Token* tok2 = tok->previous(); // Find start of statement
             for (; tok2; tok2 = tok2->previous()) {
                 if (Token::Match(tok2->previous(), ";|{|}|:"))

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1266,7 +1266,7 @@ void CheckOther::checkIncorrectLogicOperator()
     for (std::size_t ii = 0; ii < functions; ++ii) {
         const Scope * scope = symbolDatabase->functionScopes[ii];
         for (const Token* tok = scope->classStart->next(); tok != scope->classEnd; tok = tok->next()) {
-            // Find a pair of comparison expressions with or without parenthesis
+            // Find a pair of comparison expressions with or without parentheses
             // with a shared variable and constants and with a logical operator between them.
             // e.g. if (x != 3 || x != 4)
             const Token *term1Tok = NULL, *term2Tok = NULL;
@@ -2231,7 +2231,7 @@ void CheckOther::checkMathFunctions()
                 }
             }
 
-            // acos( x ), asin( x )  where x is defined for intervall [-1,+1], but not beyound
+            // acos( x ), asin( x )  where x is defined for interval [-1,+1], but not beyond
             else if (Token::Match(tok, "acos|asin ( %num% )") &&
                      std::fabs(MathLib::toDoubleNumber(tok->strAt(2))) > 1.0) {
                 mathfunctionCallError(tok);
@@ -2985,7 +2985,7 @@ void CheckOther::checkExpressionRange(const std::list<const Function*> &constFun
     for (; it != expressions.getMap().end(); ++it) {
         // check expression..
         bool valid = true;
-        unsigned int parenthesis = 0;  // ()
+        unsigned int parentheses = 0;  // ()
         unsigned int brackets = 0;     // []
 
         // taking address?
@@ -2995,13 +2995,13 @@ void CheckOther::checkExpressionRange(const std::list<const Function*> &constFun
 
         for (const Token *tok = it->second.start; tok && tok != it->second.end; tok = tok->next()) {
             if (tok->str() == "(") {
-                ++parenthesis;
+                ++parentheses;
             } else if (tok->str() == ")") {
-                if (parenthesis == 0) {
+                if (parentheses == 0) {
                     valid = false;
                     break;
                 }
-                --parenthesis;
+                --parentheses;
             } else if (tok->str() == "[") {
                 ++brackets;
             } else if (tok->str() == "]") {
@@ -3016,7 +3016,7 @@ void CheckOther::checkExpressionRange(const std::list<const Function*> &constFun
             }
         }
 
-        if (!valid || parenthesis!=0 || brackets!=0)
+        if (!valid || parentheses!=0 || brackets!=0)
             continue;
 
         const ExpressionTokens &expr = it->second;
@@ -3764,7 +3764,7 @@ void CheckOther::checkVarFuncNullUB()
             if (Token::Match(tok,"[(,] NULL [,)]")) {
                 // Locate function name in this function call.
                 const Token *ftok = tok;
-                int argnr = 1;
+                std::size_t argnr = 1;
                 while (ftok && ftok->str() != "(") {
                     if (ftok->str() == ")")
                         ftok = ftok->link();

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1344,10 +1344,10 @@ bool CheckUninitVar::checkScopeForVariable(const Scope* scope, const Token *tok,
     return false;
 }
 
-bool CheckUninitVar::checkIfForWhileHead(const Scope *scope, const Token *startparanthesis, const Variable& var, bool suppressErrors, bool isuninit)
+bool CheckUninitVar::checkIfForWhileHead(const Scope *scope, const Token *startparentheses, const Variable& var, bool suppressErrors, bool isuninit)
 {
-    const Token * const endpar = startparanthesis->link();
-    for (const Token *tok = startparanthesis->next(); tok && tok != endpar; tok = tok->next()) {
+    const Token * const endpar = startparentheses->link();
+    for (const Token *tok = startparentheses->next(); tok && tok != endpar; tok = tok->next()) {
         if (tok->varId() == var.varId()) {
             if (isVariableUsage(scope, tok, var.isPointer())) {
                 if (!suppressErrors)
@@ -1374,7 +1374,7 @@ bool CheckUninitVar::isVariableUsage(const Scope* scope, const Token *vartok, bo
     if (Token::Match(vartok->previous(), "[(,] %var% [,)]") || Token::Match(vartok->tokAt(-2), "[(,] & %var% [,)]")) {
         const bool address(vartok->previous()->str() == "&");
 
-        // locate start parenthesis in function call..
+        // locate start parentheses in function call..
         int argumentNumber = 0;
         const Token *start = vartok;
         while (start && !Token::Match(start, "[;{}(]")) {

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -65,7 +65,7 @@ public:
     void check();
     void checkScope(const Scope* scope);
     bool checkScopeForVariable(const Scope* scope, const Token *tok, const Variable& var, bool * const possibleInit, bool * const noreturn);
-    bool checkIfForWhileHead(const Scope *scope, const Token *startparanthesis, const Variable& var, bool suppressErrors, bool isuninit);
+    bool checkIfForWhileHead(const Scope *scope, const Token *startparentheses, const Variable& var, bool suppressErrors, bool isuninit);
     bool isVariableUsage(const Scope* scope, const Token *vartok, bool ispointer) const;
 
 

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -129,7 +129,7 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer)
         else
             continue;
 
-        // funcname ( => Assert that the end parenthesis isn't followed by {
+        // funcname ( => Assert that the end parentheses isn't followed by {
         if (Token::Match(funcname, "%var% (")) {
             if (Token::Match(funcname->linkAt(1), ") const|throw|{"))
                 funcname = NULL;

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -363,7 +363,7 @@ std::string MathLib::abs(const std::string &tok)
 
 bool MathLib::isEqual(const std::string &first, const std::string &second)
 {
-    // this conversion is needed for formating
+    // this conversion is needed for formatting
     // e.g. if first=0.1 and second=1.0E-1, the direct comparison of the strings whould fail
     return doubleToString(toDoubleNumber(first)) == doubleToString(toDoubleNumber(second));
 }

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -646,7 +646,7 @@ std::string Preprocessor::removeParentheses(const std::string &str)
             while ((pos = line.find(") ", pos)) != std::string::npos)
                 line.erase(pos + 1, 1);
 
-            // Remove inner parenthesis "((..))"..
+            // Remove inner parentheses "((..))"..
             pos = 0;
             while ((pos = line.find("((", pos)) != std::string::npos) {
                 ++pos;
@@ -1506,7 +1506,7 @@ void Preprocessor::simplifyCondition(const std::map<std::string, std::string> &c
         modified = false;
         modified |= tokenizer.simplifySizeof();
         modified |= tokenizer.simplifyCalculations();
-        modified |= tokenizer.simplifyRedundantParenthesis();
+        modified |= tokenizer.simplifyRedundantParentheses();
         for (Token *tok = const_cast<Token *>(tokenizer.tokens()); tok; tok = tok->next()) {
             if (Token::Match(tok, "! %num%")) {
                 tok->deleteThis();
@@ -2231,7 +2231,7 @@ static void skipstring(const std::string &line, std::string::size_type &pos)
  * @param pos  in: Position to the '('. out: Position to the ')'
  * @param params out: The extracted parameters
  * @param numberOfNewlines out: number of newlines in the macro call
- * @param endFound out: was the end parenthesis found?
+ * @param endFound out: was the end parentheses found?
  */
 static void getparams(const std::string &line,
                       std::string::size_type &pos,
@@ -2257,14 +2257,14 @@ static void getparams(const std::string &line,
 
     // scan for parameters..
     for (; pos < line.length(); ++pos) {
-        // increase parenthesis level
+        // increase parentheses level
         if (line[pos] == '(') {
             ++parlevel;
             if (parlevel == 1)
                 continue;
         }
 
-        // decrease parenthesis level
+        // decrease parentheses level
         else if (line[pos] == ')') {
             --parlevel;
             if (parlevel <= 0) {
@@ -2909,7 +2909,7 @@ std::string Preprocessor::expandMacros(const std::string &code, std::string file
 
                     // if the macro has parentheses, get parameters
                     if (macro->variadic() || macro->nopar() || macro->params().size()) {
-                        // is the end parenthesis found?
+                        // is the end parentheses found?
                         bool endFound = false;
 
                         getparams(line,pos2,params,numberOfNewlines,endFound);

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -833,7 +833,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                 _variableList[varId] = &(*var);
         }
 
-        // add all function paramaters
+        // add all function parameters
         std::list<Function>::const_iterator func;
         for (func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
             // ignore function without implementations

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1035,7 +1035,7 @@ bool TemplateSimplifier::simplifyTemplateInstantions(
         std::string templateMatchPattern(name + " < ");
         unsigned int indentlevel = 0;
         for (const Token *tok3 = tok2->tokAt(2); tok3 && (indentlevel > 0 || tok3->str() != ">"); tok3 = tok3->next()) {
-            // #2648 - unhandled parenthesis => bail out
+            // #2648 - unhandled parentheses => bail out
             // #2721 - unhandled [ => bail out
             if (tok3->str() == "(" || tok3->str() == "[") {
                 typeForNewNameStr.clear();
@@ -1090,7 +1090,7 @@ bool TemplateSimplifier::simplifyTemplateInstantions(
         for (Token *tok4 = tok2; tok4; tok4 = tok4->next()) {
             if (Token::simpleMatch(tok4, templateMatchPattern.c_str())) {
                 Token * tok5 = tok4->tokAt(2);
-                unsigned int typeCountInInstantion = 1U; // There is always atleast one type
+                unsigned int typeCountInInstantion = 1U; // There is always at least one type
                 const Token *typetok = (!typesUsedInTemplateInstantion.empty()) ? typesUsedInTemplateInstantion[0] : 0;
                 unsigned int indentlevel5 = 0;  // indentlevel for tok5
                 while (tok5 && (indentlevel5 > 0 || tok5->str() != ">")) {

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1058,7 +1058,7 @@ void Token::astFunctionCall()
     _next->_astParent = this;
 }
 
-void Token::astHandleParenthesis()
+void Token::astHandleParentheses()
 {
     Token *innerTop;
     if (_str != "(")

--- a/lib/token.h
+++ b/lib/token.h
@@ -578,7 +578,7 @@ public:
     void astOperand1(Token *tok);
     void astOperand2(Token *tok);
     void astFunctionCall();
-    void astHandleParenthesis();
+    void astHandleParentheses();
 
     const Token * astOperand1() const {
         return _astOperand1;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1209,7 +1209,7 @@ void Tokenizer::simplifyTypedef()
                     }
 
                     else if (functionPtr || functionRef || function) {
-                        // don't add parenthesis around function names because it
+                        // don't add parentheses around function names because it
                         // confuses other simplifications
                         bool needParen = true;
                         if (!inTemplate && function && tok2->next() && tok2->next()->str() != "*")
@@ -1655,7 +1655,7 @@ bool Tokenizer::tokenize(std::istream &code,
         simplifyExternC();
 
     // simplify weird but legal code: "[;{}] ( { code; } ) ;"->"[;{}] code;"
-    simplifyRoundCurlyParenthesis();
+    simplifyRoundCurlyParentheses();
 
     // check for simple syntax errors..
     for (const Token *tok = list.front(); tok; tok = tok->next()) {
@@ -1962,7 +1962,7 @@ bool Tokenizer::tokenize(std::istream &code,
     simplifyVariableMultipleAssign();
 
     // Remove redundant parentheses
-    simplifyRedundantParenthesis();
+    simplifyRedundantParentheses();
     for (Token *tok = list.front(); tok; tok = tok->next())
         while (TemplateSimplifier::simplifyNumericCalculations(tok));
 
@@ -2178,7 +2178,7 @@ void Tokenizer::simplifyExternC()
     }
 }
 
-void Tokenizer::simplifyRoundCurlyParenthesis()
+void Tokenizer::simplifyRoundCurlyParentheses()
 {
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         while (Token::Match(tok, "[;{}] ( {") &&
@@ -2866,7 +2866,7 @@ void Tokenizer::setVarId()
 
                 // Found a class function..
                 if (Token::Match(tok2, funcpattern.c_str())) {
-                    // Goto the end parenthesis..
+                    // Goto the end parentheses..
                     tok2 = tok2->linkAt(3);
                     if (!tok2)
                         break;
@@ -3135,7 +3135,7 @@ bool Tokenizer::simplifySizeof()
 
         // sizeof int -> sizeof( int )
         else if (tok->next()->str() != "(") {
-            // Add parenthesis around the sizeof
+            // Add parentheses around the sizeof
             int parlevel = 0;
             for (Token *tempToken = tok->next(); tempToken; tempToken = tempToken->next()) {
                 if (tempToken->str() == "(")
@@ -3365,7 +3365,7 @@ bool Tokenizer::simplifyTokenList()
     elseif();
     simplifyErrNoInWhile();
     simplifyIfAssign();
-    simplifyRedundantParenthesis();
+    simplifyRedundantParentheses();
     simplifyIfNot();
     simplifyIfNotNull();
     simplifyIfSameInnerCondition();
@@ -3386,7 +3386,7 @@ bool Tokenizer::simplifyTokenList()
         modified |= simplifyFunctionReturn();
         modified |= simplifyKnownVariables();
         modified |= removeRedundantConditions();
-        modified |= simplifyRedundantParenthesis();
+        modified |= simplifyRedundantParentheses();
         modified |= simplifyConstTernaryOp();
         modified |= simplifyCalculations();
     }
@@ -3519,7 +3519,7 @@ void Tokenizer::removeMacroInVarDecl()
 {
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         if (Token::Match(tok, "[;{}] %var% (") && tok->next()->isUpperCaseName()) {
-            // goto ')' paranthesis
+            // goto ')' parentheses
             const Token *tok2 = tok;
             int parlevel = 0;
             while (tok2) {
@@ -4133,9 +4133,9 @@ void Tokenizer::simplifyCompoundAssignment()
                 while (tok->next()->str() != ";")
                     tok->deleteNext();
             } else {
-                // Enclose the rhs in parenthesis..
+                // Enclose the rhs in parentheses..
                 if (!Token::Match(tok->tokAt(2), "[;)]")) {
-                    // Only enclose rhs in parenthesis if there is some operator
+                    // Only enclose rhs in parentheses if there is some operator
                     bool someOperator = false;
                     for (Token *tok2 = tok->next(); tok2; tok2 = tok2->next()) {
                         if (tok2->str() == "(")
@@ -4466,7 +4466,7 @@ bool Tokenizer::simplifyConstTernaryOp()
         if (offset == 2) {
             // go further back before the "("
             tok = tok->tokAt(-2);
-            //simplify the parenthesis
+            //simplify the parentheses
             tok->deleteNext();
             tok->next()->deleteNext();
         }
@@ -4638,7 +4638,7 @@ bool Tokenizer::simplifyFunctionParameters()
                  !(tok->strAt(-1) == ":" || tok->strAt(-1) == ",")) {
             // We have found old style function, now we need to change it
 
-            // First step: Get list of argument names in parenthesis
+            // First step: Get list of argument names in parentheses
             std::map<std::string, Token *> argumentNames;
             bool bailOut = false;
             Token * tokparam = NULL;
@@ -4696,7 +4696,7 @@ bool Tokenizer::simplifyFunctionParameters()
 
             tok1 = tok->link()->next();
 
-            // there should be the sequence '; {' after the round parenthesis
+            // there should be the sequence '; {' after the round parentheses
             for (const Token* tok2 = tok1; tok2; tok2 = tok2->next()) {
                 if (Token::simpleMatch(tok2, "; {"))
                     break;
@@ -4785,7 +4785,7 @@ bool Tokenizer::simplifyFunctionParameters()
                 //remove ';' after declaration
                 declEnd->deleteNext();
 
-                //replace the parameter name in the parenthesis with all the declaration
+                //replace the parameter name in the parentheses with all the declaration
                 Token::replace(tok->next(), declStart, declEnd);
 
                 //since there are changes to tokens, put tok where tok1 is
@@ -5453,7 +5453,7 @@ void Tokenizer::simplifyIfAssign()
         if (isNot)
             tok->next()->deleteNext();
 
-        // Delete parenthesis.. and remember how many there are with
+        // Delete parentheses.. and remember how many there are with
         // their links.
         std::stack<Token *> braces;
         while (tok->next()->str() == "(") {
@@ -6539,7 +6539,7 @@ void Tokenizer::elseif()
 }
 
 
-bool Tokenizer::simplifyRedundantParenthesis()
+bool Tokenizer::simplifyRedundantParentheses()
 {
     bool ret = false;
     for (Token *tok = list.front(); tok; tok = tok->next()) {
@@ -6559,14 +6559,14 @@ bool Tokenizer::simplifyRedundantParenthesis()
         while (Token::simpleMatch(tok, "( (") &&
                tok->link()->previous() == tok->next()->link()) {
             // We have "(( *something* ))", remove the inner
-            // parenthesis
+            // parentheses
             tok->deleteNext();
             tok->link()->tokAt(-2)->deleteNext();
             ret = true;
         }
 
         if (Token::Match(tok->previous(), "! ( %var% )")) {
-            // Remove the parenthesis
+            // Remove the parentheses
             tok->deleteThis();
             tok->deleteNext();
             ret = true;
@@ -6575,7 +6575,7 @@ bool Tokenizer::simplifyRedundantParenthesis()
         if (Token::Match(tok->previous(), "[(,;{}] ( %var% (") &&
             tok->link()->previous() == tok->linkAt(2)) {
             // We have "( func ( *something* ))", remove the outer
-            // parenthesis
+            // parentheses
             tok->link()->deleteThis();
             tok->deleteThis();
             ret = true;
@@ -6583,7 +6583,7 @@ bool Tokenizer::simplifyRedundantParenthesis()
 
         if (Token::Match(tok->previous(), "[,;{}] ( delete [| ]| %var% ) ;")) {
             // We have "( delete [| ]| var )", remove the outer
-            // parenthesis
+            // parentheses
             tok->link()->deleteThis();
             tok->deleteThis();
             ret = true;
@@ -6599,7 +6599,7 @@ bool Tokenizer::simplifyRedundantParenthesis()
         }
 
         if (Token::Match(tok->previous(), "[(!*;{}] ( %var% )") && tok->next()->varId() != 0) {
-            // We have "( var )", remove the parenthesis
+            // We have "( var )", remove the parentheses
             tok->deleteThis();
             tok->deleteNext();
             ret = true;
@@ -6612,7 +6612,7 @@ bool Tokenizer::simplifyRedundantParenthesis()
             }
             if (tok2 != tok->link())
                 break;
-            // We have "( var . var . ... . var )", remove the parenthesis
+            // We have "( var . var . ... . var )", remove the parentheses
             tok = tok->previous();
             tok->deleteNext();
             tok2->deleteThis();
@@ -6635,7 +6635,7 @@ bool Tokenizer::simplifyRedundantParenthesis()
         while (Token::Match(tok->previous(), "[{([,:] ( !!{") &&
                Token::Match(tok->link(), ") [;,])]") &&
                !Token::findsimplematch(tok, ",", tok->link())) {
-            // We have "( ... )", remove the parenthesis
+            // We have "( ... )", remove the parentheses
             tok->link()->deleteThis();
             tok->deleteThis();
             ret = true;
@@ -7569,17 +7569,17 @@ bool Tokenizer::isFunctionParameterPassedByValue(const Token *fpar) const
     const Token *ftok;
 
     // Look at function call, what parameter number is it?
-    unsigned int parenthesis = 1;
+    unsigned int parentheses = 1;
     unsigned int parameter = 1;
     for (ftok = fpar; ftok; ftok = ftok->previous()) {
         if (ftok->str() == "(") {
-            --parenthesis;
-            if (parenthesis == 0) {
+            --parentheses;
+            if (parentheses == 0) {
                 break;
             }
         } else if (ftok->str() == ")") {
-            ++parenthesis;
-        } else if (parenthesis == 1 && ftok->str() == ",") {
+            ++parentheses;
+        } else if (parentheses == 1 && ftok->str() == ",") {
             ++parameter;
         } else if (Token::Match(ftok, "[;{}]")) {
             break;
@@ -7655,7 +7655,7 @@ void Tokenizer::eraseDeadCode(Token *begin, const Token *end)
             continue;
         } else if (tok->next()->str() == ")") {
             if (!roundbraces)
-                break;  //too many ending round parenthesis
+                break;  //too many ending round parentheses
             --roundbraces;
             tok->deleteNext();
             continue;

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -390,7 +390,7 @@ public:
     void simplifyStructDecl();
 
     /**
-     * Remove redundant parenthesis:
+     * Remove redundant parentheses:
      * - "((x))" => "(x)"
      * - "(function())" => "function()"
      * - "(delete x)" => "delete x"
@@ -398,7 +398,7 @@ public:
      * @return true if modifications to token-list are done.
      *         false if no modifications are done.
      */
-    bool simplifyRedundantParenthesis();
+    bool simplifyRedundantParentheses();
 
     void simplifyCharAt();
 
@@ -435,7 +435,7 @@ public:
 
     void simplifyExternC();
 
-    void simplifyRoundCurlyParenthesis();
+    void simplifyRoundCurlyParentheses();
 
     void simplifyDebugNew();
 

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -409,7 +409,7 @@ void TokenList::createAst()
     // parentheses..
     for (Token *tok = _front; tok; tok = tok->next()) {
         if (tok->str() == "(" || tok->str() == ")" || tok->str() == "]") {
-            tok->astHandleParenthesis();
+            tok->astHandleParentheses();
         }
     }
 }

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -266,7 +266,7 @@ private:
         TEST_CASE(def_handleIncludes_ifelse1);   // problems in handleIncludes for #else
         TEST_CASE(def_handleIncludes_ifelse2);
 
-        TEST_CASE(def_valueWithParenthesis); // #3531
+        TEST_CASE(def_valueWithParentheses); // #3531
 
         // Using -U to undefine symbols
         TEST_CASE(undef1);
@@ -3424,8 +3424,8 @@ private:
                       preprocessor.handleIncludes(code, "test.c", includePaths, defs).find("123"));
     }
 
-    void def_valueWithParenthesis() {
-        // #define should introduce a new symbol regardless of parenthesis in the value
+    void def_valueWithParentheses() {
+        // #define should introduce a new symbol regardless of parentheses in the value
         // and regardless of white space in weird places (people do this for some reason).
         const char code[] = "#define A (Fred)\n"
                             "      #       define B (Flintstone)\n"

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2485,17 +2485,17 @@ private:
                             "return(-1);\n"
                             "fclose(f);\n"
                             "}\n";
-        const char *exptected = "void foo ( ) "
-                                "{ "
-                                "FILE * f ; "
-                                "f = fopen ( \"foo\" , \"r\" ) ; "
-                                "if ( ! f ) "
-                                "{ "
-                                "return -1 ; "
-                                "} "
-                                "fclose ( f ) ; "
-                                "}";
-        ASSERT_EQUALS(exptected, tok(code));
+        const char *expected = "void foo ( ) "
+                               "{ "
+                               "FILE * f ; "
+                               "f = fopen ( \"foo\" , \"r\" ) ; "
+                               "if ( ! f ) "
+                               "{ "
+                               "return -1 ; "
+                               "} "
+                               "fclose ( f ) ; "
+                               "}";
+        ASSERT_EQUALS(expected, tok(code));
     }
 
     void whileAssign1() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -2251,7 +2251,7 @@ private:
     }
 
     void simplifyKnownVariables37() {
-        // Ticket #2398 - no simplication in for loop
+        // Ticket #2398 - no simplification in for loop
         const char code[] = "void f() {\n"
                             "    double x = 0;\n"
                             "    for (int iter=0; iter<42; iter++) {\n"
@@ -6364,11 +6364,11 @@ private:
         //with '&' operator
         ASSERT_EQUALS("void f(){ ab:;& b=0;}", labels_("void f() { ab: &b=0; }"));
         ASSERT_EQUALS("void f(){ ab:;&( b. x)=0;}", labels_("void f() { ab: &(b->x)=0; }"));
-        //with '(' parenthesis
+        //with '(' parentheses
         ASSERT_EQUALS("void f(){ ab:;*(* b). x=0;}", labels_("void f() { ab: *(* b)->x=0; }"));
         ASSERT_EQUALS("void f(){ ab:;(** b). x=0;}", labels_("void f() { ab: (** b).x=0; }"));
         ASSERT_EQUALS("void f(){ ab:;&(* b. x)=0;}", labels_("void f() { ab: &(*b.x)=0; }"));
-        //with '{' parenthesis
+        //with '{' parentheses
         ASSERT_EQUALS("void f(){ ab:;{ b=0;}}", labels_("void f() { ab: {b=0;} }"));
         ASSERT_EQUALS("void f(){ ab:;{* b=0;}}", labels_("void f() { ab: { *b=0;} }"));
         ASSERT_EQUALS("void f(){ ab:;{& b=0;}}", labels_("void f() { ab: { &b=0;} }"));

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -419,7 +419,7 @@ private:
               "class derived : public base {\n"
               "private:\n"
               "    void foo() {}\n" // Skip for overrides of virtual functions of base
-              "    void bar() {}\n" // Don't skip if no function is overriden
+              "    void bar() {}\n" // Don't skip if no function is overridden
               "};");
         ASSERT_EQUALS("[test.cpp:9]: (style) Unused private function: 'derived::bar'\n", errout.str());
 


### PR DESCRIPTION
Fix compiler warnings and comment/string typos
- fix g++ warning:

> lib/checkother.cpp:3779: warning: comparison between signed and unsigned integer expressions
- fix suncc warning (see [everything2](http://everything2.com/title/C%252B%252B%253A+static+extern+%2522C%2522)):

> "lib/checkmemoryleak.cpp", line 578: Warning (Anachronism): Formal argument __compar of type extern "C" int(_)(const void_,const void_) in call to bsearch(const void_, const void_, unsigned long, unsigned long, extern "C" int(_)(const void_,const void_)) is being passed int(_)(const void_,const void*).
- prefer empty() / isEmpty() over "size() > 0" (cases not caught by stlSize)
- fix word misspellings (mostly comments, a few output lines)
  - Parenthesis => Parentheses (both variations were used in the codebase)
  - fix typo and wording ("never alwayw") in gui/test/data/benchmark/simple.cpp's CheckOther::unsignedPositive():

```
-  "An unsigned variable will never alwayw be positive so it is either pointless or "
+  "An unsigned variable can't be negative so it is either pointless or "
```
