### PR TITLE
symboldatabase: Remove unneeded check

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1298,7 +1298,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
         bool match = false;
         if (scope1->className == tok1->str() && (scope1->type != Scope::eFunction)) {
             // do the scopes match (same scope) or do their names match (multiple namespaces)
-            if ((*scope == scope1->nestedIn) || (*scope && scope1 &&
+            if ((*scope == scope1->nestedIn) || (*scope) &&
                                                  (*scope)->className == scope1->nestedIn->className &&
                                                  !(*scope)->className.empty() &&
                                                  (*scope)->type == scope1->nestedIn->type)) {


### PR DESCRIPTION
scope1 cannot be null at that point of time. If it were, the program
would have crashed, before (it's dereferenced ->)
This commit doesn't just remove dead code, but eliminates a tricky bug,
possibly introduced by over-optimizing compilers:
An explanation why the compiler could produce bad code here is found at
http://blog.regehr.org/archives/970

This commit was enabled by http://css.csail.mit.edu/stack/

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
