### PR TITLE
Ticket #5297: simplifyCalculations should pass once more on simplified tokens

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -928,8 +928,12 @@ bool TemplateSimplifier::simplifyNumericCalculations(Token *tok)
 // should be moved away.
 bool TemplateSimplifier::simplifyCalculations(Token *_tokens)
 {
-    bool ret = false;
+    bool ret = false, goback = false;
     for (Token *tok = _tokens; tok; tok = tok->next()) {
+        if (goback) {
+            tok = tok->previous();
+            goback = false;
+        }
         // Remove parentheses around variable..
         // keep parentheses here: dynamic_cast<Fred *>(p);
         // keep parentheses here: A operator * (int);
@@ -1096,6 +1100,7 @@ bool TemplateSimplifier::simplifyCalculations(Token *_tokens)
                     tok->str(result);
                     tok->deleteNext(2);
                     ret = true;
+                    goback = true;
                 }
             }
         }

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -136,6 +136,7 @@ private:
         TEST_CASE(template41);  // #4710 - const in instantiation not handled perfectly
         TEST_CASE(template42);  // #4878 - variadic templates
         TEST_CASE(template43);  // #5097 - assert due to '>>' not treated as end of template instantiation
+        TEST_CASE(template44);  // #5297 - TemplateSimplifier::simplifyCalculations not eager enough
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -2379,6 +2380,16 @@ private:
         tok(code); // Don't assert
     }
 
+    void template44() { // #5297
+        tok("template<class T> struct StackContainer {"
+            "  void foo(int i) {"
+            "    if (0 >= 1 && i<0) {}"
+            "  }"
+            "};"
+            "template<class T> class ZContainer : public StackContainer<T> {};"
+            "struct FGSTensor {};"
+            "class FoldedZContainer : public ZContainer<FGSTensor> {};");
+    }
 
     void template_default_parameter() {
         {


### PR DESCRIPTION
Hi,

This ticket is due to the fact that we simplify "0 && ..." to 0, but not "C && ..." where C can be simplified to 0. The patch does that and fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
