### PR TITLE
Remove warnings emitted by clang's -Wsign-conversion

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -304,7 +304,7 @@ static bool for_condition(const Token *tok2, unsigned int varid, std::string &mi
         Token::Match(tok2, "%varid% != %num% ; %varid% ++", varid)) {
         maxMinFlipped = false;
         const MathLib::bigint value = MathLib::toLongNumber(tok2->strAt(2));
-        max_value = MathLib::longToString(value - 1);
+        max_value = MathLib::toString(value - 1);
     } else if (Token::Match(tok2, "%varid% <= %num% ;|&&|%oror%", varid)) {
         maxMinFlipped = false;
         max_value = tok2->strAt(2);
@@ -314,7 +314,7 @@ static bool for_condition(const Token *tok2, unsigned int varid, std::string &mi
         maxMinFlipped = true;
         const MathLib::bigint value = MathLib::toLongNumber(tok2->str());
         max_value = min_value;
-        min_value = MathLib::longToString(value + 1);
+        min_value = MathLib::toString(value + 1);
     } else if (Token::Match(tok2, "%num% <= %varid% ;|&&|%oror%", varid)) {
         maxMinFlipped = true;
         max_value = min_value;
@@ -365,7 +365,7 @@ static bool for_maxvalue(const Token * const stepvalue, const std::string &min_v
     MathLib::bigint max = MathLib::toLongNumber(max_value);
     const MathLib::bigint min = MathLib::toLongNumber(min_value);
     max = ((max - min) / num) * num + min;
-    max_value = MathLib::longToString(max);
+    max_value = MathLib::toString(max);
     return true;
 }
 
@@ -2269,8 +2269,8 @@ void CheckBufferOverrun::writeOutsideBufferSize()
 void CheckBufferOverrun::writeOutsideBufferSizeError(const Token *tok, const std::size_t stringLength, const MathLib::bigint writeLength, const std::string &strFunctionName)
 {
     reportError(tok, Severity::error, "writeOutsideBufferSize",
-                "Writing " + MathLib::longToString(writeLength-stringLength) + " bytes outside buffer size.\n"
-                "The number of bytes to write (" + MathLib::longToString(writeLength) + " bytes) are bigger than the source buffer (" +MathLib::longToString(stringLength)+ " bytes)."
+                "Writing " + MathLib::toString(writeLength-stringLength) + " bytes outside buffer size.\n"
+                "The number of bytes to write (" + MathLib::toString(writeLength) + " bytes) are bigger than the source buffer (" +MathLib::toString(stringLength)+ " bytes)."
                 " Please check the second and the third parameter of the function '"+strFunctionName+"'.");
 }
 // -------------------------------------------------------------------------------------

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -522,7 +522,7 @@ void CheckOther::checkPipeParameterSize()
                 const Variable *var = varTok->variable();
                 MathLib::bigint dim;
                 if (var && var->isArray() && !var->isArgument() && ((dim=var->dimension(0U)) < 2)) {
-                    const std::string strDim = MathLib::longToString(dim);
+                    const std::string strDim = MathLib::toString(dim);
                     checkPipeParameterSizeError(varTok,varTok->str(), strDim);
                 }
             }
@@ -2278,7 +2278,7 @@ void CheckOther::zerodivcondError(const Token *tokcond, const Token *tokdiv)
         else
             condition = tokcond->str() + "!=0";
     }
-    const std::string linenr(MathLib::longToString(tokdiv ? tokdiv->linenr() : 0));
+    const std::string linenr(MathLib::toString(tokdiv ? tokdiv->linenr() : 0));
     reportError(callstack, Severity::warning, "zerodivcond", "Either the condition '"+condition+"' is useless or there is division by zero at line " + linenr + ".");
 }
 //---------------------------------------------------------------------------

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1585,7 +1585,7 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, bool cpp
         const bool address(vartok->previous()->str() == "&");
 
         // locate start parentheses in function call..
-        int argumentNumber = 0;
+        unsigned int argumentNumber = 0;
         const Token *start = vartok;
         while (start && !Token::Match(start, "[;{}(]")) {
             if (start->str() == ")")

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -75,13 +75,6 @@ MathLib::bigint MathLib::toLongNumber(const std::string &str)
     return ret;
 }
 
