### PR TITLE
Ticket #5786: Properly handle cv-qualified member pointers as template parameter

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -228,8 +228,8 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
     unsigned int level = 0;
 
     while (tok) {
-        // skip const
-        if (tok->str() == "const")
+        // skip const/volatile
+        if (Token::Match(tok, "const|volatile"))
             tok = tok->next();
 
         // skip struct/union
@@ -278,8 +278,11 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             return 0;
 
         // Function pointer or prototype..
-        while (tok && (tok->str() == "(" || tok->str() == "["))
+        while (tok && (tok->str() == "(" || tok->str() == "[")) {
             tok = tok->link()->next();
+            while (tok && Token::Match(tok, "const|volatile")) // Ticket #5786: Skip function cv-qualifiers
+                tok = tok->next();
+        }
         if (!tok)
             return 0;
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -420,6 +420,7 @@ private:
         TEST_CASE(syntax_error_templates_1);
         TEST_CASE(syntax_error_templates_2);
         TEST_CASE(syntax_error_templates_3); // Ticket #5605, #5759, #5762, #5774
+        TEST_CASE(template_member_ptr); // Ticket #5786 - crash upon valid code
 
         TEST_CASE(removeKeywords);
 
@@ -6538,6 +6539,33 @@ private:
                              "  static const int s = 0; "
                              "}; "
                              "A<int> a;");
+    }
+
+    void template_member_ptr() { // Ticket #5786
+        tokenizeAndStringify("struct A {}; "
+                             "struct B { "
+                             "template <void (A::*)() const> struct BB {}; "
+                             "template <bool BT> static bool foo(int) { return true; } "
+                             "void bar() { bool b = foo<true>(0); }"
+                             "};");
+        tokenizeAndStringify("struct A {}; "
+                             "struct B { "
+                             "template <void (A::*)() volatile> struct BB {}; "
+                             "template <bool BT> static bool foo(int) { return true; } "
+                             "void bar() { bool b = foo<true>(0); }"
+                             "};");
+        tokenizeAndStringify("struct A {}; "
+                             "struct B { "
+                             "template <void (A::*)() const volatile> struct BB {}; "
+                             "template <bool BT> static bool foo(int) { return true; } "
+                             "void bar() { bool b = foo<true>(0); }"
+                             "};");
+        tokenizeAndStringify("struct A {}; "
+                             "struct B { "
+                             "template <void (A::*)() volatile const> struct BB {}; "
+                             "template <bool BT> static bool foo(int) { return true; } "
+                             "void bar() { bool b = foo<true>(0); }"
+                             "};");
     }
 
     void removeKeywords() {


### PR DESCRIPTION
Hi,

This patch ensures that we handle pointers to cv-qualified functions as template parameters, which fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
