### PR TITLE
Ticket #5816: Properly handle template'd template parameters in enum initializers

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7572,7 +7572,9 @@ void Tokenizer::simplifyEnum()
                                 endtoken = endtoken->next();
                                 if (Token::Match(endtoken, "*|,|::|typename"))
                                     endtoken = endtoken->next();
-                            } while (Token::Match(endtoken, "%var%|%num% *| [,>]") || Token::Match(endtoken, "%var%|%num% :: %any%"));
+                                if (endtoken->str() == "<" && TemplateSimplifier::templateParameters(endtoken))
+                                    endtoken = endtoken->findClosingBracket();
+                            } while (Token::Match(endtoken, "%var%|%num% *| [,>]") || Token::Match(endtoken, "%var%|%num% ::|< %any%"));
                             if (endtoken->str() == ">") {
                                 enumValueEnd = endtoken;
                                 if (Token::simpleMatch(endtoken, "> ( )"))

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2414,6 +2414,12 @@ private:
             "enum { e = sizeof(A<int, int>) }; "
             "template <class T, class U> struct B {};");
         ASSERT_EQUALS("", errout.str());
+        tok("template<class T, class U> struct A { static const int value = 0; }; "
+            "template<class T> struct B { typedef int type; }; "
+            "template <class T> struct C { "
+            "  enum { value = A<typename B<T>::type, int>::value }; "
+            "};");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void template_default_parameter() {


### PR DESCRIPTION
Hi,

I turns out that I reduced the test case in this ticket#5816  too much in https://github.com/danmar/cppcheck/pull/310, and I fixed some issues but not the reported case... (thanks to amai for finding out!).

This patch fully fixes the ticket by properly handling template types in template'd enum initializers. Please consider merging.

Cheers,
  Simon
