### PR TITLE
Add mmap() / munmap() to posix.cfg. Enables basic mmap() leak tracking

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -348,11 +348,75 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset); -->
+  <function name="mmap">
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+    </arg>
+    <arg nr="5">
+      <not-uninit/>
+    </arg>
+    <arg nr="6">
+      <not-uninit/>
+    </arg>
+    <leak-ignore/>
+  </function>
+  <!-- void *mmap64(void *addr, size_t length, int prot, int flags, int fd, off64_t offset); -->
+  <function name="mmap64">
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+    </arg>
+    <arg nr="5">
+      <not-uninit/>
+    </arg>
+    <arg nr="6">
+      <not-uninit/>
+    </arg>
+    <leak-ignore/>
+  </function>
+  <!-- int munmap(void *addr, size_t length); -->
+  <function name="munmap">
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
   <memory>
     <dealloc>free</dealloc>
     <alloc init="true">strdup</alloc>
     <alloc init="true">strndup</alloc>
     <alloc init="true">wcsdup</alloc>
+  </memory>
+  <memory>
+    <dealloc>munmap</dealloc>
+    <alloc init="true">mmap</alloc>
+    <alloc init="true">mmap64</alloc>
   </memory>
   <resource>
     <dealloc>close</dealloc>

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -367,6 +367,7 @@ private:
 
         // test that the cfg files are configured correctly
         TEST_CASE(posixcfg);
+        TEST_CASE(posixcfg_mmap);
     }
 
     std::string getcode(const char code[], const char varname[], bool classfunc=false) {
@@ -4243,7 +4244,6 @@ private:
         ASSERT_EQUALS("[test.cpp:5]: (error) Memory leak: p\n", errout.str());
     }
 
-
     // Test that posix.cfg is configured correctly
     void posixcfg() {
         Settings settings;
@@ -4303,6 +4303,54 @@ private:
               "}", &settings);
         ASSERT_EQUALS("[test.cpp:6]: (error) Memory leak: s\n", errout.str());
     }
+
+    void posixcfg_mmap() {
+        Settings settings;
+        settings.standards.posix = true;
+        LOAD_LIB_2(settings.library, "posix.cfg");
+
+        // normal mmap
+        check("void f(int fd) {\n"
+              "    char *addr = mmap(NULL, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    munmap(addr, 255);\n"
+              "}", &settings);
+        ASSERT_EQUALS("", errout.str());
+
+        // mmap64 - large file support
+        check("void f(int fd) {\n"
+              "    char *addr = mmap64(NULL, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    munmap(addr, 255);\n"
+              "}", &settings);
+        ASSERT_EQUALS("", errout.str());
+
+        // pass in fixed address
+        check("void f(int fd) {\n"
+              "    void *fixed_addr = 123;\n"
+              "    void *mapped_addr = mmap(fixed_addr, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    munmap(mapped_addr, 255);\n"
+              "}", &settings);
+        ASSERT_EQUALS("", errout.str());
+
+        // no munmap()
+        check("void f(int fd) {\n"
+              "    void *addr = mmap(NULL, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "}", &settings);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Memory leak: addr\n", errout.str());
+
+        // wrong deallocator
+        check("void f(int fd) {\n"
+              "    void *addr = mmap(NULL, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    free(addr);\n"
+              "}", &settings);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: addr\n", errout.str());
+
+        // wrong deallocator for mmap64
+        check("void f(int fd) {\n"
+              "    void *addr = mmap64(NULL, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    free(addr);\n"
+              "}", &settings);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: addr\n", errout.str());
+	}
 };
 
 static TestMemleakInFunction testMemleakInFunction;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6383,6 +6383,21 @@ private:
               &settings_posix
              );
         ASSERT_EQUALS("[test.cpp:2]: (warning) Return value of function strdupa() is not used.\n", errout.str());
+
+        // mmap(): error about unused return address since fixed_addr is just a hint
+        check("void f(int fd) {\n"
+              "    void *fixed_addr = 123;\n"
+              "    mmap(fixed_addr, 255, PROT_NONE, MAP_PRIVATE, fd, 0);\n"
+              "    munmap(fixed_addr, 255);\n"
+              "}",
+              "test.cpp",
+              false, // experimental
+              false, // inconclusive
+              true,  // posix
+              false, // runSimpleChecks
+              &settings_posix
+             );
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Return value of function mmap() is not used.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
Includes function prototype in posix.cfg as comment
for easier overview of the function arguments.

An astyle run won't hurt since I don't have version 2.03 installed.
(only 2.04)
