### PR TITLE
Make TestSymbolDatabase::hasClassFunction's code snippet valid.

### DIFF
--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -814,7 +814,7 @@ private:
     }
 
     void hasClassFunction() {
-        GET_SYMBOL_DB("class Fred { void func(); }; Fred::func() { }\n")
+        GET_SYMBOL_DB("class Fred { void func(); }; void Fred::func() { }\n")
 
         // 3 scopes: Global, Class, and Function
         ASSERT(db && db->scopeList.size() == 3);


### PR DESCRIPTION
Hi,

While investigating ticket #6177, I've noticed that the code snippet that is used in TestSymbolDatabase::hasClassFunction is actually invalid. This trivial patch fixes that. Thanks to consider merging.

Cheers,
  Simon
