### PR TITLE
Ticket #6023: Properly handle template'd default template parameter values

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -600,11 +600,16 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                 for (std::size_t i = (templatepar - eq.size()); it != eq.end() && i < usedpar; ++i)
                     ++it;
                 while (it != eq.end()) {
+                    int indentlevel = 0;
                     tok->insertToken(",");
                     tok = tok->next();
                     const Token *from = (*it)->next();
                     std::stack<Token *> links;
-                    while (from && (!links.empty() || (from->str() != "," && from->str() != ">"))) {
+                    while (from && (!links.empty() || (from->str() != "," && (indentlevel || from->str() != ">")))) {
+                        if (from->str() == "<")
+                            ++indentlevel;
+                        else if (from->str() == ">")
+                            --indentlevel;
                         tok->insertToken(from->str(), from->originalName());
                         tok = tok->next();
                         if (Token::Match(tok, "(|["))

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -139,6 +139,7 @@ private:
         TEST_CASE(template44);  // #5297 - TemplateSimplifier::simplifyCalculations not eager enough
         TEST_CASE(template45);  // #5814 - syntax error reported for valid code
         TEST_CASE(template46);  // #5816 - syntax error reported for valid code
+        TEST_CASE(template47);  // #6023 - syntax error reported for valid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -2421,6 +2422,12 @@ private:
             "template <class T> struct C { "
             "  enum { value = A<typename B<T>::type, int>::value }; "
             "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void template47() { // #6023
+        tok("template <typename T1, typename T2 = T3<T1> > class C1 {}; "
+            "class C2 : public C1<C2> {};");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Hi,

This ticket is a (incorrect) syntax error reported because we fail to handle template'd default template parameter values, and make the code invalid when "injecting" such a default value. This patch fixes it by keeping track of the "parameter depth" in a part of the code that did not. Thanks to consider merging.

Cheers,
  Simon

PS: I plan to work on replacing ">>" by "> >" when it makes sense and factorize somehow the "parameter depth" code that's more or less duplicated several times in templatesimplifier.cpp
