### PR TITLE
Addition of a document type definition for library configurations

### DIFF
--- a/cfg/library.dtd
+++ b/cfg/library.dtd
@@ -1,0 +1,57 @@
+<!ELEMENT def (platformtype*,
+               define*,
+               function*,
+               memory*,
+               resource*,
+               podtype*)>
+<!ATTLIST def format CDATA "1">
+
+<!ELEMENT platformtype (platform+)>
+<!ATTLIST platformtype name CDATA #REQUIRED>
+<!ATTLIST platformtype value CDATA #REQUIRED>
+
+<!ELEMENT platform EMPTY>
+<!ATTLIST platform type CDATA #REQUIRED>
+
+<!ELEMENT define EMPTY>
+<!ATTLIST define name CDATA #REQUIRED>
+<!ATTLIST define value CDATA #REQUIRED>
+
+<!ELEMENT function (leak-ignore?,
+                    (noreturn|use-retval)?,
+                    arg*)>
+<!ATTLIST function name NMTOKEN #REQUIRED>
+
+<!ELEMENT leak-ignore EMPTY>
+
+<!ELEMENT noreturn EMPTY>
+
+<!ELEMENT use-retval EMPTY>
+
+<!ELEMENT arg (not-bool?,
+               not-uninit?,
+               not-null?,
+               formatstr?,
+               valid?)>
+<!ATTLIST arg nr CDATA #REQUIRED>
+
+<!ELEMENT not-bool EMPTY>
+
+<!ELEMENT not-uninit EMPTY>
+
+<!ELEMENT not-null EMPTY>
+
+<!ELEMENT formatstr EMPTY>
+
+<!ELEMENT valid ANY>
+
+<!ELEMENT memory (alloc+,
+                  dealloc*)>
+<!ELEMENT resource (alloc+,
+                    dealloc*)>
+<!ATTLIST alloc init CDATA "true">
+
+<!ELEMENT podtype EMPTY>
+<!ATTLIST podtype name NMTOKEN #REQUIRED>
+<!ATTLIST podtype sign NMTOKEN #REQUIRED>
+<!ATTLIST podtype size CDATA #REQUIRED>

--- a/cfg/library.xsd
+++ b/cfg/library.xsd
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+   <xs:key name="platform_name">
+      <xs:selector xpath="platformtype"/>
+      <xs:field xpath="@name"/>
+   </xs:key>
+   <xs:key name="definition_name">
+      <xs:selector xpath="define"/>
+      <xs:field xpath="@name"/>
+   </xs:key>
+   <xs:key name="function_name">
+      <xs:selector xpath="function"/>
+      <xs:field xpath="@name"/>
+   </xs:key>
+   <xs:key name="podtype_name">
+      <xs:selector xpath="podtype"/>
+      <xs:field xpath="@name"/>
+   </xs:key>
+   <xs:simpleType name="range">
+      <xs:restriction base="xs:string">
+         <xs:pattern value="[0-9]*(?:[0-9]*)?"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:element name="def">
+      <xs:complexType>
+         <xs:sequence>
+
+	    <xs:element name="platformtype" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="platform" minOccurs="1" maxOccurs="unbounded">
+                        <xs:complexType>
+                           <xs:attribute name="type" type="xs:string"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:string" use="required"/>
+                  <xs:attribute name="value" type="xs:string"/>
+               </xs:complexType>
+               <xs:key name="platform_type">
+                  <xs:selector xpath="platform"/>
+                  <xs:field xpath="@type"/>
+               </xs:key>
+            </xs:element>
+
+            <xs:element name="define" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required"/>
+                  <xs:attribute name="value" type="xs:string"/>
+               </xs:complexType>
+            </xs:element>
+
+            <xs:element name="function" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="leak-ignore" minOccurs="0" maxOccurs="1"/>
+                     <xs:choice minOccurs="0" maxOccurs="1">
+                        <xs:element name="noreturn"/>
+                        <xs:element name="use-retval"/>
+                     </xs:choice>
+                     <xs:element name="arg" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                           <xs:sequence>
+                              <xs:element name="not-bool"
+                                          minOccurs="0" maxOccurs="1"/>
+                              <xs:element name="not-uninit"
+                                          minOccurs="0" maxOccurs="1"/>
+                              <xs:element name="not-null"
+                                          minOccurs="0" maxOccurs="1"/>
+                              <xs:element name="formatstr"
+                                          minOccurs="0" maxOccurs="1"/>
+                              <xs:element name="valid" type="range"
+                                          minOccurs="0" maxOccurs="1"/>
+                           </xs:sequence>
+                           <xs:attribute name="nr" type="xs:int"/>
+                        </xs:complexType>
+                     </xs:element>
+                  </xs:sequence>
+                  <xs:attribute name="name" type="xs:NMTOKEN" use="required"/>
+               </xs:complexType>
+            </xs:element>
+
+	    <xs:element name="memory" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="alloc" type="xs:string"
+                                 minOccurs="1" maxOccurs="unbounded">
+                        <xs:complexType>
+                           <xs:attribute name="init" type="xs:string"/>
+                        </xs:complexType>
+                     </xs:element>
+                     <xs:element name="dealloc" type="xs:string"
+                                 minOccurs="0" maxOccurs="unbounded"/>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+
+	    <xs:element name="resource" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:sequence>
+                     <xs:element name="alloc" maxOccurs="unbounded" type="xs:string">
+                        <xs:complexType>
+                           <xs:attribute name="init" type="xs:string"/>
+                        </xs:complexType>
+                     </xs:element>
+                     <xs:element name="dealloc" type="xs:string"
+                                 minOccurs="0" maxOccurs="unbounded"/>
+                  </xs:sequence>
+               </xs:complexType>
+            </xs:element>
+
+	    <xs:element name="podtype" minOccurs="0" maxOccurs="unbounded">
+               <xs:complexType>
+                  <xs:attribute name="name" type="xs:string" use="required"/>
+                  <xs:attribute name="sign" type="xs:string"/>
+                  <xs:attribute name="size" type="xs:positiveInteger" use="required"/>
+               </xs:complexType>
+            </xs:element>
+
+         </xs:sequence>
+         <xs:attribute name="format" type="xs:positiveInteger"/>
+      </xs:complexType>
+   </xs:element>
+</xs:schema>


### PR DESCRIPTION
A document type definition can help to work with corresponding files because it describes the involved data structures to some degree. [Such a DTD](https://en.wikipedia.org/wiki/Document_type_definition "Description for document type definitions") can be added so that further improvements will become easier for the safe data exchange around library configurations for static source code analysis.

A DTD format was standardised as a basis for XML documents. Some technical challenges and limitations were noticed so that [another standard like W3C XML Schema](https://en.wikipedia.org/wiki/XML_Schema_%28W3C%29 "Description for the XML Schema standard") evolved. Such a XML schema definition can also be added so that corresponding file handling might become more consistent.
* Would you like to try this approach out?
* How are the chances to integrate this update suggestion into your source code repository?