### PR TITLE
Allow running "test_htmlreport.py" from any path

### DIFF
--- a/htmlreport/test_htmlreport.py
+++ b/htmlreport/test_htmlreport.py
@@ -99,8 +99,9 @@ def runCheck(source_filename=None, xml_version='1', xml_filename=None):
 
     subprocess.check_call(
         [HTML_REPORT_BIN,
-         '--file=' + xml_filename,
-         '--report-dir=' + output_directory])
+         '--file=' + os.path.realpath(xml_filename),
+         '--report-dir=' + os.path.realpath(output_directory)],
+        cwd=os.path.join(ROOT_DIR, 'htmlreport'))
 
     with open(os.path.join(output_directory, 'index.html')) as index_file:
         index_contents = index_file.read()


### PR DESCRIPTION
This fixes a Travis CI failure.
