### PR TITLE
Ticket #5425: Avoid infinite recursion in checkMemsetType

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1020,6 +1020,7 @@ void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Sco
         // don't warn if variable static or const, pointer or reference
         if (!var->isStatic() && !var->isConst() && !var->isPointer() && !var->isReference()) {
             const Token *tok1 = var->typeStartToken();
+            const Scope *typeScope = var->typeScope();
 
             // check for std:: type
             if (var->isStlType())
@@ -1029,8 +1030,8 @@ void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Sco
                     memsetError(tok, tok->str(), "'std::" + tok1->strAt(2) + "'", type->classDef->str());
 
             // check for known type
-            else if (var->typeScope())
-                checkMemsetType(start, tok, var->typeScope(), allocation);
+            else if (typeScope && typeScope != type)
+                checkMemsetType(start, tok, typeScope, allocation);
         }
     }
 }

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -80,6 +80,7 @@ private:
         TEST_CASE(memsetOnStruct);
         TEST_CASE(memsetVector);
         TEST_CASE(memsetOnClass);
+        TEST_CASE(memsetOnInvalid);  // Ticket #5425: Crash upon invalid
         TEST_CASE(mallocOnClass);
 
         TEST_CASE(this_subtraction);    // warn about "this-x"
@@ -2283,6 +2284,22 @@ private:
                       "  memset(b,0,4);\n"
                       "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void memsetOnInvalid() { // Ticket #5425
+    	checkNoMemset("union ASFStreamHeader {\n"
+                      "  struct AVMPACKED {\n"
+                      "    union  {\n"
+                      "      struct AVMPACKED {\n"
+                      "        int width;\n"
+                      "      } vid;\n"
+                      "    };\n"
+                      "  } hdr;\n"
+                      "};"
+                      "void parseHeader() {\n"
+                      "  ASFStreamHeader strhdr;\n"
+                      "  memset(&strhdr, 0, sizeof(strhdr));\n"
+                      "}");
     }
 
     void memsetOnStruct() {


### PR DESCRIPTION
Hi,

This patch avoid infinite recursion upon invalid input and therefore fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
