### PR TITLE
Ticket #6134: Improve the mechanism differentiating template declarations from template definitions.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -472,11 +472,19 @@ std::list<Token *> TemplateSimplifier::getTemplateDeclarations(Token *tokens, bo
             Token *parmEnd = tok->next()->findClosingBracket();
             codeWithTemplates = true;
 
+            int indentlevel = 0;
             for (const Token *tok2 = parmEnd; tok2; tok2 = tok2->next()) {
+                if (tok2->str() == "(")
+                    ++indentlevel;
+                else if (tok2->str() == ")")
+                    --indentlevel;
+
+                if (indentlevel) // In an argument list; move to the next token
+                    continue;
+
                 // Just a declaration => ignore this
                 if (tok2->str() == ";")
                     break;
-
                 // Implementation => add to "templates"
                 if (tok2->str() == "{") {
                     templates.push_back(tok);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -140,6 +140,7 @@ private:
         TEST_CASE(template45);  // #5814 - syntax error reported for valid code
         TEST_CASE(template46);  // #5816 - syntax error reported for valid code
         TEST_CASE(template47);  // #6023 - syntax error reported for valid code
+        TEST_CASE(template48);  // #6134 - 100% CPU upon invalid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -2429,6 +2430,12 @@ private:
     void template47() { // #6023
         tok("template <typename T1, typename T2 = T3<T1> > class C1 {}; "
             "class C2 : public C1<C2> {};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void template48() { // #6134
+        tok("template <int> int f( {  } ); "
+            "int foo = f<1>(0);");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Hi,

This ticket is an infinite loop upon invalid code, that's due to the code differentiating template declarations from definitions only concluding from the presence of a { or ; regardless of whether we're in parameters list of not. This patch fixes this, and the ticket as well. Thanks to consider merging.

Cheers,
  Simon
