### PR TITLE
Use "isDelete" instead of token match

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1118,8 +1118,8 @@ void CheckClass::operatorEq()
 
         for (func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
             if (func->type == Function::eOperatorEqual && func->access != Private) {
-                // skip if there's =delete in the declaration - cannot be called anyway
-                if (func->tokenDef && func->tokenDef->next() && Token::Match(func->tokenDef->next()->link(), ") const| = delete"))
+                // skip "deleted" functions - cannot be called anyway
+                if (func->isDelete)
                     continue;
                 // use definition for check so we don't have to deal with qualification
                 if (!(Token::Match(func->retDef, "%type% &") && func->retDef->str() == scope->className)) {


### PR DESCRIPTION
As suggested in this comment https://github.com/danmar/cppcheck/commit/f926958acb3b3564959040f06102c667ef577ac5#commitcomment-8726277 - there's already a property for this which can be used instead of doing a token match
