### PR TITLE
Use simple match where possible

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -632,7 +632,7 @@ void CheckBufferOverrun::checkFunctionParameter(const Token &tok, unsigned int p
         }
     }
 
-    if (Token::Match(tok.previous(), ".") || Token::Match(tok.tokAt(-2), "!!std ::"))
+    if (Token::simpleMatch(tok.previous(), ".") || Token::Match(tok.tokAt(-2), "!!std ::"))
         total_size.clear();
 
     std::map<std::string, unsigned int>::const_iterator it = total_size.find(tok.str());
@@ -1394,7 +1394,7 @@ bool CheckBufferOverrun::isArrayOfStruct(const Token* tok, int &position)
             } else
                 break;
         }
-        if (Token::Match(tok->next(),";")) {
+        if (Token::simpleMatch(tok->next(),";")) {
             position = i;
             return true;
         }

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -969,7 +969,7 @@ void CheckClass::checkMemset()
                     if (var && arg1->strAt(1) == ",") {
                         if (var->isPointer()) {
                             derefs--;
-                            if (var->typeEndToken() && Token::Match(var->typeEndToken()->previous(), "* *")) // Check if it's a pointer to pointer
+                            if (var->typeEndToken() && Token::simpleMatch(var->typeEndToken()->previous(), "* *")) // Check if it's a pointer to pointer
                                 derefs--;
                         }
 

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1333,7 +1333,7 @@ CheckIO::ArgumentInfo::ArgumentInfo(const Token * tok, const Settings *settings)
         } else if (tok->str() == "&" || tok->type() == Token::eVariable ||
                    tok->type() == Token::eFunction || Token::Match(tok, "%type% ::") ||
                    (Token::Match(tok, "static_cast|reinterpret_cast|const_cast <") &&
-                    Token::Match(tok->linkAt(1), "> (") &&
+                    Token::simpleMatch(tok->linkAt(1), "> (") &&
                     Token::Match(tok->linkAt(1)->linkAt(1), ") ,|)"))) {
             if (Token::Match(tok, "static_cast|reinterpret_cast|const_cast")) {
                 typeToken = tok->tokAt(2);

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -410,7 +410,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown)
             return false;
 
         // OK to delete a null
-        if (Token::Match(prev, "delete") || Token::Match(prev->tokAt(-2), "delete [ ]"))
+        if (Token::simpleMatch(prev, "delete") || Token::Match(prev->tokAt(-2), "delete [ ]"))
             return false;
 
         // OK to check if pointer is null

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -83,7 +83,7 @@ static bool isSameExpression(const Token *tok1, const Token *tok2, const std::se
         (Token::Match(tok2, "%var% <") && tok2->next()->link())) {
 
         // non-const template function that is not a dynamic_cast => return false
-        if (Token::Match(tok1->next()->link(), "> (") &&
+        if (Token::simpleMatch(tok1->next()->link(), "> (") &&
             !(tok1->function() && tok1->function()->isConst) &&
             tok1->str() != "dynamic_cast")
             return false;
@@ -2178,7 +2178,7 @@ void CheckOther::checkIncompleteStatement()
             tok = tok->linkAt(2);
 
         // C++11 initialize set in initalizer list : [,:] std::set<int>{1} [{,]
-        else if (Token::Match(tok,"> {") && tok->link())
+        else if (Token::simpleMatch(tok,"> {") && tok->link())
             tok = tok->next()->link();
 
         else if (Token::Match(tok, "[;{}] %str%") || Token::Match(tok, "[;{}] %num%")) {

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -296,11 +296,11 @@ void CheckSizeof::sizeofVoid()
                 const Token* tok2 = tok->tokAt(index);
                 if (index == 0) {
                     bool isMember = false;
-                    while (Token::Match(tok2->previous(), ".")) {
+                    while (Token::simpleMatch(tok2->previous(), ".")) {
                         isMember = true;
-                        if (Token::Match(tok2->tokAt(-2), ")"))
+                        if (Token::simpleMatch(tok2->tokAt(-2), ")"))
                             tok2 = tok2->tokAt(-2)->link();
-                        else if (Token::Match(tok2->tokAt(-2), "]"))
+                        else if (Token::simpleMatch(tok2->tokAt(-2), "]"))
                             tok2 = tok2->tokAt(-2)->link()->previous();
                         else
                             tok2 = tok2->tokAt(-2);
@@ -315,7 +315,7 @@ void CheckSizeof::sizeofVoid()
                 // Check for cast on operations with '+|-'
                 if (Token::Match(tok, "%var% +|-")) {
                     // Check for cast expression
-                    if (Token::Match(tok2->previous(), ")") && !Token::Match(tok2->previous()->link(), "( const| void *"))
+                    if (Token::simpleMatch(tok2->previous(), ")") && !Token::Match(tok2->previous()->link(), "( const| void *"))
                         continue;
                 }
                 arithOperationsOnVoidPointerError(tok, varname,

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1506,10 +1506,10 @@ void CheckStl::checkDereferenceInvalidIterator()
 
             // For "for" loops, only search between the two semicolons
             if (i->type == Scope::eFor) {
-                startOfCondition = Token::findmatch(tok->tokAt(2), ";", endOfCondition);
+                startOfCondition = Token::findsimplematch(tok->tokAt(2), ";", endOfCondition);
                 if (!startOfCondition)
                     continue;
-                endOfCondition = Token::findmatch(startOfCondition->next(), ";", endOfCondition);
+                endOfCondition = Token::findsimplematch(startOfCondition->next(), ";", endOfCondition);
                 if (!endOfCondition)
                     continue;
             }
@@ -1591,11 +1591,11 @@ void CheckStl::readingEmptyStlContainer()
         if (Token::Match(tok, "%var% =|[")) {
             const Token *tok2;
 
-            if (Token::Match(tok->next(), "="))
+            if (Token::simpleMatch(tok->next(), "="))
                 tok2 = tok->tokAt(2);
 
             // to check cases like Cmap[1]; or i = Cmap[1] -- the right wld evaluate true when token reaches it.
-            else if (Token::Match(tok->next()," [") && Token::Match(tok->linkAt(1),"] ="))
+            else if (Token::Match(tok->next()," [") && Token::simpleMatch(tok->linkAt(1),"] ="))
                 tok2 = tok->next()->link()->tokAt(2);
 
             else

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -373,7 +373,7 @@ private:
                 break;
             if (Token::Match(tok2, "%var% ("))
                 break;
-            if (Token::Match(tok2, "%var% <") && Token::Match(tok2->linkAt(1), "> ("))
+            if (Token::Match(tok2, "%var% <") && Token::simpleMatch(tok2->linkAt(1), "> ("))
                 break;
             if (tok2->varId() &&
                 !Token::Match(tok2->previous(), "&|::") &&

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -752,7 +752,7 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
             variables.clear();
             break;
         }
-        if (Token::Match(tok, "goto")) { // https://sourceforge.net/apps/trac/cppcheck/ticket/4447
+        if (Token::simpleMatch(tok, "goto")) { // https://sourceforge.net/apps/trac/cppcheck/ticket/4447
             variables.clear();
             break;
         }
@@ -790,7 +790,7 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
                 for (const Token *body = end->linkAt(-1); body != end; body = body->next()) {
                     if (body->varId() == 0U)
                         continue;
-                    if (!Token::Match(body->next(),"="))
+                    if (!Token::simpleMatch(body->next(),"="))
                         readvar.insert(body->varId());
                     else if (readvar.find(body->varId()) != readvar.end())
                         variables.erase(body->varId());

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -77,7 +77,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                 if (tok2 && tok2->next()) {
                     if (tok2->next()->str() == ";")
                         tok = tok2->next();
-                    else if (Token::Match(tok2->next(), "= {") &&
+                    else if (Token::simpleMatch(tok2->next(), "= {") &&
                              tok2->linkAt(2)->next()->str() == ";")
                         tok = tok2->linkAt(2)->next();
                     else if (Token::Match(tok2->next(), "(|{")  &&
@@ -1066,7 +1066,7 @@ void Variable::evaluate()
         setFlag(fIsArray, arrayDimensions(_dimensions, _name->next()));
     if (_start) {
         setFlag(fIsClass, !_start->isStandardType() && !isPointer() && !isReference());
-        _stlType = Token::Match(_start, "std ::");
+        _stlType = Token::simpleMatch(_start, "std ::");
     }
     if (_access == Argument) {
         tok = _name;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2204,7 +2204,7 @@ static bool setVarIdParseDeclaration(const Token **tok, const std::map<std::stri
                 ++typeCount;
             }
         } else if ((TemplateSimplifier::templateParameters(tok2) > 0) ||
-                   Token::Match(tok2, "< >") /* Ticket #4764 */) {
+                   Token::simpleMatch(tok2, "< >") /* Ticket #4764 */) {
             tok2 = tok2->findClosingBracket();
             if (!Token::Match(tok2, ">|>>"))
                 break;
@@ -2727,7 +2727,7 @@ void Tokenizer::createLinks2()
             }
 
             // if > is followed by ; .. "new a<b>;" is expected
-            if (Token::Match(token->next(), ";")) {
+            if (Token::simpleMatch(token->next(), ";")) {
                 Token *prev = type.top()->previous();
                 while (prev && Token::Match(prev->previous(), ":: %var%"))
                     prev = prev->tokAt(-2);
@@ -4231,8 +4231,8 @@ Token *Tokenizer::simplifyAddBracesPair(Token *tok, bool commandWithCondition)
     if (tokAfterCondition->str()=="{") {
         // already surrounded by braces
         tokBracesEnd=tokAfterCondition->link();
-    } else if (Token::Match(tokAfterCondition, "try {") &&
-               Token::Match(tokAfterCondition->linkAt(1), "} catch (")) {
+    } else if (Token::simpleMatch(tokAfterCondition, "try {") &&
+               Token::simpleMatch(tokAfterCondition->linkAt(1), "} catch (")) {
         tokAfterCondition->previous()->insertToken("{");
         Token * tokOpenBrace = tokAfterCondition->previous();
         Token * tokEnd = tokAfterCondition->linkAt(1)->linkAt(2)->linkAt(1);
@@ -5497,7 +5497,7 @@ void Tokenizer::simplifyPlatformTypes()
             } else if (Token::Match(tok, "HRESULT|LONG")) {
                 tok->originalName(tok->str());
                 tok->str("long");
-            } else if (Token::Match(tok, "INT8")) {
+            } else if (tok->str() == "INT8") {
                 tok->originalName(tok->str());
                 tok->str("char");
                 tok->isSigned(true);
@@ -5749,7 +5749,7 @@ void Tokenizer::simplifyIfAndWhileAssign()
         const bool iswhile(tok->next()->str() == "while");
 
         // simplifying a "do { } while(cond);" condition ?
-        const bool isDoWhile = iswhile && Token::Match(tok, "}") && Token::Match(tok->link()->previous(), "do");
+        const bool isDoWhile = iswhile && Token::simpleMatch(tok, "}") && Token::simpleMatch(tok->link()->previous(), "do");
         Token* openBraceTok = tok->link();
 
         // delete the "if|while"

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -51,7 +51,7 @@ static bool bailoutFunctionPar(const Token *tok, const ValueFlow::Value &value, 
         return false;
 
     // address of variable
-    const bool addressOf = tok && Token::Match(tok->previous(), "&");
+    const bool addressOf = tok && Token::simpleMatch(tok->previous(), "&");
 
     // passing variable to subfunction?
     if (Token::Match(tok->tokAt(-2), ") & %var% [,)]") && Token::Match(tok->linkAt(-2)->previous(), "[,(] ("))
@@ -406,7 +406,7 @@ static void valueFlowBeforeCondition(TokenList *tokenlist, ErrorLogger *errorLog
             } else if (tok2->str() == "{") {
                 // if variable is assigned in loop don't look before the loop
                 if (tok2->previous() &&
-                    (Token::Match(tok2->previous(), "do") ||
+                    (Token::simpleMatch(tok2->previous(), "do") ||
                      (tok2->strAt(-1) == ")" && Token::Match(tok2->linkAt(-1)->previous(), "for|while (")))) {
 
                     const Token *start = tok2;
@@ -422,7 +422,7 @@ static void valueFlowBeforeCondition(TokenList *tokenlist, ErrorLogger *errorLog
                 if (!var->isLocal()) {
                     if (!Token::Match(tok2->previous(), ")|else|do {"))
                         break;
-                    if (Token::Match(tok2->previous(), ") {") &&
+                    if (Token::simpleMatch(tok2->previous(), ") {") &&
                         !Token::Match(tok2->linkAt(-1)->previous(), "if|for|while ("))
                         break;
                 }
@@ -484,7 +484,7 @@ static void valueFlowAfterAssign(TokenList *tokenlist, ErrorLogger *errorLogger,
                 tok2 = tok2->linkAt(1);
 
             // conditional block of code that assigns variable..
-            if (Token::Match(tok2, "%var% (") && Token::Match(tok2->linkAt(1), ") {")) {
+            if (Token::Match(tok2, "%var% (") && Token::simpleMatch(tok2->linkAt(1), ") {")) {
                 Token * const start = tok2->linkAt(1)->next();
                 Token * const end   = start->link();
                 if (Token::findmatch(start, "%varid%", end, varid)) {
@@ -508,7 +508,7 @@ static void valueFlowAfterAssign(TokenList *tokenlist, ErrorLogger *errorLogger,
                 // noreturn scopes..
                 if (number_of_if > 0 &&
                     (Token::findmatch(start, "return|continue|break", end) ||
-                     (Token::Match(end,"} else {") && Token::findmatch(end, "return|continue|break", end->linkAt(2))))) {
+                     (Token::simpleMatch(end,"} else {") && Token::findmatch(end, "return|continue|break", end->linkAt(2))))) {
                     if (settings->debugwarnings)
                         bailout(tokenlist, errorLogger, tok2, "variable " + var->nameToken()->str() + ". noreturn conditional scope.");
                     break;
@@ -612,7 +612,7 @@ static void valueFlowAfterAssign(TokenList *tokenlist, ErrorLogger *errorLogger,
 static void valueFlowForLoop(TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
 {
     for (Token *tok = tokenlist->front(); tok; tok = tok->next()) {
-        if (!Token::Match(tok, "for ("))
+        if (!Token::simpleMatch(tok, "for ("))
             continue;
 
         tok = tok->tokAt(2);


### PR DESCRIPTION
Fixes these warnings found by "--enable=internal":

[lib/checkclass.cpp:972]: (warning) Found simple pattern inside Token::Match() call: "\* *"
[lib/checkbufferoverrun.cpp:635]: (warning) Found simple pattern inside Token::Match() call: "."
[lib/checkbufferoverrun.cpp:1397]: (warning) Found simple pattern inside Token::Match() call: ";"
[lib/checksizeof.cpp:299]: (warning) Found simple pattern inside Token::Match() call: "."
[lib/checksizeof.cpp:301]: (warning) Found simple pattern inside Token::Match() call: ")"
[lib/checksizeof.cpp:303]: (warning) Found simple pattern inside Token::Match() call: "]"
[lib/checksizeof.cpp:318]: (warning) Found simple pattern inside Token::Match() call: ")"
[lib/checknullpointer.cpp:413]: (warning) Found simple pattern inside Token::Match() call: "delete"
[lib/checkio.cpp:1336]: (warning) Found simple pattern inside Token::Match() call: "> ("
[lib/checkstl.cpp:1509]: (warning) Found simple pattern inside Token::findmatch() call: ";"
[lib/checkstl.cpp:1512]: (warning) Found simple pattern inside Token::findmatch() call: ";"
[lib/checkstl.cpp:1594]: (warning) Found simple pattern inside Token::Match() call: "="
[lib/checkstl.cpp:1598]: (warning) Found simple pattern inside Token::Match() call: "] ="
[lib/checkunusedvar.cpp:755]: (warning) Found simple pattern inside Token::Match() call: "goto"
[lib/checkunusedvar.cpp:793]: (warning) Found simple pattern inside Token::Match() call: "="
[lib/checkuninitvar.cpp:376]: (warning) Found simple pattern inside Token::Match() call: "> ("
[lib/checkother.cpp:86]: (warning) Found simple pattern inside Token::Match() call: "> ("
[lib/checkother.cpp:2181]: (warning) Found simple pattern inside Token::Match() call: "> {"
[lib/valueflow.cpp:54]: (warning) Found simple pattern inside Token::Match() call: "&"
[lib/valueflow.cpp:409]: (warning) Found simple pattern inside Token::Match() call: "do"
[lib/valueflow.cpp:425]: (warning) Found simple pattern inside Token::Match() call: ") {"
[lib/valueflow.cpp:487]: (warning) Found simple pattern inside Token::Match() call: ") {"
[lib/valueflow.cpp:511]: (warning) Found simple pattern inside Token::Match() call: "} else {"
[lib/valueflow.cpp:615]: (warning) Found simple pattern inside Token::Match() call: "for ("
[lib/symboldatabase.cpp:80]: (warning) Found simple pattern inside Token::Match() call: "= {"
[lib/symboldatabase.cpp:1069]: (warning) Found simple pattern inside Token::Match() call: "std ::"
[lib/tokenize.cpp:2207]: (warning) Found simple pattern inside Token::Match() call: "< >"
[lib/tokenize.cpp:2730]: (warning) Found simple pattern inside Token::Match() call: ";"
[lib/tokenize.cpp:4234]: (warning) Found simple pattern inside Token::Match() call: "try {"
[lib/tokenize.cpp:4235]: (warning) Found simple pattern inside Token::Match() call: "} catch ("
[lib/tokenize.cpp:5500]: (warning) Found simple pattern inside Token::Match() call: "INT8"
[lib/tokenize.cpp:5752]: (warning) Found simple pattern inside Token::Match() call: "}"
[lib/tokenize.cpp:5752]: (warning) Found simple pattern inside Token::Match() call: "do"
