### PR TITLE
Cleanup code - reorder checks and make variable declaration scope narrower

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -281,10 +281,10 @@ static const Token *for_init(const Token *tok, unsigned int &varid, std::string 
 
         varid = tok->varId();
         varname = tok->str();
-        tok = tok->tokAt(4);
-
         if (varid == 0)
             return 0;  // failed
+
+        tok = tok->tokAt(4);
     } else if (Token::Match(tok, "%type% %var% = %any% ;")) {
         if (tok->tokAt(3)->isNumber()) {
             init_value = tok->strAt(3);


### PR DESCRIPTION
This addresses minor issues:
- makes cheaper checks run first
- omits redundant actions when we return anyway
- declares a variable such that it's clear that it's variable is not persistent between usages and it's always initialized
