### PR TITLE
Ticket #5268: Properly detect function heads when in Tokenizer::simplifyEnum

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7614,7 +7614,7 @@ void Tokenizer::simplifyEnum()
                         const Token *prev = tok2->previous();
                         bool type = false;
                         while (prev && (prev->isName() || Token::Match(prev, "*|&|::"))) {
-                            type |= Token::Match(prev, "%type% !!::");
+                            type |= (Token::Match(prev, "%type% !!::") && !Token::Match(prev, "throw|return"));
                             prev = prev->previous();
                         }
                         if (type && (!prev || Token::Match(prev, "[;{}]"))) {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -197,6 +197,7 @@ private:
         TEST_CASE(simplifyKnownVariables55);    // pointer alias
         TEST_CASE(simplifyKnownVariables56);    // ticket #5301 - >>
         TEST_CASE(simplifyKnownVariables57);    // ticket #4724
+        TEST_CASE(simplifyKnownVariables58);    // ticket #5268
         TEST_CASE(simplifyKnownVariablesIfEq1); // if (a==5) => a is 5 in the block
         TEST_CASE(simplifyKnownVariablesIfEq2); // if (a==5) { buf[a++] = 0; }
         TEST_CASE(simplifyKnownVariablesIfEq3); // #4708 - if (a==5) { buf[--a] = 0; }
@@ -2976,6 +2977,21 @@ private:
     void simplifyKnownVariables57() { // #4724
         ASSERT_EQUALS("unsigned long long x ; x = 9223372036854775808 ;", tokenizeAndStringify("unsigned long long x = 1UL << 63 ;", true));
         ASSERT_EQUALS("long long x ; x = -9223372036854775808 ;", tokenizeAndStringify("long long x = 1L << 63 ;", true));
+    }
+
+    void simplifyKnownVariables58() { // #5268
+        const char code[] = "enum e { VAL1 = 1, VAL2 }; "
+                            "typedef char arr_t[VAL2]; "
+                            "int foo(int) ; "
+                            "void bar () { "
+                            "  throw foo (VAL1); "
+                            "} "
+                            "int baz() { "
+                            "  return sizeof(arr_t); "
+                            "}";
+        ASSERT_EQUALS("int foo ( int ) ; "
+                      "void bar ( ) { throw foo ( 1 ) ; } "
+                      "int baz ( ) { return 2 ; }", tokenizeAndStringify(code, true));
     }
 
     void simplifyKnownVariablesIfEq1() {


### PR DESCRIPTION
Hi,

This ticket's incomplete simplification of enum values is due to the fix for ticket #3953 not properly detecting function heads (to skip them), which this patch fixes. Thanks to consider merging.

Cheers,
  Simon
