### PR TITLE
Fixed segmentation fault in SymbolDatabase::SymbolDatabase(Ticket #4892)

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -742,6 +742,11 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
         for (std::list<Scope>::iterator it = scopeList.begin(); it != scopeList.end(); ++it) {
             scope = &(*it);
 
+            if (!scope->definedType) {
+                _blankTypes.push_back(Type());
+                scope->definedType = &_blankTypes.back();
+            }
+
             if (scope->isClassOrStruct() && scope->definedType->needInitialization == Type::Unknown) {
                 // check for default constructor
                 bool hasDefaultConstructor = false;
@@ -799,7 +804,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                     if (scope->definedType->needInitialization == Type::Unknown)
                         unknowns++;
                 }
-            } else if (scope->type == Scope::eUnion && scope->definedType && scope->definedType->needInitialization == Type::Unknown)
+            } else if (scope->type == Scope::eUnion && scope->definedType->needInitialization == Type::Unknown)
                 scope->definedType->needInitialization = Type::True;
         }
 

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -730,6 +730,9 @@ private:
 
     /** variable symbol table */
     std::vector<const Variable *> _variableList;
+
+    /** list for missing types */
+    std::list<Type> _blankTypes;
 };
 
 #endif

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -193,6 +193,7 @@ private:
         TEST_CASE(symboldatabase33); // ticket #4682 (false negatives)
         TEST_CASE(symboldatabase34); // ticket #4694 (segmentation fault)
         TEST_CASE(symboldatabase35); // ticket #4806 (segmentation fault)
+        TEST_CASE(symboldatabase36); // ticket #4892 (segmentation fault)
 
         TEST_CASE(isImplicitlyVirtual);
 
@@ -1510,6 +1511,11 @@ private:
     void symboldatabase35() { // ticket #4806 and #4841
         check("class FragmentQueue : public CL_NS(util)::PriorityQueue<CL_NS(util)::Deletor::Object<TextFragment> >\n"
               "{};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void symboldatabase36() { // ticket #4892
+        check("void struct ( ) { if ( 1 ) } int main ( ) { }");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Ticket:
http://sourceforge.net/apps/trac/cppcheck/ticket/4892

Problem:
equal to Ticket #4694(https://github.com/danmar/cppcheck/pull/139), but in another place
(https://github.com/danmar/cppcheck/blob/d96fb577cd87dd9b11477a361ff4dffeeeeb8b20/lib/symboldatabase.cpp#L745):

``` c
for (std::list<Scope>::iterator it = scopeList.begin(); it != scopeList.end(); ++it) {
    scope = &(*it);

    if (scope->isClassOrStruct() && scope->definedType->needInitialization == Type::Unknown) {
```

scope->definedType = 0x0;

The code contains 61 references to scope->definedType. I don't think it would be right to change them all from

``` c
if (scope->isClassOrStruct() && scope->definedType->needInitialization == Type::Unknown) {
```

to

``` c
if (scope->isClassOrStruct() && scope->definedType && scope->definedType->needInitialization == Type::Unknown) {
```

I could be wrong, but that's my solution to the problem:
create blank Type for scopes without Type.
