### PR TITLE
Fix ticket #4900

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -482,6 +482,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
             unsigned int numFormat = 0;
             bool percent = false;
             const Token* argListTok2 = argListTok;
+            std::set<unsigned int> parameterPositionsUsed;
             for (std::string::iterator i = formatString.begin(); i != formatString.end(); ++i) {
                 if (*i == '%') {
                     percent = !percent;
@@ -503,6 +504,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
 
                     bool _continue = false;
                     std::string width;
+                    unsigned int parameterPosition = 0; bool hasParameterPosition = false;
                     while (i != formatString.end() && *i != ']' && !std::isalpha(*i)) {
                         if (*i == '*') {
                             if (scan)
@@ -512,8 +514,13 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                 if (argListTok)
                                     argListTok = argListTok->nextArgument();
                             }
-                        } else if (std::isdigit(*i))
+                        } else if (std::isdigit(*i)) {
                             width += *i;
+                        } else if (*i == '$') {
+                            parameterPosition = static_cast<unsigned int>(std::atoi(width.c_str()));
+                            hasParameterPosition = true;
+                            width.clear();
+                        }
                         ++i;
                     }
                     if (i == formatString.end())
@@ -522,7 +529,15 @@ void CheckIO::checkWrongPrintfScanfArguments()
                         continue;
 
                     if (scan || *i != 'm') { // %m is a non-standard extension that requires no parameter on print functions.
-                        numFormat++;
+                        ++numFormat;
+                        
+                        // Handle parameter positions (POSIX extension) - Ticket #4900
+                        if(hasParameterPosition) {
+                            if(parameterPositionsUsed.find(parameterPosition) == parameterPositionsUsed.end())
+                                parameterPositionsUsed.insert(parameterPosition);
+                            else // Parameter already referenced, hence don't consider it a new format
+                                --numFormat;
+                        }
 
                         // Perform type checks
                         if (argListTok && Token::Match(argListTok->next(), "[,)]")) { // We can currently only check the type of arguments matching this simple pattern.
@@ -639,6 +654,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                 numFunction++;
                 argListTok2 = argListTok2->nextArgument(); // Find next argument
             }
+            
+            // Check that all parameter positions reference an actual parameter
+            for(std::set<unsigned int>::const_iterator it = parameterPositionsUsed.begin() ; it != parameterPositionsUsed.end() ; ++it) {
+                if((*it == 0) || (*it > numFormat))
+                    wrongPrintfScanfPosixParameterPositionError(tok, tok->str(), *it, numFormat);
+            }
 
             // Mismatching number of parameters => warning
             if (numFormat != numFunction)
@@ -666,6 +687,21 @@ void CheckIO::wrongPrintfScanfArgumentsError(const Token* tok,
            << " are given.";
 
     reportError(tok, severity, "wrongPrintfScanfArgNum", errmsg.str());
+}
+
+void CheckIO::wrongPrintfScanfPosixParameterPositionError(const Token* tok, const std::string& functionName,
+                                                          unsigned int index, unsigned int numFunction)
+{
+    if (!_settings->isEnabled("style"))
+        return;
+    std::ostringstream errmsg;
+    errmsg << functionName << ": ";
+    if(index == 0) {
+        errmsg << "parameter positions start at 1, not 0";
+    } else {
+        errmsg << "referencing parameter " << index << " while " << numFunction << " arguments given";
+    }
+    reportError(tok, Severity::warning, "wrongPrintfScanfParameterError", errmsg.str());
 }
 
 void CheckIO::invalidScanfArgTypeError(const Token* tok, const std::string &functionName, unsigned int numFormat)

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -82,6 +82,8 @@ private:
                                         const std::string &function,
                                         unsigned int numFormat,
                                         unsigned int numFunction);
+    void wrongPrintfScanfPosixParameterPositionError(const Token* tok, const std::string& functionName,
+                                                     unsigned int index, unsigned int numFunction);
     void invalidScanfArgTypeError(const Token* tok, const std::string &functionName, unsigned int numFormat);
     void invalidPrintfArgTypeError_s(const Token* tok, unsigned int numFormat);
     void invalidPrintfArgTypeError_n(const Token* tok, unsigned int numFormat);

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -46,6 +46,7 @@ private:
 
         TEST_CASE(testScanfArgument);
         TEST_CASE(testPrintfArgument);
+        TEST_CASE(testPosixPrintfScanfParameterPosition); // #4900
     }
 
     void check(const char code[], bool inconclusive = false, bool portability = false, Settings::PlatformType platform = Settings::Unspecified) {
@@ -752,6 +753,29 @@ private:
                       "[test.cpp:7]: (warning) 'z' in format string (no. 1) is a length modifier and cannot be used without a conversion specifier.\n"
                       "[test.cpp:8]: (warning) 't' in format string (no. 1) is a length modifier and cannot be used without a conversion specifier.\n"
                       "[test.cpp:9]: (warning) 'L' in format string (no. 1) is a length modifier and cannot be used without a conversion specifier.\n", errout.str());
+    }
+
+    void testPosixPrintfScanfParameterPosition() { // #4900  - No support for parameters in format strings
+        check("void foo() {"
+              "  int bar;"
+              "  printf(\"%1$d\", 1);"
+              "  printf(\"%1$d, %d, %1$d\", 1, 2);"
+              "  scanf(\"%1$d\", &bar);" 
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo() {\n"
+              "  int bar;\n"
+              "  printf(\"%1$d\");\n"
+              "  printf(\"%1$d, %d, %4$d\", 1, 2, 3);\n"
+              "  scanf(\"%2$d\", &bar);\n"
+              "  printf(\"%0$f\", 0.0);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) printf format string has 1 parameters but only 0 are given.\n"
+                      "[test.cpp:4]: (warning) printf: referencing parameter 4 while 3 arguments given\n"
+                      "[test.cpp:5]: (warning) scanf: referencing parameter 2 while 1 arguments given\n"
+                      "[test.cpp:6]: (warning) printf: parameter positions start at 1, not 0\n"
+                      "", errout.str());
     }
 };
 


### PR DESCRIPTION
Hello,

This patch adds support for parameter specification in scanf/printf format strings, which fixes the ticket. Thanks to consider pulling.

Best regards,
  Simon
