### PR TITLE
cmdlineparser: remove --xml-version option, instead, --xml and --xml1 will use XML1 and --xml2 will use XML2.

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -290,18 +290,18 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
             _settings->_xml = true;
 
         // Define the XML file version (and enable XML output)
-        else if (std::strncmp(argv[i], "--xml-version=", 14) == 0) {
-            std::string numberString(argv[i]+14);
+        else if (std::strncmp(argv[i], "--xml2", 5) == 0) {
+            std::string numberString(argv[i]+5);
 
             std::istringstream iss(numberString);
             if (!(iss >> _settings->_xml_version)) {
-                PrintMessage("cppcheck: argument to '--xml-version' is not a number.");
+                PrintMessage("cppcheck: 'use --xml or --xml1 for XML 1, --xml2 for XML 2'");
                 return false;
             }
 
             if (_settings->_xml_version < 0 || _settings->_xml_version > 2) {
                 // We only have xml versions 1 and 2
-                PrintMessage("cppcheck: '--xml-version' can only be 1 or 2.");
+                PrintMessage("cppcheck: 'use --xml or --xml1 for XML 1, --xml2 for XML 2'");
                 return false;
             }
 
@@ -740,7 +740,7 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
     }
 
     if (_settings->inconclusive && _settings->_xml && _settings->_xml_version == 1U) {
-        PrintMessage("cppcheck: inconclusive messages will not be shown, because the old xml format is not compatible. It's recommended to use the new xml format (use --xml-version=2).");
+        PrintMessage("cppcheck: inconclusive messages will not be shown, because the old xml format is not compatible. It's recommended to use the new xml format (use --xml2).");
     }
 
     if (argc <= 1)
@@ -935,7 +935,7 @@ void CmdLineParser::PrintHelp()
               "    -v, --verbose        Output more detailed error information.\n"
               "    --version            Print out version number.\n"
               "    --xml                Write results in xml format to error stream (stderr).\n"
-              "    --xml-version=<version>\n"
+              "    --xml<version>\n"
               "                         Select the XML file version. Currently versions 1 and\n"
               "                         2 are available. The default version is 1."
               "\n"

--- a/createrelease
+++ b/createrelease
@@ -9,7 +9,7 @@
 # make test
 # cppcheck --errorlist > errlist.xml
 # xmllint --noout errlist.xml
-# cppcheck --xml-version=2 --errorlist > errlist.xml
+# cppcheck --xml2 --errorlist > errlist.xml
 # xmllint --noout errlist.xml
 #
 # Update AUTHORS using output from:

--- a/htmlreport/check.sh
+++ b/htmlreport/check.sh
@@ -6,12 +6,12 @@
 echo -e "\n"
 
 
-../cppcheck ../gui/test --enable=all  --inconclusive --xml-version=2 2> gui_test.xml
+../cppcheck ../gui/test --enable=all  --inconclusive --xml2 2> gui_test.xml
 xmllint --noout gui_test.xml
 ./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive test" --report-dir .
 echo ""
 
-../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml-version=2 2> gui_test.xml
+../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml2 2> gui_test.xml
 xmllint --noout gui_test.xml
 ./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive + verbose test" --report-dir .
 echo -e "\n"
@@ -22,6 +22,6 @@ xmllint --noout errorlist.xml
 ./cppcheck-htmlreport --file ./errorlist.xml --title "errorlist" --report-dir .
 echo ""
 
-../cppcheck --errorlist --inconclusive --xml-version=2 > errorlist.xml
+../cppcheck --errorlist --inconclusive --xml2 > errorlist.xml
 xmllint --noout errorlist.xml
 ./cppcheck-htmlreport --file ./errorlist.xml --title "errorlist" --report-dir .

--- a/htmlreport/test_htmlreport.py
+++ b/htmlreport/test_htmlreport.py
@@ -92,7 +92,7 @@ def runCheck(source_filename=None, xml_version='1', xml_filename=None):
         with open(xml_filename, 'w') as output_file:
             subprocess.check_call(
                 [CPPCHECK_BIN, '--xml', source_filename,
-                 '--xml-version=' + xml_version],
+                 '--xml' + xml_version],
                 stderr=output_file)
 
     assert os.path.exists(xml_filename)

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -224,7 +224,7 @@ std::string ErrorLogger::ErrorMessage::toXML(bool verbose, int version) const
         return printer.CStr();
     }
 
