### PR TITLE
Tokenize GNU extension "a ? : b" the same as "a ? a : b".

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4711,8 +4711,8 @@ bool Tokenizer::simplifyConstTernaryOp()
         if (tok->str() != "?")
             continue;
 
-        if (!Token::Match(tok->tokAt(-2), "<|=|,|(|[|{|}|;|case|return %bool%|%num%") &&
-            !Token::Match(tok->tokAt(-4), "<|=|,|(|[|{|}|;|case|return ( %bool%|%num% )"))
+        if (!Token::Match(tok->tokAt(-2), "<|=|,|(|[|{|}|;|case|return %bool%|%num%|%var%") &&
+            !Token::Match(tok->tokAt(-4), "<|=|,|(|[|{|}|;|case|return ( %bool%|%num%|%var% )"))
             continue;
 
         const int offset = (tok->previous()->str() == ")") ? 2 : 1;
@@ -4728,6 +4728,9 @@ bool Tokenizer::simplifyConstTernaryOp()
         //handle the GNU extension: "x ? : y" <-> "x ? x : y"
         if (semicolon->previous() == tok->next())
             tok->insertToken(tok->strAt(-offset));
+
+        if (!Token::Match(tok->tokAt(-offset), "%bool%|%num%"))
+            continue; // We can't do anything more as we don't know the variable's value
 
         // go back before the condition, if possible
         tok = tok->tokAt(-2);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -66,6 +66,7 @@ private:
         TEST_CASE(tokenize29);  // #5506 (segmentation fault upon invalid code)
         TEST_CASE(tokenize30);  // #5356 (segmentation fault upon invalid code)
         TEST_CASE(tokenize31);  // #3503 (Wrong handling of member function taking function pointer as argument)
+        TEST_CASE(tokenize32);  // Elvis operator (http://en.wikipedia.org/wiki/Elvis_operator) tokenizing
 
         // don't freak out when the syntax is wrong
         TEST_CASE(wrong_syntax1);
@@ -883,6 +884,12 @@ private:
                       tokenizeAndStringify("struct TTestClass { TTestClass() { }\n"
                                            "    void SetFunction(Other(*m_f)());\n"
                                            "};"));
+    }
+
+    void tokenize32() { // Elvis operator support
+        const char expected[] = "int a ; if ( x ) { a = x ; } else { a = 1 ; }";
+        ASSERT_EQUALS(expected, tokenizeAndStringify("int a = x ? x : 1 ;", true));
+        ASSERT_EQUALS(expected, tokenizeAndStringify("int a = x ? : 1 ;", true));
     }
 
     void wrong_syntax1() {


### PR DESCRIPTION
Hi,

I've found out that we don't tokenize GNU extension "a ? : b" the same as we tokenize "a ? a : b", which I figure we don't want to ensure all checks behave the same for both. This PR changes this. Thanks to consider merging.

Cheers,
  Simon
