### PR TITLE
Build with GNU's STL on OS X Mavericks to workaround clang's bug #17782

### DIFF
--- a/Cppcheck.xcodeproj/project.pbxproj
+++ b/Cppcheck.xcodeproj/project.pbxproj
@@ -845,7 +845,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_CXX_LIBRARY = "libstdc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -883,7 +883,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_CXX_LIBRARY = "libstdc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -939,6 +939,7 @@
 				F4C34863182566E800521683 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};


### PR DESCRIPTION
Hi,

This patch forces the usage of libstdc++ when building testrunner on OS X since the default STL on Mavericks is buggy; see http://llvm.org/bugs/show_bug.cgi?id=17782. Thanks to consider merging.

Best regards,
 Simon
