### PR TITLE
CheckMemoryLeak: improve leak checking in function parameters

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2726,7 +2726,7 @@ void CheckMemoryLeakNoVar::check()
                     for (const Token *tok3 = tok2; tok3; tok3 = tok3->previous()) {
                         if (tok3->str() == "(") {
                             // Is it a function call..
-                            if (Token::Match(tok3->tokAt(-2), "[;{}] %var% (")) {
+                            if (!Token::Match(tok3->tokAt(-2), "= %var% (")) {
                                 const std::string& functionName = tok3->strAt(-1);
                                 if (functionName == "delete" ||
                                     functionName == "free" ||

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -5562,6 +5562,24 @@ private:
               "    close(fd);\n"
               "}");
         TODO_ASSERT_EQUALS("[test.cpp:4]: (error) Allocation with strdup, mkstemp doesn't release it.\n", "", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    if(TRUE || strcmp(strdup(a), b));\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Allocation with strdup, strcmp doesn't release it.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    if(!strcmp(strdup(a), b) == 0);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Allocation with strdup, strcmp doesn't release it.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    42, strcmp(strdup(a), b);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Allocation with strdup, strcmp doesn't release it.\n", errout.str());
     }
 
     void missingAssignment() {


### PR DESCRIPTION
cppcheck fails for checking leak in:

```
void f() {
    if(TRUE || strcmp(strdup(a), b))
    if(!strcmp(strdup(a), b) == 0)
    42, strcmp(strdup(a), b);
}
```

Assuming that only a = f(leak()) is balcklisted passes all tests. Also added tests for undetected leaks.
