### PR TITLE
daca: count varid 0 occurences per file

### DIFF
--- a/tools/daca2-report.py
+++ b/tools/daca2-report.py
@@ -58,7 +58,8 @@ mainpage.write(
     '<th>Performance</th>' +
     '<th>Portability</th>' +
     '<th>Style</th>' +
-    '<th>Crashes</th></tr>\n')
+    '<th>Crashes</th>' +
+    '<th>VarID 0</th></tr>\n')
 
 lastupdate = None
 recent = []
@@ -104,6 +105,7 @@ for lib in range(2):
                 '<td>' + str(data.count('(portability)')) + '</td>' +
                 '<td>' + str(data.count('(style)')) + '</td>' +
                 '<td>' + str(data.count('Crash?')) + '</td>' +
+                '<td>' + str(data.count('with varid 0.')) + '</td>' +
                 '</tr>\n')
 
             data = data.replace('&', '&amp;')


### PR DESCRIPTION
Count varID0s per file (as we do for the crashes) and print them into the table.

I didn't test this, but since there was no escaping on the brackets or the question mark needed, I assume the whitespaces and the dot don't need to be escaped.
