### PR TITLE
Fix bad installation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,9 @@ tags:
 	ctags -R --exclude=doxyoutput .
 
 install: cppcheck
-	install -d ${DESTDIR}${BIN}
-	install cppcheck ${DESTDIR}${BIN}
-	install htmlreport/cppcheck-htmlreport ${DESTDIR}${BIN}
+	install -d ${BIN}
+	install cppcheck ${BIN}
+	install htmlreport/cppcheck-htmlreport ${BIN}
 ifdef CFGDIR 
 	install -d ${DESTDIR}${CFGDIR}
 	install -m 644 cfg/* ${DESTDIR}${CFGDIR}

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -411,9 +411,9 @@ int main(int argc, char **argv)
     fout << "tags:\n";
     fout << "\tctags -R --exclude=doxyoutput .\n\n";
     fout << "install: cppcheck\n";
-    fout << "\tinstall -d ${DESTDIR}${BIN}\n";
-    fout << "\tinstall cppcheck ${DESTDIR}${BIN}\n";
-    fout << "\tinstall htmlreport/cppcheck-htmlreport ${DESTDIR}${BIN}\n";
+    fout << "\tinstall -d ${BIN}\n";
+    fout << "\tinstall cppcheck ${BIN}\n";
+    fout << "\tinstall htmlreport/cppcheck-htmlreport ${BIN}\n";
     fout << "ifdef CFGDIR \n";
     fout << "\tinstall -d ${DESTDIR}${CFGDIR}\n";
     fout << "\tinstall -m 644 cfg/* ${DESTDIR}${CFGDIR}\n";


### PR DESCRIPTION
https://www.gnu.org/prep/standards/html_node/DESTDIR.html

This should fix the installation in debian
