### PR TITLE
gui: Attempt to load library from the cfg subfolder of the current working directory

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -531,6 +531,11 @@ bool MainWindow::LoadLibrary(Library *library, QString filename)
     if (library->load(NULL, (path+"/"+filename).toLatin1()))
         return true;
 
+    // Try to load the library from the cfg subfolder of the current working directory
+    path = QDir::currentPath() + "/cfg";
+    if (library->load(NULL, (path+"/"+filename).toLatin1()))
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
This removes the requirement that the cppcheck-gui executable and the cfg subfolder
has to be in the same directory.

This allows for greater flexibility, for example out-of-source builds of cppcheck-gui.
