### PR TITLE
Add new style check to catch ineffective pointer statements.

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1220,12 +1220,12 @@ void CheckBufferOverrun::checkStructVariable()
                     // If struct is declared in a function then check
                     // if scope_func matches
                     if (scope->nestedIn->type == Scope::eFunction &&
-                        scope->nestedIn != &*func_scope) {
+                        scope->nestedIn != func_scope) {
                         continue;
                     }
 
                     // check for member variables
-                    if (func_scope->functionOf == &*scope) {
+                    if (func_scope->functionOf == scope) {
                         // only check non-empty function
                         if (func_scope->classStart->next() != func_scope->classEnd) {
                             // start checking after the {

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2278,9 +2278,9 @@ void CheckMemoryLeakInClass::check()
                 const Token *tok = var->typeStartToken();
                 if (tok->isStandardType()) {
                     if (var->isPrivate())
-                        checkPublicFunctions(&(*scope), var->nameToken());
+                        checkPublicFunctions(scope, var->nameToken());
 
-                    variable(&(*scope), var->nameToken());
+                    variable(scope, var->nameToken());
                 }
 
                 // known class?
@@ -2288,9 +2288,9 @@ void CheckMemoryLeakInClass::check()
                     // not derived?
                     if (var->type()->derivedFrom.empty()) {
                         if (var->isPrivate())
-                            checkPublicFunctions(&(*scope), var->nameToken());
+                            checkPublicFunctions(scope, var->nameToken());
 
-                        variable(&(*scope), var->nameToken());
+                        variable(scope, var->nameToken());
                     }
                 }
             }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2853,3 +2853,29 @@ void CheckOther::ignoredReturnValueError(const Token* tok, const std::string& fu
     reportError(tok, Severity::warning, "ignoredReturnValue",
                 "Return value of function " + function + "() is not used.", false);
 }
+
+void CheckOther::checkIneffectivePointerOp()
+{
+    if (!_settings->isEnabled("style"))
+        return;
+
+    const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();
+    for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next()) {
+        if (Token::Match(tok, "& (| * %var%")) {
+            const Token *vartok = tok->tokAt(2);
+            if (vartok->str() == "*")
+                vartok = vartok->next();
+            const Variable *var = symbolDatabase->getVariableFromVarId(vartok->varId());
+            if (!var || !var->isPointer())
+                continue;
+
+            ineffectivePointerOpError(vartok, var->name());
+        }
+    }
+}
+
+void CheckOther::ineffectivePointerOpError(const Token* tok, const std::string &varname)
+{
+    reportError(tok, Severity::style, "ineffectivePointerOp",
+                "Ineffective pointer operation on " + varname + " - it's already a pointer.", false);
+}

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -74,6 +74,7 @@ public:
         checkOther.checkNanInArithmeticExpression();
         checkOther.checkCommaSeparatedReturn();
         checkOther.checkIgnoredReturnValue();
+        checkOther.checkIneffectivePointerOp();
     }
 
     /** @brief Run checks against the simplified token list */
@@ -233,6 +234,9 @@ public:
     /** @brief %Check for ignored return values. */
     void checkIgnoredReturnValue();
 
+    /** @brief %Check for ineffective pointer operations */
+    void checkIneffectivePointerOp();
+
 private:
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &strFunctionName, const std::string &varName, const bool result);
@@ -288,6 +292,7 @@ private:
     void varFuncNullUBError(const Token *tok);
     void commaSeparatedReturnError(const Token *tok);
     void ignoredReturnValueError(const Token* tok, const std::string& function);
+    void ineffectivePointerOpError(const Token* tok, const std::string& varname);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
         CheckOther c(0, settings, errorLogger);
@@ -345,6 +350,7 @@ private:
         c.nanInArithmeticExpressionError(0);
         c.commaSeparatedReturnError(0);
         c.ignoredReturnValueError(0, "malloc");
+        c.ineffectivePointerOpError(0, "varname");
     }
 
     static std::string myName() {
@@ -402,7 +408,8 @@ private:
                "- NaN (not a number) value used in arithmetic expression.\n"
                "- comma in return statement (the comma can easily be misread as a semicolon).\n"
                "- prefer erfc, expm1 or log1p to avoid loss of precision.\n"
-               "- identical code in both branches of if/else or ternary operator.\n";
+               "- identical code in both branches of if/else or ternary operator.\n"
+               "- ineffective pointer operation on pointer like &*some_ptr.\n";
     }
 };
 /// @}

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1087,7 +1087,7 @@ void CheckUnusedVar::checkFunctionVariableUsage()
         // varId, usage {read, write, modified}
         Variables variables;
 
-        checkFunctionVariableUsage_iterateScopes(&*scope, variables, false);
+        checkFunctionVariableUsage_iterateScopes(scope, variables, false);
 
 
         // Check usage of all variables in the current scope..

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1680,7 +1680,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
                             addNewFunction(scope, tok);
                             if (*scope) {
                                 (*scope)->functionOf = func->nestedIn;
-                                (*scope)->function = &*func;
+                                (*scope)->function = func;
                                 (*scope)->function->functionScope = *scope;
                             }
                             return;
@@ -1751,7 +1751,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
                             addNewFunction(scope, tok);
                             if (*scope) {
                                 (*scope)->functionOf = scope1;
-                                (*scope)->function = &*func;
+                                (*scope)->function = func;
                                 (*scope)->function->functionScope = *scope;
                             }
                             return;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -176,6 +176,8 @@ private:
 
         TEST_CASE(testReturnIgnoredReturnValue);
         TEST_CASE(testReturnIgnoredReturnValuePosix);
+
+        TEST_CASE(ineffectivePointerOp);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool posix = false, bool runSimpleChecks=true, Settings* settings = 0) {
@@ -6454,6 +6456,18 @@ private:
               false  // runSimpleChecks
              );
         ASSERT_EQUALS("[test.cpp:3]: (warning) Return value of function mmap() is not used.\n", errout.str());
+    }
+
+    void ineffectivePointerOp() {
+        check("int *f(int *x) {\n"
+              "    return &*x;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Ineffective pointer operation on x - it's already a pointer.\n", errout.str());
+
+        check("int *f(int *y) {\n"
+              "    return &(*y);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Ineffective pointer operation on y - it's already a pointer.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
Doing "&*some_ptr_var" is ineffective and might be
the remainder of a refactoring.
