### PR TITLE
 htmlreport: give warnig boxes ("HTML_ERROR") smaller frame and padding so they don't overlap each other if there is another one in next line.

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -146,7 +146,7 @@ HTML_FOOTER = """
 </html>
 """
 
-HTML_ERROR = "<span style=\"border-width: 2px;border-color: black;border-style: solid;background: #ffaaaa;padding: 3px;\">&lt;--- %s</span>\n"
+HTML_ERROR = "<span style=\"border-width: 1px;border-color: black;border-style: solid;background: #ffaaaa;padding: 1px;font-size: 11px;\">&lt;--- %s</span>\n"
 
 
 class AnnotateCodeFormatter(HtmlFormatter):


### PR DESCRIPTION
borderwith: 2px -> 1px
padding:    3px -> 1px
font-size: 13px -> 11px

old: http://i.imgur.com/43FVXlu.png (probably zoomed out there a bit)
new: http://i.imgur.com/ynO0cbK.png