-std::string MathLib::longToString(const bigint value)
-{
-    std::ostringstream result;
-    result << value;
-    return result.str();
-}
-
 double MathLib::toDoubleNumber(const std::string &str)
 {
     if (isHex(str))
@@ -96,7 +89,7 @@ double MathLib::toDoubleNumber(const std::string &str)
     return ret;
 }
 
-std::string MathLib::doubleToString(const double value)
+template<> std::string MathLib::toString(double value)
 {
     std::ostringstream result;
     result.precision(12);
@@ -242,25 +235,25 @@ bool MathLib::isInt(const std::string & s)
 std::string MathLib::add(const std::string & first, const std::string & second)
 {
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return longToString(toLongNumber(first) + toLongNumber(second));
+        return toString(toLongNumber(first) + toLongNumber(second));
     }
 
     double d1 = toDoubleNumber(first);
     double d2 = toDoubleNumber(second);
 
     int count = 0;
-    while (d1 > 100000.0 * d2 && doubleToString(d1+d2)==first && ++count<5)
+    while (d1 > 100000.0 * d2 && toString(d1+d2)==first && ++count<5)
         d2 *= 10.0;
-    while (d2 > 100000.0 * d1 && doubleToString(d1+d2)==second && ++count<5)
+    while (d2 > 100000.0 * d1 && toString(d1+d2)==second && ++count<5)
         d1 *= 10.0;
 
-    return doubleToString(d1 + d2);
+    return toString(d1 + d2);
 }
 
 std::string MathLib::subtract(const std::string &first, const std::string &second)
 {
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return longToString(toLongNumber(first) - toLongNumber(second));
+        return toString(toLongNumber(first) - toLongNumber(second));
     }
 
     if (first == second)
@@ -270,12 +263,12 @@ std::string MathLib::subtract(const std::string &first, const std::string &secon
     double d2 = toDoubleNumber(second);
 
     int count = 0;
-    while (d1 > 100000.0 * d2 && doubleToString(d1-d2)==first && ++count<5)
+    while (d1 > 100000.0 * d2 && toString(d1-d2)==first && ++count<5)
         d2 *= 10.0;
-    while (d2 > 100000.0 * d1 && doubleToString(d1-d2)==second && ++count<5)
+    while (d2 > 100000.0 * d1 && toString(d1-d2)==second && ++count<5)
         d1 *= 10.0;
 
-    return doubleToString(d1 - d2);
+    return toString(d1 - d2);
 }
 
 std::string MathLib::divide(const std::string &first, const std::string &second)
@@ -287,19 +280,19 @@ std::string MathLib::divide(const std::string &first, const std::string &second)
             throw InternalError(0, "Internal Error: Division overflow");
         if (b == 0)
             throw InternalError(0, "Internal Error: Division by zero");
-        return longToString(toLongNumber(first) / b);
+        return toString(toLongNumber(first) / b);
     } else if (second == "0.0") {
         return "inf.0";
     }
-    return doubleToString(toDoubleNumber(first) / toDoubleNumber(second));
+    return toString(toDoubleNumber(first) / toDoubleNumber(second));
 }
 
 std::string MathLib::multiply(const std::string &first, const std::string &second)
 {
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return longToString(toLongNumber(first) * toLongNumber(second));
+        return toString(toLongNumber(first) * toLongNumber(second));
     }
-    return doubleToString(toDoubleNumber(first) * toDoubleNumber(second));
+    return toString(toDoubleNumber(first) * toDoubleNumber(second));
 }
 
 std::string MathLib::mod(const std::string &first, const std::string &second)
@@ -308,9 +301,9 @@ std::string MathLib::mod(const std::string &first, const std::string &second)
         bigint b = toLongNumber(second);
         if (b == 0)
             throw InternalError(0, "Internal Error: Division by zero");
-        return longToString(toLongNumber(first) % b);
+        return toString(toLongNumber(first) % b);
     }
-    return doubleToString(std::fmod(toDoubleNumber(first),toDoubleNumber(second)));
+    return toString(std::fmod(toDoubleNumber(first),toDoubleNumber(second)));
 }
 
 std::string MathLib::calculate(const std::string &first, const std::string &second, char action)
