### PR TITLE
Remove reflection from the markup block in library code.

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -52,21 +52,9 @@
   </markup>
 
   <!-- qt can call methods as strings using invokeMethod -->
-  <markup ext=".c" reporterrors="true">
-    <reflection>
-      <call arg="4">invokeMethod</call>
-    </reflection>
-  </markup>
-  <markup ext=".cpp" reporterrors="true">
-    <reflection>
-      <call arg="4">invokeMethod</call>
-    </reflection>
-  </markup>
-  <markup ext=".cxx" reporterrors="true">
-    <reflection>
-      <call arg="4">invokeMethod</call>
-    </reflection>
-  </markup>
+  <reflection>
+    <call arg="4">invokeMethod</call>
+  </reflection>
 
   <!-- the SLOT/SIGNAL methods can be cause false-positives for pure
   virtual functions being called in the constructor because it sees

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -163,8 +163,8 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char Fi
             }
         }
 
-        if (settings->library.isreflection(FileName, tok->str())) {
-            const int index = settings->library.reflectionArgument(FileName, tok->str());
+        if (settings->library.isreflection(tok->str())) {
+            const int index = settings->library.reflectionArgument(tok->str());
             if (index >= 0) {
                 const Token * funcToken = tok->tokAt(index);
                 if (funcToken) {

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -209,6 +209,19 @@ bool Library::load(const tinyxml2::XMLDocument &doc)
             }
         }
 
+        else if (strcmp(node->Name(), "reflection") == 0) {
+            for (const tinyxml2::XMLElement *reflectionnode = node->FirstChildElement(); reflectionnode; reflectionnode = reflectionnode->NextSiblingElement()) {
+                if (strcmp(reflectionnode->Name(), "call") != 0)
+                    return false;
+
+                const char * const argString = reflectionnode->Attribute("arg");
+                if (!argString)
+                    return false;
+
+                _reflection[reflectionnode->GetText()] = atoi(argString);
+            }
+        }
+
         else if (strcmp(node->Name(), "markup") == 0) {
             const char * const extension = node->Attribute("ext");
             if (!extension)
@@ -256,19 +269,6 @@ bool Library::load(const tinyxml2::XMLDocument &doc)
                             _importers[extension].insert(librarynode->GetText());
                         else
                             return false;
-                    }
-                }
-
-                else if (strcmp(markupnode->Name(), "reflection") == 0) {
-                    for (const tinyxml2::XMLElement *reflectionnode = markupnode->FirstChildElement(); reflectionnode; reflectionnode = reflectionnode->NextSiblingElement()) {
-                        if (strcmp(reflectionnode->Name(), "call") != 0)
-                            return false;
-
-                        const char * const argString = reflectionnode->Attribute("arg");
-                        if (!argString)
-                            return false;
-
-                        _reflection[extension][reflectionnode->GetText()] = atoi(argString);
                     }
                 }
 

--- a/lib/library.h
+++ b/lib/library.h
@@ -248,22 +248,18 @@ public:
         return (it != _importers.end() && it->second.count(importer) > 0);
     }
 
-    bool isreflection(const std::string& file, const std::string &token) const {
-        const std::map<std::string,std::map<std::string,int> >::const_iterator it
-            = _reflection.find(Path::getFilenameExtensionInLowerCase(file));
-        return (it != _reflection.end() && it->second.count(token));
+    bool isreflection(const std::string &token) const {
+        const std::map<std::string,int>::const_iterator it
+            = _reflection.find(token);
+        return it != _reflection.end();
     }
 
-    int reflectionArgument(const std::string& file, const std::string &token) const {
+    int reflectionArgument(const std::string &token) const {
         int argIndex = -1;
-        const std::map<std::string,std::map<std::string,int> >::const_iterator it
-            = _reflection.find(Path::getFilenameExtensionInLowerCase(file));
+        const std::map<std::string,int>::const_iterator it
+            = _reflection.find(token);
         if (it != _reflection.end()) {
-            const std::map<std::string,int>::const_iterator it2 =
-                it->second.find(token);
-            if (it2 != it->second.end()) {
-                argIndex = it2->second;
-            }
+            argIndex = it->second;
         }
         return argIndex;
     }
@@ -338,7 +334,7 @@ private:
     std::map<std::string, CodeBlock> _executableblocks; // keywords for blocks of executable code
     std::map<std::string, ExportedFunctions> _exporters; // keywords that export variables/functions to libraries (meta-code/macros)
     std::map<std::string, std::set<std::string> > _importers; // keywords that import variables/functions
-    std::map<std::string, std::map<std::string,int> > _reflection; // invocation of reflection
+    std::map<std::string,int> _reflection; // invocation of reflection
     std::map<std::string, std::pair<bool, bool> > _formatstr; // Parameters for format string checking
 
 

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -211,7 +211,7 @@ bool Path::isCPP(const std::string &path)
 
 bool Path::acceptFile(const std::string &path, const std::set<std::string> &extra)
 {
-    return Path::isHeader(path) || (Path::isCPP(path) || Path::isC(path) || extra.find(getFilenameExtension(path)) != extra.end());
+    return !Path::isHeader(path) && (Path::isCPP(path) || Path::isC(path) || extra.find(getFilenameExtension(path)) != extra.end());
 }
 
 bool Path::isHeader(const std::string &path)


### PR DESCRIPTION
Make the reflection source-code based.

Previously the reflection was applied to markup languages but reflection is part of the Qt C++ spec and not markup so that reflection block should be removed from markup and made generic.
