### PR TITLE
Ticket #5605: Don't consider '>' as a default template parameter value.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -528,7 +528,7 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                 ++templatepar;
 
             // default parameter value
-            else if (tok->str() == "=")
+            else if (Token::Match(tok, "= !!>"))
                 eq.push_back(tok);
         }
         if (eq.empty() || classname.empty())

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -416,6 +416,7 @@ private:
         TEST_CASE(syntax_error);
         TEST_CASE(syntax_error_templates_1);
         TEST_CASE(syntax_error_templates_2);
+        TEST_CASE(syntax_error_templates_3); // Ticket #5605 - invalid template declaration
 
         TEST_CASE(removeKeywords);
 
@@ -6491,6 +6492,10 @@ private:
         Settings settings;
         Tokenizer tokenizer(&settings, this);
         tokenizer.tokenize(istr, "test.cpp");   // shouldn't segfault
+    }
+
+    void syntax_error_templates_3() { // Ticket #5605
+        tokenizeAndStringify("template < T = typename = > struct a { f <int> }");
     }
 
     void removeKeywords() {


### PR DESCRIPTION
Hi,

This trivial patch fixes this ticket, a core upon an invalid template declaration. We should not consider that "= >" in a template declaration is a parameter default value. Thanks to consider merging.

Cheers,
  Simon
