### PR TITLE
Ticket #5625: Simplify constant ternary operator in template parameters.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -246,8 +246,8 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             continue;
         }
 
-        // Skip '='
-        if (tok && tok->str() == "=")
+        // Skip '=', '?', ':'
+        if (tok && Token::Match(tok, "=|?|:"))
             tok = tok->next();
         if (!tok)
             return 0;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4862,7 +4862,7 @@ bool Tokenizer::simplifyConstTernaryOp()
 
                 else if (endTok->str() == "?")
                     ++ternaryOplevel;
-                else if (Token::Match(endTok, ")|}|]|;|,|:")) {
+                else if (Token::Match(endTok, ")|}|]|;|,|:|>")) {
                     if (endTok->str() == ":" && ternaryOplevel)
                         --ternaryOplevel;
                     else {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -254,6 +254,7 @@ private:
         TEST_CASE(simplify_constants3);
         TEST_CASE(simplify_constants4);
         TEST_CASE(simplify_constants5);
+        TEST_CASE(simplify_constants6);     // Ticket #5625: Ternary operator as template parameter
         TEST_CASE(simplify_null);
         TEST_CASE(simplifyMulAndParens);    // Ticket #2784 + #3184
 
@@ -3589,6 +3590,20 @@ private:
                             "x = NELEMS;\n"
                             "y = NELEMS2;\n";
         ASSERT_EQUALS("int buffer [ 10 ] ;\n\n\nx = 10 ;\ny = 10 ;", tokenizeAndStringify(code,true));
+    }
+
+    void simplify_constants6() { // Ticket #5625
+        const char code[] = "template < class T > struct foo ;\n"
+                            "void bar ( ) {\n"
+                              "foo < 1 ? 0 ? 1 : 6 : 2 > x ;\n"
+                              "foo < 1 ? 0 : 2 > y ;\n"
+                            "}";
+        const char exp [] = "template < class T > struct foo ;\n"
+                            "void bar ( ) {\n"
+                              "foo < 6 > x ;\n"
+                              "foo < 0 > y ;\n"
+                            "}";
+        ASSERT_EQUALS(exp, tokenizeAndStringify(code, true));
     }
 
     void simplify_null() {


### PR DESCRIPTION
Hi,

This patch ensures that TemplateSimplifier::templateParameters doest not fail when a ternary operator is used as a template parameter and adjusts Tokenizer::simplifyConstTernaryOp accordingly, which fixes the ticket. Thanks to consider merging.

Cheers,
  Simon
