### PR TITLE
Don't include tinyxml from both lib.pri and test.pro

### DIFF
--- a/test/test.pro
+++ b/test/test.pro
@@ -8,8 +8,6 @@ CONFIG -= qt app_bundle
 
 include(../console_common.pri)
 
-BASEPATH = ../externals/tinyxml/
-include(../externals/tinyxml/tinyxml.pri)
 BASEPATH = ../lib/
 include(../lib/lib.pri)
 BASEPATH = .


### PR DESCRIPTION
Same thing as with the cli.pro file, QtCreator was unable to build the project because of multiple definitions
