### PR TITLE
Implemented a new check for arithmetic with Booleans.

### DIFF
--- a/lib/checkbool.h
+++ b/lib/checkbool.h
@@ -67,6 +67,7 @@ public:
         checkBool.checkIncrementBoolean();
         checkBool.checkAssignBoolToPointer();
         checkBool.checkBitwiseOnBoolean();
+        checkBool.checkArithmeticOnBoolean();
     }
 
     /** @brief %Check for comparison of function returning bool*/
@@ -87,6 +88,9 @@ public:
     /** @brief %Check for using bool in bitwise expression */
     void checkBitwiseOnBoolean();
 
+    /** @brief %Check for using Boolean in arithmetic expression */
+    void checkArithmeticOnBoolean();
+
     /** @brief %Check for comparing a bool expression with an integer other than 0 or 1 */
     void checkComparisonOfBoolExpressionWithInt();
 
@@ -106,6 +110,7 @@ private:
     void bitwiseOnBooleanError(const Token *tok, const std::string &varname, const std::string &op);
     void comparisonOfBoolExpressionWithIntError(const Token *tok, bool n0o1);
     void pointerArithBoolError(const Token *tok);
+    void checkArithmeticOnBooleanError(const Token * const tok, const std::string &varname1, const std::string &arithmeticOperation, const std::string &varname2);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
         CheckBool c(0, settings, errorLogger);
@@ -119,6 +124,7 @@ private:
         c.bitwiseOnBooleanError(0, "varname", "&&");
         c.comparisonOfBoolExpressionWithIntError(0, true);
         c.pointerArithBoolError(0);
+        c.checkArithmeticOnBooleanError(0, "varname1", "arithmetic_operation", "varname2");
     }
 
     static std::string myName() {
@@ -134,7 +140,8 @@ private:
                "* comparison of a function returning boolean value using relational operator\n"
                "* comparison of a boolean value with boolean value using relational operator\n"
                "* using bool in bitwise expression\n"
-               "* pointer addition in condition (either dereference is forgot or pointer overflow is required to make the condition false)\n";
+               "* pointer addition in condition (either dereference is forgot or pointer overflow is required to make the condition false)\n"
+               "* using bool in arithmetic expression\n";
     }
 };
 /// @}

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -60,6 +60,8 @@ private:
 
         // Converting pointer addition result to bool
         TEST_CASE(pointerArithBool1);
+
+        TEST_CASE(checkArithmeticOnBoolean);
     }
 
     void check(const char code[], bool experimental = false, const char filename[] = "test.cpp") {
@@ -905,6 +907,20 @@ private:
               "    if (p && p+1){}\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (error) Converting pointer arithmetic result to bool. The bool is always true unless there is undefined behaviour.\n", errout.str());
+    }
+
+    void checkArithmeticOnBoolean() {
+        check("int f(bool a, bool b) {return a+b;}");
+        ASSERT_EQUALS("[test.cpp:1]: (style) Boolean used in arithmetic operation.\n", errout.str());
+
+        check("int f(bool a, bool b) {return a-b;}");
+        ASSERT_EQUALS("[test.cpp:1]: (style) Boolean used in arithmetic operation.\n", errout.str());
+
+        check("int f(bool a, bool b) {return a*b;}");
+        ASSERT_EQUALS("[test.cpp:1]: (style) Boolean used in arithmetic operation.\n", errout.str());
+
+        check("int f(bool a, bool b) {return a/b;}");
+        ASSERT_EQUALS("[test.cpp:1]: (style) Boolean used in arithmetic operation.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
This new check raises a warning when two Boolean variables are used within an arithmetic operation.

For example

```
int f(bool a, bool b) {return a + b;}
```
