### PR TITLE
Ticket #5139: Properly handle recursive macro definitions

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1134,7 +1134,7 @@ static Token *simplifyVarMapExpandValue(Token *tok, const std::map<std::string, 
             // expand token list
             for (Token *tok2 = tokenList.front(); tok2; tok2 = tok2->next()) {
                 if (tok2->isName()) {
-                    simplifyVarMapExpandValue(tok2, variables, seenVariables);
+                    tok2 = simplifyVarMapExpandValue(tok2, variables, seenVariables);
                 }
             }
 

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -95,6 +95,7 @@ private:
         TEST_CASE(test7e);
         TEST_CASE(test8);  // #if A==1  => cfg: A=1
         TEST_CASE(test9);  // Don't crash for invalid code
+        TEST_CASE(test10); // Ticket #5139
 
         // #error => don't extract any code
         TEST_CASE(error1);
@@ -793,6 +794,21 @@ private:
         settings.userDefines = "X";
         Preprocessor preprocessor(&settings, this);
         preprocessor.preprocess(istr, actual, "file.c"); // <- don't crash
+    }
+    
+    void test10() { // Ticket #5139
+        const char filedata[] = "#define foo a.foo\n"
+                                "#define bar foo\n"
+                                "#define baz bar+0\n"
+                                "#if 0\n"
+                                "#endif";
+        
+        // Preprocess => actual result..
+        std::istringstream istr(filedata);
+        std::map<std::string, std::string> actual;
+        Settings settings;
+        Preprocessor preprocessor(&settings, this);
+        preprocessor.preprocess(istr, actual, "file.c");
     }
 
     void error1() {


### PR DESCRIPTION
Hi,

This trivial patch fixes ticket #5139 by passing the set of already expanded variables by reference and not copy, so that recursive macros definitions are properly handled. Thanks to consider merging.

Best regards,
  Simon
