### PR TITLE
Library: add mk[sd]temp to Posix

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -4,6 +4,10 @@
   <function name="_exit">    <noreturn>true</noreturn>                                                        </function>
   <function name="closedir"> <noreturn>false</noreturn> <arg nr="1"><not-bool/><not-uninit/><not-null/></arg> </function>
 
+  <function name="mkstemp"> <noreturn>false</noreturn> <arg nr="1"><not-uninit/><not-null/></arg> <leak-ignore/> </function>
+  <function name="mkdtemp"> <noreturn>false</noreturn> <arg nr="1"><not-uninit/><not-null/></arg> <leak-ignore/> </function>
+  <function name="mktemp"> <noreturn>false</noreturn> <arg nr="1"><not-uninit/><not-null/></arg> <leak-ignore/> </function>
+
   <resource>
     <dealloc>close</dealloc>
     <alloc init="true">socket</alloc>

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -4248,6 +4248,14 @@ private:
         ASSERT_EQUALS("[test.cpp:5]: (error) Resource leak: leak1\n"
                       "[test.cpp:5]: (error) Resource leak: leak2\n"
                       "[test.cpp:5]: (error) Resource leak: leak3\n", errout.str());
+
+        check("void f(char *a) {\n"
+              "    char *s = g_strdup(a);\n"
+              "    mkstemp(s);\n"
+              "    mkdtemp(s);\n"
+              "    mktemp(s);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:6]: (error) Memory leak: s\n", errout.str());
     }
 };
 


### PR DESCRIPTION
At least mkdtemp is not present in cppcheck whitelist.

mktemp is outdated and it's better to warn about using this but it shouldn't break leak-checking.
