### PR TITLE
Many platforms do not support backtraces. Fix compile on Solaris platfor...

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -34,10 +34,14 @@
 
 #if !defined(NO_UNIX_SIGNAL_HANDLING) && defined(__GNUC__) && !defined(__MINGW32__) && !defined(__CYGWIN__) && !defined(__OS2__)
 #define USE_UNIX_SIGNAL_HANDLING
-#include <execinfo.h>
 #include <cxxabi.h>
 #include <signal.h>
 #include <cstdio>
+#endif
+
+#if !defined(NO_UNIX_BACKTRACE_SUPPORT) && defined(USE_UNIX_SIGNAL_HANDLING) && !defined(__SVR4)
+#define USE_UNIX_BACKTRACE_SUPPORT
+#include <execinfo.h>
 #endif
 
 #if defined(_MSC_VER)
@@ -237,7 +241,7 @@ static const char *signal_name(int signo)
  */
 static void print_stacktrace(FILE* f, bool demangling)
 {
-#if defined(__GNUC__)
+#if defined(USE_UNIX_BACKTRACE_SUPPORT)
     void *array[32]= {0}; // the less resources the better...
     const int depth = backtrace(array, (int)GetArrayLength(array));
     char **symbolstrings = backtrace_symbols(array, depth);
@@ -460,7 +464,7 @@ int CppCheckExecutor::check_wrapper(CppCheck& cppcheck, int argc, const char* co
     __try {
         return check_internal(cppcheck, argc, argv);
     } __except (filterException(GetExceptionCode(), GetExceptionInformation())) {
-        // reporting to stdout may not be helpful within a GUI application..
+        // reporting to stdout may not be helpful within a I application..
         fprintf(f, "Please report this to the cppcheck developers!\n");
         return -1;
     }

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -20,6 +20,9 @@
 #include "cppcheck.h"
 #include "cppcheckexecutor.h"
 #include <iostream>
+#ifdef __SVR4  // Solaris
+#include <sys/loadavg.h>
+#endif
 #ifdef THREADING_MODEL_FORK
 #include <algorithm>
 #include <sys/select.h>


### PR DESCRIPTION
...m.

This change was tested with Solaris 10 on X86 and SPARC.

More information on Unix Backtrace Support
- http://www.gnu.org/software/libc/manual/html_node/Backtraces.html

It is not supported on the following platforms:
- https://www.gnu.org/software/gnulib/manual/html_node/execinfo_002eh.html
  
  ```
  Mac OS X 10.3,
  FreeBSD 6.0,
  NetBSD 5.0,
  OpenBSD 3.8,
  Minix 3.1.8,
  AIX 5.1,
  HP-UX 11,
  IRIX 6.5,
  OSF/1 5.1,
  Solaris 10,
  Cygwin,
  mingw,
  MSVC 9,
  Interix 3.5,
  BeOS.
  ```
