### PR TITLE
Ticket #4764: Handle template instantiations with only default parameters

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2661,7 +2661,9 @@ static bool setVarIdParseDeclaration(const Token **tok, const std::map<std::stri
             } else {
                 ++typeCount;
             }
-        } else if (tok2->str() == "<" && TemplateSimplifier::templateParameters(tok2) > 0) {
+        } else if ((TemplateSimplifier::templateParameters(tok2) > 0) ||
+                   Token::Match(tok2, "< >") /* Ticket #4764 */)
+        {
             tok2 = tok2->findClosingBracket();
             if (!Token::Match(tok2, ">|>>"))
                 break;

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -215,6 +215,7 @@ private:
 
         TEST_CASE(varid1);
         TEST_CASE(varid2);
+        TEST_CASE(varid3);  // ticket #4764
 
         TEST_CASE(assign1);
 
@@ -3213,6 +3214,14 @@ private:
               "        memset(str,0,50);\n"
               "    }\n"
               "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+    
+    void varid3() { // #4764
+        check("struct foo {\n"
+              "  void bar() { return; }\n"
+              "  type<> member[1];\n"
+              "};");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Hello,

This patch properly handles template instantiations not specifying a single parameter, which fixes the ticket. Please consider merging.

Best regards,
  Simon
