### PR TITLE
travis: change build optimization level back to -O2 (from -O3) as discussed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
 #   unfortunately we need this to stay within 50min timelimit given by travis.
 #   this also turns off the debug/warning cxxflags
-    - CXXFLAGS="-O3 -march=native -mtune=native -Wunreachable-code"
+    - CXXFLAGS="-O2 -march=native -mtune=native -Wunreachable-code"
   matrix:
 #    special CXXFLAGS for maximum speed, overrides global CXXFLAGS, CHECK_CLANG is the var that controls if we download and check clang in that travis job
     - CXXFLAGS="${CXXFLAGS} -DCHECK_INTERNAL"


### PR DESCRIPTION
in https://github.com/danmar/cppcheck/commit/59077b06f9be2597db57753a27aff93ee294a670
