### PR TITLE
Ticket #5952: Simplify redundant parentheses in pointer variable declarations

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7026,6 +7026,20 @@ bool Tokenizer::simplifyRedundantParentheses()
             tok->deleteThis();
             ret = true;
         }
+
+        if (Token::Match(tok->previous(), "*|& ( %var% )")) {
+            // We may have a variable declaration looking like "type_name *(var_name)"
+            Token *tok2 = tok->tokAt(-2);
+            while (tok2 && Token::Match(tok2, "%type%|static|const|extern") && tok2->str() != "operator") {
+                tok2 = tok2->previous();
+            }
+            if (tok2 && !Token::Match(tok2, "[;,{]")) {
+                // Not a variable declaration
+            } else {
+                tok->deleteThis();
+                tok->deleteNext();
+            }
+        }
     }
     return ret;
 }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -377,6 +377,7 @@ private:
         TEST_CASE(removeParentheses19);      // ((typeof(x) *)0)
         TEST_CASE(removeParentheses20);      // Ticket #5479: a<b<int>>(2);
         TEST_CASE(removeParentheses21);      // Don't "simplify" casts
+        TEST_CASE(removeParentheses22);
 
         TEST_CASE(tokenize_double);
         TEST_CASE(tokenize_strings);
@@ -5749,6 +5750,20 @@ private:
 
     void removeParentheses21() {
         ASSERT_EQUALS("a = ( int ) - b ;", tokenizeAndStringify("a = ((int)-b);", false));
+    }
+
+    void removeParentheses22() {
+        static char code[] = "struct S { "
+                             "char *(a); "
+                             "char &(b); "
+                             "const static char *(c); "
+                             "} ;";
+        static char  exp[] = "struct S { "
+                             "char * a ; "
+                             "char & b ; "
+                             "const static char * c ; "
+                             "} ;";
+        ASSERT_EQUALS(exp, tokenizeAndStringify(code));
     }
 
     void tokenize_double() {


### PR DESCRIPTION
Hi,

This patch fixes this ticket by properly detecting variable declarations in Tokenizer::simplifyRedundantParentheses. Thanks to consider merging.

Cheers,
  Simon
