### PR TITLE
travis: use -j 4 to build cppcheck, the testrunner and cppcheck-gui.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ compiler:
   - clang
 script:
   - mkdir build
-  - make test SRCDIR=build VERIFY=1
+  - make test SRCDIR=build VERIFY=1 -j 4
   - ./cppcheck --error-exitcode=1 -Ilib --enable=style --suppress=duplicateBranch cli gui lib -igui/test
   - sudo apt-get update
   - sudo apt-get install python-pygments libqt4-core libqt4-gui libqt4-dev qt4-dev-tools qt4-qmake
   - cd gui
   - qmake
-  - make
+  - make -j 4
   - cd ../
   - ./htmlreport/test_htmlreport.py
   - cd htmlreport


### PR DESCRIPTION
Sets -j 4 as make flag for make check and make of the gui, so that travis build takes roughly 10 minutes less.
