### PR TITLE
Ticket #5506: Don't crash upon invalid template declaration

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -443,9 +443,10 @@ std::list<Token *> TemplateSimplifier::getTemplateDeclarations(Token *tokens, bo
             tok = tok->linkAt(2);
 
         if (Token::simpleMatch(tok, "template <")) {
+            Token *parmEnd = tok->next()->findClosingBracket();
             codeWithTemplates = true;
 
-            for (const Token *tok2 = tok; tok2; tok2 = tok2->next()) {
+            for (const Token *tok2 = parmEnd; tok2; tok2 = tok2->next()) {
                 // Just a declaration => ignore this
                 if (tok2->str() == ";")
                     break;

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -61,6 +61,7 @@ private:
         TEST_CASE(tokenize26);  // #4245 (segmentation fault)
         TEST_CASE(tokenize27);  // #4525 (segmentation fault)
         TEST_CASE(tokenize28);  // #4725 (writing asm() around "^{}")
+        TEST_CASE(tokenize29);  // #5506 (segmentation fault upon invalid code)
 
         // don't freak out when the syntax is wrong
         TEST_CASE(wrong_syntax1);
@@ -823,6 +824,11 @@ private:
         ASSERT_EQUALS("void f ( ) { asm ( \"^{}\" ) ; }", tokenizeAndStringify("void f() { ^{} }"));
         ASSERT_EQUALS("void f ( ) { asm ( \"x(^{})\" ) ; }", tokenizeAndStringify("void f() { x(^{}); }"));
         ASSERT_EQUALS("; asm ( \"voidf^{return}intmain\" ) ; ( ) { }", tokenizeAndStringify("; void f ^ { return } int main ( ) { }"));
+    }
+
+    // #5506 - segmentation fault upon invalid code
+    void tokenize29() {
+        tokenizeAndStringify("A template < int { int = -1 ; } template < int N > struct B { int [ A < N > :: zero ] ;  } ; B < 0 > b ;");
     }
 
     void wrong_syntax1() {


### PR DESCRIPTION
Hi,

This patch fixes the ticket by properly skipping template parameters in TemplateSimplifier::getTemplateDeclarations, so that we don't believe we're seeing a declaration for invalid code with a ; in the parameters. Thanks to consider merging.

Best regards,
  Simon
