### PR TITLE
travis: check cppcheck-htmlreport compatibility with --inconclusive and --verbose flags 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
   - ./cppcheck-htmlreport --file ../gui/test/data/xmlfiles/xmlreport_v2.xml --title "xml2 test" --report-dir . --source-dir ../test/
   - ../cppcheck ../gui/test --enable=all  --inconclusive --xml-version=2 2> gui_test.xml
   - ./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive test" --report-dir . --source-dir ../gui/test
+    - ../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml-version=2 2> gui_test.xml
+  - ./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive + verbose test" --report-dir . --source-dir ../gui/test
   - cd ../
   - mkdir install_test
   - make DESTDIR=install_test install


### PR DESCRIPTION
Checks if htmlreport can handle output generated with --inconclusive and --inconclusive --verbose.
Currently it seems like it can't do this unfortunately.
