### PR TITLE
Ticket #5024: Don't crash upon invalid code when checking auto variables

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -101,6 +101,9 @@ static bool checkRvalueExpression(const Token * const vartok)
 
 static bool variableIsUsedInScope(const Token* start, unsigned int varId, const Scope *scope)
 {
+    if(!start) // Ticket #5024
+        return false;
+    
     for (const Token *tok = start; tok != scope->classEnd; tok = tok->next()) {
         if (tok->varId() == varId)
             return true;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -78,6 +78,7 @@ private:
         TEST_CASE(testautovar9);
         TEST_CASE(testautovar10); // ticket #2930 - void f(char *p) { p = '\0'; }
         TEST_CASE(testautovar11); // ticket #4641 - fp, assign local struct member address to function parameter
+        TEST_CASE(testautovar12); // ticket #5024 - crash
         TEST_CASE(testautovar_array1);
         TEST_CASE(testautovar_array2);
         TEST_CASE(testautovar_return1);
@@ -324,6 +325,10 @@ private:
               "    *p = &a.data[0];\n"
               "}");
         ASSERT_EQUALS("[test.cpp:6]: (error) Address of local auto-variable assigned to a function parameter.\n", errout.str());
+    }
+    
+    void testautovar12() { // Ticket #5024 - Crash on invalid input
+        check("void f(int* a) { a = }");
     }
 
     void testautovar_array1() {


### PR DESCRIPTION
Hello,

This trivial patch fixes the case initially reported in this ticket (the second part is rather different and would require a separate ticket IMHO). Thanks to consider merging.

Best regards,
  Simon
