### PR TITLE
Ticket #5478: Only functions and equal operators might return a temporary

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -292,6 +292,9 @@ bool CheckAutoVariables::returnTemporary(const Token *tok) const
 
     const Function *function = tok->function();
     if (function) {
+        // Ticket #5478: Only functions or operator equal might return a temporary
+        if (function->type != Function::eOperatorEqual && function->type != Function::eFunction)
+            return false;
         retref = function->tokenDef->strAt(-1) == "&";
         if (!retref) {
             const Token *start = function->retDef;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -107,6 +107,8 @@ private:
         TEST_CASE(testglobalnamespace);
 
         TEST_CASE(returnParameterAddress);
+
+        TEST_CASE(testconstructor); // ticket #5478 - crash
     }
 
 
@@ -807,6 +809,15 @@ private:
               "}");
 
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void testconstructor() { // Ticket #5478 - crash while checking a constructor
+        check("class const_tree_iterator {\n"
+              "  const_tree_iterator(bool (*_incream)(node_type*&)) {}\n"
+              "  const_tree_iterator& parent() {\n"
+              "    return const_tree_iterator(foo);\n"
+              "  }\n"
+              "};");
     }
 
 };


### PR DESCRIPTION
Hi,

This patch fixes the ticket by ensuring everything that's not a function or equal operator is skipped when checking if a temporary is returned. Without this, the code crashes dereferencing a 0 function->retDef. Thanks to consider pulling.

Cheers,
  Simon
