### PR TITLE
Some arguments are better off as references.

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1028,7 +1028,7 @@ void CheckClass::checkMemset()
     }
 }
 
-void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Scope *type, bool allocation, std::list<const Scope *> parsedTypes)
+void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Scope *type, bool allocation, std::list<const Scope * >& parsedTypes)
 {
     // If type has been checked there is no need to check it again
     if (std::find(parsedTypes.begin(), parsedTypes.end(), type) != parsedTypes.end())

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -94,7 +94,7 @@ public:
      * Important: The checking doesn't work on simplified tokens list.
      */
     void checkMemset();
-    void checkMemsetType(const Scope *start, const Token *tok, const Scope *type, bool allocation, std::list<const Scope *> parsedTypes);
+    void checkMemsetType(const Scope *start, const Token *tok, const Scope *type, bool allocation, std::list<const Scope *>& parsedTypes);
 
     /** @brief 'operator=' should return something and it should not be const. */
     void operatorEq();

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -312,7 +312,7 @@ bool Library::load(const tinyxml2::XMLDocument &doc)
     return true;
 }
 
-bool Library::isargvalid(const std::string &functionName, int argnr, const MathLib::bigint argvalue) const
+bool Library::isargvalid(const std::string &functionName, int argnr, const MathLib::bigint& argvalue) const
 {
     const ArgumentChecks *ac = getarg(functionName, argnr);
     if (!ac || ac->valid.empty())

--- a/lib/library.h
+++ b/lib/library.h
@@ -168,7 +168,7 @@ public:
         return arg && arg->strz;
     }
 
-    bool isargvalid(const std::string &functionName, int argnr, const MathLib::bigint argvalue) const;
+    bool isargvalid(const std::string &functionName, int argnr, const MathLib::bigint& argvalue) const;
 
     std::string validarg(const std::string &functionName, int argnr) const {
         const ArgumentChecks *arg = getarg(functionName, argnr);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1135,7 +1135,7 @@ std::string Preprocessor::getdef(std::string line, bool def)
 }
 
 /** Simplify variable in variable map. */
-static Token *simplifyVarMapExpandValue(Token *tok, const std::map<std::string, std::string> &variables, std::set<std::string> seenVariables)
+static Token *simplifyVarMapExpandValue(Token *tok, const std::map<std::string, std::string> &variables, std::set<std::string>& seenVariables)
 {
     // TODO: handle function-macros too.
 
@@ -1732,7 +1732,7 @@ void Preprocessor::simplifyCondition(const std::map<std::string, std::string> &c
         condition = "0";
 }
 
-bool Preprocessor::match_cfg_def(std::map<std::string, std::string> cfg, std::string def)
+bool Preprocessor::match_cfg_def(std::map<std::string, std::string>& cfg, std::string def)
 {
     /*
         std::cout << "cfg: \"";

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -231,7 +231,7 @@ public:
      * @param def condition
      * @return result when evaluating the condition
      */
-    bool match_cfg_def(std::map<std::string, std::string> cfg, std::string def);
+    bool match_cfg_def(std::map<std::string, std::string>& cfg, std::string def);
 
     static void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings);
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1235,7 +1235,7 @@ void Token::printValueFlow() const
     }
 }
 
-const ValueFlow::Value * Token::getValueLE(const MathLib::bigint val, const Settings *settings) const
+const ValueFlow::Value * Token::getValueLE(const MathLib::bigint& val, const Settings *settings) const
 {
     const ValueFlow::Value *ret = nullptr;
     std::list<ValueFlow::Value>::const_iterator it;
@@ -1256,7 +1256,7 @@ const ValueFlow::Value * Token::getValueLE(const MathLib::bigint val, const Sett
     return ret;
 }
 
-const ValueFlow::Value * Token::getValueGE(const MathLib::bigint val, const Settings *settings) const
+const ValueFlow::Value * Token::getValueGE(const MathLib::bigint& val, const Settings *settings) const
 {
     const ValueFlow::Value *ret = nullptr;
     std::list<ValueFlow::Value>::const_iterator it;

--- a/lib/token.h
+++ b/lib/token.h
@@ -632,7 +632,7 @@ public:
     /** Values of token */
     std::list<ValueFlow::Value> values;
 
-    const ValueFlow::Value * getValue(const MathLib::bigint val) const {
+    const ValueFlow::Value * getValue(const MathLib::bigint& val) const {
         std::list<ValueFlow::Value>::const_iterator it;
         for (it = values.begin(); it != values.end(); ++it) {
             if (it->intvalue == val)
@@ -652,8 +652,8 @@ public:
         return ret;
     }
 
-    const ValueFlow::Value * getValueLE(const MathLib::bigint val, const Settings *settings) const;
-    const ValueFlow::Value * getValueGE(const MathLib::bigint val, const Settings *settings) const;
+    const ValueFlow::Value * getValueLE(const MathLib::bigint& val, const Settings *settings) const;
+    const ValueFlow::Value * getValueGE(const MathLib::bigint& val, const Settings *settings) const;
 
 private:
 


### PR DESCRIPTION
Hi,

This trivial patch turns some method parameters to references, which makes sense in particular for "complex" ones. Thanks to consider merging.

Cheers,
  Simon
