### PR TITLE
Reduce bitwise ops abuse, break loops earlier, return earlier, make cheaper checks run earlier

### DIFF
--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -81,7 +81,10 @@ void CheckAssert::assertWithSideEffects()
 
                     bool noReturnInScope = true;
                     for (std::vector<const Token*>::iterator rt = returnTokens.begin(); rt != returnTokens.end(); ++rt) {
-                        noReturnInScope &= !inSameScope(*rt, tok2);
+                        if (!inSameScope(*rt, tok2)) {
+                            noReturnInScope = false;
+                            break;
+                        }
                     }
                     if (noReturnInScope) continue;
                     bool isAssigned = checkVariableAssignment(tok2, false);

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1937,8 +1937,8 @@ void CheckMemoryLeakInFunction::simplifycode(Token *tok) const
                     if (Token::Match(_tok, "if return|break use| ;"))
                         _tok = _tok->tokAt(2);
 
-                    incase |= (_tok->str() == "case");
-                    incase &= (_tok->str() != "break" && _tok->str() != "return");
+                    incase = incase || (_tok->str() == "case");
+                    incase = incase && (_tok->str() != "break" && _tok->str() != "return");
                 }
 
                 if (!incase && valid) {
@@ -2123,26 +2123,26 @@ void CheckMemoryLeakInFunction::checkScope(const Token *Tok1, const std::string 
     }
 
     // detect cases that "simplifycode" don't handle well..
-    else if (_settings->debugwarnings) {
+    else if (tok && _settings->debugwarnings) {
         Token *first = tok;
         while (first && first->str() == ";")
             first = first->next();
 
         bool noerr = false;
-        noerr |= Token::simpleMatch(first, "alloc ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; dealloc ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; return use ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; use ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; use ; return ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; dealloc ; return ; }");
-        noerr |= Token::simpleMatch(first, "if alloc ; dealloc ; }");
-        noerr |= Token::simpleMatch(first, "if alloc ; return use ; }");
-        noerr |= Token::simpleMatch(first, "if alloc ; use ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; ifv return ; dealloc ; }");
-        noerr |= Token::simpleMatch(first, "alloc ; if return ; dealloc; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; dealloc ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; return use ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; use ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; use ; return ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; dealloc ; return ; }");
+        noerr = noerr || Token::simpleMatch(first, "if alloc ; dealloc ; }");
+        noerr = noerr || Token::simpleMatch(first, "if alloc ; return use ; }");
+        noerr = noerr || Token::simpleMatch(first, "if alloc ; use ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; ifv return ; dealloc ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; if return ; dealloc; }");
 
         // Unhandled case..
-        if (!noerr && tok) {
+        if (!noerr) {
             std::ostringstream errmsg;
             errmsg << "inconclusive leak of " << varname << ": ";
             errmsg << tok->stringifyList(false, false, false, false, false, 0, 0);

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3324,12 +3324,14 @@ void CheckOther::oppositeInnerCondition()
             if (cond->varId()) {
                 vars.insert(cond->varId());
                 const Variable *var = cond->variable();
-                nonlocal |= (var && (!var->isLocal() || var->isStatic()) && !var->isArgument());
-                // TODO: if var is pointer check what it points at
-                nonlocal |= (var && (var->isPointer() || var->isReference()));
+                if (var) {
+                    nonlocal = nonlocal || (!var->isLocal() || var->isStatic()) && !var->isArgument();
+                    // TODO: if var is pointer check what it points at
+                    nonlocal = nonlocal || (var->isPointer() || var->isReference());
+                }
             } else if (cond->isName()) {
                 // varid is 0. this is possibly a nonlocal variable..
-                nonlocal |= (cond->astParent() && cond->astParent()->isConstOp());
+                nonlocal = nonlocal || (cond->astParent() && cond->astParent()->isConstOp());
             }
         }
 

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -185,17 +185,17 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
                             bool range = false;
                             for (; *p; p++) {
                                 if (std::isdigit(*p))
-                                    error |= (*(p+1) == '-');
+                                    error = error || (*(p+1) == '-');
                                 else if (*p == ':')
                                     error |= range;
                                 else if (*p == '-')
-                                    error |= (!std::isdigit(*(p+1)));
+                                    error = error || (!std::isdigit(*(p+1)));
                                 else if (*p == ',')
                                     range = false;
                                 else
                                     error = true;
 
-                                range |= (*p == ':');
+                                range = range || (*p == ':');
                             }
                             if (error)
                                 return Error(BAD_ATTRIBUTE_VALUE, argnode->GetText());


### PR DESCRIPTION
This reduces unneeded computations by making use of short-circuiting, breaking loops earlier, moving declarations closer to where they are needed.
