### PR TITLE
Fix ticket #5605 (take 2)

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -240,6 +240,12 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
         if (Token::Match(tok, "& ::| %var%"))
             tok = tok->next();
 
+        // Skip '='
+        if (Token::Match(tok, "="))
+            tok = tok->next();
+        if (!tok)
+            return 0;
+
         // skip std::
         if (tok && tok->str() == "::")
             tok = tok->next();
@@ -508,20 +514,31 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
         //     x = y
         // this list will contain all the '=' tokens for such arguments
         std::list<Token *> eq;
+        // and this set the position of parameters with a default value
+        std::set<std::size_t> defaultedArgPos;
 
         // parameter number. 1,2,3,..
         std::size_t templatepar = 1;
+
+        // parameter depth
+        std::size_t templateParmDepth = 0;
 
         // the template classname. This will be empty for template functions
         std::string classname;
 
         // Scan template declaration..
         for (Token *tok = *iter1; tok; tok = tok->next()) {
+
+            if (tok->str() == "<" && templateParameters(tok))
+                ++templateParmDepth;
+
             // end of template parameters?
-            if (tok->str() == ">") {
-                if (Token::Match(tok, "> class|struct %var%"))
+            if (tok->str() == ">" || tok->str() == ">>") {
+                if (Token::Match(tok, ">|>> class|struct %var%"))
                     classname = tok->strAt(2);
-                break;
+                templateParmDepth -= (1 + (tok->str() == ">>"));
+                if(0 == templateParmDepth)
+                    break;
             }
 
             // next template parameter
@@ -529,8 +546,15 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                 ++templatepar;
 
             // default parameter value
-            else if (tok->str() == "=")
-                eq.push_back(tok);
+            else if (Token::Match(tok, "= !!>")) {
+                if(defaultedArgPos.insert(templatepar).second) {
+                    eq.push_back(tok);
+                } else {
+                    // Ticket #5605: Syntax error (two equal signs for the same parameter), bail out
+                    eq.clear();
+                    break;
+                }
+            }
         }
         if (eq.empty() || classname.empty())
             continue;

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2461,10 +2461,10 @@ private:
         }
         {
             const char code[] = "template<class T, class T2 = A<T>> class B {};\n"
-                                "template<class B = A, typename C = C<B>> class C;\n"
+                                "template<class B = A, typename C = C<B>> class C {};\n"
                                 "template<class B, typename C> class D { };\n";
             ASSERT_EQUALS("template < class T , class T2 > class B { } ; "
-                          "template < class B , typename C > class C ; "
+                          "template < class B , typename C > class C { } ; "
                           "template < class B , typename C > class D { } ;", tok(code));
         }
     }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -416,6 +416,7 @@ private:
         TEST_CASE(syntax_error);
         TEST_CASE(syntax_error_templates_1);
         TEST_CASE(syntax_error_templates_2);
+        TEST_CASE(syntax_error_templates_3); // Ticket #5605 - invalid template declaration
 
         TEST_CASE(removeKeywords);
 
@@ -6495,6 +6496,13 @@ private:
         Settings settings;
         Tokenizer tokenizer(&settings, this);
         tokenizer.tokenize(istr, "test.cpp");   // shouldn't segfault
+    }
+
+    void syntax_error_templates_3() { // Ticket #5605
+        tokenizeAndStringify("foo() template<typename T1 = T2 = typename = unused, T5 = = unused> struct tuple Args> tuple<Args...> { } main() { foo<int,int,int,int,int,int>(); }");
+        tokenizeAndStringify("( ) template < T1 = typename = unused> struct Args { } main ( ) { foo < int > ( ) ; }");
+        tokenizeAndStringify("() template < T = typename = x > struct a {} { f <int> () }");
+        tokenizeAndStringify("template < T = typename = > struct a { f <int> }");
     }
 
     void removeKeywords() {


### PR DESCRIPTION
Hi,

This is a follow-up to https://github.com/danmar/cppcheck/pull/290 that contained an incomplete fix for this ticket, as it only corrected the last reduction, and not the previous ones...

This updated patch fixes all the cases reported in the ticket by:
- Making sure that TemplateSimplifier::templateParameters is not confused by default values
- Keeping track of each parameter's "level" in TemplateSimplifier::useDefaultArgumentValues, and bailing out if several '=' signs are encountered for a single template parameter

Thanks to consider merging.

Cheers,
  Simon
