### PR TITLE
Don't care which type protected operator= returns

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1117,7 +1117,7 @@ void CheckClass::operatorEq()
         std::list<Function>::const_iterator func;
 
         for (func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
-            if (func->type == Function::eOperatorEqual && func->access != Private) {
+            if (func->type == Function::eOperatorEqual && func->access == Public) {
                 // skip "deleted" functions - cannot be called anyway
                 if (func->isDelete)
                     continue;

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -574,6 +574,13 @@ private:
 
         checkOpertorEq("class A\n"
                        "{\n"
+                       "protected:\n"
+                       "    void operator=(const A&);\n"
+                       "};");
+        ASSERT_EQUALS("", errout.str());
+
+        checkOpertorEq("class A\n"
+                       "{\n"
                        "private:\n"
                        "    void operator=(const A&)=delete;\n"
                        "};");


### PR DESCRIPTION
The current implementation allows any return type for private assignment operators but not for protected ones. Actually they don't differ much. Return type only matters for "chain assignment" scenario (`a=b=c`) and how much is it more likely in a derived class compared to the same class? I'd say not much. The return type does matter for public assignment operators.
