### PR TITLE
Ticket #4959: Simplify {in,de}crements of known variables.

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -2753,12 +2753,6 @@ private:
                             "        buf[x--] = 0;\n"
                             "    }\n"
                             "}";
-        const char current[] = "void f ( int x ) {\n"
-                               "if ( x == 5 ) {\n"
-                               "buf [ x ++ ] = 0 ;\n"
-                               "buf [ x -- ] = 0 ;\n"
-                               "}\n"
-                               "}";
         // Increment and decrements should be computed
         const char expected[] = "void f ( int x ) {\n"
                                 "if ( x == 5 ) {\n"
@@ -2766,7 +2760,7 @@ private:
                                 "buf [ 6 ] = 0 ;\n"
                                 "}\n"
                                 "}";
-        TODO_ASSERT_EQUALS(expected, current, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
+        ASSERT_EQUALS(expected, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
     }
 
     void simplifyKnownVariablesIfEq3() {
@@ -2777,23 +2771,15 @@ private:
                             "        buf[--x] = 0;\n"
                             "    }\n"
                             "}";
-        const char current[] =  "void f ( int x ) {\n"
-                                "if ( x == 5 ) {\n"
-                                "buf [ ++ x ] = 0 ;\n"
-                                "buf [ ++ x ] = 0 ;\n"
-                                "buf [ -- x ] = 0 ;\n"
-                                "}\n"
-                                "}";
-        // Increment and decrements should be computed
         const char expected[] = "void f ( int x ) {\n"
-                                "if ( x == 5 ) {\n"
+                                "if ( x == 5 ) { "
                                 "x = 6 ;\n"
                                 "buf [ 6 ] = 0 ;\n"
                                 "buf [ 7 ] = 0 ;\n"
                                 "buf [ 6 ] = 0 ;\n"
                                 "}\n"
                                 "}";
-        TODO_ASSERT_EQUALS(expected, current, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
+        ASSERT_EQUALS(expected, tokenizeAndStringify(code, true, true, Settings::Unspecified, "test.c"));
     }
 
     void simplifyKnownVariablesBailOutAssign1() {


### PR DESCRIPTION
Hello,

This patch is a follow-up to the remark done on the fix for ticket #4708, and properly simplifies {in,de}crements of known variables. Please consider merging.

Best regards,
  Simon
