### PR TITLE
Don't show warning for same expressions alongside == in static_assert

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2292,8 +2292,18 @@ void CheckOther::checkDuplicateExpression()
                         const bool assignment = tok->str() == "=";
                         if (assignment)
                             selfAssignmentError(tok, tok->astOperand1()->expressionString());
-                        else
+                        else {
+                            if (_settings->CPP && _settings->standards.CPP11 && tok->str() == "==") {
+                                const Token* parent = tok->astParent();
+                                while (parent && parent->astParent()) {
+                                    parent = parent->astParent();
+                                }
+                                if (parent && parent->previous() && parent->previous()->str() == "static_assert") {
+                                    continue;
+                                }
+                            }
                             duplicateExpressionError(tok, tok, tok->str());
+                        }
                     }
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
                     if (tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(tok->astOperand2(), tok->astOperand1()->astOperand2(), _settings->library.functionpure) && isWithoutSideEffects(_tokenizer, tok->astOperand2()))

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4102,6 +4102,38 @@ private:
               "        a++;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (style) Same expression on both sides of '&&'.\n", errout.str());
+
+        check("void f() {\n"
+              "    enum { Four = 4 };\n"
+              "    if (Four == 4) {}"
+              "}", nullptr, false, true, false, false);
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:3]: (style) Same expression on both sides of '=='.\n", errout.str());
+
+        check("void f() {\n"
+              "    enum { Four = 4 };\n"
+              "    static_assert(Four == 4, "");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    enum { Four = 4 };\n"
+              "    static_assert(4 == Four, "");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    enum { FourInEnumOne = 4 };\n"
+              "    enum { FourInEnumTwo = 4 };\n"
+              "    if (FourInEnumOne == FourInEnumTwo) {}\n"
+              "}", nullptr, false, true, false, false);
+        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:4]: (style) Same expression on both sides of '=='.\n", errout.str());
+
+        check("void f() {\n"
+              "    enum { FourInEnumOne = 4 };\n"
+              "    enum { FourInEnumTwo = 4 };\n"
+              "    static_assert(FourInEnumOne == FourInEnumTwo, "");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateExpression2() { // check if float is NaN or Inf


### PR DESCRIPTION
Code like this is very common in various compile time check. Static analysis tools must identify such cases and keep silent.
