### PR TITLE
Add a .mailmap file.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,49 @@
+Andreas Bießmann <andreas@biessmann.de> <andreas.biessmann@corscience.de>
+Andrew Martin <andrew.c.martin@saic.com> acm4me
+Ankita Gupta <ankigupta@paypal.com> Ankita-gupta
+Benjamin Goose <gans+github@tngtech.com> <gansb+github@tngtech.com>
+Daniel Marjamäki <daniel.marjamaki@gmail.com> <hyd_danmar@users.sourceforge.net>
+Daniel Marjamäki <daniel.marjamaki@gmail.com> <danielm77@spray.se>
+Daniel Marjamäki <daniel.marjamaki@gmail.com> Daniel Marjam�ki
+Daniel Marjamäki <daniel.marjamaki@gmail.com> <daniel@daniel-laptop.(none)>
+Daniel Marjamäki <daniel.marjamaki@gmail.com> <daniel@raspberrypi.(none)>
+Deepak Gupta <deepak.dce01@gmail.com> deepak gupta
+Ettl Martin <ettl.martin78@googlemail.com> Martin Ettl
+Ettl Martin <ettl.martin78@googlemail.com> <ettl.martin@gmx.de>
+Ettl Martin <ettl.martin78@googlemail.com> Martin Ettl <martin@martin.(none)>
+Frank Zingsheim <f.zingsheim@gmx.de> <zingsheim@users.sourceforge.net>
+Gianluca Scacco <gscacco@users.sourceforge.net> <gianluca@gianluca-laptop.(none)>
+Gianluca Scacco <gscacco@users.sourceforge.net> <giangy@giangy-desktop.(none)>
+Henrik Nilsson <henrik.nilsson@tvaaker.se> <henrik.nilsson@proceranetworks.com>
+Kimmo Varis <kimmov@gmail.com> Kimmo varis
+Kimmo Varis <kimmov@gmail.com> <kimmov@users.sourceforge.net>
+Kimmo Varis <kimmov@gmail.com> <ext-kimmo.1.varis@nokia.com>
+Kimmo Varis <kimmov@gmail.com> <kimmo@kimmoDesktop.(none)>
+Kimmo Varis <kimmov@gmail.com> <kimmo@kimmo-VirtualBox.(none)>
+Kimmo Varis <kimmov@gmail.com> <kimmo@kimmo-laptop.(none)>
+Kimmo Varis <kimmov@gmail.com> <kimmov@kimmolaptop.(none)>
+Leandro Penz <lpenz@users.sourceforge.net> Leandro Lisboa Penz <llpenz@gmail.com>
+Leandro Penz <lpenz@users.sourceforge.net> Leandro Lisboa Penz <lpenz@notebook.penz>
+makulik <g-makulik@t-online.de> unknown <g-makulik@t-online.de>
+Nicolas Le Cam <kush@users.sourceforge.net> <niko.lecam@gmail.com>
+Pete Johns <paj-github@johnsy.com> <pete@johnsy.com>
+PKEuS <philipp.kloke@web.de> Philipp K
+PKEuS <philipp.kloke@web.de> Philipp Kloke
+PKEuS <philipp.kloke@web.de> <philipp@kloke-witten.dyndns.org>
+Reijo Tomperi <aggro80@users.sourceforge.net> <dvice_null@yahoo.com>
+Robert Reif <reif@earthlink.net> <reif@eartlink.net>
+Ryan Pavlik <rpavlik@iastate.edu> <ryan.pavlik@snc.edu>
+
+Sébastien Debrard <sebastien.debrard@gmail.com> seb777
+Sébastien Debrard <sebastien.debrard@gmail.com> S�bastien Debrard
+Sébastien Debrard <sebastien.debrard@gmail.com> Debrard Sébastien
+
+Stefan Weil <weil@mail.berlios.de> <sw@weilnetz.de>
+Tim Gerundt <tim@gerundt.de> <gerundt@users.sourceforge.net>
+Vesa Pikki <spyree@gmail.com> <spyree@users.sourceforge.net>
+XhmikosR <xhmikosr@users.sourceforge.net> <xhmikosr@yahoo.com>
+Zachary Blair <zack_blair@hotmail.com> <ack_blair@outlook.com>
+Zachary Blair <zack_blair@hotmail.com> <zack_blair@outlook.com>
+Zachary Blair <zack_blair@hotmail.com> zblair
+
+


### PR DESCRIPTION
The .mailmap feature is used to coalesce together commits
by the same person in the shortlog, where their name and/or
email address was spelled differently.
  -- "man git shortlog"

As this corrects the author information at the root (this repository),
all services parsing these information will improve by this contribution.
As discussed on IRC, this also removes the need for different aliases
on ohloh.net (currently https://www.ohloh.net/p/cppcheck/aliases)

```
    # Finding out duplicates by comparing email addresses:
    git shortlog -sne |awk '{ print $NF }' |sort |uniq -d

    # Finding out duplicates by comparing names:
    git shortlog -sne |awk '{ NF--; $1=""; print }' |sort |uniq -d
```

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
