### PR TITLE
Fix potential infinite loop

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1691,7 +1691,7 @@ void CheckMemoryLeakInFunction::simplifycode(Token *tok) const
             // Reduce "while1 continue| ;" => "use ;"
             if (Token::Match(tok2, "while1 if| continue| ;")) {
                 tok2->str("use");
-                while (tok2->strAt(1) != ";")
+                while (tok2->next() && tok2->next()->str() != ";")
                     tok2->deleteNext();
                 done = false;
             }


### PR DESCRIPTION
The original code would yield an infinite loop if `next()` is null - the inequality comparison would yield `true` and the loop would continue forever. Maybe it doesn't matter here but it will once the surrounding code is changed or this code is copy-pasted somewhere else.
