### PR TITLE
Ticket #5373: delete can match %type% in C

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -29,7 +29,7 @@
 #include <map>
 #include <stack>
 
-Token::Token(Token **t) :
+Token::Token(Token **t, Tokenizer *tokenizer) :
     tokensBack(t),
     _next(0),
     _previous(0),
@@ -52,7 +52,8 @@ Token::Token(Token **t) :
     _isAttributeUnused(false),
     _astOperand1(nullptr),
     _astOperand2(nullptr),
-    _astParent(nullptr)
+    _astParent(nullptr),
+    _tokenizer(tokenizer)
 {
 }
 
@@ -137,6 +138,9 @@ void Token::update_property_isStandardType()
     }
 }
 
+bool Token::isCPP() const {
+    return !(_tokenizer && _tokenizer->isC());
+}
 
 bool Token::isUpperCaseName() const
 {
@@ -600,7 +604,7 @@ bool Token::Match(const Token *tok, const char pattern[], unsigned int varid)
                 // Type (%type%)
             {
                 p += 5;
-                multicompare(p,tok->isName() && tok->varId() == 0 && tok->str() != "delete",ismulticomp);
+                multicompare(p, tok->isName() && tok->varId() == 0 && !(tok->isCPP() && tok->str() == "delete"), ismulticomp);
             }
             break;
             case 'a':
@@ -927,7 +931,7 @@ void Token::insertToken(const std::string &tokenStr, bool prepend)
     if (_str.empty())
         newToken = this;
     else
-        newToken = new Token(tokensBack);
+        newToken = new Token(tokensBack, _tokenizer);
     newToken->str(tokenStr);
     newToken->_linenr = _linenr;
     newToken->_fileIndex = _fileIndex;
@@ -967,7 +971,7 @@ void Token::insertToken(const std::string &tokenStr, const std::string &original
     if (_str.empty())
         newToken = this;
     else
-        newToken = new Token(tokensBack);
+        newToken = new Token(tokensBack, _tokenizer);
     newToken->str(tokenStr);
     newToken->_originalName = originalNameStr;
     newToken->_linenr = _linenr;

--- a/lib/token.h
+++ b/lib/token.h
@@ -32,6 +32,7 @@
 class Scope;
 class Function;
 class Variable;
+class Tokenizer;
 
 /// @addtogroup Core
 /// @{
@@ -65,7 +66,7 @@ public:
         eNone
     };
 
-    explicit Token(Token **tokensBack);
+    explicit Token(Token **tokensBack, Tokenizer *tokenizer = 0);
     ~Token();
 
     void str(const std::string &s);
@@ -678,6 +679,9 @@ private:
 
     // original name like size_t
     std::string _originalName;
+
+    Tokenizer *_tokenizer;
+    bool isCPP() const;
 
 public:
     void astOperand1(Token *tok);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -36,7 +36,7 @@
 //---------------------------------------------------------------------------
 
 Tokenizer::Tokenizer() :
-    list(0),
+    list(0, this),
     _settings(0),
     _errorLogger(0),
     _symbolDatabase(0),
@@ -50,7 +50,7 @@ Tokenizer::Tokenizer() :
 }
 
 Tokenizer::Tokenizer(const Settings *settings, ErrorLogger *errorLogger) :
-    list(settings),
+    list(settings, this),
     _settings(settings),
     _errorLogger(errorLogger),
     _symbolDatabase(0),
@@ -2815,7 +2815,7 @@ bool Tokenizer::simplifySizeof()
 
             else if (Token::Match(tok->previous(), "%type% %var% [ %num% ] [,)]") ||
                      Token::Match(tok->tokAt(-2), "%type% * %var% [ %num% ] [,)]")) {
-                Token tempTok(0);
+                Token tempTok(0, this);
                 tempTok.str("*");
                 sizeOfVar[varId] = MathLib::toString(sizeOfType(&tempTok));
             }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -31,10 +31,11 @@
 #include <stack>
 
 
-TokenList::TokenList(const Settings* settings) :
+TokenList::TokenList(const Settings* settings, Tokenizer *tokenizer) :
     _front(0),
     _back(0),
-    _settings(settings)
+    _settings(settings),
+    _tokenizer(tokenizer)
 {
 }
 
@@ -113,7 +114,7 @@ void TokenList::addtoken(const char str[], const unsigned int lineno, const unsi
     if (_back) {
         _back->insertToken(str2.str());
     } else {
-        _front = new Token(&_back);
+        _front = new Token(&_back, _tokenizer);
         _back = _front;
         _back->str(str2.str());
     }
@@ -130,7 +131,7 @@ void TokenList::addtoken(const Token * tok, const unsigned int lineno, const uns
     if (_back) {
         _back->insertToken(tok->str(), tok->originalName());
     } else {
-        _front = new Token(&_back);
+        _front = new Token(&_back, _tokenizer);
         _back = _front;
         _back->str(tok->str());
         _back->originalName(tok->originalName());

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -27,13 +27,14 @@
 
 class Token;
 class Settings;
+class Tokenizer;
 
 /// @addtogroup Core
 /// @{
 
 class CPPCHECKLIB TokenList {
 public:
-    TokenList(const Settings* settings);
+    TokenList(const Settings* settings, Tokenizer* tokenizer = 0);
     ~TokenList();
 
     void setSettings(const Settings *settings) {
@@ -127,6 +128,9 @@ private: /// private
 
     /** settings */
     const Settings* _settings;
+
+    /** tokenizer */
+    Tokenizer* _tokenizer;
 };
 
 /// @}

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -263,6 +263,7 @@ private:
         TEST_CASE(varid53); // #4172 - Template instantiation: T<&functionName> list[4];
         TEST_CASE(varid54); // hang
         TEST_CASE(varid_cpp_keywords_in_c_code);
+        TEST_CASE(varid_cpp_keywords_in_c_code2); // #5373: varid=0 for argument called "delete"
         TEST_CASE(varidFunctionCall1);
         TEST_CASE(varidFunctionCall2);
         TEST_CASE(varidFunctionCall3);
@@ -3983,6 +3984,19 @@ private:
                                 "4: }\n";
 
         ASSERT_EQUALS(expected, tokenizeDebugListing(code,false,"test.c"));
+    }
+
+    void varid_cpp_keywords_in_c_code2() { // #5373
+        const char code[] = "int clear_extent_bit(struct extent_io_tree *tree, u64 start, u64 end, "
+                            "unsigned long bits, int wake, int delete, struct extent_state **cached_state, "
+                            "gfp_t mask) {\n"
+                            "  struct extent_state *state;\n"
+                            "}"
+                            "int clear_extent_dirty() {\n"
+                            "  return clear_extent_bit(tree, start, end, EXTENT_DIRTY | EXTENT_DELALLOC | "
+                            "                          EXTENT_DO_ACCOUNTING, 0, 0, NULL, mask);\n"
+                            "}";
+        tokenizeDebugListing(code, false, "test.c");
     }
 
     void varidFunctionCall1() {


### PR DESCRIPTION
Hi,

This patch fixes Token::Match with %type%: the "delete" string can be a type in C... To do so, I keep track of the Tokenizer that create Tokens in the Token class. Thanks to review and comment.

Cheers,
  Simon
