### PR TITLE
Factorize type name equality checks in CheckIO

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -470,6 +470,12 @@ static bool findFormat(unsigned int arg, const Token *firstArg,
     return false;
 }
 
+// Utility function returning whether iToTest equals iTypename or iOptionalPrefix+iTypename
+inline bool typesMatch(const std::string& iToTest, const std::string& iTypename, const std::string& iOptionalPrefix = "std::")
+{
+    return (iToTest == iTypename) || (iToTest == iOptionalPrefix + iTypename);
+}
+
 void CheckIO::checkWrongPrintfScanfArguments()
 {
     const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();
@@ -711,21 +717,15 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     if (specifier[1] == 'l') {
                                                         if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                        else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::size_t" ||
-                                                                 argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
-                                                                 argInfo.typeToken->originalName() == "intmax_t" ||
-                                                                 argInfo.typeToken->originalName() == "uintmax_t")
+                                                        else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
+                                                                 typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
+                                                                 typesMatch(argInfo.typeToken->originalName(), "intmax_t", "u"))
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     } else if (argInfo.typeToken->str() != "long" || argInfo.typeToken->isLong())
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
-                                                             argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "intmax_t" ||
-                                                             argInfo.typeToken->originalName() == "uintmax_t")
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
+                                                             typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
+                                                             typesMatch(argInfo.typeToken->originalName(), "intmax_t", "u"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'I':
@@ -735,10 +735,8 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    } else if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                               argInfo.typeToken->originalName() != "std::ptrdiff_t" &&
-                                                               argInfo.typeToken->originalName() != "size_t" &&
-                                                               argInfo.typeToken->originalName() != "std::size_t")
+                                                    } else if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") &&
+                                                               !typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'j':
@@ -746,13 +744,11 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "size_t" &&
-                                                        argInfo.typeToken->originalName() != "std::size_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 't':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'L':
@@ -762,12 +758,9 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                 default:
                                                     if (argInfo.typeToken->str() != "int")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
-                                                             argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "intmax_t" ||
-                                                             argInfo.typeToken->originalName() == "uintmax_t")
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
+                                                             typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
+                                                             typesMatch(argInfo.typeToken->originalName(), "intmax_t", "u"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 }
@@ -802,14 +795,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     if (specifier[1] == 'l') {
                                                         if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
-                                                        else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                        else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                                  argInfo.typeToken->originalName() == "intmax_t")
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     } else if (argInfo.typeToken->str() != "long" || argInfo.typeToken->isLong())
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
-                                                    else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                              argInfo.typeToken->originalName() == "intmax_t")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
@@ -820,8 +811,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
-                                                    } else if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                               argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    } else if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
                                                 case 'j':
@@ -829,15 +819,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "ssize_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ssize_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") &&
+                                                        !typesMatch(argInfo.typeToken->originalName(), "ssize_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
                                                 case 't':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
                                                 case 'L':
@@ -847,8 +834,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                 default:
                                                     if (argInfo.typeToken->str() != "int")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
-                                                    else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                              argInfo.typeToken->originalName() == "intmax_t")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, false);
                                                     break;
@@ -882,14 +868,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     if (specifier[1] == 'l') {
                                                         if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                        else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::size_t" ||
+                                                        else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                                  argInfo.typeToken->originalName() == "uintmax_t")
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     } else if (argInfo.typeToken->str() != "long" || argInfo.typeToken->isLong())
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                              argInfo.typeToken->originalName() == "uintmax_t")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
@@ -900,8 +884,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    } else if (argInfo.typeToken->originalName() != "size_t" &&
-                                                               argInfo.typeToken->originalName() != "std::size_t")
+                                                    } else if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'j':
@@ -909,30 +892,25 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "size_t" &&
-                                                        argInfo.typeToken->originalName() != "std::size_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 't':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 case 'L':
                                                     if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                              argInfo.typeToken->originalName() == "uintmax_t")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
                                                 default:
                                                     if (argInfo.typeToken->str() != "int")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
-                                                             argInfo.typeToken->originalName() == "ssize_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ssize_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
+                                                             typesMatch(argInfo.typeToken->originalName(), "ssize_t") ||
                                                              argInfo.typeToken->originalName() == "uintmax_t")
                                                         invalidScanfArgTypeError_int(tok, numFormat, specifier, &argInfo, true);
                                                     break;