@@ -332,13 +325,13 @@ std::string MathLib::calculate(const std::string &first, const std::string &seco
         return MathLib::mod(first, second);
 
     case '&':
-        return MathLib::longToString(MathLib::toLongNumber(first) & MathLib::toLongNumber(second));
+        return MathLib::toString(MathLib::toLongNumber(first) & MathLib::toLongNumber(second));
 
     case '|':
-        return MathLib::longToString(MathLib::toLongNumber(first) | MathLib::toLongNumber(second));
+        return MathLib::toString(MathLib::toLongNumber(first) | MathLib::toLongNumber(second));
 
     case '^':
-        return MathLib::longToString(MathLib::toLongNumber(first) ^ MathLib::toLongNumber(second));
+        return MathLib::toString(MathLib::toLongNumber(first) ^ MathLib::toLongNumber(second));
 
     default:
         throw InternalError(0, std::string("Unexpected action '") + action + "' in MathLib::calculate(). Please report this to Cppcheck developers.");
@@ -347,31 +340,31 @@ std::string MathLib::calculate(const std::string &first, const std::string &seco
 
 std::string MathLib::sin(const std::string &tok)
 {
-    return doubleToString(std::sin(toDoubleNumber(tok)));
+    return toString(std::sin(toDoubleNumber(tok)));
 }
 
 
 std::string MathLib::cos(const std::string &tok)
 {
-    return doubleToString(std::cos(toDoubleNumber(tok)));
+    return toString(std::cos(toDoubleNumber(tok)));
 }
 
 std::string MathLib::tan(const std::string &tok)
 {
-    return doubleToString(std::tan(toDoubleNumber(tok)));
+    return toString(std::tan(toDoubleNumber(tok)));
 }
 
 
 std::string MathLib::abs(const std::string &tok)
 {
-    return doubleToString(std::abs(toDoubleNumber(tok)));
+    return toString(std::abs(toDoubleNumber(tok)));
 }
 
 bool MathLib::isEqual(const std::string &first, const std::string &second)
 {
     // this conversion is needed for formatting
     // e.g. if first=0.1 and second=1.0E-1, the direct comparison of the strings would fail
-    return doubleToString(toDoubleNumber(first)) == doubleToString(toDoubleNumber(second));
+    return toString(toDoubleNumber(first)) == toString(toDoubleNumber(second));
 }
 
 bool MathLib::isNotEqual(const std::string &first, const std::string &second)

--- a/lib/mathlib.h
+++ b/lib/mathlib.h
@@ -35,9 +35,13 @@ public:
     typedef long long bigint;
 
     static bigint toLongNumber(const std::string & str);
-    static std::string longToString(const bigint value);
+    template<class T> static std::string toString(T value)
+    {
+        std::ostringstream result;
+        result << value;
+        return result.str();
+    }
     static double toDoubleNumber(const std::string & str);
-    static std::string doubleToString(const double value);
 
     static bool isInt(const std::string & str);
     static bool isFloat(const std::string &str);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -272,7 +272,7 @@ std::string Preprocessor::readpreprocessor(std::istream &istr, const unsigned in
     enum { NEWLINE, SPACE, PREPROCESSOR, BACKSLASH, OTHER } state = NEWLINE;
     std::ostringstream code;
     unsigned int newlines = 1;
-    char chPrev = ' ';
+    unsigned char chPrev = ' ';
     for (unsigned char ch = readChar(istr,bom); istr.good(); ch = readChar(istr,bom)) {
         // Replace assorted special chars with spaces..
         if (((ch & 0x80) == 0) && (ch != '\n') && (std::isspace(ch) || std::iscntrl(ch)))

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -793,9 +793,9 @@ bool TemplateSimplifier::simplifyNumericCalculations(Token *tok)
                 result = MathLib::calculate(tok->str(), tok->strAt(2), cop);
             else if (cop == '<') {
                 if (tok->previous()->str() != "<<" && rightInt > 0) // Ensure that its not a shift operator as used for streams
-                    result = MathLib::longToString(leftInt << rightInt);
+                    result = MathLib::toString(leftInt << rightInt);
             } else if (rightInt > 0)
-                result = MathLib::longToString(leftInt >> rightInt);
+                result = MathLib::toString(leftInt >> rightInt);
 
             if (!result.empty()) {
                 ret = true;
@@ -858,7 +858,7 @@ bool TemplateSimplifier::simplifyCalculations(Token *_tokens)
         }
 
         if (Token::Match(tok->previous(), "(|&&|%oror% %char% %comp% %num% &&|%oror%|)")) {
-            tok->str(MathLib::longToString(tok->str()[1] & 0xff));
+            tok->str(MathLib::toString(tok->str()[1] & 0xff));
         }
 
         if (tok->isNumber()) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -389,7 +389,7 @@ static Token *splitDefinitionFromTypedef(Token *tok)
                 name = tok1->next()->str();
             else { // create a unique name
                 static unsigned int count = 0;
-                name = "Unnamed" + MathLib::longToString(count++);
+                name = "Unnamed" + MathLib::toString(count++);
             }
             tok->next()->insertToken(name);
         } else
@@ -2292,7 +2292,7 @@ void Tokenizer::simplifyFileAndLineMacro()
         if (tok->str() == "__FILE__")
             tok->str("\"" + list.file(tok) + "\"");
         else if (tok->str() == "__LINE__")
-            tok->str(MathLib::longToString(tok->linenr()));
+            tok->str(MathLib::toString(tok->linenr()));
     }
 }
 
@@ -2494,7 +2494,7 @@ void Tokenizer::arraySize()
         if (addlength || Token::Match(tok, "%var% [ ] = %str% ;")) {
             tok = tok->next();
             std::size_t sz = tok->strAt(3).length() - 1;
-            tok->insertToken(MathLib::longToString((unsigned int)sz));
+            tok->insertToken(MathLib::toString((unsigned int)sz));
             addlength = false;
             tok = tok->tokAt(5);
         }
@@ -2520,7 +2520,7 @@ void Tokenizer::arraySize()
             }
 
             if (sz != 0)
