### PR TITLE
Fixed #389: Providing negative value to memory allocation function.

### DIFF
--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -218,6 +218,7 @@ private:
     void bufferOverrunError(const Token *tok, const std::string &varnames = "");
     void bufferOverrunError(const std::list<const Token *> &callstack, const std::string &varnames = "");
     void strncatUsageError(const Token *tok);
+    void negativeMemoryAllocationSizeError(const Token *tok); // provide a negative value to memory allocation function
     void outOfBoundsError(const Token *tok, const std::string &what, const bool show_size_info, const MathLib::bigint &supplied_size, const MathLib::bigint &actual_size);
     void sizeArgumentAsCharError(const Token *tok);
     void terminateStrncpyError(const Token *tok, const std::string &varname);
@@ -251,6 +252,7 @@ public:
         c.possibleReadlinkBufferOverrunError(0, "readlink", "buffer");
         c.argumentSizeError(0, "function", "array");
         c.writeOutsideBufferSizeError(0,2,3,"write");
+        c.negativeMemoryAllocationSizeError(0);
     }
 private:
 

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -267,6 +267,8 @@ private:
         TEST_CASE(readlinkat);
 
         TEST_CASE(writeOutsideBufferSize)
+
+        TEST_CASE(negativeMemoryAllocationSizeError) // #389
     }
 
 
@@ -4110,6 +4112,40 @@ private:
               "    write(1, 0, 1);\n"
               "}");
         TODO_ASSERT_EQUALS("[test.cpp:3]: (error) Writing 1 bytes outside buffer size.\n", "", errout.str());
+    }
+
+    void negativeMemoryAllocationSizeError() { // #389
+        check("void f()\n"
+              "{\n"
+              "   int *a;\n"
+              "   a = new int[-1];\n"
+              "   delete [] a;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory allocation size have to be greater or equal to 0.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "   int *a;\n"
+              "   a = malloc( -10 );\n"
+              "   free(a);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory allocation size have to be greater or equal to 0.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "   int *a;\n"
+              "   a = malloc( -10);\n"
+              "   free(a);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory allocation size have to be greater or equal to 0.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "   int *a;\n"
+              "   a = alloca( -10 );\n"
+              "   free(a);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory allocation size have to be greater or equal to 0.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
This PR is based on the patch, provided in ticket #389. I cleaned up the patch, because it did not apply anymore. Furthermore, the new[]-operator was not supported and i rephrased the error message slightly.

Thanks for consider pulling and best regards

Martin Ettl
