### PR TITLE
Fix -Wsign-compare warnings from gcc

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -59,7 +59,7 @@ bool astIsFloat(const Token *tok, bool unknown)
     return unknown;
 }
 
-static bool astGetSizeSign(const Settings *settings, const Token *tok, int *size, char *sign)
+static bool astGetSizeSign(const Settings *settings, const Token *tok, unsigned int *size, char *sign)
 {
     if (!tok)
         return false;
@@ -72,7 +72,7 @@ static bool astGetSizeSign(const Settings *settings, const Token *tok, int *size
         if (tok->str().find("L") != std::string::npos)
             return false;
         MathLib::bigint value = MathLib::toLongNumber(tok->str());
-        int sz;
+        unsigned int sz;
         if (value >= -(1<<7) && value <= (1<<7)-1)
             sz = 8;
         else if (value >= -(1<<15) && value <= (1<<15)-1)
@@ -95,7 +95,7 @@ static bool astGetSizeSign(const Settings *settings, const Token *tok, int *size
         const Variable *var = tok->variable();
         if (!var)
             return false;
-        int sz = 0;
+        unsigned int sz = 0;
         for (const Token *type = var->typeStartToken(); type; type = type->next()) {
             if (type->str() == "*")
                 return false;  // <- FIXME: handle pointers
@@ -2818,7 +2818,7 @@ void CheckOther::checkIntegerOverflow()
                 continue;
 
             // get size and sign of result..
-            int  size = 0;
+            unsigned int  size = 0;
             char sign = 0;
             if (!astGetSizeSign(_settings, tok, &size, &sign))
                 continue;


### PR DESCRIPTION
This commit fixes -Wsign-compare warnings from gcc. No functional changes.

It fixes:

```
g++ -c -pipe -std=c++0x -g -Wall -W -D_REENTRANT -DQT_GUI_LIB -DQT_CORE_LIB -DQT_SHARED -I/usr/share/qt4/mkspecs/linux-g++ -I. -I/usr/include/qt4/QtCore -I/usr/include/qt4/QtGui -I/usr/include/qt4 -I. -I../lib -I../externals/tinyxml -Itemp -Itemp -o temp/checkother.o ../lib/checkother.cpp
../lib/checkother.cpp: In function ‘bool astGetSizeSign(const Settings*, const Token*, int*, char*)’:
../lib/checkother.cpp:84:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (sz < 8 * settings->sizeof_int)
                ^
```
