### PR TITLE
Remove unnecessary declaration (one line before the actual definition...)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2065,8 +2065,6 @@ void Tokenizer::arraySize()
     }
 }
 
-static Token *skipTernaryOp(Token *);
-
 static Token *skipTernaryOp(Token *tok)
 {
     if (!tok || tok->str() != "?")


### PR DESCRIPTION
Hi,

I just spotted this unnecessary static function declaration right before its actual definition... Thanks to consider merging.

Cheers,
  Simon
