### PR TITLE
Must limit AST parent search to some reasonable depth.

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1353,9 +1353,16 @@ static void valueFlowSubFunction(TokenList *tokenlist, ErrorLogger *errorLogger,
         const Token * const argumentToken = tok->next();
 
         // is this a function call?
+        int traverseDepth = 0; // Unlimited search takes hours on long comma-separated lists
         const Token *ftok = tok;
-        while (ftok && ftok->str() != "(")
+        while (ftok && ftok->str() != "(") {
             ftok = ftok->astParent();
+            traverseDepth++;
+            if (traverseDepth > 100) {
+                ftok = 0;
+                break;
+            }
+        }
         if (!ftok || !ftok->astOperand1() || !ftok->astOperand2() || !ftok->astOperand1()->function())
             continue;
 


### PR DESCRIPTION
Current implementation takes hours (maybe days) on long initializer lists such as this:

```
const char whatever[size] = { 1, 2, 1, 2 ...} //the list should be something like 600 thousand elements long. 
```

The problem is that the loop which searches for the AST parent starts with the first comma and then traverses all the commas in the list. Then it moves to the second comma and again traverses all commas on the right of that second comma. On a long enough list this takes ages. One solution is to limit the search depth.
