### PR TITLE
Ticket #5201: Get rid of internal error when checking valid C input for leaks

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7020,6 +7020,13 @@ bool Tokenizer::simplifyRedundantParentheses()
             tok->deleteNext();
             ret = true;
         }
+        
+        if (Token::Match(tok->previous(), "[,;{}] ( %var% ) .")) {
+            // Remove the parentheses
+            tok->deleteThis();
+            tok->deleteNext();
+            ret = true;
+        }
 
         if (Token::Match(tok->previous(), "[(,;{}] ( %var% (") &&
             tok->link()->previous() == tok->linkAt(2)) {


### PR DESCRIPTION
Hello,

This patch fixes ticket #5201, an internal error when looking for memory leaks in (valid) C input that uses the (variable).attribute notation. Thanks to consider merging.

Best regards,
  Simon
