### PR TITLE
Ticket #5203: Don't crash when checking buffer overrun for invalid code.

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -229,6 +229,8 @@ static bool bailoutIfSwitch(const Token *tok, const unsigned int varid)
     const Token* end = tok->linkAt(1)->linkAt(1);
     if (Token::simpleMatch(end, "} else {")) // scan the else-block
         end = end->linkAt(2);
+    if (Token::simpleMatch(end, "{")) // Ticket #5203: Invalid code, bailout
+        return true;
     for (; tok != end; tok = tok->next()) {
         // If scanning a "if" block then bailout for "break"
         if (is_if && (tok->str() == "break" || tok->str() == "continue"))

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -240,6 +240,8 @@ private:
         TEST_CASE(crash2);  // Ticket #2607 - crash
         TEST_CASE(crash3);  // Ticket #3034 - crash
 
+        TEST_CASE(garbage1);  // Ticket #5203
+
         TEST_CASE(executionPaths1);
         TEST_CASE(executionPaths2);
         TEST_CASE(executionPaths3);   // no FP for function parameter
@@ -3633,6 +3635,9 @@ private:
               "}");
     }
 
+    void garbage1() { // Ticket #5203
+        check("int f ( int* r ) { {  int s[2] ; f ( s ) ; if ( ) } }");
+    }
 
     void epcheck(const char code[], const char filename[] = "test.cpp") {
         // Clear the error buffer..


### PR DESCRIPTION
Hi,

This patch fixes ticket #5203 by ensuring that we're not "going backwards" via linkAt(1)->linkAt(1) in bailoutIfSwitch. Thanks to consider merging.

Best regards,
  Simon
