### PR TITLE
travis: replace kernel check with clang check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 
 script:
 # download clang git, compile cppcheck, run cppcheck on clang code to look for crashes in cppcheck. if this is done, terminate build
-  - if [[ "$CHECK_CLANG" == "yes" ]] && [[ "$CC" == "gcc" ]]; then wget "https://github.com/llvm-mirror/clang/archive/0ddd258c374240c22a53e3e71200048ec3a64284.zip" & make -j 4 & wait; unzip 0ddd258c374240c22a53e3e71200048ec3a64284.zip > /dev/null; touch /tmp/clang.cppcheck; cd ./clang-0ddd258c374240c22a53e3e71200048ec3a64284 ; ../cppcheck . --max-configs=1 --enable=all --inconclusive --exception-handling -iINPUTS -j 2 |& tee /tmp/clang.cppcheck; cd ../ ; ! grep "process crashed with signal" /tmp/clang.cppcheck; exit; fi
+  - if [[ "$CHECK_CLANG" == "yes" ]] && [[ "$CC" == "gcc" ]]; then wget "https://github.com/llvm-mirror/clang/archive/0ddd258c374240c22a53e3e71200048ec3a64284.zip" & make -j 4 & wait; unzip 0ddd258c374240c22a53e3e71200048ec3a64284.zip > /dev/null; touch /tmp/clang.cppcheck; cd ./clang-0ddd258c374240c22a53e3e71200048ec3a64284 ; ../cppcheck . --max-configs=1 --enable=all --inconclusive --exception-handling -iINPUTS -j 2 |& tee /tmp/clang.cppcheck; cd ../ ; ! grep "process crashed with signal\|Internal error\. compiled" /tmp/clang.cppcheck; exit; fi
 # compile cppcheck, default build
   - make -j4
   - make test -j4


### PR DESCRIPTION
Check clang instead of kernel, which is a lot faster.
Make clang check failure fatal to the build.

remove SRCDIR=build VERIFY=1 jobs, we already have the same just with HAVE_RULES added.
also check VERIFY=1 in combination with -DCHECK_INTERNAL ( #4798 #5869)

CURRENT ISSUES:
cppcheck throws internal errors its own code when compiled with DCHECK_INTERNAL and VERIFY=1, SRCDIR=build
cppcheck crashes on two files in the clang testsuit
cppcheck throws numerous (around 50 !!) internal errors on clang testsuite
