### PR TITLE
Fixed #4708: prefix {in,de}crement too eagerly computed.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6713,7 +6713,7 @@ bool Tokenizer::simplifyKnownVariablesSimplify(Token **tok2, Token *tok3, unsign
             ret = true;
         }
 
-        if (indentlevel == indentlevel3 && Token::Match(tok3->next(), "++|-- %varid%", varid) && MathLib::isInt(value) &&
+        if (!skipincdec && indentlevel == indentlevel3 && Token::Match(tok3->next(), "++|-- %varid%", varid) && MathLib::isInt(value) &&
             !Token::Match(tok3->tokAt(3), "[.[]")) {
             incdec(value, tok3->next()->str());
             (*tok2)->tokAt(2)->str(value);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -178,6 +178,7 @@ private:
         TEST_CASE(simplifyKnownVariables53);    // references
         TEST_CASE(simplifyKnownVariablesIfEq1); // if (a==5) => a is 5 in the block
         TEST_CASE(simplifyKnownVariablesIfEq2); // if (a==5) { buf[a++] = 0; }
+        TEST_CASE(simplifyKnownVariablesIfEq3); // #4708 - if (a==5) { buf[--a] = 0; }
         TEST_CASE(simplifyKnownVariablesBailOutAssign1);
         TEST_CASE(simplifyKnownVariablesBailOutAssign2);
         TEST_CASE(simplifyKnownVariablesBailOutAssign3); // #4395 - nested assignments
@@ -2749,14 +2750,50 @@ private:
         const char code[] = "void f(int x) {\n"
                             "    if (x==5) {\n"
                             "        buf[x++] = 0;\n"
+                            "        buf[x--] = 0;\n"
                             "    }\n"
                             "}";
-        const char expected[] = "void f ( int x ) {\n"
+        const char current[] = "void f ( int x ) {\n"
                                 "if ( x == 5 ) {\n"
                                 "buf [ x ++ ] = 0 ;\n"
+                                "buf [ x -- ] = 0 ;\n"
                                 "}\n"
                                 "}";
-        ASSERT_EQUALS(expected, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
+        // Increment and decrements should be computed
+        const char expected[] = "void f ( int x ) {\n"
+                                "if ( x == 5 ) {\n"
+                                "buf [ 5 ] = 0 ;\n"
+                                "buf [ 6 ] = 0 ;\n"
+                                "}\n"
+                                "}";
+        TODO_ASSERT_EQUALS(expected, current, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
+    }
+
+    void simplifyKnownVariablesIfEq3() {
+        const char code[] = "void f(int x) {\n"
+                            "    if (x==5) {\n"
+                            "        buf[++x] = 0;\n"
+                            "        buf[++x] = 0;\n"
+                            "        buf[--x] = 0;\n"
+                            "    }\n"
+                            "}";
+        const char current[] =  "void f ( int x ) {\n"
+                                "if ( x == 5 ) {\n"
+                                "buf [ ++ x ] = 0 ;\n"
+                                "buf [ ++ x ] = 0 ;\n"
+                                "buf [ -- x ] = 0 ;\n"
+                                "}\n"
+                                "}";
+        // Increment and decrements should be computed
+        const char expected[] = "void f ( int x ) {\n"
+                                "if ( x == 5 ) {\n"
+                                "x = 6 ;\n"
+                                "buf [ 6 ] = 0 ;\n"
+                                "buf [ 7 ] = 0 ;\n"
+                                "buf [ 6 ] = 0 ;\n"
+                                "}\n"
+                                "}";
+        TODO_ASSERT_EQUALS(expected, current, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
     }
 
     void simplifyKnownVariablesBailOutAssign1() {


### PR DESCRIPTION
Hello,

This patch fixes ticket #4708, where --var is replaced by the computed value while it should not. Please consider merging.

Thanks,
  Simon
