### PR TITLE
Process header files.

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -211,7 +211,7 @@ bool Path::isCPP(const std::string &path)
 
 bool Path::acceptFile(const std::string &path, const std::set<std::string> &extra)
 {
-    return !Path::isHeader(path) && (Path::isCPP(path) || Path::isC(path) || extra.find(getFilenameExtension(path)) != extra.end());
+    return Path::isHeader(path) || (Path::isCPP(path) || Path::isC(path) || extra.find(getFilenameExtension(path)) != extra.end());
 }
 
 bool Path::isHeader(const std::string &path)


### PR DESCRIPTION
Header files should be processed - especially if we've got in-lined code in header files that won't be checked as part of the standard cpp checks.
