### PR TITLE
Ticket #4994: Don't crash when checking variable scope for invalid input

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2254,8 +2254,11 @@ void Scope::getVariableList()
 
         // skip return and delete
         else if (Token::Match(tok, "return|delete")) {
-            while (tok->next() && tok->next()->str() != ";")
+            while (tok->next() &&
+                   tok->next()->str() != ";" &&
+                   tok->next()->str() != "}" /* ticket #4994 */) {
                 tok = tok->next();
+            }
             continue;
         }
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -73,6 +73,7 @@ private:
         TEST_CASE(varScope16);
         TEST_CASE(varScope17);
         TEST_CASE(varScope18);
+        TEST_CASE(varScope19);      // Ticket #4994
 
         TEST_CASE(oldStylePointerCast);
         TEST_CASE(invalidPointerCast);
@@ -1005,6 +1006,15 @@ private:
                  "            break;\n"
                  "    }\n"
                  "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void varScope19() { // Ticket #4994
+        varScope("long f () {\n"
+                 "  return a >> extern\n"
+                 "}\n"
+                 "long a = 1 ;\n"
+                 "long b = 2 ;");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Hi,

This patch fixes ticket #4994 by avoiding null pointer dereferencing when running CheckOther::checkVariableScope on invalid input. Thanks to consider merging.

Best regards,
  Simon