-    // The xml format you get when you use --xml-version=2
+    // The xml format you get when you use --xml2
     else if (version == 2) {
         tinyxml2::XMLPrinter printer(0, false, 2);
         printer.OpenElement("error", false);

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -137,7 +137,7 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
       <arg choice="opt"><option>--verbose</option></arg>
       <arg choice="opt"><option>--version</option></arg>
       <arg choice="opt"><option>--xml</option></arg>
-      <arg choice="opt"><option>--xml-version=&lt;version&gt;]</option></arg>
+      <arg choice="opt"><option>--xml&lt;version&gt;]</option></arg>
       <arg choice="opt"><option>file or path</option></arg>
       <arg choice="plain"><option>...</option></arg>
     </cmdsynopsis>
@@ -526,7 +526,7 @@ There are false positives with this option. Each result must be carefully invest
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--xml-version=&lt;version&gt;</option></term>
+        <term><option>--xml&lt;version&gt;</option></term>
         <listitem>
           <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1.</para>
         </listitem>

--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -297,7 +297,7 @@ cppcheck -DA --force file.c</programlisting>
     attributes and elements. A sample command to check a file and output
     errors in the new <literal>XML</literal> format:</para>
 
-    <para><programlisting>cppcheck --xml-version=2 file1.cpp</programlisting>Here
+    <para><programlisting>cppcheck --xml2 file1.cpp</programlisting>Here
     is a sample version 2 report:</para>
 
     <programlisting>&lt;?xml version="1.0" encoding="UTF-8"?&gt;

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -827,7 +827,7 @@ private:
 
     void xmlver1() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml-version=1", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml1", "file.cpp"};
         settings._xml_version = 1;
         settings._xml = false;
         ASSERT(defParser.ParseFromArgs(3, argv));
@@ -837,7 +837,7 @@ private:
 
     void xmlver2() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml-version=2", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml2", "file.cpp"};
         settings._xml_version = 1;
         settings._xml = false;
         ASSERT(defParser.ParseFromArgs(3, argv));
@@ -847,7 +847,7 @@ private:
 
     void xmlver2both() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml", "--xml-version=2", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml", "--xml2", "file.cpp"};
         settings._xml_version = 1;
         settings._xml = false;
         ASSERT(defParser.ParseFromArgs(4, argv));
@@ -857,7 +857,7 @@ private:
 
     void xmlver2both2() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml-version=2", "--xml", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml2", "--xml", "file.cpp"};
         settings._xml_version = 1;
         settings._xml = false;
         ASSERT(defParser.ParseFromArgs(4, argv));
@@ -867,14 +867,14 @@ private:
 
     void xmlverunknown() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml", "--xml-version=3", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml", "--xml3", "file.cpp"};
         // FAils since unknown XML format version
         ASSERT_EQUALS(false, defParser.ParseFromArgs(4, argv));
     }
 
     void xmlverinvalid() {
         REDIRECT;
-        const char *argv[] = {"cppcheck", "--xml", "--xml-version=a", "file.cpp"};
+        const char *argv[] = {"cppcheck", "--xml", "--xmla", "file.cpp"};
         // FAils since unknown XML format version
         ASSERT_EQUALS(false, defParser.ParseFromArgs(4, argv));
     }


### PR DESCRIPTION
basically, as the heading says:
--xml => XML1 
--xml1 => XML1
--xml2 => XML 2

however
--xml2 --xml => XML2
--xml2 --xml1 => XML1
is this an issue?
