### PR TITLE
GUI while opening FileDialog now remembers last path used

### DIFF
--- a/gui/common.h
+++ b/gui/common.h
@@ -59,7 +59,7 @@
 #define SETTINGS_STD_POSIX              "Platform Posix"
 
 // Other settings
-#define SETTINGS_CHECK_PATH             "Check path"
+#define SETTINGS_LAST_USED_PATH         "Last used path"
 #define SETTINGS_CHECK_FORCE            "Check force"
 #define SETTINGS_CHECK_THREADS          "Check threads"
 #define SETTINGS_SHOW_FULL_PATH         "Show full path"
@@ -82,7 +82,6 @@
 #define PROGRESS_MAX                    1024.0
 
 #define SETTINGS_CHECKED_PLATFORM       "Checked platform"
-#define SETTINGS_LAST_PROJECT_PATH      "Last project path"
 
 /// @}
 #endif

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -689,11 +689,13 @@ QString ResultsTree::AskFileDir(const QString &file)
     msgbox.setText(text);
     msgbox.setIcon(QMessageBox::Warning);
     msgbox.exec();
-
+    
+    QSettings settings;
     QString dir = QFileDialog::getExistingDirectory(this, tr("Select Directory"),
-                  "",
+                  settings.value(SETTINGS_LAST_USED_PATH, "").toString(),
                   QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
     mCheckPath = dir;
+    settings.setValue(SETTINGS_LAST_USED_PATH, dir);
     return dir;
 }
 

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -308,12 +308,14 @@ bool SettingsDialog::ShowErrorId() const
 
 void SettingsDialog::AddIncludePath()
 {
+    QSettings settings;
     QString selectedDir = QFileDialog::getExistingDirectory(this,
                           tr("Select include directory"),
-                          QString());
+                          settings.value(SETTINGS_LAST_USED_PATH, "").toString());
 
     if (!selectedDir.isEmpty()) {
         AddIncludePath(selectedDir);
+        settings.setValue(SETTINGS_LAST_USED_PATH, selectedDir);
     }
 }
 


### PR DESCRIPTION
It was a bit frustrating to start in the same cppcheck directory every time any file/directory selection dialog was opened. Now the last visited path is used to initialize the window. Exception is editor application selection windo which probably should not be connected with the source code paths.
