### PR TITLE
Fix Ticket 4887

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4119,6 +4119,8 @@ Token *Tokenizer::simplifyAddBracesPair(Token *tok, bool commandWithCondition)
         tokBracesEnd=tokAfterCondition->link();
     } else {
         Token * tokEnd = simplifyAddBracesToCommand(tokAfterCondition);
+        if (!tokEnd) // Ticket #4887
+            return tok;
         if (tokEnd->str()!="}") {
             // Token does not end with brace
             // Look for ; to add own closing brace after it

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -72,6 +72,7 @@ private:
         TEST_CASE(garbageCode1);
         TEST_CASE(garbageCode2); // #4300
         TEST_CASE(garbageCode3); // #4869
+        TEST_CASE(garbageCode4); // #4887
 
         TEST_CASE(simplifyFileAndLineMacro);  // tokenize "return - __LINE__;"
 
@@ -910,6 +911,10 @@ private:
 
     void garbageCode3() { //#4849 (segmentation fault in Tokenizer::simplifyStructDecl (invalid code))
         tokenizeAndStringify("enum {  D = 2 s ; struct y  { x } ; } { s.a = C ; s.b = D ; }");
+    }
+
+    void garbageCode4() { // #4887
+        tokenizeAndStringify("void f ( ) { = a ; if ( 1 ) if = ( 0 ) ; }");
     }
 
     void simplifyFileAndLineMacro() { // tokenize 'return - __LINE__' correctly


### PR DESCRIPTION
This patch improves handling of syntax errors in Tokenizer::simplifyAddBracesPair and fixes ticket 4887. Please consider pulling.

Thanks,
  Simon
