### PR TITLE
Ticket #5709: Comma operator not properly tokenized.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7086,6 +7086,7 @@ bool Tokenizer::simplifyRedundantParentheses()
 
         while (Token::Match(tok->previous(), "[{([,] ( !!{") &&
                Token::Match(tok->link(), ") [;,])]") &&
+               !Token::simpleMatch(tok->tokAt(-2), "operator ,") && // Ticket #5709
                !Token::findsimplematch(tok, ",", tok->link())) {
             // We have "( ... )", remove the parentheses
             tok->link()->deleteThis();
@@ -10161,7 +10162,7 @@ void Tokenizer::simplifyOperatorName()
                     }
                     done = false;
                 }
-                if (Token::Match(par, ".|%op%")) {
+                if (Token::Match(par, ".|%op%|,")) {
                     op += par->str();
                     par = par->next();
                     done = false;

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -507,6 +507,7 @@ private:
         TEST_CASE(simplifyOperatorName6); // ticket #3194
         TEST_CASE(simplifyOperatorName7); // ticket #4619
         TEST_CASE(simplifyOperatorName8); // ticket #5706
+        TEST_CASE(simplifyOperatorName9); // ticket #5709 - comma operator not properly tokenized
 
         TEST_CASE(simplifyNull);
 
@@ -8171,6 +8172,11 @@ private:
         const char code6[] = "value_type * operator += (int) const throw ( ) ;";
         const char result6[] = "value_type * operator+= ( int ) const throw ( ) ;";
         ASSERT_EQUALS(result6, tokenizeAndStringify(code6,false));
+    }
+
+    void simplifyOperatorName9() { // Ticket #5709
+        const char code[] = "struct R { R operator, ( R b ) ; } ;";
+        ASSERT_EQUALS(code, tokenizeAndStringify(code));
     }
 
     void simplifyNull() {


### PR DESCRIPTION
Hi,

This patch fixes the ticket by ensuring comma operators are properly tokenized. Thanks to consider merging.

Cheers,
  Simon
