### PR TITLE
Fixed #5747 (When socket() returns -1 on error, this shouldn't be marked...

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -280,6 +280,10 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     varInfo2.erase(tok->tokAt(2)->varId());
                 } else if (Token::Match(tok->next(), "( 0 < %var% )|&&")) {
                     varInfo2.erase(tok->tokAt(4)->varId());
+                } else if (Token::Match(tok->next(), "( %var% == -1 )|&&")) {
+                    varInfo1.erase(tok->tokAt(2)->varId());
+                } else if (Token::Match(tok->next(), "( -1 == %var% )|&&")) {
+                    varInfo1.erase(tok->tokAt(4)->varId());
                 }
 
                 checkScope(tok2->next(), &varInfo1, notzero);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -75,6 +75,7 @@ private:
         TEST_CASE(ifelse5);
         TEST_CASE(ifelse6); // #3370
         TEST_CASE(ifelse7); // #5576 - if (fd < 0)
+        TEST_CASE(ifelse8); // #5747 - if (fd == -1)
 
         // switch
         TEST_CASE(switch1);
@@ -489,6 +490,15 @@ private:
               "    if (x < 0)\n"  // assume negative value indicates its unallocated
               "        return;\n"
               "    free(x);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void ifelse8() { // #5747
+        check("void f() {\n"
+              "    int fd = socket(AF_INET, SOCK_PACKET, 0 );\n"
+              "    if (fd == -1)\n"
+              "        return;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
... as a resource leak)
