### PR TITLE
stdout: insert space between filename and three dots ("Checking foo.c..." -> "Checking foo.c ...")

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -140,7 +140,7 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
     if (_settings._errorsOnly == false) {
         std::string fixedpath = Path::simplifyPath(filename.c_str());
         fixedpath = Path::toNativeSeparators(fixedpath);
-        _errorLogger.reportOut(std::string("Checking ") + fixedpath + std::string("..."));
+        _errorLogger.reportOut(std::string("Checking ") + fixedpath + std::string(" ..."));
     }
 
     try {
@@ -211,7 +211,7 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
             if (_settings._errorsOnly == false && it != configurations.begin()) {
                 std::string fixedpath = Path::simplifyPath(filename.c_str());
                 fixedpath = Path::toNativeSeparators(fixedpath);
-                _errorLogger.reportOut(std::string("Checking ") + fixedpath + ": " + cfg + std::string("..."));
+                _errorLogger.reportOut(std::string("Checking ") + fixedpath + ": " + cfg + std::string(" ..."));
             }
 
             if (!_settings.userDefines.empty()) {


### PR DESCRIPTION
On some terminals you can double click on a string in order to copy it (and then paste it back into command line for example to open the file with an editor in the case of cppcheck).
The dots were selected as well so one had to remove them after pasting because the file "foo.c..." did not exist.

Inserting spaces between the file name and the dots fixes this problem, on doubleclick on the file, only the file is selected.
