### PR TITLE
Ticket #5868: Ignore variables called like a typedef when substituting typedefs

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1114,6 +1114,8 @@ void Tokenizer::simplifyTypedef()
                                     tok2 = tok2->next();
                                 }
                             }
+                        } else if (tok2->tokAt(-2) && Token::Match(tok2->tokAt(-2), "%type% *|&")) {
+                            // Ticket #5868: Don't substitute variable names
                         } else if (tok2->previous()->str() != ".") {
                             simplifyType = true;
                         }


### PR DESCRIPTION
Hi,

This patch detects variables names in Tokenizer::simplifyTypedef so that they are ignored during typedef simplification, which fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
