### PR TITLE
Detect -> accesses on uninitialized pointers

### DIFF
--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -168,16 +168,6 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown)
 
     // read/write member variable
     if (firstOperand && parent->str() == "." && (!parent->astParent() || parent->astParent()->str() != "&")) {
-        const Token* rightTok = parent->astOperand2();
-        if (rightTok) {
-            const Function* func = rightTok->function();
-            if (func && func->isStatic)
-                return false;
-            const Variable* var = rightTok->variable();
-            if (var && var->isStatic()) {
-                return false;
-            }
-        }
         if (!parent->astParent() || parent->astParent()->str() != "(" || parent->astParent() == tok->previous())
             return true;
         unknown = true;

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1671,6 +1671,21 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, bool all
     if (Token::Match(vartok->tokAt(-3), "typeof|__alignof__ ( * %var%"))
         return false;
 
+    // Accessing Rvalue member using "." or "->" 
+    if (vartok->strAt(1) == "." && vartok->strAt(-1) != "&") {
+        bool assignment = false;
+        const Token* parent = vartok->astParent();
+        while (parent) {
+            if (parent->str() == "=") {
+                assignment = true;
+                break;
+            }
+            parent = parent->astParent();
+        }
+        if(!assignment) 
+            return true;
+    }
+
     // Passing variable to function..
     if (Token::Match(vartok->previous(), "[(,] %var% [,)]") || Token::Match(vartok->tokAt(-2), "[(,] & %var% [,)]")) {
         const bool address(vartok->previous()->str() == "&");

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3171,7 +3171,15 @@ private:
                         "void test() {\n"
                         "    Element *element; element->f();\n"
                         "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        checkUninitVar2("class Element {\n"
+                        "    static void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).f();\n"
+                        "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         checkUninitVar2("class Element {\n"
                         "    static int v;\n"
@@ -3179,7 +3187,15 @@ private:
                         "void test() {\n"
                         "    Element *element; element->v;\n"
                         "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        checkUninitVar2("class Element {\n"
+                        "    static int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).v;\n"
+                        "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         checkUninitVar2("class Element {\n"
                         "    void f() { }\n"
@@ -3190,10 +3206,26 @@ private:
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         checkUninitVar2("class Element {\n"
+                        "    void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).f();\n"
+                        "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        checkUninitVar2("class Element {\n"
                         "    int v;\n"
                         "};\n"
                         "void test() {\n"
                         "    Element *element; element->v;\n"
+                        "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        checkUninitVar2("class Element {\n"
+                        "    int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).v;\n"
                         "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
@@ -3429,7 +3461,9 @@ private:
                         "    struct AB *ab = malloc(sizeof(struct AB));\n"
                         "    return ab->a;\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized struct member: ab.a\n", errout.str());
+        ASSERT_EQUALS(  "[test.cpp:4]: (error) Memory is allocated but not initialized: ab\n"
+                        "[test.cpp:4]: (error) Uninitialized struct member: ab.a\n",
+                        errout.str());
 
         checkUninitVar2("struct t_udf_file {  int dir_left; };\n"
                         "\n"


### PR DESCRIPTION
This detects `->` accesses via uninitialized pointers as discussed here https://github.com/danmar/cppcheck/pull/421#issuecomment-54943202

Some concerns:
- not at all sure the loop which traverses the AST until it finds a suitable parent is fast enough in generic cases
- one of the testcases now emits two warnings, both correct, which means that the test has to expect them is some specific order, I'm not sure if that's good
