### PR TITLE
Calling a function using Class::func() syntax should not be simplified

### DIFF
--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -262,6 +262,12 @@ private:
         TEST_CASE(removeUnnecessaryQualification8);
         TEST_CASE(removeUnnecessaryQualification9);  // ticket #3151
         TEST_CASE(removeUnnecessaryQualification10); // ticket #3310 segmentation fault
+        TEST_CASE(removeUnnecessaryQualification11);
+        TEST_CASE(removeUnnecessaryQualification12);
+        TEST_CASE(removeUnnecessaryQualification13);
+        TEST_CASE(removeUnnecessaryQualification14);
+        TEST_CASE(removeUnnecessaryQualification15);
+        TEST_CASE(removeUnnecessaryQualification16);
 
         TEST_CASE(simplifyVarDecl1); // ticket # 2682 segmentation fault
         TEST_CASE(simplifyVarDecl2); // ticket # 2834 segmentation fault
@@ -3951,7 +3957,7 @@ private:
                             "   };\n"
                             "}\n";
         tok(code, false);
-        ASSERT_EQUALS("[test.cpp:11]: (portability) The extra qualification 'two::c::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
     }
 
     void removeUnnecessaryQualification6() {
@@ -4010,6 +4016,62 @@ private:
                             "};\n";
         tok(code, false);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void removeUnnecessaryQualification11() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred& Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification12() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred* Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+   void removeUnnecessaryQualification13() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred** Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification14() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred*& Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
+    }
+
+    void removeUnnecessaryQualification15() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    Fred*& Magic() {\n"
+                            "        Fred::Magic(param);\n"
+                            "    }\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void removeUnnecessaryQualification16() {
+        const char code[] = "class Fred {\n"
+                            "public:\n"
+                            "    void Fred::Magic();\n"
+                            "};\n";
+        tok(code, false);
+        ASSERT_EQUALS("[test.cpp:3]: (portability) The extra qualification 'Fred::' is unnecessary and is considered an error by many compilers.\n", errout.str());
     }
 
     void simplifyVarDecl1() { // ticket # 2682 segmentation fault


### PR DESCRIPTION
This is https://github.com/danmar/cppcheck/pull/504 resubmitted after (presumably) dealing with gcc warning mentioned here https://github.com/danmar/cppcheck/pull/504#issuecomment-72323919 and resolving tons of merge conflicts