### PR TITLE
Don't proceed to outer scope once match is found

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2254,6 +2254,8 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
                                     break;
                             }
                         }
+                        if (argType)
+                            break;
                         parent = parent->nestedIn;
                     }
                 }


### PR DESCRIPTION
I'm not sure about this. The current code has this comment:

```
// look for variable type in any using namespace in this scope or above
```

which somehow implies that the first match found would be the right one. However the implementation only breaks the inner loop and so effectively proceeds to outer scope. Either the code is right (and then the comment should be fixed) or the code is wrong (and then this PR should be merged).
