### PR TITLE
Ticket #5816: Skip typename in template arguments for enum initializers.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7558,23 +7558,17 @@ void Tokenizer::simplifyEnum()
 
                     enumValueStart = tok1;
                     enumValueEnd = tok1;
-                    int level = 0;
-                    while (enumValueEnd->next() && (!Token::Match(enumValueEnd->next(), "[},]") || level)) {
-                        if (Token::Match(enumValueEnd, "(|["))
-                            ++level;
-                        else if (Token::Match(enumValueEnd->next(), "]|)"))
-                            --level;
-                        else if (Token::Match(enumValueEnd, "%type% <") && isCPP() && TemplateSimplifier::templateParameters(enumValueEnd->next()) > 1U) {
-                            Token *endtoken = enumValueEnd->tokAt(2);
-                            while ((Token::Match(endtoken,"%any% *| [,>]") || Token::Match(endtoken,"%any% :: %any%")) && (endtoken->isName() || endtoken->isNumber())) {
+                    while (enumValueEnd->next() && (!Token::Match(enumValueEnd->next(), "[},]"))) {
+                        if (Token::Match(enumValueEnd, "(|[")) {
+                            enumValueEnd = enumValueEnd->link();
+                            continue;
+                        } else if (Token::Match(enumValueEnd, "%type% <") && isCPP() && TemplateSimplifier::templateParameters(enumValueEnd->next()) > 1U) {
+                            Token *endtoken = enumValueEnd->next();
+                            do {
                                 endtoken = endtoken->next();
-                                if (endtoken->str() == "*")
+                                if (Token::Match(endtoken, "*|,|::|typename"))
                                     endtoken = endtoken->next();
-                                if (endtoken->str() == ",")
-                                    endtoken = endtoken->next();
-                                if (endtoken->str() == "::")
-                                    endtoken = endtoken->next();
-                            }
+                            } while (Token::Match(endtoken, "%var%|%num% *| [,>]") || Token::Match(endtoken, "%var%|%num% :: %any%"));
                             if (endtoken->str() == ">") {
                                 enumValueEnd = endtoken;
                                 if (Token::simpleMatch(endtoken, "> ( )"))

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -138,6 +138,7 @@ private:
         TEST_CASE(template43);  // #5097 - assert due to '>>' not treated as end of template instantiation
         TEST_CASE(template44);  // #5297 - TemplateSimplifier::simplifyCalculations not eager enough
         TEST_CASE(template45);  // #5814 - syntax error reported for valid code
+        TEST_CASE(template46);  // #5816 - syntax error reported for valid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -2400,6 +2401,18 @@ private:
             "template <class T> struct FOO { "
             "  enum { value = TypeMath<T, Constants::fourtytwo>::something }; "
             "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void template46() { // #5816
+        tok("template<class T, class U> struct A { static const int value = 0; }; "
+            "template <class T> struct B { "
+            "  enum { value = A<typename T::type, int>::value }; "
+            "};");
+        ASSERT_EQUALS("", errout.str());
+        tok("template <class T, class U> struct A {}; "
+            "enum { e = sizeof(A<int, int>) }; "
+            "template <class T, class U> struct B {};");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Hi,

This patch rewrites a bit Tokenizer::simplifyEnum and skips 'typename' in template parameters for enum initializers, which fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
