### PR TITLE
Calling a funtion using Class::func() syntax should not be simplified

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10253,7 +10253,30 @@ void Tokenizer::removeUnnecessaryQualification()
                 } else if (tok->strAt(2) == "~")
                     tok1 = tok1->next();
 
-                if (tok1 && Token::Match(tok1->link(), ") const| {|;|:")) {
+                if (!tok1 || !Token::Match(tok1->link(), ") const| {|;|:")) {
+                    continue;
+                }
+
+                const bool isConstructorOrDestructor =
+                    Token::Match(tok, "%type% :: ~| %type%") && (tok->strAt(2) == tok->str() || (tok->strAt(2) == "~" && tok->strAt(3) == tok->str()));
+                if (!isConstructorOrDestructor) {
+                    bool isPrependedByType = Token::Match(tok->previous(), "%type%");
+                    if (!isPrependedByType) {
+                        const Token* tok2 = tok->tokAt(-2);
+                        isPrependedByType = Token::Match(tok2, "%type% *|&");
+                    }
+                    if (!isPrependedByType) {
+                        const Token* tok3 = tok->tokAt(-3);
+                        isPrependedByType = Token::Match(tok3, "%type% * *|&");
+                    }
+                    if (!isPrependedByType) {
+                        // It's not a constructor declaration and it's not a function declaration so
+                        // this is a function call which can have all the qualifiers just fine - skip.
+                        continue;
+                    }
+                }
+
+                {
                     std::string qualification;
                     if (portabilityEnabled)
                         qualification = tok->str() + "::";

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -260,6 +260,12 @@ private:
         TEST_CASE(removeUnnecessaryQualification8);
         TEST_CASE(removeUnnecessaryQualification9);  // ticket #3151
         TEST_CASE(removeUnnecessaryQualification10); // ticket #3310 segmentation fault
+        TEST_CASE(removeUnnecessaryQualification11);
+        TEST_CASE(removeUnnecessaryQualification12);
+        TEST_CASE(removeUnnecessaryQualification13);
+        TEST_CASE(removeUnnecessaryQualification14);
+        TEST_CASE(removeUnnecessaryQualification15);
+        TEST_CASE(removeUnnecessaryQualification16);
 
         TEST_CASE(simplifyIfNotNull);
         TEST_CASE(simplifyVarDecl1); // ticket # 2682 segmentation fault
@@ -3939,7 +3945,7 @@ private:
                             "   };\n"
                             "}\n";
         tok(code, false);
-        ASSERT_EQUALS("[test.cpp:11]: (portability) The extra qualification 'two::c::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
     }
 
     void removeUnnecessaryQualification6() {
@@ -3998,6 +4004,62 @@ private:
                             "};\n";
         tok(code, false);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void removeUnnecessaryQualification11() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred& Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification12() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred* Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+   void removeUnnecessaryQualification13() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred** Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification14() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred*& Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification15() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred*& Magic() {\n"
+                            "        Fred::Magic(param);\n"
+                            "    }\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void removeUnnecessaryQualification16() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    void Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
     }
 
     void simplifyIfNotNull() {


### PR DESCRIPTION
It's perfectly okay to call `Class::exit()` from within class to tell that it is not `::exit()`