### PR TITLE
Ticket #6172: Properly grok %type%... template parameters.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -240,8 +240,8 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
         if (Token::Match(tok, "& ::| %var%"))
             tok = tok->next();
 
-        // Skip 'typename...' and 'class...' (Ticket #5774, #6059)
-        if (Token::Match(tok, "typename|class . . .")) {
+        // Skip variadic types (Ticket #5774, #6059, #6172)
+        if (Token::Match(tok, "%type% . . .")) {
             tok = tok->tokAt(4);
             continue;
         }

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -85,6 +85,7 @@ private:
         TEST_CASE(template48);  // #6134 - 100% CPU upon invalid code
         TEST_CASE(template49);  // #6237 - template instantiation
         TEST_CASE(template50);  // #4272 - simple partial specialization
+        TEST_CASE(template51);  // #6172 - crash upon valid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -917,7 +918,16 @@ private:
         ASSERT_EQUALS(expected, tok(code));
     }
 
-
+    void template51() { // #6172
+        tok("template<int N, int ... M> struct A { "
+            "  static void foo() { "
+            "    int i = N; "
+            "  } "
+            "}; "
+            "void bar() { "
+            "  A<0>::foo(); "
+            "}");
+    }
 
     void template_default_parameter() {
         {


### PR DESCRIPTION
Hi,

This patch fixes this ticket by properly considering template parameter lists containing %type%... arguments as valid. Thanks to consider merging.

Cheers,
 Simon
