### PR TITLE
Fix gui compilation with old gcc

### DIFF
--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -147,5 +147,5 @@ win32 {
 }
 
 contains(QMAKE_CC, gcc) {
-    QMAKE_CXXFLAGS += -std=c++0x
+    QMAKE_CXXFLAGS += -std=c++0x -include ../lib/cxx11emu.h
 }


### PR DESCRIPTION
cppcheck itself builds fine with gcc 4.4 because of c++11 emulation but gui doesn't because of missing cxx11emu.h
