### PR TITLE
Use Token::Match instead of explicit Token::str() comparisons.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -638,7 +638,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                     }
 
                     // has body?
-                    if (scopeBegin->str() == "{" || scopeBegin->str() == ":") {
+                    if (Token::Match(scopeBegin, "{|:")) {
                         tok = funcStart;
 
                         // class function
@@ -1164,7 +1164,7 @@ void Variable::evaluate()
             tok = tok->next();
     }
 
-    while (_start && _start->next() && (_start->str() == "static" || _start->str() == "const"))
+    while (_start && _start->next() && Token::Match(_start, "static|const"))
         _start = _start->next();
     while (_end && _end->previous() && _end->str() == "const")
         _end = _end->previous();
@@ -1203,9 +1203,9 @@ void Variable::evaluate()
     }
 
     if (_start) {
-        if (_start->str() == "bool" || _start->str() == "char" || _start->str() == "short" || _start->str() == "int" || _start->str() == "long")
+        if (Token::Match(_start, "bool|char|short|int|long"))
             setFlag(fIsIntType, true);
-        else if (_start->str() == "float" || _start->str() == "double")
+        else if (Token::Match(_start, "float|double"))
             setFlag(fIsFloatType, true);
     }
 }
@@ -1578,7 +1578,7 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
     // skip to start of function
     bool foundInitLit = false;
     while (tok1 && (tok1->str() != "{" || (foundInitLit && tok1->previous()->isName()))) {
-        if (tok1->str() == "(" || tok1->str() == "{")
+        if (Token::Match(tok1, "(|{"))
             tok1 = tok1->link();
         if (tok1->str() == ":")
             foundInitLit = true;
@@ -2192,7 +2192,7 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
             const Token* endTok   = nullptr;
             const Token* nameTok  = nullptr;
 
-            if (tok->str() == "," || tok->str() == ")")
+            if (Token::Match(tok, ",|)"))
                 return; // Syntax error
 
             do {
@@ -2608,7 +2608,7 @@ const Token *Scope::checkVariable(const Token *tok, AccessControl varaccess)
     if (tok && isVariableDeclaration(tok, vartok, typetok)) {
         // If the vartok was set in the if-blocks above, create a entry for this variable..
         tok = vartok->next();
-        while (tok && (tok->str() == "[" || tok->str() == "{"))
+        while (tok && Token::Match(tok, "[|{"))
             tok = tok->link()->next();
 
         if (vartok->varId() == 0) {
@@ -2681,7 +2681,7 @@ static const Token* skipPointers(const Token* tok)
 
 bool Scope::isVariableDeclaration(const Token* tok, const Token*& vartok, const Token*& typetok) const
 {
-    if (tok && check && check->_tokenizer->isCPP() && (tok->str() == "throw" || tok->str() == "new"))
+    if (tok && check && check->_tokenizer->isCPP() && Token::Match(tok, "throw|new"))
         return false;
 
     const Token* localTypeTok = skipScopeIdentifiers(tok);

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -285,7 +285,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             return 0;
 
         // Function pointer or prototype..
-        while (tok && (tok->str() == "(" || tok->str() == "[")) {
+        while (tok && Token::Match(tok, "(|[")) {
             tok = tok->link()->next();
             while (tok && Token::Match(tok, "const|volatile")) // Ticket #5786: Skip function cv-qualifiers
                 tok = tok->next();
@@ -303,7 +303,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             return 0;
 
         // ,/>
-        while (tok->str() == ">" || tok->str() == ">>") {
+        while (Token::Match(tok, ">|>>")) {
             if (level == 0)
                 return numberOfParameters;
             --level;
@@ -564,7 +564,7 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                 ++templateParmDepth;
 
             // end of template parameters?
-            if (tok->str() == ">" || tok->str() == ">>") {
+            if (Token::Match(tok, ">|>>")) {
                 if (Token::Match(tok, ">|>> class|struct %var%"))
                     classname = tok->strAt(2);
                 templateParmDepth -= (1 + (tok->str() == ">>"));
@@ -722,7 +722,7 @@ void TemplateSimplifier::expandTemplate(
     std::list<Token *> &templateInstantiations)
 {
     for (const Token *tok3 = tokenlist.front(); tok3; tok3 = tok3 ? tok3->next() : nullptr) {
-        if (tok3->str() == "{" || tok3->str() == "(" || tok3->str() == "[")
+        if (Token::Match(tok3, "{|(|["))
             tok3 = tok3->link();
 
         // Start of template..
@@ -843,11 +843,11 @@ static bool isLowerThanShift(const Token* lower)
 }
 static bool isLowerThanPlusMinus(const Token* lower)
 {
-    return isLowerThanShift(lower) || lower->str() == "<<" || lower->str() == ">>";
+    return isLowerThanShift(lower) || Token::Match(lower, "<<|>>");
 }
 static bool isLowerThanMulDiv(const Token* lower)
 {
-    return isLowerThanPlusMinus(lower) || lower->str() == "+" || lower->str() == "-";
+    return isLowerThanPlusMinus(lower) || Token::Match(lower, "+|-");
 }
 static bool isLowerEqualThanMulDiv(const Token* lower)
 {
@@ -1222,7 +1222,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
         for (const Token *tok3 = tok2->tokAt(2); tok3 && (indentlevel > 0 || tok3->str() != ">"); tok3 = tok3->next()) {
             // #2648 - unhandled parentheses => bail out
             // #2721 - unhandled [ => bail out
-            if (tok3->str() == "(" || tok3->str() == "[") {
+            if (Token::Match(tok3, "(|[")) {
                 typeForNewNameStr.clear();
                 break;
             }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -719,9 +719,9 @@ Token* Token::nextArgument() const
     for (const Token* tok = this; tok; tok = tok->next()) {
         if (tok->str() == ",")
             return tok->next();
-        else if (tok->link() && (tok->str() == "(" || tok->str() == "{" || tok->str() == "[" || tok->str() == "<"))
+        else if (tok->link() && Token::Match(tok, "(|{|[|<"))
             tok = tok->link();
-        else if (tok->str() == ")" || tok->str() == ";")
+        else if (Token::Match(tok, ")|;"))
             return 0;
     }
     return 0;
@@ -732,13 +732,13 @@ Token* Token::nextArgumentBeforeCreateLinks2() const
     for (const Token* tok = this; tok; tok = tok->next()) {
         if (tok->str() == ",")
             return tok->next();
-        else if (tok->link() && (tok->str() == "(" || tok->str() == "{" || tok->str() == "["))
+        else if (tok->link() && Token::Match(tok, "(|{|["))
             tok = tok->link();
         else if (tok->str() == "<") {
             const Token* temp = tok->findClosingBracket();
             if (temp)
                 tok = temp;
-        } else if (tok->str() == ")" || tok->str() == ";")
+        } else if (Token::Match(tok, ")|;"))
             return 0;
     }
     return 0;
@@ -751,9 +751,9 @@ const Token * Token::findClosingBracket() const
     if (_str == "<") {
         unsigned int depth = 0;
         for (closing = this; closing != nullptr; closing = closing->next()) {
-            if (closing->str() == "{" || closing->str() == "[" || closing->str() == "(")
+            if (Token::Match(closing, "{|[|("))
                 closing = closing->link();
-            else if (closing->str() == "}" || closing->str() == "]" || closing->str() == ")" || closing->str() == ";" || closing->str() == "=")
+            else if (Token::Match(closing, "}|]|)|;|="))
                 break;
             else if (closing->str() == "<")
                 ++depth;

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -511,7 +511,7 @@ static void compileTerm(Token *&tok, AST_state& state)
         return;
     if (Token::Match(tok, "L %str%|%char%"))
         tok = tok->next();
-    if (state.inArrayAssignment && tok->str() == "." && (tok->strAt(-1) == "," || tok->strAt(-1) == "{")) // Jump over . in C style struct initialization
+    if (state.inArrayAssignment && tok->str() == "." && Token::Match(tok->tokAt(-1), ",|{")) // Jump over . in C style struct initialization
         tok = tok->next();
 
     if (tok->isLiteral()) {
@@ -758,7 +758,7 @@ static void compileAnd(Token *&tok, AST_state& state)
             Token* tok2 = tok->next();
             if (tok2->str() == "&")
                 tok2 = tok2->next();
-            if (state.cpp && (tok2->str() == "," || tok2->str() == ")")) {
+            if (state.cpp && Token::Match(tok2, ",|)")) {
                 tok = tok2;
                 break; // rValue reference
             }
@@ -855,7 +855,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
                 init1 = tok2;
                 AST_state state1(cpp);
                 compileExpression(tok2, state1);
-                if (tok2->str() == ";" || tok2->str() == ")")
+                if (Token::Match(tok2, ";|)"))
                     break;
                 init1 = 0;
             }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -260,7 +260,7 @@ static bool isVariableChanged(const Token *start, const Token *end, const unsign
                 return true;
 
             const Token *parent = tok->astParent();
-            while (parent && (parent->str() == "." || parent->str() == "::"))
+            while (parent && Token::Match(parent, ".|::"))
                 parent = parent->astParent();
             if (parent && parent->type() == Token::eIncDecOp)
                 return true;
@@ -1154,7 +1154,7 @@ static void execute(const Token *expr,
             *error = true;
     }
 
-    else if (expr->str() == "++" || expr->str() == "--") {
+    else if (Token::Match(expr, "++|--")) {
         if (!expr->astOperand1() || expr->astOperand1()->varId() == 0U)
             *error = true;
         else {
@@ -1522,7 +1522,7 @@ static void valueFlowSubFunction(TokenList *tokenlist, ErrorLogger *errorLogger,
                 if (Token::Match(tok2, "%varid% !!=", varid2)) {
                     for (std::list<ValueFlow::Value>::const_iterator val = argvalues.begin(); val != argvalues.end(); ++val)
                         setTokenValue(const_cast<Token*>(tok2), *val);
-                } else if (tok2->str() == "{" || tok2->str() == "?") {
+                } else if (Token::Match(tok2, "{|?")) {
                     if (settings->debugwarnings)
                         bailout(tokenlist, errorLogger, tok2, "parameter " + arg->name() + ", at '" + tok2->str() + "'");
                     break;


### PR DESCRIPTION
Hi,

I've noticed that we have several chains of the form "tok->str() == ... || tok->str() = ..." that can be replaced by a single call to Token::Match. This mechanical patch does this, which improves readability IMHO. Thanks to consider merging.

Cheers,
  Simon