-                tok->insertToken(MathLib::longToString(sz));
+                tok->insertToken(MathLib::toString(sz));
 
             tok = end->next() ? end->next() : end;
         }
@@ -2623,7 +2623,7 @@ void Tokenizer::simplifyTemplates()
             Token * const tok3 = tok->next();
             const unsigned int sizeOfResult = sizeOfType(tok3->tokAt(3));
             tok3->deleteNext(4);
-            tok3->insertToken(MathLib::longToString(sizeOfResult));
+            tok3->insertToken(MathLib::toString(sizeOfResult));
         }
     }
 
@@ -3212,7 +3212,7 @@ bool Tokenizer::simplifySizeof()
                     continue;
                 }
 
-                sizeOfVar[varId] = MathLib::longToString(size);
+                sizeOfVar[varId] = MathLib::toString(size);
             }
 
             else if (Token::Match(tok->previous(), "%type% %var% [ %num% ] [;=]") ||
@@ -3221,14 +3221,14 @@ bool Tokenizer::simplifySizeof()
                 if (size == 0)
                     continue;
 
-                sizeOfVar[varId] = MathLib::longToString(size * static_cast<unsigned long>(MathLib::toLongNumber(tok->strAt(2))));
+                sizeOfVar[varId] = MathLib::toString(size * static_cast<unsigned long>(MathLib::toLongNumber(tok->strAt(2))));
             }
 
             else if (Token::Match(tok->previous(), "%type% %var% [ %num% ] [,)]") ||
                      Token::Match(tok->tokAt(-2), "%type% * %var% [ %num% ] [,)]")) {
                 Token tempTok(0);
                 tempTok.str("*");
-                sizeOfVar[varId] = MathLib::longToString(sizeOfType(&tempTok));
+                sizeOfVar[varId] = MathLib::toString(sizeOfType(&tempTok));
             }
         }
     }
@@ -3359,7 +3359,7 @@ bool Tokenizer::simplifySizeof()
         }
 
         if (Token::simpleMatch(tok->next(), "( * )")) {
-            tok->str(MathLib::longToString(sizeOfType(tok->tokAt(2))));
+            tok->str(MathLib::toString(sizeOfType(tok->tokAt(2))));
             tok->deleteNext(3);
             ret = true;
         }
