### PR TITLE
daca2: count crashes of cppcheck in index table.

### DIFF
--- a/tools/daca2-report.py
+++ b/tools/daca2-report.py
@@ -59,7 +59,8 @@ mainpage.write(
     '<td>Warning</td>' +
     '<td>Performance</td>' +
     '<td>Portability</td>' +
-    '<td>Style</td></tr>\n')
+    '<td>Style</td>' +
+    '<td>Crashes</td></tr>\n')
 
 lastupdate = None
 recent = []
@@ -104,6 +105,7 @@ for lib in range(2):
                 '<td>' + str(data.count('(performance)')) + '</td>' +
                 '<td>' + str(data.count('(portability)')) + '</td>' +
                 '<td>' + str(data.count('(style)')) + '</td>' +
+                '<td>' + str(data.count('Crash?')) + '</td>' +
                 '</tr>\n')
 
             data = data.replace('&', '&amp;')


### PR DESCRIPTION
Attempt to make daca list how often cppcheck crashed per "name" (a, b, c, liba libb libc ...).

NOTE: unfortunately I was unable to test if this works locally.
