### PR TITLE
Break the loop once the result can no longer change.

### DIFF
--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -81,7 +81,7 @@ void CheckAssert::assertWithSideEffects()
 
                     bool noReturnInScope = true;
                     for (std::vector<const Token*>::iterator rt = returnTokens.begin(); rt != returnTokens.end(); ++rt) {
-                        if (!inSameScope(*rt, tok2)) {
+                        if (inSameScope(*rt, tok2)) {
                             noReturnInScope = false;
                             break;
                         }


### PR DESCRIPTION
This reduces bitwise ops abuse and makes the loop a bit faster.
