### PR TITLE
Cleanup code:

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7417,7 +7417,7 @@ void Tokenizer::simplifyEnum()
             tok = tok->previous();
         }
 
-        if (tok->next() &&
+        if (tok && tok->next() &&
             (!tok->previous() || (tok->previous()->str() != "enum")) &&
             Token::Match(tok, "class|struct|namespace")) {
             className = tok->next()->str();


### PR DESCRIPTION
1. reorder checks so that cheaper ones go first
2. reuse previously computed values
3. return early on edge condition

I'm not completely sure the first change doesn't break anything.
