### PR TITLE
5505: FP: Array accessed out of bounds

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -688,7 +688,7 @@ void CheckBufferOverrun::checkFunctionParameter(const Token &tok, unsigned int p
 
             // Check the parameter usage in the function scope..
             for (const Token* ftok = func->functionScope->classStart; ftok != func->functionScope->classEnd; ftok = ftok->next()) {
-                if (Token::Match(ftok, "if|for|while (")) {
+                if (Token::Match(ftok, "if|for|switch|while (")) {
                     // bailout if there is buffer usage..
                     if (bailoutIfSwitch(ftok, parameter->declarationId())) {
                         break;

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -2774,6 +2774,17 @@ private:
               "    f(a);\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(int a[]) {\n"
+              "  switch (2) {\n"
+              "    case 1:\n"
+              "      a[1] = 1;\n"
+              "    }\n"
+              "}\n"
+              "int a[1];\n"
+              "f(a);\n"
+              "");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void possible_buffer_overrun_1() { // #3035


### PR DESCRIPTION
CheckBufferOverrun::checkFunctionParameter alreacy considered usage of a
function parameter inside an if block as a special case.

With the patch the same is done for switch statements.

A test is added.

Signed-off-by: Heinrich Schuchardt xypron.glpk@gmx.de
