### PR TITLE
Ticket #5125: Avoid infinite recursion for recursive class definitions

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2510,6 +2510,8 @@ const Function* Scope::findFunction(const Token *tok) const
         for (std::size_t i = 0; i < definedType->derivedFrom.size(); ++i) {
             const Type *base = definedType->derivedFrom[i].type;
             if (base && base->classScope) {
+                if (base->classScope == this) // Ticket #5125: Recursive class; tok should have been found already
+                    continue;
                 const Function * func = base->classScope->findFunction(tok);
                 if (func)
                     return func;

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -199,6 +199,7 @@ private:
         TEST_CASE(symboldatabase35); // ticket #4806 (segmentation fault)
         TEST_CASE(symboldatabase36); // ticket #4892 (segmentation fault)
         TEST_CASE(symboldatabase37);
+        TEST_CASE(symboldatabase38); // ticket #5125 (infinite recursion)
 
         TEST_CASE(isImplicitlyVirtual);
 
@@ -1637,6 +1638,18 @@ private:
         ASSERT(db && db->getVariableFromVarId(1) && db->getVariableFromVarId(1)->type() && db->getVariableFromVarId(1)->type()->name() == "Barney");
         ASSERT(db && db->getVariableFromVarId(2) && db->getVariableFromVarId(2)->type() && db->getVariableFromVarId(2)->type()->name() == "Wilma");
         ASSERT(db && db->getVariableFromVarId(3) && db->getVariableFromVarId(3)->type() && db->getVariableFromVarId(3)->type()->name() == "Barney");
+    }
+
+    void symboldatabase38() { // ticket #5125
+        check("template <typename T = class service> struct scoped_service;\n"
+              "struct service {};\n"
+              "template <> struct scoped_service<service> {};\n"
+              "template <typename T>\n"
+              "struct scoped_service : scoped_service<service>\n"
+              "{\n"
+              "  scoped_service( T* ptr ) : scoped_service<service>(ptr), m_ptr(ptr) {}\n"
+              "  T* const m_ptr;\n"
+              "};");
     }
 
     void isImplicitlyVirtual() {


### PR DESCRIPTION
Hi,

This simple fix makes sure that we don't go into infinite recursion when looking for symbols in recursive class definitions. Thanks to consider merging.

Best regards,
  Simon
