### PR TITLE
Get rid of tokAt() and strAt() in trivial cases.

### DIFF
--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -40,7 +40,7 @@ void CheckAssert::assertWithSideEffects()
     const Token *endTok = tok ? tok->next()->link() : nullptr;
 
     while (tok && endTok) {
-        for (const Token* tmp = tok->tokAt(1); tmp != endTok; tmp = tmp->next()) {
+        for (const Token* tmp = tok->next(); tmp != endTok; tmp = tmp->next()) {
             checkVariableAssignment(tmp, true);
 
             if (tmp->isName() && tmp->type() == Token::eFunction) {

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -104,7 +104,10 @@ public:
     }
 
     const std::string& name() const {
-        return classDef->next()->isName() ? classDef->strAt(1) : emptyString;
+        const Token* next = classDef->next();
+        if (next->isName())
+            return next->str();
+        return emptyString;
     }
 
     const Token *initBaseInfo(const Token *tok, const Token *tok1);


### PR DESCRIPTION
Using `tokAt(1)` and `strAt(1)` makes no sense performance-wise when `next()` can be used instead.
