### PR TITLE
Reinstate error message.

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -584,7 +584,7 @@ bool Token::Match(const Token *tok, const char pattern[], unsigned int varid)
                     multicompare(p,tok->isName(),ismulticomp);
                 } else { // %varid%
                     if (varid == 0) {
-                        throw InternalError(tok, "Internal error. Tokentch called with varid 0. Please report this to Cppcheck developers");
+                        throw InternalError(tok, "Internal error. Token::Match called with varid 0. Please report this to Cppcheck developers");
                     }
 
                     if (tok->varId() != varid)


### PR DESCRIPTION
Hi,

An unexpected change in commit 520aaf71b850ecf21915dbca6a24543cbb5d6923 turned Token::Match into Tokentch... This patch reinstates the proper text. Thanks to consider merging.

Cheers,
  Simon
