### PR TITLE
Ticket #4801

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -525,7 +525,7 @@ void CheckOther::checkPipeParameterSize()
 
                 const Variable *var = varTok->variable();
                 MathLib::bigint dim;
-                if (var && (var->isArray() || var->isPointer()) && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
+                if (var && var->isArray() && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
                     const std::string strDim = MathLib::longToString(dim);
                     checkPipeParameterSizeError(varTok,varTok->str(), strDim);
                 }


### PR DESCRIPTION
Ticket:
http://sourceforge.net/apps/trac/cppcheck/ticket/4801
File lib/checkother.cpp:525 (https://github.com/danmar/cppcheck/blob/d96fb577cd87dd9b11477a361ff4dffeeeeb8b20/lib/checkother.cpp#L525)

``` c
const Variable *var = varTok->variable();
MathLib::bigint dim;
if (var && (var->isArray() || var->isPointer()) && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
    const std::string strDim = MathLib::longToString(dim);
    checkPipeParameterSizeError(varTok,varTok->str(), strDim);
}
```

Test code:

``` c
void foo()
{
    int *cp;
    if (pipe(cp) == -1) {
        return;
    }
}
```

Aborted:

``` c
if (var && (var->isArray() || var->isPointer()) && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
```

var->dimension(0U) is aborted because var->dimension.size() = 0.
var->_name->str() = "cp"
var->_start->str() = "int"
var->_end->str() = "*"

"dimension" vector is edited in "Variable::evaluate()" with "Variable::arrayDimensions()" function (https://github.com/danmar/cppcheck/blob/d96fb577cd87dd9b11477a361ff4dffeeeeb8b20/lib/symboldatabase.cpp#L1013).
"Variable::arrayDimensions()" function (https://github.com/danmar/cppcheck/blob/d96fb577cd87dd9b11477a361ff4dffeeeeb8b20/lib/symboldatabase.cpp#L1523) can't add dimension for pointer.
Is "var->isPointer()" necessary in "if" statement? Can we check dimensions for pointer?
Commit with "var->isPointer()":
danmar/cppcheck@f451dd1137bee425d2b704a67caae4b8491dcdef

I could be wrong, but that's my solution to the problem:

``` c
if (var && var->isArray() && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
```
