### PR TITLE
Ticket #6187: Avoid infinite loop if eraseDeadCode does not remove anything

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9066,8 +9066,7 @@ void Tokenizer::simplifyWhile0()
         if (Token::simpleMatch(tok->next()->link(), ") {")) {
             Token *end = tok->next()->link();
             end = end->next()->link();
-            tok = tok->previous();
-            eraseDeadCode(tok, end->next());
+            eraseDeadCode(tok->previous(), end->next());
         }
     }
 }

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2372,6 +2372,16 @@ private:
 
         ASSERT_EQUALS("void foo ( ) { exit ( 0 ) ; }",
                       tokWithStdLib("void foo() { do { exit(0); } while (true); }"));
+
+        // #6187
+        tokWithStdLib("void foo() {\n"
+                      "  goto label;\n"
+                      "  for (int i = 0; i < 0; ++i) {\n"
+                      "    ;\n"
+                      "label:\n"
+                      "    ;\n"
+                      "  }\n"
+                      "}");
     }
 
     void strcat1() {


### PR DESCRIPTION
Hi,

This patch fixes the ticket, where we end up in an infinite loop upon invalid code (goto into the body of a dead loop): we continuously
- Decrement the iterator
- Call eraseDeadCode (that does nothing)
- Increment the iterator

Thanks to consider merging.

Cheers,
  Simon
