### PR TITLE
Proper resolve CID 1037085

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1375,6 +1375,7 @@ MathLib::bigint CheckBufferOverrun::countSprintfLength(const std::string &input_
             case 'X':
             case 'i':
                 i_d_x_f_found = true;
+                // fall through
             case 'c':
             case 'e':
             case 'E':


### PR DESCRIPTION
This was simply silenced as "intentional" in Scan - without even a comment in code. According to this http://security.coverity.com/blog/2013/Sep/gimme-a-break.html the comment added should cause the analyzer to understand it is intentional. Humans will be thankful too.
