### PR TITLE
travis: sent out build failure notification as soon as the first job fails using    matrix: fast_finish: true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
     - SRCDIR=build VERIFY=1
     - MAKEFLAGS="HAVE_RULES=yes"
     -
+# do notify immediately about it when a sub-job of a  build fails.
+matrix:
+  fast_finish: true
 before_install:
 # install needed deps
  - sudo apt-get update -qq


### PR DESCRIPTION
Do not wait for all other jobs to come to end in order to sent failure notification via mail/IRC.
