### PR TITLE
Ticket #5373: delete can match %type% in C (take #2)

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -29,6 +29,8 @@
 #include <map>
 #include <stack>
 
+bool Token::_isCPP = true;
+
 Token::Token(Token **t) :
     tokensBack(t),
     _next(0),
@@ -600,7 +602,7 @@ bool Token::Match(const Token *tok, const char pattern[], unsigned int varid)
                 // Type (%type%)
             {
                 p += 5;
-                multicompare(p,tok->isName() && tok->varId() == 0 && tok->str() != "delete",ismulticomp);
+                multicompare(p, tok->isName() && tok->varId() == 0 && (tok->str() != "delete" || !Token::isCPP()), ismulticomp);
             }
             break;
             case 'a':

--- a/lib/token.h
+++ b/lib/token.h
@@ -679,6 +679,8 @@ private:
     // original name like size_t
     std::string _originalName;
 
+    static bool _isCPP;
+
 public:
     void astOperand1(Token *tok);
     void astOperand2(Token *tok);
@@ -728,6 +730,8 @@ public:
     void printAst(bool verbose) const;
 
     void printValueFlow() const;
+    static void isCPP(bool isCPP) { _isCPP = isCPP; }
+    static bool isCPP() { return _isCPP; }
 };
 
 /// @}

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1589,6 +1589,8 @@ bool Tokenizer::tokenize(std::istream &code,
         return false;
     }
 
+    Token::isCPP(isCPP());
+
     if (simplifyTokenList1()) {
 
         createSymbolDatabase();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -263,6 +263,7 @@ private:
         TEST_CASE(varid53); // #4172 - Template instantiation: T<&functionName> list[4];
         TEST_CASE(varid54); // hang
         TEST_CASE(varid_cpp_keywords_in_c_code);
+        TEST_CASE(varid_cpp_keywords_in_c_code2); // #5373: varid=0 for argument called "delete"
         TEST_CASE(varidFunctionCall1);
         TEST_CASE(varidFunctionCall2);
         TEST_CASE(varidFunctionCall3);
@@ -3983,6 +3984,19 @@ private:
                                 "4: }\n";
 
         ASSERT_EQUALS(expected, tokenizeDebugListing(code,false,"test.c"));
+    }
+
+    void varid_cpp_keywords_in_c_code2() { // #5373
+       const char code[] = "int clear_extent_bit(struct extent_io_tree *tree, u64 start, u64 end, "
+                           "unsigned long bits, int wake, int delete, struct extent_state **cached_state, "
+                            "gfp_t mask) {\n"
+                            "  struct extent_state *state;\n"
+                            "}"
+                            "int clear_extent_dirty() {\n"
+                            "  return clear_extent_bit(tree, start, end, EXTENT_DIRTY | EXTENT_DELALLOC | "
+                            "                          EXTENT_DO_ACCOUNTING, 0, 0, NULL, mask);\n"
+                            "}";
+        tokenizeDebugListing(code, false, "test.c");
     }
 
     void varidFunctionCall1() {

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -113,8 +113,8 @@ class MatchCompiler:
             return '(tok->type()==Token::eString)'
         elif tok == '%type%':
             return (
-                '(tok->isName() && tok->varId()==0U && tok->str() != ' +
-                self._insertMatchStr('delete') + '/* delete */)'
+                '(tok->isName() && tok->varId()==0U && (tok->str() != ' +
+                self._insertMatchStr('delete') + '/* delete */ || !Token::isCPP()))'
             )
         elif tok == '%var%':
             return 'tok->isName()'


### PR DESCRIPTION
Hi,

This is an alternative to PR#248 that implements the suggestion to add a flag to Token to know whether we're processing a C++ file or not. Thanks to consider pulling.

Cheers,
  Simon
