### PR TITLE
Fix Ticket #4450

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5244,7 +5244,11 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, Token * tokEnd, bool only_k_r_
                         if (isstatic) {
                             if (Token::Match(tok2->next(), "%num% ,"))
                                 tok2 = tok2->tokAt(2);
-                            else
+                            else if (Token::Match(tok2->next(), "( %num% ) ,")) { // ticket #4450
+                                tok2->deleteNext();
+                                tok2->next()->deleteNext();
+                                tok2 = tok2->tokAt(2);
+                            } else
                                 tok2 = NULL;
                         } else if (isconst && !ispointer) {
                             //do not split const non-pointer variables..

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5581,6 +5581,13 @@ private:
             const char code[] = "static unsigned int *a=0, *b=0;";
             ASSERT_EQUALS("static unsigned int * a = 0 ; static unsigned int * b = 0 ;", tokenizeAndStringify(code));
         }
+
+        {
+            const char code[] = "static int large_eeprom_type = (13 | (5)), "
+                                "default_flash_type = 42;";
+            ASSERT_EQUALS("static int large_eeprom_type = 13 ; static int default_flash_type = 42 ;",
+                          tokenizeAndStringify(code));
+        }
     }
 
     void vardecl6() {


### PR DESCRIPTION
Hi,

This patch fixes ticket #4450 by simplifying comma separated static variable declarations with initialisers between brackets. I've tried to simplify it in a more generic part of the code but did not manage to find the right spot (if any), while the one I touch here is rather obvious.

Best regards,
  Simon
