### PR TITLE
Extended std.cfg about <cstring> functions and added testcases.

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -38,15 +38,19 @@
 
   <function name="strcat">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
   <function name="strchr">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> </function>
-  <function name="strcpy">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
   <function name="strcmp">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
+  <function name="strcpy">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
   <function name="strdup">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> </function>
   <function name="strlen">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> </function>
-  <function name="strncat"> <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> <arg nr="3"><not-bool/><valid>0-</valid></arg> </function>
   <function name="strncpy"> <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/></arg> <arg nr="2"><not-null/><not-uninit/></arg> <arg nr="3"><not-bool/><valid>0-</valid></arg> </function>
+  <function name="strncat"> <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> <arg nr="3"><not-bool/><valid>0-</valid></arg> </function>
   <function name="strncmp"> <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> <arg nr="3"><not-bool/><valid>0-</valid></arg> </function>
   <function name="strstr">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
-
+  <function name="strspn">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
+  <function name="strerror"> <noreturn>false</noreturn> <leak-ignore/></function>
+  <function name="strcspn">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
+  <function name="strcoll">  <noreturn>false</noreturn> <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
+  
   <function name="strtol">   <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="3"><valid>0,2-36</valid></arg> </function>
   <function name="strtoll">  <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="3"><valid>0,2-36</valid></arg> </function>
   <function name="strtoul">  <leak-ignore/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="3"><valid>0,2-36</valid></arg> </function>

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2409,6 +2409,15 @@ private:
         check("void f(char*p,char*q){ strcpy (p,q);if(!p||!q){}}");
         ASSERT_EQUALS(errpq,errout.str());
 
+        check("void f(char*p,char*q){ strspn (p,q);if(!p||!q){}}");
+        ASSERT_EQUALS(errpq,errout.str());
+
+        check("void f(char*p,char*q){ strcspn (p,q);if(!p||!q){}}");
+        ASSERT_EQUALS(errpq,errout.str());
+
+        check("void f(char*p,char*q){ strcoll (p,q);if(!p||!q){}}");
+        ASSERT_EQUALS(errpq,errout.str());
+
         check("void f(char*p,char*q){ strcat (p,q);if(!p||!q){}}");
         ASSERT_EQUALS(errpq,errout.str());
 


### PR DESCRIPTION
I have added a few function definitions to std.cfg and the corresponding test cases.

Note: I also tried to add the following two lines:

```
   <function name="strrchr">  <noreturn>false</noreturn> <leak-igonre/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
   <function name="strpbrk"> <noreturn>false</noreturn> <leak-igonre/> <arg nr="1"><not-null/><not-uninit/></arg> <arg nr="2"><not-null/><not-uninit/></arg> </function>
```

These two lines lead to failing tests in in our testsuite, does anybody know why? I have excluded this lines from this pull request so far, so it can go in.
