### PR TITLE
Properly detect the end of the "false part" of ternary operators when it contains '>'

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4822,8 +4822,13 @@ bool Tokenizer::simplifyConstTernaryOp()
 
         const int offset = (tok->previous()->str() == ")") ? 2 : 1;
 
-        if (tok->strAt(-2*offset) == "<" && !TemplateSimplifier::templateParameters(tok->tokAt(-2*offset)))
-            continue;
+        bool inTemplateParameter = false;
+        if (tok->strAt(-2*offset) == "<") {
+            if (!TemplateSimplifier::templateParameters(tok->tokAt(-2*offset)))
+                continue;
+            else
+                inTemplateParameter = true;
+        }
 
         // Find the token ":" then go to the next token
         Token *semicolon = skipTernaryOp(tok);
@@ -4868,6 +4873,8 @@ bool Tokenizer::simplifyConstTernaryOp()
                 else if (Token::Match(endTok, ")|}|]|;|,|:|>")) {
                     if (endTok->str() == ":" && ternaryOplevel)
                         --ternaryOplevel;
+                    else if (endTok->str() == ">" && !inTemplateParameter)
+                        ;
                     else {
                         Token::eraseTokens(semicolon->tokAt(-2), endTok);
                         ret = true;

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -3599,17 +3599,24 @@ private:
     }
 
     void simplify_constants6() { // Ticket #5625
-        const char code[] = "template < class T > struct foo ;\n"
-                            "void bar ( ) {\n"
-                            "foo < 1 ? 0 ? 1 : 6 : 2 > x ;\n"
-                            "foo < 1 ? 0 : 2 > y ;\n"
-                            "}";
-        const char exp [] = "template < class T > struct foo ;\n"
-                            "void bar ( ) {\n"
-                            "foo < 6 > x ;\n"
-                            "foo < 0 > y ;\n"
-                            "}";
-        ASSERT_EQUALS(exp, tokenizeAndStringify(code, true));
+        {
+            const char code[] = "template < class T > struct foo ;\n"
+                                "void bar ( ) {\n"
+                                "foo < 1 ? 0 ? 1 : 6 : 2 > x ;\n"
+                                "foo < 1 ? 0 : 2 > y ;\n"
+                                "}";
+            const char exp [] = "template < class T > struct foo ;\n"
+                                "void bar ( ) {\n"
+                                "foo < 6 > x ;\n"
+                                "foo < 0 > y ;\n"
+                                "}";
+            ASSERT_EQUALS(exp, tokenizeAndStringify(code, true));
+        }
+        {
+            const char code[] = "bool b = true ? false : 1 > 2 ;";
+            const char exp [] = "bool b ; b = false ;";
+            ASSERT_EQUALS(exp, tokenizeAndStringify(code, true));
+        }
     }
 
     void simplify_null() {


### PR DESCRIPTION
Hi,

As noticed by PKEuS, my fix for ticket #5625 causes a regression as it does not detect the end of the "false part" of ternary operator expressions such as "a ? b : c > d". This patch fixes it by only considering '>' as a terminator when the ternary operator is in some template parameter. Thanks to consider merging.

Cheers,
  Simon
