### PR TITLE
Fix compilation with GCC 4.4.

### DIFF
--- a/lib/cxx11emu.h
+++ b/lib/cxx11emu.h
@@ -24,7 +24,7 @@
 /* Emulate certain features of C++11 in a C++98-compatible way. */
 
 #ifdef __cplusplus
-#if !defined(__GXX_EXPERIMENTAL_CXX0X__) && __cplusplus < 201103L
+#if (__GNUC__ <= 4 && __GNUC_MINOR__ < 6) || __cplusplus < 201103L
 
 // Null pointer literal
 // Source: SC22/WG21/N2431 = J16/07-0301


### PR DESCRIPTION
It was broken by fe468ac14255f079cd4ad0546d3c51f8e3f8031a.

The _nullptr_ is supported by GCC 4.6 and newer, but `__GXX_EXPERIMENTAL_CXX0X__` is already defined in GCC 4.4, so it is not a valid way to check for nullptr availability. Let's just look at the GCC version then.
