### PR TITLE
Resolve CID 1037101

### DIFF
--- a/lib/executionpath.cpp
+++ b/lib/executionpath.cpp
@@ -317,6 +317,8 @@ void ExecutionPath::checkScope(const Token *tok, std::list<ExecutionPath *> &che
                     if (tok->varId())
                         ExecutionPath::bailOutVar(checks, tok->varId());
                 }
+                if (!tok)
+                    break;
             }
         }
 


### PR DESCRIPTION
This resolves potential null pointer dereference when doing

```
if (tok->str() == ")" && tok->next() && tok->next()->str() == "{") {
```

in the code that follows immediately.

I'm not sure that _break_ is the right thing here.
