### PR TITLE
Fix compilation (on Cygwin), by adding the necessary includes.

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -95,6 +95,9 @@ void CheckOther::checkZeroDivision()
 
 #include "cppcheckexecutor.h"
 
+#include <cstdio>
+#include <cstdlib>
+
 #ifdef _WIN32
 #include <windows.h>
 static char exename[1024] = {0};


### PR DESCRIPTION
No idea why this problem has not shown up on other platforms; the includes are by no means Cygwin-specific.
