### PR TITLE
travis: allow failure of the kernel job. It sometimes times out when travis is on heavy load (which is a false positive).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,10 @@ script:
   - make -j4
 # building gui generates some more files that cppcheck can check, so check the repo *after* building gui
   - cd ../
-  - ./cppcheck --error-exitcode=1 -Ilib --enable=style --suppressions-list=.travis_suppressions .
+# use same hack as for kernel to work around cppchecks broken exit status with -j 2 ; create file, tee everything to the file and stdout, grep for errors in the file
+  - touch /tmp/cppcheck.cppcheck
+  - ./cppcheck --error-exitcode=1 -Ilib --enable=style --suppressions-list=.travis_suppressions . -j 2 |& tee /tmp/cppcheck.cppcheck
+  - sh -c "! grep "^\[" /tmp/cppcheck.cppcheck"
   - cd ./gui
 # clean rebuild
   - git clean -dfx .


### PR DESCRIPTION
If kernel job fails, it will still be shown when you check the travis page of the build, but it wont make the entire build fail.
