### PR TITLE
Ticket #5857: Don't crash in CheckOther::strPlusChar upon invalid code.

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2183,7 +2183,7 @@ void CheckOther::strPlusChar()
         const Scope * scope = symbolDatabase->functionScopes[i];
         for (const Token* tok = scope->classStart->next(); tok != scope->classEnd; tok = tok->next()) {
             if (tok->str() == "+" && tok->astOperand2()) {
-                if (tok->astOperand1()->type() == Token::eString) { // string literal...
+                if (tok->astOperand1() && tok->astOperand1()->type() == Token::eString) { // string literal...
                     if (tok->astOperand2() && (tok->astOperand2()->type() == Token::eChar || isChar(tok->astOperand2()->variable()))) // added to char variable or char constant
                         strPlusCharError(tok);
                 }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -61,6 +61,7 @@ private:
         TEST_CASE(strPlusChar1);     // "/usr" + '/'
         TEST_CASE(strPlusChar2);     // "/usr" + ch
         TEST_CASE(strPlusChar3);     // ok: path + "/sub" + '/'
+        TEST_CASE(strPlusChar4);     // Ticket #5857 - Crash upon invalid input
 
         TEST_CASE(varScope1);
         TEST_CASE(varScope2);
@@ -891,7 +892,10 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-
+    void strPlusChar4() { // Ticket #5857
+        strPlusChar("void test() { int +; }");
+        ASSERT_EQUALS("", errout.str());
+    }
 
     void varScope(const char code[]) {
         // Clear the error buffer..


### PR DESCRIPTION
Hi,

This trivial patch fixes the ticket by ensuring we don't dereference 0 in strPlusChar upon invalid code. I've tried to detect that we have a syntax error or at least not setup the token's operand2 pointer in that case, but failed to up to now as it caused regressions. Until I figure out how to do it (if it actually is doable...), thanks to consider merging.

Cheers,
  Simon
