### PR TITLE
Fix SEGV on Solaris x86

### DIFF
--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -42,3 +42,7 @@ void Check::reportError(const ErrorLogger::ErrorMessage &errmsg)
 {
     std::cout << errmsg.toXML(true, 1) << std::endl;
 }
+std::list<Check *> &Check::instances() {
+        static std::list<Check *> *_instances= new std::list<Check *>;
+        return *_instances;
+    }

--- a/lib/check.h
+++ b/lib/check.h
@@ -53,10 +53,7 @@ public:
     }
 
     /** List of registered check classes. This is used by Cppcheck to run checks and generate documentation */
-    static std::list<Check *> &instances() {
-        static std::list<Check *> _instances;
-        return _instances;
-    }
+    static std::list<Check *> &instances(); 
 
     /** run checks, the token list is not simplified */
     virtual void runChecks(const Tokenizer *, const Settings *, ErrorLogger *) {


### PR DESCRIPTION
On Solaris x86, with both GCC 4.8 and 4.9, running cppcheck causes a segmentation fault when process terminates.

The backtrace (dbx) where
=>[1] _ZNSt14_List_iteratorIP5CheckEppEv(0x804798c, 0x8047994, 0xc0d61d6, 0x291a), at 0x8291b7c
  [2] std::list<Check*, std::allocator, <Check*>void>::remove(0x84ab328, 0x80479c8, 0x80479d4, 0x82d96fc), at 0x82da984
  [3] Check::~Check(0x84a9fc4, 0x83d232c, 0xfef411fb, 0x83d135c), at 0x82d9709
  [4] CheckExceptionSafety::~CheckExceptionSafety(0x84a9fc4, 0xfee82a40, 0xfee82a40, 0xfedcf000), at 0x8311e7d
  [5] __static_initialization_and_destruction_0(0x0, 0xffff, 0xfedd4c80, 0xfedcf000), at 0x81b01f8
  [6] _GLOBAL__sub_D__ZN20CheckExceptionSafety11destructorsEv(0x83d135c, 0xfedd4f18, 0x8047a50, 0x828a5f5, 0xfedcf000, 0x8047a68), at 0x81b023c
  [7] __do_global_dtors_aux(0xfedcf000, 0x8047a68, 0xfece28cd, 0x8047b08, 0x8047a48, 0xfedcf000), at 0x8185b90
  [8] _fini(0x8047b08, 0x8047a48, 0xfedcf000, 0xfedd4f00, 0x8047a80, 0xfecd4e72), at 0x828a5f5
  [9] _exithandle(0xfeffb7d8, 0x8185a1a, 0x0, 0x0, 0x0, 0x0), at 0xfece28cd
  [10] exit(0x1, 0x8047b70, 0x0, 0x8047ba3, 0x8047bba, 0x8047ce6), at 0xfecd4e72

The destructor order is somehow getting messed up on this platform.

This fix moves the code away from header file and ensures _instances remains valid during termination.
