### PR TITLE
Fix compilation (on Cygwin), by adding the necessary include also to testrunner.cpp

### DIFF
--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdio>
 #include <cstdlib>
 #include "testsuite.h"
 #include "options.h"


### PR DESCRIPTION
No idea why this problem has not shown up on other platforms; the includes are by no means Cygwin-specific.

This is a continuation to pull request #447, sorry for missing this file the first time.
