### PR TITLE
Make use of Visual C++ runtime memory leak tracing

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -108,6 +108,11 @@ void CheckOther::checkZeroDivision()
  */
 int main(int argc, char* argv[])
 {
+    // MS Visual C++ memory leak debug tracing
+#if defined(_MSC_VER) && defined(_DEBUG)
+    _CrtSetDbgFlag( _CrtSetDbgFlag( _CRTDBG_REPORT_FLAG ) | _CRTDBG_LEAK_CHECK_DF);
+#endif
+
     CppCheckExecutor exec;
 #ifdef _WIN32
     char exename[1024] = {0};

--- a/lib/config.h
+++ b/lib/config.h
@@ -13,4 +13,10 @@
 #  define CPPCHECKLIB
 #endif
 
+// MS Visual C++ memory leak debug tracing
+#if defined(_MSC_VER) && defined(_DEBUG)
+#  define _CRTDBG_MAP_ALLOC
+#  include <crtdbg.h>
+#endif
+
 #endif // configH


### PR DESCRIPTION
These changes ask Visual C++ runtime to track all memory allocations and then dump all memory leaks when the program is exiting. The changes are conditionally compiled only when the compilation is being done with Visual C++ and the current configuration is "debug".
