### PR TITLE
Restore build on Mac OSX >= 10.7 since the inclusion of ucontext.h

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -38,7 +38,13 @@
 #include <cstdio>
 #include <signal.h>
 #include <unistd.h>
-#include <ucontext.h>
+#if defined(__APPLE__)
+#   define _XOPEN_SOURCE // ucontext.h APIs can only be used on Mac OSX >= 10.7 if _XOPEN_SOURCE is defined
+#   include <ucontext.h>
+#   undef _XOPEN_SOURCE
+#else
+#   include <ucontext.h>
+#endif
 #ifdef __linux__
 #include <sys/syscall.h>
 #include <sys/types.h>


### PR DESCRIPTION
Hi,

Commit 5786be99c56091d63a4a5f377093a3db65144bce added the inclusion of ucontext.h, that requires _XOPEN_SOURCE to be defined to work properly on Mac OSX >= 10.7, where the build is therefore broken. This patch fixes this. Thanks to consider merging.

Cheers,
  Simon
