### PR TITLE
Ticket #6187: Avoid infinite loop if eraseDeadCode does not remove anything (this time without memory corruption).

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8967,10 +8967,13 @@ void Tokenizer::simplifyWhile0()
 
         // remove "while (0) { .. }"
         if (Token::simpleMatch(tok->next()->link(), ") {")) {
-            Token *end = tok->next()->link();
+            Token *end = tok->next()->link(), *old_prev = tok->previous();
             end = end->next()->link();
-            tok = tok->previous();
-            eraseDeadCode(tok, end->next());
+            eraseDeadCode(old_prev, end->next());
+            if (old_prev && old_prev->next())
+                tok = old_prev->next();
+            else
+                break;
         }
     }
 }

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2393,6 +2393,16 @@ private:
 
         ASSERT_EQUALS("void foo ( ) { exit ( 0 ) ; }",
                       tokWithStdLib("void foo() { do { exit(0); } while (true); }"));
+
+        // #6187
+        tokWithStdLib("void foo() {\n"
+                      "  goto label;\n"
+                      "  for (int i = 0; i < 0; ++i) {\n"
+                      "    ;\n"
+                      "label:\n"
+                      "    ;\n"
+                      "  }\n"
+                      "}");
     }
 
     void strcat1() {


### PR DESCRIPTION
Hi,

This PR is a follow-up to https://github.com/danmar/cppcheck/pull/450/ that fixed the bug but introduced a memory corruption, and was therefore reverted (sorry about this!). This new version is a bit more clever and valgrind is now happy. Please consider merging.

Cheers,
  Simon
