### PR TITLE
Remove completely redundant code

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -93,11 +93,6 @@ bool CheckCondition::assignIfParseScope(const Token * const assignTok,
                 mismatchingBitAndError(assignTok, num, tok2, num2);
         }
         if (Token::Match(tok2, "%varid% =", varid)) {
-            if ((bitop == '&') && Token::Match(tok2->tokAt(2), "%varid% %cop% %num% ;", varid) && tok2->strAt(3) == std::string(1U, bitop)) {
-                const MathLib::bigint num2 = MathLib::toLongNumber(tok2->strAt(4));
-                if (0 == (num & num2))
-                    mismatchingBitAndError(assignTok, num, tok2, num2);
-            }
             return true;
         }
         if (Token::Match(tok2, "++|-- %varid%", varid) || Token::Match(tok2, "%varid% ++|--", varid))


### PR DESCRIPTION
The code removed is executed unconditionally before the `if`.