@@ -3381,7 +3381,7 @@ bool Tokenizer::simplifySizeof()
         else if (Token::Match(tok, "sizeof ( %type% )")) {
             unsigned int size = sizeOfType(tok->tokAt(2));
             if (size > 0) {
-                tok->str(MathLib::longToString(size));
+                tok->str(MathLib::toString(size));
                 tok->deleteNext(3);
                 ret = true;
             }
@@ -3410,7 +3410,7 @@ bool Tokenizer::simplifySizeof()
             }
 
             if (sz > 0) {
-                tok->str(MathLib::longToString(sz));
+                tok->str(MathLib::toString(sz));
                 Token::eraseTokens(tok, tok->next()->link()->next());
                 ret = true;
             }
@@ -3568,7 +3568,7 @@ bool Tokenizer::simplifyTokenList()
         // replace strlen(str)
         for (Token *tok = list.front(); tok; tok = tok->next()) {
             if (Token::Match(tok, "strlen ( %str% )")) {
-                tok->str(MathLib::longToString(Token::getStrLength(tok->tokAt(2))));
+                tok->str(MathLib::toString(Token::getStrLength(tok->tokAt(2))));
                 tok->deleteNext(3);
                 modified = true;
             }
@@ -4061,7 +4061,7 @@ void Tokenizer::removeRedundantFor()
                 // get the correct end value
                 Token *tok2 = tok->next()->link();
                 tok2->insertToken(";");
-                tok2->insertToken(MathLib::longToString(num2));
+                tok2->insertToken(MathLib::toString(num2));
                 tok2->insertToken("=");
                 tok2->insertToken(varname);
                 tok2->next()->varId(varid);
@@ -6360,7 +6360,7 @@ bool Tokenizer::simplifyKnownVariablesGetData(unsigned int varid, Token **_tok2,
             value = tok2->strAt(6);
             valueVarId = tok2->tokAt(6)->varId();
         } else
-            value = MathLib::longToString(MathLib::toLongNumber(tok2->strAt(6)) + 1);
+            value = MathLib::toString(MathLib::toLongNumber(tok2->strAt(6)) + 1);
 
         // Skip for-body..
         tok3 = tok2->previous()->link()->next()->link()->next();
@@ -7560,7 +7560,7 @@ void Tokenizer::simplifyEnum()
                         enumValueEnd = tok1->next();
                     } else {
                         // value is previous numeric value + 1
-                        tok1->insertToken(MathLib::longToString(lastValue));
+                        tok1->insertToken(MathLib::toString(lastValue));
                         enumValue = tok1->next();
                     }
                 } else if (Token::Match(tok1->previous(), ",|{ %type% = %num% ,|}")) {
@@ -8274,7 +8274,7 @@ void Tokenizer::simplifyMathFunctions()
             tok->deleteThis();
 
             // Convert string into a number
-            tok->str(MathLib::longToString(MathLib::toLongNumber(tok->strValue())));
+            tok->str(MathLib::toString(MathLib::toLongNumber(tok->strValue())));
 
             // Delete remaining )
             tok->deleteNext();
@@ -8742,7 +8742,7 @@ void Tokenizer::simplifyFuncInWhile()
         Token *end = tok->next()->link()->next()->link();
 
         const unsigned int varid = ++_varId; // Create new variable
-        const std::string varname("cppcheck:r" + MathLib::longToString(++count));
+        const std::string varname("cppcheck:r" + MathLib::toString(++count));
         tok->str("int");
         tok->next()->insertToken(varname);
         tok->tokAt(2)->varId(varid);
@@ -8781,7 +8781,7 @@ void Tokenizer::simplifyStructDecl()
         // check for anonymous struct/union
         if (Token::Match(tok, "struct|union {")) {
             if (Token::Match(tok->next()->link(), "} *|&| %type% ,|;|[")) {
-                tok->insertToken("Anonymous" + MathLib::longToString(count++));
+                tok->insertToken("Anonymous" + MathLib::toString(count++));
             }
         }
     }


### PR DESCRIPTION
This PR is basically https://github.com/danmar/cppcheck/pull/145 brought back to sync with the current head, as request by danmar.

Regards,
  Simon
