### PR TITLE
Respect DESTDIR setting when installing config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,8 +263,8 @@ install: cppcheck
 	install cppcheck ${BIN}
 	install htmlreport/cppcheck-htmlreport ${BIN}
 ifdef CFGDIR 
-	install -d ${CFGDIR}
-	install -m 644 cfg/* ${CFGDIR}
+	install -d $(DESTDIR)/${CFGDIR}
+	install -m 644 cfg/* $(DESTDIR)/${CFGDIR}
 endif
 
 


### PR DESCRIPTION
I think, it's not very convenient that config files are getting installed to `$(CFGDIR)`, they should go to the `$(DESTDIR)/$(CFGDIR)` instead.
I use the following commands to build cppcheck:

```
make \
 CXXFLAGS="-O2 -mtune=native -pipe -DNDEBUG -Wall" \
 SRCDIR=build \
 PREFIX=/usr \
 CFGDIR=/usr/share/cppcheck/cfg/ \
 HAVE_RULES=yes || exit 1
make install \
 PREFIX=/usr \
 CFGDIR=/usr/share/cppcheck/cfg/ \
 DESTDIR=/tmp/tgz/package-cppcheck || exit 1
```
