### PR TITLE
travis: compile with -Wunreachable-code .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   global:
 #   unfortunately we need this to stay within 50min timelimit given by travis.
 #   this also turns off the debug/warning cxxflags
-    - CXXFLAGS=-O2
+    - CXXFLAGS="-O2 -Wunreachable-code"
   matrix:
     - MAKEFLAGS="HAVE_RULES=yes" SRCDIR=build VERIFY=1
     - SRCDIR=build VERIFY=1


### PR DESCRIPTION
compiles with -Wunreachable-code

gcc does ignore this flag unfortunately, it has been disabled, however for clang it works.
