### PR TITLE
travis: remove hack to terminate clang kernel jobs early, instead avoid it properly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,37 @@
 language: cpp
+
 compiler:
   - gcc
   - clang
+
 env:
   global:
 #   unfortunately we need this to stay within 50min timelimit given by travis.
 #   this also turns off the debug/warning cxxflags
     - CXXFLAGS="-O2 -Wunreachable-code"
   matrix:
-#    special CXXFLAGS for maximum speed, overrides global CXXFLAGS  CHECK_KERNEL is the var that controlls if we check and clone the kernel in that travis job
+#    special CXXFLAGS for maximum speed, overrides global CXXFLAGS, CHECK_KERNEL is the var that controlls if we download and check the kernel in that travis job
     - CXXFLAGS="-O3 -march=native -mtune=native" SRCDIR=build CHECK_KERNEL=yes
     - MAKEFLAGS="HAVE_RULES=yes" SRCDIR=build VERIFY=1
     - SRCDIR=build VERIFY=1
     -
-# do notify immediately about it when a sub-job of a  build fails.
+
 matrix:
+# do notify immediately about it when a job of a build fails.
   fast_finish: true
+# exclude kernel checking with clang binary, not needed
+  exclude:
+    - compiler: clang
+      env: CXXFLAGS="-O3 -march=native -mtune=native" SRCDIR=build CHECK_KERNEL=yes
+
 before_install:
 # install needed deps
  - sudo apt-get update -qq
  - sudo apt-get install -qq python-pygments libqt4-core libqt4-gui libqt4-dev qt4-dev-tools qt4-qmake libxml2-utils libpcre3 gdb
+
 script:
 # download 3.14-rc6 kernel, compile cppcheck, run cppcheck on the kernel to look for crashes in cppcheck. if this is done, terminate build to prevent it from timing out
   - if [[ "$CHECK_KERNEL" == "yes" ]] && [[ "$CC" == "gcc" ]]; then wget https://www.kernel.org/pub/linux/kernel/v3.x/testing/linux-3.14-rc6.tar.xz; mkdir kernel; tar -xJf linux-3.14-rc6.tar.xz -C kernel & make -j 4 & wait; touch /tmp/kernel.cppcheck; ./cppcheck kernel --max-configs=1 -j 2 |& tee /tmp/kernel.cppcheck; ! grep "process crashed with signal 11" /tmp/kernel.cppcheck; exit; fi
-# if compiler is clang, exit the build to save travis some resources
-  - if [[ "$CHECK_KERNEL" == "yes" ]] && [[ "$CC" == "clang" ]]; then exit; fi
 # compile cppcheck, default build
   - make -j4
   - make test -j4
@@ -71,6 +78,7 @@ script:
   - ./dmake
 #   now, if dmake modified the makefile, return false!
   - git diff --exit-code
+
 notifications:
   irc:
     channels:
@@ -79,4 +87,3 @@ notifications:
       - "[%{commit} : %{author}] %{message}"
       - "%{build_url}"
     skip_join: true
-


### PR DESCRIPTION
(and do some minor style changes)

I asked in #travis how to exclude a job and apparently it was possible in a non hacky way :)
