### PR TITLE
Add robustness test case for checking usleep() parameter interval check.

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <def format="1">
+  <!--int usleep(useconds_t usec); -->
+  <!--A function to suspend execution for microsecond intervals. -->
   <function name="usleep">
     <noreturn>false</noreturn>
     <arg nr="1">

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6188,6 +6188,16 @@ private:
     void checkSleepTimeIntervall() {
         // check usleep(), which is allowed to be called with in a range of [0,999999]
         check("void f(){\n"
+              "usleep(-1);\n"
+              "}",nullptr,false,false,true);
+        ASSERT_EQUALS("[test.cpp:2]: (error) Invalid usleep() argument nr 1. The value is -1 but the valid values are '0:999999'.\n", errout.str());
+
+        check("void f(){\n"
+              "usleep(0);\n"
+              "}",nullptr,false,false,true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(){\n"
               "usleep(10000);\n"
               "}",nullptr,false,false,true);
         ASSERT_EQUALS("", errout.str());


### PR DESCRIPTION
Also the documentation in ```posix.cfg``` is a bit improved.