### PR TITLE
(WIP) Fixed #5392 (new check: recommend expm1, log1p, erfc)

### DIFF
--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -91,6 +91,7 @@ public:
         checkOther.invalidFunctionUsage();
         checkOther.checkZeroDivision();
         checkOther.checkMathFunctions();
+        checkOther.checkSpecialMath();
 
         checkOther.redundantGetAndSetUserId();
         checkOther.checkIncorrectLogicOperator();
@@ -171,6 +172,7 @@ public:
 
     /** @brief %Check for parameters given to math function that do not make sense*/
     void checkMathFunctions();
+    void checkSpecialMath();
 
     /** @brief % Check for seteuid(geteuid()) or setuid(getuid())*/
     void redundantGetAndSetUserId();
@@ -290,6 +292,7 @@ private:
     void zerodivcondError(const Token *tokcond, const Token *tokdiv);
     void nanInArithmeticExpressionError(const Token *tok);
     void mathfunctionCallError(const Token *tok, const unsigned int numParam = 1);
+    void specialmathError(const Token *tok, const std::string &strVarName);
     void redundantAssignmentError(const Token *tok1, const Token* tok2, const std::string& var, bool inconclusive);
     void redundantAssignmentInSwitchError(const Token *tok1, const Token *tok2, const std::string &var);
     void redundantCopyError(const Token *tok1, const Token* tok2, const std::string& var);

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -88,6 +88,7 @@ private:
         TEST_CASE(passedByValue);
 
         TEST_CASE(mathfunctionCall_fmod);
+        TEST_CASE(mathfunctionspecial_expm1);
         TEST_CASE(mathfunctionCall_sqrt);
         TEST_CASE(mathfunctionCall_log);
         TEST_CASE(mathfunctionCall_acos);
@@ -1733,6 +1734,47 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
     }
+
+
+    void mathfunctionspecial_expm1() {
+        check("void f(double a)\n"
+              "{\n"
+              "    exp(b) - 1.;\n"
+              "    -1.0 + exp(b);\n"
+              "   exp(b) - 1.;\n"
+              "   exp(b + 1) - 1.;\n" 
+              "   exp(b) - 1;\n"
+              "   exp(b) - 1.0;\n"
+              "   exp(b) - 1.0001; // no replace 9\n"
+              "   b = -1. + exp(b); //fails\n"
+              "   log(1. + b);\n"
+              "   log(1 + b);\n"
+              "   log(b + 1.);\n"
+              "   log(b + 1.f);\n"
+              "   b = 1. - erf(b); // fails\n"
+              "   - erf(b) + 1.; // fails\n"
+              "   exp(b) * 3. + 1.; // no replace fails\n" 
+              "   3. * exp(b) + 1.; // no replace\n"
+              "   b = 1. - erf(b) * b; // no replace \n"
+              "   b = 1. - b * erf(b); // no replace \n"
+              "   b = b * 1. - b * erf(b); // no replace fails\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:4]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:5]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:6]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:7]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:8]: (error) can be replaced with expm(x)\n"
+                      "[test.cpp:10]: (error) can be replaced with log1p(x)\n"
+                      "[test.cpp:11]: (error) can be replaced with log1p(x)\n"
+                      "[test.cpp:12]: (error) can be replaced with log1p(x)\n"
+                      "[test.cpp:13]: (error) can be replaced with log1p(x)\n"
+                      "[test.cpp:14]: (error) can be replaced with erfc(x)\n"
+                      "[test.cpp:15]: (error) can be replaced with erfc(x)\n"
+                      ,
+                      errout.str());
+    }
+
 
     void switchRedundantAssignmentTest() {
 


### PR DESCRIPTION
my first attempt at adding the new check from trac 5392.
still very much a prototype with style, naming and category issues, but as I couldn't find a developer guide I need some early hints.
has some basic tests, the ones that fail are where I need help.

main issues:
Token::Match seems to just a simple pattern matcher not a real semantic matcher, is there a semantic matcher similar to _semantic patch language_ available?
my simple patterns would work for 

```
function(variable) - constant`
```

patterns but fail for

```
function(expression) - constant
```

E.g.

```
exp(a + b / 3) - 1.
```

does not trigger it, am I just overlooking the `expression` pattern? `%any%` does not work.

```
function(variable) + constant operator expression
```

also false positives if operator has higher precedence as `+`, can I bound the pattern to an expression respecting precedence rules somehow to avoid this?

```
b = 1. - erf(b)
```

also does not trigger, I don't see why, is the `b =` included in the pattern match somehow?
