### PR TITLE
Fix ticket #4922 by checking the return value of string::find().

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -508,8 +508,11 @@ std::string Preprocessor::removeComments(const std::string &str, const std::stri
                 // Ticket 4873: Extract comments from the __asm / __asm__'s content
                 std::string asmBody;
                 while (i < str.size() && str[i] != '}') {
-                    if (str[i] == ';')
-                        i = str.find("\n", i);
+                    if (str[i] == ';') {
+                        std::string::size_type backslashN = str.find("\n", i);
+                        if (backslashN != std::string::npos) // Ticket #4922: Don't go in infinite loop or crash if there is no '\n'
+                            i = backslashN;
+                    }
                     asmBody += str[i++];
                 }
                 code << removeComments(asmBody, filename);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -149,6 +149,7 @@ private:
         TEST_CASE(if_macro_eq_macro); // #3536
         TEST_CASE(ticket_3675);
         TEST_CASE(ticket_3699);
+        TEST_CASE(ticket_4922); // #4922
 
         TEST_CASE(multiline1);
         TEST_CASE(multiline2);
@@ -1702,6 +1703,17 @@ private:
 
         // First, it must not hang. Second, inline must becomes inline, and __forceinline must become __forceinline.
         ASSERT_EQUALS("\n\n\n\n\n$$$__forceinline $$inline $$__forceinline\n", actual[""]);
+    }
+
+    void ticket_4922() {// #4922
+        const std::string code("__asm__ \n"
+                               "{ int extern __value) 0; (double return (\"\" } extern\n"
+                               "__typeof __finite (__finite) __finite __inline \"__GI___finite\");");
+        Settings settings;
+        Preprocessor preprocessor(&settings, this);
+        std::istringstream istr(code);
+        std::map<std::string, std::string> actual;
+        preprocessor.preprocess(istr, actual, "file.cpp");
     }
 
     void multiline1() {


### PR DESCRIPTION
Hi,

This patch ensures the return value of string::find is checked to avoid an infinite loop (on my Mac) or an assertion (on the bug reporter's machine) upon invalid input. Thanks to consider pulling.

Best regards,
  Simon
