### PR TITLE
Add support for the AppVeyor CI system for checked Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: 1.69.{build}
+
+configuration:
+- Debug
+- Release
+
+platform:
+- Win32
+- x64
+
+build:
+  project: cppcheck.sln
+  parallel: true
+  verbosity: minimal
+
+test_script:
+- if "%CONFIGURATION%" == "Release" bin\testrunner.exe
+- if "%CONFIGURATION%" == "Debug"   bin\debug\testrunner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 build:
   project: cppcheck.sln
   parallel: true
-  verbosity: normal
+  verbosity: detailed
 
 test_script:
 - if "%CONFIGURATION%" == "Release" bin\testrunner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 build:
   project: cppcheck.sln
   parallel: true
-  verbosity: minimal
+  verbosity: normal
 
 test_script:
 - if "%CONFIGURATION%" == "Release" bin\testrunner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 build:
   project: cppcheck.sln
   parallel: true
-  verbosity: detailed
+  verbosity: minimal
 
 test_script:
 - if "%CONFIGURATION%" == "Release" bin\testrunner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ platform:
 build:
   project: cppcheck.sln
   parallel: true
-  verbosity: minimal
+  verbosity: detailed
 
 test_script:
 - if "%CONFIGURATION%" == "Release" bin\testrunner.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,8 @@ platform:
 - Win32
 - x64
 
-build:
-  project: cppcheck.sln
-  parallel: true
-  verbosity: detailed
+build_script:
+- msbuild "cppcheck.sln" /m /verbosity:minimal
 
 test_script:
 - if "%CONFIGURATION%" == "Release" bin\testrunner.exe

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Cppcheck [![Build Status](https://travis-ci.org/danmar/cppcheck.svg?branch=master)](https://travis-ci.org/danmar/cppcheck) [![Coverity Scan Build Status](https://scan.coverity.com/projects/512/badge.svg)](https://scan.coverity.com/projects/512)
+# Cppcheck [![Build Status](https://travis-ci.org/danmar/cppcheck.svg?branch=master)](https://travis-ci.org/danmar/cppcheck) [![Coverity Scan Build Status](https://scan.coverity.com/projects/512/badge.svg)](https://scan.coverity.com/projects/512) [![Build status AppVeyor](https://ci.appveyor.com/api/projects/status/mnxvm33u3xf8baml/branch/master?svg=true)](https://ci.appveyor.com/project/Kosta-Github/cppcheck/branch/master)
 
 ## Donations
 


### PR DESCRIPTION
You need to register for [AppVeyor CI](http://www.appveyor.com) which is a free service and very similar to [Travis CI](https://travis-ci.org/) but this time for checked Windows builds.

And then you need to change the links in the readme.md file to point to your account instead.