### PR TITLE
CheckMemoryLeak: use library while checking whitelist functions

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -18,7 +18,7 @@
     <use>g_register_data</use>
   </memory>
 
-  <function name="g_strcmp">
+  <function name="g_strcmp0">
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>

--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -204,6 +204,7 @@ public:
 
     /** @brief Unit testing : testing the white list */
     static bool test_white_list(const std::string &funcname);
+    static bool test_white_list_with_lib(const std::string &funcname, const Settings *settings);
 
     /** @brief Perform checking */
     void check();


### PR DESCRIPTION
The problem was in ignoring library functions while testing leaks in function arguments. Also there was another `test_white_list` calls, I'm not sure they all should be replaced or not. I kept old `test_white_list` for tests.

Take a look at tests to see difference.

P.S. Maybe passing settings is redundant but `test_white_list` is static and settings is private.
