### PR TITLE
travis: check kernel as part of travis testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
 #   this also turns off the debug/warning cxxflags
     - CXXFLAGS="-O2 -Wunreachable-code"
   matrix:
+#    special CXXFLAGS for maximum speed, overrides global CXXFLAGS  CHECK_KERNEL is the var that controlls if we check and clone the kernel in that travis job
+    - CXXFLAGS="-O3 -march=native -mtune=native" SRCDIR=build CHECK_KERNEL=yes
     - MAKEFLAGS="HAVE_RULES=yes" SRCDIR=build VERIFY=1
     - SRCDIR=build VERIFY=1
     - MAKEFLAGS="HAVE_RULES=yes"
@@ -20,6 +22,8 @@ before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-pygments libqt4-core libqt4-gui libqt4-dev qt4-dev-tools qt4-qmake libxml2-utils libpcre3 gdb
 script:
+# download 3.14-rc6 kernel, compile cppcheck, run cppcheck on the kernel to look for crashes in cppcheck. if this is done, terminate build to prevent it from timing out
+  - if [[ "$CHECK_KERNEL" == "yes" ]]; then wget https://www.kernel.org/pub/linux/kernel/v3.x/testing/linux-3.14-rc6.tar.xz; mkdir kernel; tar -xJf linux-3.14-rc6.tar.xz -C kernel & make -j 4 & wait; touch /tmp/kernel.cppcheck; ./cppcheck kernel --max-configs=1 -j 2 |& tee /tmp/kernel.cppcheck; ! grep "process crashed with signal 11" /tmp/kernel.cppcheck; exit; fi
 # compile cppcheck, default build
   - make -j4
   - make test -j4


### PR DESCRIPTION
add 2 more jobs (one for gcc, one for clang) which only compile Cppcheck with opimization CXXFLAGS to afterwards check a fixed version of the linux kernel to see if cppcheck crashes.

more detailed:
we add 2 additional jobs with CXXFLAGS that will speed  up cppcheck and set a control var.
Then we install the dependencies etc as usual.
Now, instead of running make and make check, we download a kernel tarball and extract it, build cppcheck with the CXXFLAGS.
If this is done, let cppcheck check the kernel and write the results to a log file.
When we are finished, we check the log file if it says that cppcheck has crashed while checking the kernel, if it did, return false and make travis fail the job. When this is done, end the job to prevent us from timing out (and do not run make check, build gui etc etc in that job).

In comparison to master branch this will slow down travis build by around 10 minutes (also depends on travis which can behave funky sometimes), but we will find more bug of cppcheck that the test suit wont cover. There have been a few cases since 1.64 where cppcheck crashed against the kernel which was not noticed in any way by the test suit or travis.
