### PR TITLE
Fix ticket #5605 (take 3)

### DIFF
--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2461,10 +2461,10 @@ private:
         }
         {
             const char code[] = "template<class T, class T2 = A<T>> class B {};\n"
-                                "template<class B = A, typename C = C<B>> class C;\n"
+                                "template<class B = A, typename C = C<B>> class C {};\n"
                                 "template<class B, typename C> class D { };\n";
             ASSERT_EQUALS("template < class T , class T2 > class B { } ; "
-                          "template < class B , typename C > class C ; "
+                          "template < class B , typename C > class C { } ; "
                           "template < class B , typename C > class D { } ;", tok(code));
         }
     }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -417,6 +417,7 @@ private:
         TEST_CASE(syntax_error);
         TEST_CASE(syntax_error_templates_1);
         TEST_CASE(syntax_error_templates_2);
+        TEST_CASE(syntax_error_templates_3); // Ticket #5605 - invalid template declaration
 
         TEST_CASE(removeKeywords);
 
@@ -6501,6 +6502,20 @@ private:
         Settings settings;
         Tokenizer tokenizer(&settings, this);
         tokenizer.tokenize(istr, "test.cpp");   // shouldn't segfault
+    }
+
+    void syntax_error_templates_3() { // Ticket #5605, #5759, #5762
+        tokenizeAndStringify("foo() template<typename T1 = T2 = typename = unused, T5 = = unused> struct tuple Args> tuple<Args...> { } main() { foo<int,int,int,int,int,int>(); }");
+        tokenizeAndStringify("( ) template < T1 = typename = unused> struct Args { } main ( ) { foo < int > ( ) ; }");
+        tokenizeAndStringify("() template < T = typename = x > struct a {} { f <int> () }");
+        tokenizeAndStringify("template < T = typename = > struct a { f <int> }");
+        tokenizeAndStringify("struct S { int i, j; }; "
+                             "template<int S::*p, typename U> struct X {}; "
+                             "X<&S::i, int> x = X<&S::i, int>(); "
+                             "X<&S::j, int> y = X<&S::j, int>(); ");
+        tokenizeAndStringify("template <typename T> struct A {}; "
+                             "template <> struct A<void> {}; "
+                             "void foo(const void* f = 0) {}");
     }
 
     void removeKeywords() {


### PR DESCRIPTION
Hi,

This PR is a follow-up to https://github.com/danmar/cppcheck/pull/291, that unfortunately caused a regression (see ticket #5759): we need to be a bit more clever at handling template parameters if they contain pointers to class members.

Thanks to consider merging.

Cheers,
  Simon
