### PR TITLE
Ticket #5823: Properly count template parameters in TemplateSimplifier::useDefaultArgumentValues

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6554,7 +6554,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");   // shouldn't segfault
     }
 
-    void syntax_error_templates_3() { // Ticket #5605, #5759, #5762, #5774
+    void syntax_error_templates_3() { // Ticket #5605, #5759, #5762, #5774, #5823
         tokenizeAndStringify("foo() template<typename T1 = T2 = typename = unused, T5 = = unused> struct tuple Args> tuple<Args...> { } main() { foo<int,int,int,int,int,int>(); }");
         tokenizeAndStringify("( ) template < T1 = typename = unused> struct Args { } main ( ) { foo < int > ( ) ; }");
         tokenizeAndStringify("() template < T = typename = x > struct a {} { f <int> () }");
@@ -6570,6 +6570,12 @@ private:
                              "  static const int s = 0; "
                              "}; "
                              "A<int> a;");
+        tokenizeAndStringify("template<class T, class U> class A {}; "
+                             "template<class T = A<int, int> > class B {}; "
+                             "template<class T = B<int> > class C { "
+                             "    C() : _a(0), _b(0) {} "
+                             "    int _a, _b; "
+                             "};");
     }
 
     void template_member_ptr() { // Ticket #5786


### PR DESCRIPTION
Hi,

This patch fixes the ticket by ensuring we properly count arguments in useDefaultArgumentValues when default values are templates with more than one argument.

Somehow this "broke" TestTokenize::cpp0xtemplate3, a TODO_ASSERT. Since it did not bring the expected value, I've had to modify a bit TemplateSimplifier::templateParameters that did not properly handle default values involving casts; it does now and the TODO_ASSERT remains as it was before. The change makes sense IMHO.

Please consider merging.

Cheers,
  Simon
