### PR TITLE
Must catch and translate exceptions on top level

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -119,7 +119,17 @@ int main(int argc, char* argv[])
     GetModuleFileNameA(NULL, exename, sizeof(exename)/sizeof(exename[0])-1);
     argv[0] = exename;
 #endif
-    return exec.check(argc, argv);
+
+    try {
+        return exec.check(argc, argv);
+    } catch (const InternalError& e) {
+        printf("%s\n", e.errorMessage.c_str());
+    } catch (const std::exception& error) {
+        printf("%s\n", error.what());
+    } catch (...) {
+        printf("Unknown exception\n");
+    }
+    return EXIT_FAILURE;
 }
 
 

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -22,9 +22,17 @@
 
 int main(int argc, char *argv[])
 {
-    options args(argc, const_cast<const char**>(argv));
+    try {
+        options args(argc, const_cast<const char**>(argv));
 
-    std::size_t failedTestsCount = TestFixture::runTests(args);
-
-    return (failedTestsCount == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+        std::size_t failedTestsCount = TestFixture::runTests(args);
+        return (failedTestsCount == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+    } catch (const InternalError& e) {
+        printf("%s\n", e.errorMessage.c_str());
+    } catch (const std::exception& error) {
+        printf("%s\n", error.what());
+    } catch (...) {
+        printf("Unknown exception\n");
+    }
+    return EXIT_FAILURE;
 }


### PR DESCRIPTION
If there's an unhandled exception the runtime can call `terminate()` immediately without unwinding the stack and this can cause a whole bunch of undesired side effects. This change uses `printf()` because it is exception safe. Resolves CIDs 1037072, 1037071, 1037070, 1037068, 1037067.
