### PR TITLE
Make Valgrind happy

### DIFF
--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -42,11 +42,3 @@ void Check::reportError(const ErrorLogger::ErrorMessage &errmsg)
 {
     std::cout << errmsg.toXML(true, 1) << std::endl;
 }
-
-#ifdef __SVR4
-std::list<Check *> &Check::instances()
-{
-    static std::list<Check *> *_instances= new std::list<Check *>;
-    return *_instances;
-}
-#endif

--- a/lib/check.h
+++ b/lib/check.h
@@ -53,14 +53,18 @@ public:
     }
 
     /** List of registered check classes. This is used by Cppcheck to run checks and generate documentation */
-    #ifdef __SVR4
-    static std::list<Check *> &instances();
-    #else
     static std::list<Check *> &instances() {
+#ifdef __SVR4
+        // Under Solaris, destructors are called in wrong order which causes a segmentation fault.
+        // This fix ensures pointer remains valid and reachable until program terminates.
+        static std::list<Check *> *_instances= new std::list<Check *>;
+        return *_instances;
+#else
         static std::list<Check *> _instances;
         return _instances;
+#endif
+
     }
-    #endif
 
     /** run checks, the token list is not simplified */
     virtual void runChecks(const Tokenizer *, const Settings *, ErrorLogger *) {


### PR DESCRIPTION
This version compiles on Solaris x86 and SPARC and does not SEGV.

On Solaris, there will be a 40 bytes of reachable memory on exit.

On other platforms all reachable memory will be freed.

Under Linux (Ubuntu 12.04) "valgrind --leak-check=full cppcheck" says:

 HEAP SUMMARY:
    in use at exit: 0 bytes in 0 blocks
  total heap usage: 461 allocs, 461 frees, 41,015 bytes allocated

 All heap blocks were freed -- no leaks are possible
