### PR TITLE
fix misspellings & gcc v3.4.6 warnings

### DIFF
--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -220,7 +220,7 @@ unsigned int ThreadExecutor::check()
                     if (FD_ISSET(*rp, &rfds)) {
                         int readRes = handleRead(*rp, result);
                         if (readRes == -1) {
-                            long size = 0;
+                            std::size_t size = 0;
                             std::map<int, std::string>::iterator p = pipeFile.find(*rp);
                             if (p != pipeFile.end()) {
                                 std::string name = p->second;
@@ -408,7 +408,7 @@ unsigned int __stdcall ThreadExecutor::threadProc(void *args)
 
         }
         const std::string &file = it->first;
-        const int fileSize = it->second;
+        const std::size_t fileSize = it->second;
         it++;
 
         LeaveCriticalSection(&threadExecutor->_fileSync);

--- a/gui/projectfile.cpp
+++ b/gui/projectfile.cpp
@@ -27,7 +27,7 @@
 static const char ProjectElementName[] = "project";
 static const char ProjectVersionAttrib[] = "version";
 static const char ProjectFileVersion[] = "1";
-static const char IncludDirElementName[] = "includedir";
+static const char IncludeDirElementName[] = "includedir";
 static const char DirElementName[] = "dir";
 static const char DirNameAttrib[] = "name";
 static const char DefinesElementName[] = "defines";
@@ -84,7 +84,7 @@ bool ProjectFile::Read(const QString &filename)
                 ReadCheckPaths(xmlReader);
 
             // Find include directory from inside project element
-            if (insideProject && xmlReader.name() == IncludDirElementName)
+            if (insideProject && xmlReader.name() == IncludeDirElementName)
                 ReadIncludeDirs(xmlReader);
 
             // Find preprocessor define from inside project element
@@ -187,7 +187,7 @@ void ProjectFile::ReadIncludeDirs(QXmlStreamReader &reader)
             break;
 
         case QXmlStreamReader::EndElement:
-            if (reader.name().toString() == IncludDirElementName)
+            if (reader.name().toString() == IncludeDirElementName)
                 allRead = true;
             break;
 
@@ -369,7 +369,7 @@ bool ProjectFile::Write(const QString &filename)
     }
 
     if (!mIncludeDirs.isEmpty()) {
-        xmlWriter.writeStartElement(IncludDirElementName);
+        xmlWriter.writeStartElement(IncludeDirElementName);
         foreach(QString incdir, mIncludeDirs) {
             xmlWriter.writeStartElement(DirElementName);
             xmlWriter.writeAttribute(DirNameAttrib, incdir);

--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -218,7 +218,7 @@ public:
     /**
      * @brief %Check if there is a "!var" match inside a condition
      * @param tok      first token to match
-     * @param varid    variabla id
+     * @param varid    variable id
      * @param endpar   if this is true the "!var" must be followed by ")"
      * @return true if match
      */

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -246,7 +246,7 @@ void CheckOther::clarifyConditionError(const Token *tok, bool assign, bool boolo
 }
 
 //---------------------------------------------------------------------------
-// Clarify (meaningless) statements like *foo++; with parantheses.
+// Clarify (meaningless) statements like *foo++; with parentheses.
 //---------------------------------------------------------------------------
 void CheckOther::clarifyStatement()
 {
@@ -1933,8 +1933,8 @@ void CheckOther::lookupVar(const Token *tok, const Variable* var)
         tok = tok->next();
 
     // Check if the variable is used in this indentlevel..
-    bool used1 = false;   // used in one sub-scope -> reducable
-    bool used2 = false;   // used in more sub-scopes -> not reducable
+    bool used1 = false;   // used in one sub-scope -> reducible
+    bool used2 = false;   // used in more sub-scopes -> not reducible
     unsigned int indentlevel = 0;
     int parlevel = 0;
     bool for_or_while = false;  // is sub-scope a "for/while/etc". anything that is not "if"

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -119,7 +119,7 @@ public:
         checkOther.checkSuspiciousEqualityComparison();
     }
 
-    /** To check the dead code in a program, which is unaccessible due to the counter-conditions check in nested-if statements **/
+    /** To check the dead code in a program, which is inaccessible due to the counter-conditions check in nested-if statements **/
     void oppositeInnerCondition();
 
     /** @brief Clarify calculation for ".. a * b ? .." */
@@ -183,7 +183,7 @@ public:
     /** @brief %Check for suspicious calculations with sizeof results */
     void suspiciousSizeofCalculation();
 
-    /** @brief copying to memory or assigning to a variablen twice */
+    /** @brief copying to memory or assigning to a variable twice */
     void checkRedundantAssignment();
 
     /** @brief %Check for assigning to the same variable twice in a switch statement*/
@@ -470,7 +470,7 @@ private:
                "* subsequent assignment or copying to a variable or buffer\n"
 
                // style
-               "* Find dead code which is unaccessible due to the counter-conditions check in nested if statements\n"
+               "* Find dead code which is inaccessible due to the counter-conditions check in nested if statements\n"
                "* C-style pointer cast in cpp file\n"
                "* casting between incompatible pointer types\n"
                "* redundant if\n"
@@ -481,7 +481,7 @@ private:
                "* [[charvar|check how signed char variables are used]]\n"
                "* variable scope can be limited\n"
                "* condition that is always true/false\n"
-               "* unusal pointer arithmetic. For example: \"abc\" + 'd'\n"
+               "* unusual pointer arithmetic. For example: \"abc\" + 'd'\n"
                "* redundant assignment in a switch statement\n"
                "* redundant pre/post operation in a switch statement\n"
                "* redundant bitwise operation in a switch statement\n"

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -705,7 +705,7 @@ void CheckStl::invalidPointerError(const Token *tok, const std::string &func, co
 
 
 
-void CheckStl::stlBoundries()
+void CheckStl::stlBoundaries()
 {
     const SymbolDatabase* const symbolDatabase = _tokenizer->getSymbolDatabase();
     const std::size_t functions = symbolDatabase->functionScopes.size();
@@ -729,9 +729,9 @@ void CheckStl::stlBoundries()
                     const Token* const end = tok->scope()->classEnd;
                     for (const Token *tok2 = tok; tok2 != end; tok2 = tok2->next()) {
                         if (Token::Match(tok2, "!!* %varid% <", iteratorid)) {
-                            stlBoundriesError(tok2, container_name);
+                            stlBoundariesError(tok2, container_name);
                         } else if (Token::Match(tok2, "> %varid% !!.", iteratorid)) {
-                            stlBoundriesError(tok2, container_name);
+                            stlBoundariesError(tok2, container_name);
                         }
                     }
                 }
@@ -741,9 +741,9 @@ void CheckStl::stlBoundries()
 }
 
 // Error message for bad boundary usage..
-void CheckStl::stlBoundriesError(const Token *tok, const std::string &container_name)
+void CheckStl::stlBoundariesError(const Token *tok, const std::string &container_name)
 {
-    reportError(tok, Severity::error, "stlBoundries",
+    reportError(tok, Severity::error, "stlBoundaries",
                 "Dangerous iterator comparison using operator< on 'std::" + container_name + "'.\n"
                 "Iterator of container 'std::" + container_name + "' compared with operator<. "
                 "This is dangerous since the order of items in the container is not guaranteed. "
@@ -885,7 +885,7 @@ void CheckStl::if_findError(const Token *tok, bool str)
     if (str)
         reportError(tok, Severity::performance, "stlIfStrFind",
                     "Inefficient usage of string::find() in condition; string::compare() would be faster.\n"
-                    "Either inefficent or wrong usage of string::find(). string::compare() will be faster if "
+                    "Either inefficient or wrong usage of string::find(). string::compare() will be faster if "
                     "string::find's result is compared with 0, because it will not scan the whole "
                     "string. If your intention is to check that there are no findings in the string, "
                     "you should compare with std::string::npos.");

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -55,7 +55,7 @@ public:
         checkStl.mismatchingContainers();
         checkStl.erase();
         checkStl.pushback();
-        checkStl.stlBoundries();
+        checkStl.stlBoundaries();
         checkStl.if_find();
         checkStl.string_c_str();
         checkStl.checkAutoPointer();
@@ -101,7 +101,7 @@ public:
     /**
      * bad condition.. "it < alist.end()"
      */
-    void stlBoundries();
+    void stlBoundaries();
 
     /** if (a.find(x)) - possibly incorrect condition */
     void if_find();
@@ -164,7 +164,7 @@ private:
     void mismatchingContainersError(const Token *tok);
     void invalidIteratorError(const Token *tok, const std::string &func, const std::string &iterator_name);
     void invalidPointerError(const Token *tok, const std::string &func, const std::string &pointer_name);
-    void stlBoundriesError(const Token *tok, const std::string &container_name);
+    void stlBoundariesError(const Token *tok, const std::string &container_name);
     void if_findError(const Token *tok, bool str);
     void sizeError(const Token *tok);
     void redundantIfRemoveError(const Token *tok);
@@ -188,7 +188,7 @@ private:
         c.stlOutOfBoundsError(0, "i", "foo", false);
         c.invalidIteratorError(0, "push_back|push_front|insert", "iterator");
         c.invalidPointerError(0, "push_back", "pointer");
-        c.stlBoundriesError(0, "container");
+        c.stlBoundariesError(0, "container");
         c.if_findError(0, false);
         c.if_findError(0, true);
         c.string_c_strError(0);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1923,14 +1923,14 @@ std::string Preprocessor::handleIncludes(const std::string &code, const std::str
     const std::string path(filePath.substr(0, 1 + filePath.find_last_of("\\/")));
 
     // current #if indent level.
-    unsigned int indent = 0;
+    std::stack<bool>::size_type indent = 0;
 
     // how deep does the #if match? this can never be bigger than "indent".
-    unsigned int indentmatch = 0;
+    std::stack<bool>::size_type indentmatch = 0;
 
     // has there been a true #if condition at the current indentmatch level?
     // then no more #elif or #else can be true before the #endif is seen.
-    std::vector<bool> elseIsTrueStack;
+    std::stack<bool> elseIsTrueStack;
 
     unsigned int linenr = 0;
 
@@ -1951,8 +1951,15 @@ std::string Preprocessor::handleIncludes(const std::string &code, const std::str
 
         // has there been a true #if condition at the current indentmatch level?
         // then no more #elif or #else can be true before the #endif is seen.
-        elseIsTrueStack.resize(1U + indentmatch, true);
-        std::vector<bool>::reference elseIsTrue = elseIsTrueStack[indentmatch];
+        while (elseIsTrueStack.size() != indentmatch + 1) {
+            if (elseIsTrueStack.size() < indentmatch + 1) {
+                elseIsTrueStack.push(true);
+            } else {
+                elseIsTrueStack.pop();
+            }
+        }
+
+        std::stack<bool>::reference elseIsTrue = elseIsTrueStack.top();
 
         if (line.compare(0,7,"#ifdef ") == 0) {
             if (indent == indentmatch) {

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -62,7 +62,7 @@ public:
      * @param istr The (file/string) stream to read from.
      * @param result The map that will get the results
      * @param filename The name of the file to check e.g. "src/main.cpp"
-     * @param includePaths List of paths where incude files should be searched from,
+     * @param includePaths List of paths where include files should be searched from,
      * single path can be e.g. in format "include/".
      * There must be a path separator at the end. Default parameter is empty list.
      * Note that if path from given filename is also extracted and that is used as
@@ -81,7 +81,7 @@ public:
      * @param resultConfigurations List of configurations. Pass these one by one
      * to getcode() with processedFile.
      * @param filename The name of the file to check e.g. "src/main.cpp"
-     * @param includePaths List of paths where incude files should be searched from,
+     * @param includePaths List of paths where include files should be searched from,
      * single path can be e.g. in format "include/".
      * There must be a path separator at the end. Default parameter is empty list.
      * Note that if path from given filename is also extracted and that is used as
@@ -253,7 +253,7 @@ private:
      * file
      * @param code The source code to modify
      * @param filePath Relative path to file to check e.g. "src/main.cpp"
-     * @param includePaths List of paths where incude files should be searched from,
+     * @param includePaths List of paths where include files should be searched from,
      * single path can be e.g. in format "include/".
      * There must be a path separator at the end. Default parameter is empty list.
      * Note that if path from given filename is also extracted and that is used as

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -139,7 +139,7 @@ bool Suppressions::FileMatcher::match(const std::string &pattern, const std::str
             return true;
         }
 
-        // If there are no other paths to tray, then fail
+        // If there are no other paths to try, then fail
         if (backtrack.empty()) {
             return false;
         }
@@ -223,8 +223,13 @@ std::string Suppressions::addSuppression(const std::string &errorId, const std::
         return "Failed to add suppression. No id.";
     }
     if (errorId != "*") {
+        // Support "stlBoundries", as that was the name of the errorId until v1.59.
+        if (errorId == "stlBoundries") {
+            return _suppressions["stlBoundaries"].addFile(file, line);
+        }
+
         for (std::string::size_type pos = 0; pos < errorId.length(); ++pos) {
-            if (errorId[pos] < 0 || (!std::isalnum(errorId[pos]) &&  errorId[pos] != '_')) {
+            if (errorId[pos] < 0 || (!std::isalnum(errorId[pos]) && errorId[pos] != '_')) {
                 return "Failed to add suppression. Invalid id \"" + errorId + "\"";
             }
             if (pos == 0 && std::isdigit(errorId[pos])) {

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -91,7 +91,7 @@ public:
     std::string addSuppressionLine(const std::string &line);
 
     /**
-     * @brief Don't show this error. If file and/or line are optional. In which case
+     * @brief Don't show this error. File and/or line are optional. In which case
      * the errorId alone is used for filtering.
      * @param errorId the id for the error, e.g. "arrayIndexOutOfBounds"
      * @param file File name with the path, e.g. "src/main.cpp"

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -50,7 +50,7 @@ struct Dimension {
 
     const Token *start;  // size start token
     const Token *end;    // size end token
-    MathLib::bigint num; // (assumpted) dimension length when size is a number, 0 if not known
+    MathLib::bigint num; // (assumed) dimension length when size is a number, 0 if not known
     bool known;          // Known size
 };
 
@@ -162,7 +162,7 @@ public:
 
     /**
      * Get index of variable in declared order.
-     * @return varaible index
+     * @return variable index
      */
     std::size_t index() const {
         return _index;

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -114,11 +114,11 @@ public:
         const std::string &name,
         std::vector<const Token *> &typeParametersInDeclaration,
         const std::string &newName,
-        std::vector<const Token *> &typesUsedInTemplateInstantion,
+        std::vector<const Token *> &typesUsedInTemplateInstantiation,
         std::list<Token *> &templateInstantiations);
 
     /**
-     * Simplify templates : expand all instantiatiations for a template
+     * Simplify templates : expand all instantiations for a template
      * @todo It seems that inner templates should be instantiated recursively
      * @param tokenlist token list
      * @param errorlogger error logger
@@ -128,7 +128,7 @@ public:
      * @param expandedtemplates all templates that has been expanded so far. The full names are stored.
      * @return true if the template was instantiated
      */
-    static bool simplifyTemplateInstantions(
+    static bool simplifyTemplateInstantiations(
         TokenList& tokenlist,
         ErrorLogger& errorlogger,
         const Settings *_settings,
@@ -159,7 +159,7 @@ public:
 
     /**
      * Simplify constant calculations such as "1+2" => "3".
-     * This also perform simple cleanup of parantheses etc.
+     * This also performs simple cleanup of parentheses etc.
      * @param _tokens start token
      * @return true if modifications to token-list are done.
      *         false if no modifications are done.

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -980,7 +980,7 @@ std::string Token::stringifyList(bool varid, bool attributes, bool linenumbers, 
     std::ostringstream ret;
 
     unsigned int lineNumber = _linenr;
-    int fileInd = files?-1:_fileIndex;
+    int fileInd = files ? -1 : static_cast<int>(_fileIndex);
     std::map<int, unsigned int> lineNumbers;
     for (const Token *tok = this; tok != end; tok = tok->next()) {
         bool fileChange = false;

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -411,7 +411,7 @@ private:
             ASSERT_EQUALS(Settings::C, settings.enforcedLang);
         }
         {
-            const char *argv[] = {"cppcheck", "--language=unknwonLanguage", "file.cpp"};
+            const char *argv[] = {"cppcheck", "--language=unknownLanguage", "file.cpp"};
             Settings settings;
             CmdLineParser parser(&settings);
             ASSERT(!parser.ParseFromArgs(3, argv));

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3072,7 +3072,7 @@ private:
     }
 
     void testMisusedScopeObjectDoesNotPickConstructorDeclaration() {
-        check("class Something : public SomthingElse\n"
+        check("class Something : public SomethingElse\n"
               "{\n"
               "public:\n"
               "~Something ( ) ;\n"

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2412,7 +2412,7 @@ private:
     }
 
     void templateParameters1() {
-        // #4169 - semgentation fault (invalid code)
+        // #4169 - segmentation fault (invalid code)
         const char code[] = "volatile true , test < test < #ifdef __ppc__ true ,";
         // do not crash on invalid code
         ASSERT_EQUALS(0, templateParameters(code));

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -89,10 +89,10 @@ private:
 
         TEST_CASE(invalidcode);
 
-        TEST_CASE(stlBoundries1);
-        TEST_CASE(stlBoundries2);
-        TEST_CASE(stlBoundries3);
-        TEST_CASE(stlBoundries4); // #4364
+        TEST_CASE(stlBoundaries1);
+        TEST_CASE(stlBoundaries2);
+        TEST_CASE(stlBoundaries3);
+        TEST_CASE(stlBoundaries4); // #4364
 
         // if (str.find("ab"))
         TEST_CASE(if_find);
@@ -1200,7 +1200,7 @@ private:
 
 
 
-    void stlBoundries1() {
+    void stlBoundaries1() {
         const int STL_CONTAINER_LIST = 9;
         const std::string stlCont[STL_CONTAINER_LIST] = {
             "deque", "list", "set", "multiset", "map",
@@ -1225,7 +1225,7 @@ private:
         ASSERT_EQUALS("[test.cpp:3]: (error) Dangerous iterator comparison using operator< on 'std::forward_list'.\n", errout.str());
     }
 
-    void stlBoundries2() {
+    void stlBoundaries2() {
         check("void f()\n"
               "{\n"
               "    std::vector<std::string> files;\n"
@@ -1237,7 +1237,7 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void stlBoundries3() {
+    void stlBoundaries3() {
         check("void f()\n"
               "{\n"
               "    set<int> files;\n"
@@ -1257,7 +1257,7 @@ private:
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid iterator 'current' used.\n", errout.str());
     }
 
-    void stlBoundries4() {
+    void stlBoundaries4() {
 
         check("void f() {\n"
               "    std::forward_list<std::vector<std::vector<int>>>::iterator it;\n"

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -34,7 +34,7 @@ private:
     std::vector<std::string> arithmeticalOps;
     std::vector<std::string> logicalOps;
     std::vector<std::string> bitOps;
-    std::vector<std::string> comparisionOps;
+    std::vector<std::string> comparisonOps;
     std::vector<std::string> extendedOps;
     std::vector<std::string> assignmentOps;
 
@@ -484,12 +484,12 @@ private:
         logicalOps.push_back("&&");
         logicalOps.push_back("||");
         logicalOps.push_back("!");
-        comparisionOps.push_back("==");
-        comparisionOps.push_back("!=");
-        comparisionOps.push_back("<");
-        comparisionOps.push_back("<=");
-        comparisionOps.push_back(">");
-        comparisionOps.push_back(">=");
+        comparisonOps.push_back("==");
+        comparisonOps.push_back("!=");
+        comparisonOps.push_back("<");
+        comparisonOps.push_back("<=");
+        comparisonOps.push_back(">");
+        comparisonOps.push_back(">=");
         bitOps.push_back("&");
         bitOps.push_back("|");
         bitOps.push_back("^");
@@ -520,7 +520,7 @@ private:
         std::vector<std::string> test_ops;
         append_vector(test_ops, arithmeticalOps);
         append_vector(test_ops, bitOps);
-        append_vector(test_ops, comparisionOps);
+        append_vector(test_ops, comparisonOps);
         append_vector(test_ops, logicalOps);
 
         std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.end();
@@ -550,7 +550,7 @@ private:
         // Negative test against other operators
         std::vector<std::string> other_ops;
         append_vector(other_ops, bitOps);
-        append_vector(other_ops, comparisionOps);
+        append_vector(other_ops, comparisonOps);
         append_vector(other_ops, logicalOps);
         append_vector(other_ops, extendedOps);
         append_vector(other_ops, assignmentOps);
@@ -567,7 +567,7 @@ private:
         std::vector<std::string> test_ops;
         append_vector(test_ops, arithmeticalOps);
         append_vector(test_ops, bitOps);
-        append_vector(test_ops, comparisionOps);
+        append_vector(test_ops, comparisonOps);
         append_vector(test_ops, logicalOps);
 
         std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.end();
@@ -594,7 +594,7 @@ private:
         std::vector<std::string> test_ops;
         append_vector(test_ops, arithmeticalOps);
         append_vector(test_ops, bitOps);
-        append_vector(test_ops, comparisionOps);
+        append_vector(test_ops, comparisonOps);
         append_vector(test_ops, logicalOps);
         append_vector(test_ops, extendedOps);
 
@@ -626,7 +626,7 @@ private:
         std::vector<std::string> other_ops;
         append_vector(other_ops, arithmeticalOps);
         append_vector(other_ops, bitOps);
-        append_vector(other_ops, comparisionOps);
+        append_vector(other_ops, comparisonOps);
         append_vector(other_ops, logicalOps);
         append_vector(other_ops, extendedOps);
 
@@ -655,7 +655,7 @@ private:
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eBitOp, tok.type());
         }
-        for (test_op = comparisionOps.begin(); test_op != comparisionOps.end(); ++test_op) {
+        for (test_op = comparisonOps.begin(); test_op != comparisonOps.end(); ++test_op) {
             Token tok(NULL);
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eComparisonOp, tok.type());

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5983,20 +5983,20 @@ private:
             tokenizer.tokenize(istr, "test.cpp");
             const Token *tok = tokenizer.tokens();
             // template<
-            ASSERT_EQUALS((long long)tok->tokAt(6), (long long)tok->linkAt(4));
-            ASSERT_EQUALS((long long)tok->tokAt(4), (long long)tok->linkAt(6));
+            ASSERT_EQUALS(true, tok->tokAt(6) == tok->linkAt(4));
+            ASSERT_EQUALS(true, tok->tokAt(4) == tok->linkAt(6));
 
             // bar<
-            ASSERT_EQUALS((long long)tok->tokAt(17), (long long)tok->linkAt(10));
-            ASSERT_EQUALS((long long)tok->tokAt(10), (long long)tok->linkAt(17));
+            ASSERT_EQUALS(true, tok->tokAt(17) == tok->linkAt(10));
+            ASSERT_EQUALS(true, tok->tokAt(10) == tok->linkAt(17));
 
             // x<
-            ASSERT_EQUALS((long long)tok->tokAt(16), (long long)tok->linkAt(14));
-            ASSERT_EQUALS((long long)tok->tokAt(14), (long long)tok->linkAt(16));
+            ASSERT_EQUALS(true, tok->tokAt(16) == tok->linkAt(14));
+            ASSERT_EQUALS(true, tok->tokAt(14) == tok->linkAt(16));
 
             // a<b && b>f
-            ASSERT_EQUALS(0, (long long)tok->linkAt(28));
-            ASSERT_EQUALS(0, (long long)tok->linkAt(32));
+            ASSERT_EQUALS(true, 0 == tok->linkAt(28));
+            ASSERT_EQUALS(true, 0 == tok->linkAt(32));
 
             ASSERT_EQUALS("", errout.str());
         }
@@ -6013,8 +6013,8 @@ private:
             const Token *tok = tokenizer.tokens();
 
             // static_cast<
-            ASSERT_EQUALS((long long)tok->tokAt(9), (long long)tok->linkAt(7));
-            ASSERT_EQUALS((long long)tok->tokAt(7), (long long)tok->linkAt(9));
+            ASSERT_EQUALS(true, tok->tokAt(9) == tok->linkAt(7));
+            ASSERT_EQUALS(true, tok->tokAt(7) == tok->linkAt(9));
 
             ASSERT_EQUALS("", errout.str());
         }
@@ -6031,8 +6031,8 @@ private:
             const Token *tok = tokenizer.tokens();
 
             // nvwa<(x > y)>
-            ASSERT_EQUALS((long long)tok->tokAt(12), (long long)tok->linkAt(6));
-            ASSERT_EQUALS((long long)tok->tokAt(6), (long long)tok->linkAt(12));
+            ASSERT_EQUALS(true, tok->tokAt(12) == tok->linkAt(6));
+            ASSERT_EQUALS(true, tok->tokAt(6) == tok->linkAt(12));
 
             ASSERT_EQUALS("", errout.str());
         }


### PR DESCRIPTION
This is a cleanup of pull request #129.
1.  fix typos / misspellings
   - Fix misspelling within comments, variable/function names, stdout messages
   - changes the name of an error code: `stlBoundries` changed to `stlBoundaries`.  Silently aliases the old name (`stlBoundries`) to the new one.
2.  fix gcc v3.4.6 32bit & 64bit warnings 
   - fixes gcc v3.4.6 warnings, except for those in tinyxml and "-Wmissing-declarations" makefile warnings
   - in Preprocessor::handleIncludes(), replace a `vector <bool>` with `stack<bool>` (see `vector<bool>` warning below).
     - this is the only `vector<bool>` in the codebase
   - `vector <bool>` is actually a case of template specialization, and is not recommended, according to the following links:

http://stackoverflow.com/q/6461487
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2160.html
http://stackoverflow.com/q/670308
- in the codebase before and after this change, testrunner SEGVs in a number of places on gcc v3.4.6, including `Check::~Check()`, among others
  - fc42fc95 fixes this particular runtime issue for DJGPP & __sun

gcc 3.4.6 warnings:

```
lib/token.cpp: In member function `std::string Token::stringifyList(bool, bool, bool, bool, bool, const std::vector<std::string, std::allocator<std::string> >*, const Token*) const':
lib/token.cpp:977: warning: converting of negative value `-0x00000000000000001' to `unsigned int'

/opt/gcc-3.4.6/lib/gcc/x86_64-unknown-linux-gnu/3.4.6/../../../../include/c++/3.4.6/bits/stl_bvector.h: In instantiation of `std::_Bvector_base<std::allocator<bool> >::_Bvector_impl':
/opt/gcc-3.4.6/lib/gcc/x86_64-unknown-linux-gnu/3.4.6/../../../../include/c++/3.4.6/bits/stl_bvector.h:375:   instantiated from `std::_Bvector_base<std::allocator<bool> >'
/opt/gcc-3.4.6/lib/gcc/x86_64-unknown-linux-gnu/3.4.6/../../../../include/c++/3.4.6/bits/stl_bvector.h:416:   instantiated from `std::vector<bool, std::allocator<bool> >'
lib/preprocessor.cpp:1933:   instantiated from here
/opt/gcc-3.4.6/lib/gcc/x86_64-unknown-linux-gnu/3.4.6/../../../../include/c++/3.4.6/bits/stl_bvector.h:356: warning: `std::_Bvector_base<std::allocator<bool> >::_Bvector_impl::_M_finish' contains empty classes which may cause base classes to be placed at different locations in a future version of GCC

test/testtokenize.cpp: In member function `void TestTokenizer::createLinks()':
test/testtokenize.cpp:5967: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5967: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5968: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5968: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5971: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5971: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5972: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5972: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5975: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5975: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5976: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5976: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5979: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5980: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5997: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5997: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5998: warning: cast from pointer to integer of different size
test/testtokenize.cpp:5998: warning: cast from pointer to integer of different size
test/testtokenize.cpp:6015: warning: cast from pointer to integer of different size
test/testtokenize.cpp:6015: warning: cast from pointer to integer of different size
test/testtokenize.cpp:6016: warning: cast from pointer to integer of different size
test/testtokenize.cpp:6016: warning: cast from pointer to integer of different size
```
