### PR TITLE
Ticket #5266: Properly tokenize "complex" static variable declarations.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5385,28 +5385,17 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, Token * tokEnd, bool only_k_r_
                 if (varName->str() != "operator") {
                     tok2 = varName->next(); // The ',' or '=' token
 
-                    if (tok2->str() == "=") {
-                        if (isstatic) {
-                            if (Token::Match(tok2->next(), "%num%|%var% ,")) // ticket #5121
-                                tok2 = tok2->tokAt(2);
-                            else if (Token::Match(tok2->next(), "( %num%|%var% ) ,")) { // ticket #4450
-                                tok2->deleteNext();
-                                tok2->next()->deleteNext();
-                                tok2 = tok2->tokAt(2);
-                            } else
-                                tok2 = NULL;
-                        } else if (isconst && !ispointer) {
-                            //do not split const non-pointer variables..
-                            while (tok2 && tok2->str() != "," && tok2->str() != ";") {
-                                if (tok2->str() == "{" || tok2->str() == "(" || tok2->str() == "[")
-                                    tok2 = tok2->link();
-                                if (tok2->str() == "<" && TemplateSimplifier::templateParameters(tok2) > 0)
-                                    tok2 = tok2->findClosingBracket();
-                                tok2 = tok2->next();
-                            }
-                            if (tok2 && tok2->str() == ";")
-                                tok2 = NULL;
+                    if (tok2->str() == "=" && (isstatic || (isconst && !ispointer))) {
+                        //do not split const non-pointer variables..
+                        while (tok2 && tok2->str() != "," && tok2->str() != ";") {
+                            if (tok2->str() == "{" || tok2->str() == "(" || tok2->str() == "[")
+                                tok2 = tok2->link();
+                            if (tok2->str() == "<" && TemplateSimplifier::templateParameters(tok2) > 0)
+                                tok2 = tok2->findClosingBracket();
+                            tok2 = tok2->next();
                         }
+                        if (tok2 && tok2->str() == ";")
+                            tok2 = NULL;
                     }
                 } else
                     tok2 = NULL;

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5777,6 +5777,19 @@ private:
                           "}",
                           tokenizeAndStringify(code));
         }
+
+        {
+            // Ticket #5266
+            const char code[] = "class Machine {\n"
+                                "  static int const STACK_ORDER = 10, STACK_MAX = 1 << STACK_ORDER,"
+                                "                   STACK_GUARD = 2;\n"
+                                "};";
+            ASSERT_EQUALS("class Machine {\n"
+                          "static const int STACK_ORDER = 10 ; static const int STACK_MAX = 1 << STACK_ORDER ; "
+                          "static const int STACK_GUARD = 2 ;\n"
+                          "} ;",
+                          tokenizeAndStringify(code));
+        }
     }
 
     void vardecl6() {


### PR DESCRIPTION
Hi,

This patch fixes the ticket and simplifies Tokenizer::simplifyVarDecl to do the same for static and const variables that are simultaneously declared and defined. Thanks to consider merging.

Best regards,
  Simon
