### PR TITLE
Add memory leak tracing

### DIFF
--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -22,6 +22,11 @@
 
 int main(int argc, char *argv[])
 {
+    // MS Visual C++ memory leak debug tracing
+#if defined(_MSC_VER) && defined(_DEBUG)
+    _CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
+#endif
+
     options args(argc, const_cast<const char**>(argv));
 
     std::size_t ret = TestFixture::runTests(args);


### PR DESCRIPTION
Tracing memory leaks won't hurt in the autotest either.
