### PR TITLE
travis: add gdb as dependency, it is used for cppcheck-gui.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 before_install:
 # install needed deps
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-pygments libqt4-core libqt4-gui libqt4-dev qt4-dev-tools qt4-qmake libxml2-utils libpcre3
+ - sudo apt-get install -qq python-pygments libqt4-core libqt4-gui libqt4-dev qt4-dev-tools qt4-qmake libxml2-utils libpcre3 gdb
 script:
 # compile cppcheck, default build
   - make -j4


### PR DESCRIPTION
former output:

{ test -n "" && DESTDIR="" || DESTDIR=.; } && test $(gdb --version | sed -e 's,[^0-9]+([0-9]).([0-9]).*,\1\2,;q') -gt 72
&& gdb --nx --batch --quiet -ex 'set confirm off' -ex "save gdb-index $DESTDIR" -ex quit 'cppcheck-gui' && test -f
cppcheck-gui.gdb-index && objcopy --add-section '.gdb_index=cppcheck-gui.gdb-index' --set-section-flags '.gdb_index=readonly'
'cppcheck-gui' 'cppcheck-gui' && rm -f cppcheck-gui.gdb-index || true
/bin/sh: 1: gdb: not found
/bin/sh: 1: test: -gt: unexpected operator

fixes the "gdb not found" issue.
