### PR TITLE
RFC: Restore build on OSX

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -463,7 +463,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
 
             if (Token::Match(tok->next(), "( %any%") && _settings->library.formatstr_function(tok->str())) {
                 const std::map<int, Library::ArgumentChecks>& argumentChecks = _settings->library.argumentChecks.at(tok->str());
-                for (std::map<int, Library::ArgumentChecks>::const_iterator i = argumentChecks.cbegin(); i != argumentChecks.cend(); ++i) {
+                for (std::map<int, Library::ArgumentChecks>::const_iterator i = argumentChecks.begin(); i != argumentChecks.end(); ++i) {
                     if (i->second.formatstr) {
                         formatStringArgNo = i->first - 1;
                         break;

--- a/lib/library.h
+++ b/lib/library.h
@@ -85,7 +85,7 @@ public:
     }
 
     bool formatstr_function(const std::string& funcname) const {
-        return _formatstr.find(funcname) != _formatstr.cend();
+        return _formatstr.find(funcname) != _formatstr.end();
     }
 
     bool formatstr_scan(const std::string& funcname) const {

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -270,7 +270,7 @@ std::size_t TestFixture::runTests(const options& args)
 
     if (!missingLibs.empty()) {
         std::cerr << "Missing libraries: ";
-        for (std::set<std::string>::const_iterator i = missingLibs.cbegin(); i != missingLibs.cend(); ++i)
+        for (std::set<std::string>::const_iterator i = missingLibs.begin(); i != missingLibs.end(); ++i)
             std::cerr << *i << "  ";
         std::cerr << std::endl << std::endl;
     }


### PR DESCRIPTION
Hi,

I need to apply this patch to build / test cppcheck on OSX, that's current in a "special" situation: the compiler supports C++11, but one can't use the built-in STL due to TODO, hence we need to use GNU's, that does not have cend/cbegin yet. Please consider merging so that one can contribute from OSX

Thanks,
  Simon
