### PR TITLE
Implement check if a global function can be made static

### DIFF
--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -32,12 +32,14 @@
 class CPPCHECKLIB CheckUnusedFunctions : public Check {
 public:
     /** @brief This constructor is used when registering the CheckUnusedFunctions */
-    CheckUnusedFunctions() : Check(myName()) {
+    CheckUnusedFunctions() : Check(myName())
+        , function_can_be_static_test(true) {
     }
 
     /** @brief This constructor is used when running checks. */
     CheckUnusedFunctions(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
-        : Check(myName(), tokenizer, settings, errorLogger) {
+        : Check(myName(), tokenizer, settings, errorLogger)
+        , function_can_be_static_test(true) {
     }
 
     // Parse current tokens and determine..
@@ -53,6 +55,9 @@ public:
     /** @brief Analyse all file infos for all TU */
     void analyseWholeProgram(const std::list<Check::FileInfo*> &fileInfo, ErrorLogger &errorLogger);
 
+    /** @brief Disable "function can be made static" test. Used by the unit test */
+    void configureFunctionCanBeStaticTest(bool enable);
+
     static CheckUnusedFunctions instance;
 
 private:
@@ -60,6 +65,7 @@ private:
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
         CheckUnusedFunctions c(0, settings, errorLogger);
         c.unusedFunctionError(errorLogger, "", 0, "funcName");
+        c.functionCanBeStaticError(errorLogger, "", 0, "funcName");
     }
 
     /**
@@ -68,6 +74,11 @@ private:
     static void unusedFunctionError(ErrorLogger * const errorLogger,
                                     const std::string &filename, unsigned int lineNumber,
                                     const std::string &funcname);
+
+
+    static void functionCanBeStaticError(ErrorLogger * const errorLogger,
+                                         const std::string &filename, unsigned int lineNumber,
+                                         const std::string &funcname);
 
     /**
      * Dummy implementation, just to provide error for --errorlist
@@ -86,15 +97,20 @@ private:
 
     class CPPCHECKLIB FunctionUsage {
     public:
-        FunctionUsage() : lineNumber(0), usedSameFile(false), usedOtherFile(false) {
+        FunctionUsage() : lineNumber(0)
+            , usedSameFile(false)
+            , usedOtherFile(false)
+            , isGlobalNonStatic(false) {
         }
 
         std::string filename;
         unsigned int lineNumber;
         bool   usedSameFile;
         bool   usedOtherFile;
+        bool   isGlobalNonStatic;
     };
 
+    bool function_can_be_static_test;
     std::map<std::string, FunctionUsage> _functions;
 };
 /// @}

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -52,6 +52,7 @@ private:
         TEST_CASE(initializer_list);
         TEST_CASE(member_function_ternary);
         TEST_CASE(boost);
+        TEST_CASE(canBeStatic);
 
         TEST_CASE(multipleFiles);   // same function name in multiple files
 
@@ -60,7 +61,7 @@ private:
         TEST_CASE(ignore_declaration); // ignore declaration
     }
 
-    void check(const char code[]) {
+    void check(const char code[], bool function_can_be_static=false) {
         // Clear the error buffer..
         errout.str("");
 
@@ -75,6 +76,7 @@ private:
         // Check for unused functions..
         CheckUnusedFunctions checkUnusedFunctions(&tokenizer, &settings, this);
         checkUnusedFunctions.parseTokens(tokenizer,  "someFile.c", &settings);
+        checkUnusedFunctions.configureFunctionCanBeStaticTest(function_can_be_static);
         checkUnusedFunctions.check(this);
     }
 
@@ -380,6 +382,58 @@ private:
 
         check("void f(void) {}\n"
               "void (*list[])(void) = {f}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void canBeStatic() {
+        check("int f1()\n"
+              "{\n"
+              "}\n"
+              "int main()\n"
+              "{\n"
+              "    f1();"
+              "}\n", true
+             );
+        ASSERT_EQUALS("[test.cpp:1]: (style) The function 'f1' is used in this file only. It can be made static.\n", errout.str());
+
+        // ensure global static functions don't issue a style warning
+        check("static int f1()\n"
+              "{\n"
+              "}\n"
+              "int main()\n"
+              "{\n"
+              "    f1();"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
+
+        // ensure class functions are quiet
+        check("struct Foo {\n"
+              "    void F1() {}\n"
+              "};\n"
+              "int main() {\n"
+              "    Foo foo;\n"
+              "    foo.F1();\n"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
+
+        // test that anonymous namespaces are quiet
+        check("namespace {\n"
+              "    void F1() {}\n"
+              "};\n"
+              "int main() {\n"
+              "    F1();\n"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
+
+        // declaration has the static keyword, implementation not
+        check("static int f1();\n"
+              "int f1()\n"
+              "{\n"
+              "}\n"
+              "int main()\n"
+              "{\n"
+              "    f1();"
+              "}\n", true);
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
The new check can be enabled/disabled for the unit test via
configureFunctionCanBeStaticTest(). Otherwise we get a lot
of noise for our unused function tests.