### PR TITLE
Simplify code - bail out early, vreak loops early, reorder checks and declarations

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1404,7 +1404,7 @@ CheckIO::ArgumentInfo::ArgumentInfo(const Token * tok, const Settings *settings)
                     break;
                 } else if (tok1->str() == "(" || tok1->str() == "{" || tok1->str() == "[")
                     tok1 = tok1->link();
-                else if (tok1->str() == "<" && tok1->link())
+                else if (tok1->link() && tok1->str() == "<")
                     tok1 = tok1->link();
 
                 // check for some common well known functions
@@ -1419,10 +1419,13 @@ CheckIO::ArgumentInfo::ArgumentInfo(const Token * tok, const Settings *settings)
                             tempToken->str("long");
                             if (settings->sizeof_long != 8)
                                 tempToken->isLong(true);
-                        } else if (settings->sizeof_size_t == 4 && settings->sizeof_long == 4)
-                            tempToken->str("long");
-                        else if (settings->sizeof_size_t == 4)
-                            tempToken->str("int");
+                        } else if (settings->sizeof_size_t == 4) {
+                            if (settings->sizeof_long == 4) {
+                                tempToken->str("long");
+                            } else {
+                                tempToken->str("int");
+                            }
+                        }
 
                         tempToken->originalName("size_t");
                         tempToken->isUnsigned(true);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1820,7 +1820,7 @@ std::string Preprocessor::getcode(const std::string &filedata, const std::string
         const std::string def = getdef(line, true);
         const std::string ndef = getdef(line, false);
 
-        const bool emptymatch = matching_ifdef.empty() | matched_ifdef.empty();
+        const bool emptymatch = matching_ifdef.empty() || matched_ifdef.empty();
 
         if (line.compare(0, 8, "#define ") == 0) {
             match = true;
@@ -1842,8 +1842,14 @@ std::string Preprocessor::getcode(const std::string &filedata, const std::string
                 }
             }
 
-            for (std::list<bool>::const_iterator it = matching_ifdef.begin(); it != matching_ifdef.end(); ++it)
-                match &= bool(*it);
+            if (match) {
+                for (std::list<bool>::const_iterator it = matching_ifdef.begin(); it != matching_ifdef.end(); ++it) {
+                    if (!bool(*it)) {
+                        match = false;
+                        break;
+                    }
+                }
+            }
 
             if (match) {
                 std::string::size_type pos = line.find_first_of(" (", 8);
@@ -1915,8 +1921,12 @@ std::string Preprocessor::getcode(const std::string &filedata, const std::string
 
         if (!line.empty() && line[0] == '#') {
             match = true;
-            for (std::list<bool>::const_iterator it = matching_ifdef.begin(); it != matching_ifdef.end(); ++it)
-                match &= bool(*it);
+            for (std::list<bool>::const_iterator it = matching_ifdef.begin(); it != matching_ifdef.end(); ++it) {
+                if (!bool(*it)) {
+                    match = false;
+                    break;
+                }
+            }
         }
 
         // #error => return ""


### PR DESCRIPTION
This removes numerous redundant actions by breaking loops early also reorders checks to make cheaper ones run first and moves declarations closer to where they are first used.
