### PR TITLE
travis: fix grep of cppcheck.cppcheck log checking cppcheck code for errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
 # use same hack as for kernel to work around cppchecks broken exit status with -j 2 ; create file, tee everything to the file and stdout, grep for errors in the file
   - touch /tmp/cppcheck.cppcheck
   - ./cppcheck --error-exitcode=1 -Ilib --enable=style --suppressions-list=.travis_suppressions . -j 2 |& tee /tmp/cppcheck.cppcheck
-  - sh -c "! grep "^\[" /tmp/cppcheck.cppcheck"
+  - sh -c "! grep '^\[' /tmp/cppcheck.cppcheck"
   - cd ./gui
 # clean rebuild
   - git clean -dfx .


### PR DESCRIPTION
I'm sorry, I broke checking for errors in cppchecks own code.
I forgot to escape the quotation marks in the grep command which broke grepping for errors in the log.
Since I also negated the exit status to return false upon match, the error didn't cause the build to fail.

The build fails now because this
[test/testio.cpp:1138]: (style) Variable 'result_win64' is assigned a value that is never used.
is now successfully detected.
