### PR TITLE
Ticket #5168: Don't crash when simplifying bit-fields for invalid code.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9580,7 +9580,7 @@ void Tokenizer::simplifyBitfields()
                    tok->next()->str() != "default") {
             const bool offset = (tok->next()->str() == "const");
 
-            if (!Token::Match(tok->tokAt(3 + (offset ? 1 : 0)), "[{};]")) {
+            if (!Token::Match(tok->tokAt(3 + (offset ? 1 : 0)), "[{};()]")) {
                 tok->deleteNext(4 + (offset ? 1 : 0));
                 goback = true;
             }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -74,6 +74,7 @@ private:
         TEST_CASE(garbageCode2); // #4300
         TEST_CASE(garbageCode3); // #4869
         TEST_CASE(garbageCode4); // #4887
+        TEST_CASE(garbageCode5); // #5168
 
         TEST_CASE(simplifyFileAndLineMacro);  // tokenize "return - __LINE__;"
 
@@ -974,6 +975,10 @@ private:
 
     void garbageCode4() { // #4887
         tokenizeAndStringify("void f ( ) { = a ; if ( 1 ) if = ( 0 ) ; }");
+    }
+
+    void garbageCode5() { // #5168
+        tokenizeAndStringify("( asm : ; void : );");
     }
 
     void simplifyFileAndLineMacro() { // tokenize 'return - __LINE__' correctly


### PR DESCRIPTION
Hi,

This patch fixes ticket #5168 by making sure one does not oversimplify bit-fields. Please consider merging.

Best regards,
  Simon
