### PR TITLE
Fix typo in getting line number

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -187,7 +187,7 @@ class CppCheckHandler(XmlContentHandler):
 
         self.errors.append({
             "file" : attributes.get("file", ""),
-            "line" : int(attributes.get("line"), 0),
+            "line" : int(attributes.get("line", 0)),
             "id" : attributes["id"],
             "severity" : attributes["severity"],
             "msg" : attributes["msg"]

--- a/htmlreport/example.cc
+++ b/htmlreport/example.cc
@@ -1,0 +1,7 @@
+#include "missing.h"
+
+int main()
+{
+    int x;
+    x++;
+}

--- a/htmlreport/example.xml
+++ b/htmlreport/example.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<results>
+Checking example.cc...
+    <error file="example.cc" line="5" id="unassignedVariable" severity="style" msg="Variable &apos;x&apos; is not assigned a value."/>
+    <error file="example.cc" line="6" id="uninitvar" severity="error" msg="Uninitialized variable: x"/>
+Checking usage of global functions..
+    <error id="missingInclude" severity="style" msg="Cppcheck cannot find all the include files (use --check-config for details)"/>
+</results>

--- a/htmlreport/test_htmlreport.py
+++ b/htmlreport/test_htmlreport.py
@@ -63,9 +63,21 @@ class TestHTMLReport(unittest.TestCase):
             self.assertFalse(
                 os.path.exists(os.path.join(output_directory, '0.html')))
 
+    def testMissingInclude(self):
+        with runCheck(
+            xml_filename=os.path.join(ROOT_DIR, 'htmlreport', 'example.xml'),
+        ) as (report, output_directory):
+            self.assertIn('<html', report)
+
+            self.assertIn('Uninitialized variable:', report)
+            self.assertIn('example.cc', report)
+
+            self.assertTrue(
+                os.path.exists(os.path.join(output_directory, '0.html')))
+
 
 @contextlib.contextmanager
-def runCheck(source_file, xml_version):
+def runCheck(source_filename=None, xml_version='1', xml_filename=None):
     """Run cppcheck and cppcheck-htmlreport.
 
     Yield a tuple containing the resulting HTML report index and the directory
@@ -73,13 +85,15 @@ def runCheck(source_file, xml_version):
 
     """
     output_directory = tempfile.mkdtemp(dir='.')
-    xml_filename = os.path.join(output_directory, 'output.xml')
+    if xml_filename is None:
+        assert source_filename
+        xml_filename = os.path.join(output_directory, 'output.xml')
 
-    with open(xml_filename, 'w') as output_file:
-        subprocess.check_call(
-            [CPPCHECK_BIN, '--xml', source_file,
-             '--xml-version=' + xml_version],
-            stderr=output_file)
+        with open(xml_filename, 'w') as output_file:
+            subprocess.check_call(
+                [CPPCHECK_BIN, '--xml', source_filename,
+                 '--xml-version=' + xml_version],
+                stderr=output_file)
 
     assert os.path.exists(xml_filename)
 


### PR DESCRIPTION
The closing parenthesis was in the wrong place resulting in the default value not getting set. This adds a test case.
