### PR TITLE
runastyle: Ignore user's default options file

### DIFF
--- a/runastyle
+++ b/runastyle
@@ -14,7 +14,7 @@ if [[ "`astyle --version 2>&1`" != ${ASTYLE_VERSION}* ]]; then
 fi
 
 style="--style=stroustrup --indent=spaces=4 --indent-namespaces --lineend=linux --min-conditional-indent=0"
-options="--pad-header --unpad-paren --suffix=none --convert-tabs"
+options="--options=none --pad-header --unpad-paren --suffix=none --convert-tabs"
 
 astyle $style $options cli/*.cpp
 astyle $style $options cli/*.h


### PR DESCRIPTION
If we pass --options=none to astyle, it ignores the user's
default options file, and only uses the command line parameters.
This way, if the user has a default options file, it won't conflict
with the style set by the script.
