### PR TITLE
Set CFGDIR when building via XCode to enable to run the generated binary

### DIFF
--- a/Cppcheck.xcodeproj/project.pbxproj
+++ b/Cppcheck.xcodeproj/project.pbxproj
@@ -794,7 +794,7 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_MODEL_TUNING = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = "";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "CFGDIR=\\\"$SRCROOT/cfg/\\\"";
 				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = externals/tinyxml;
 				INSTALL_PATH = /usr/local/bin;
@@ -809,6 +809,7 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				GCC_MODEL_TUNING = "";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "CFGDIR=\\\"$SRCROOT/cfg/\\\"";
 				HEADER_SEARCH_PATHS = externals/tinyxml;
 				INSTALL_PATH = /usr/local/bin;
 				PRODUCT_NAME = cppcheck;


### PR DESCRIPTION
Hi,

This patch ensures that cppcheck is built via XCode with CFGDIR properly defined, so that the generated binary runs again (otherwise one gets an error that the installation is broken). Thanks to consider merging.

Regards,
  Simon