@@ -1076,13 +1054,11 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidPrintfArgTypeError_int(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "size_t" &&
-                                                        argInfo.typeToken->originalName() != "std::size_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidPrintfArgTypeError_int(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 't':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidPrintfArgTypeError_int(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'I':
@@ -1092,10 +1068,8 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidPrintfArgTypeError_int(tok, numFormat, specifier, &argInfo);
-                                                    } else if (!(argInfo.typeToken->originalName() == "size_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::size_t" ||
-                                                                 argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                    } else if (!(typesMatch(argInfo.typeToken->originalName(), "size_t") ||
+                                                                 typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                                  argInfo.typeToken->originalName() == "WPARAM" ||
                                                                  argInfo.typeToken->originalName() == "UINT_PTR" ||
                                                                  argInfo.typeToken->originalName() == "LONG_PTR" ||
@@ -1136,14 +1110,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     if (specifier[1] == 'l') {
                                                         if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                             invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
-                                                        else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                        else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                                  argInfo.typeToken->originalName() == "intmax_t")
                                                             invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     } else if (argInfo.typeToken->str() != "long" || argInfo.typeToken->isLong())
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
-                                                    else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                              argInfo.typeToken->originalName() == "intmax_t")
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     break;
@@ -1152,8 +1124,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 't':
-                                                    if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'I':
@@ -1163,20 +1134,17 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
-                                                    } else if (argInfo.typeToken->originalName() != "ptrdiff_t" &&
-                                                               argInfo.typeToken->originalName() != "std::ptrdiff_t")
+                                                    } else if (!typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t"))
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "ssize_t" &&
-                                                        argInfo.typeToken->originalName() != "std::ssize_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "ssize_t"))
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 default:
                                                     if (!Token::Match(argInfo.typeToken, "bool|char|short|int"))
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
-                                                    else if (argInfo.typeToken->originalName() == "ptrdiff_t" ||
-                                                             argInfo.typeToken->originalName() == "std::ptrdiff_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "ptrdiff_t") ||
                                                              argInfo.typeToken->originalName() == "intmax_t")
                                                         invalidPrintfArgTypeError_sint(tok, numFormat, specifier, &argInfo);
                                                     break;
@@ -1208,14 +1176,12 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     if (specifier[1] == 'l') {
                                                         if (argInfo.typeToken->str() != "long" || !argInfo.typeToken->isLong())
                                                             invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
-                                                        else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                                 argInfo.typeToken->originalName() == "std::size_t" ||
+                                                        else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                                  argInfo.typeToken->originalName() == "uintmax_t")
                                                             invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     } else if (argInfo.typeToken->str() != "long" || argInfo.typeToken->isLong())
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                              argInfo.typeToken->originalName() == "uintmax_t")
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;
@@ -1224,8 +1190,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'z':
-                                                    if (argInfo.typeToken->originalName() != "size_t" &&
-                                                        argInfo.typeToken->originalName() != "std::size_t")
+                                                    if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 case 'I':
@@ -1235,15 +1200,13 @@ void CheckIO::checkWrongPrintfScanfArguments()
                                                     } else if (specifier.find("I32") != std::string::npos) {
                                                         if (argInfo.typeToken->str() != "int" || argInfo.typeToken->isLong())
                                                             invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
-                                                    } else if (argInfo.typeToken->originalName() != "size_t" &&
-                                                               argInfo.typeToken->originalName() != "std::size_t")
+                                                    } else if (!typesMatch(argInfo.typeToken->originalName(), "size_t"))
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;
                                                 default:
                                                     if (!Token::Match(argInfo.typeToken, "bool|char|short|int"))
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
-                                                    else if (argInfo.typeToken->originalName() == "size_t" ||
-                                                             argInfo.typeToken->originalName() == "std::size_t" ||
+                                                    else if (typesMatch(argInfo.typeToken->originalName(), "size_t") ||
                                                              argInfo.typeToken->originalName() == "intmax_t")
                                                         invalidPrintfArgTypeError_uint(tok, numFormat, specifier, &argInfo);
                                                     break;


### PR DESCRIPTION
Hi,

This mechanical patch factorizes code a bit in CheckIO by adding a utility function returning whether a type name matches another one, possibly prefixed by some value. Thanks to consider merging.

Cheers,
  Simon
