### PR TITLE
Ticket #5774: Properly handle "typename..." in template parameter list.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -240,6 +240,12 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
         if (Token::Match(tok, "& ::| %var%"))
             tok = tok->next();
 
+        // Skip 'typename...' (Ticket #5774)
+        if (Token::Match(tok, "typename . . .")) {
+            tok = tok->tokAt(4);
+            continue;
+        }
+
         // Skip '='
         if (Token::Match(tok, "="))
             tok = tok->next();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -418,7 +418,7 @@ private:
         TEST_CASE(syntax_error);
         TEST_CASE(syntax_error_templates_1);
         TEST_CASE(syntax_error_templates_2);
-        TEST_CASE(syntax_error_templates_3); // Ticket #5605 - invalid template declaration
+        TEST_CASE(syntax_error_templates_3); // Ticket #5605, #5759, #5762, #5774
 
         TEST_CASE(removeKeywords);
 
@@ -6517,7 +6517,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");   // shouldn't segfault
     }
 
-    void syntax_error_templates_3() { // Ticket #5605, #5759, #5762
+    void syntax_error_templates_3() { // Ticket #5605, #5759, #5762, #5774
         tokenizeAndStringify("foo() template<typename T1 = T2 = typename = unused, T5 = = unused> struct tuple Args> tuple<Args...> { } main() { foo<int,int,int,int,int,int>(); }");
         tokenizeAndStringify("( ) template < T1 = typename = unused> struct Args { } main ( ) { foo < int > ( ) ; }");
         tokenizeAndStringify("() template < T = typename = x > struct a {} { f <int> () }");
@@ -6529,6 +6529,10 @@ private:
         tokenizeAndStringify("template <typename T> struct A {}; "
                              "template <> struct A<void> {}; "
                              "void foo(const void* f = 0) {}");
+        tokenizeAndStringify("template<typename... T> struct A { "
+                             "  static const int s = 0; "
+                             "}; "
+                             "A<int> a;");
     }
 
     void removeKeywords() {


### PR DESCRIPTION
Hi,

This ticket is another fallout of my fix for ticket #5605 (thanks to matthiaskrgr for the report and to amai for pointing me to it!), that is fixed by skipping "typename..." in TemplateSimplifier::templateParameters. Thanks to consider merging.

Cheers,
  Simon
