### PR TITLE
Revert fix for #6181, that caused #6354 and #6414.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1320,8 +1320,6 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
                         ++indentlevel5;
                     else if (indentlevel5 > 0 && Token::Match(tok5, "> [,>]"))
                         --indentlevel5;
-                    else if (indentlevel5 > 0 && tok5->str() == ">>")
-                        indentlevel5 -= 2;
                     else if (indentlevel5 == 0) {
                         if (tok5->str() != ",") {
                             if (!typetok ||

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -827,7 +827,7 @@ private:
                             "void z() {\n"
                             "    vector<int> VI;\n"
                             "}\n";
-        tokenizeAndStringify(code, true);
+        ASSERT_THROW(tokenizeAndStringify(code, true), InternalError);
     }
 
     void tokenize34() { // #6121
@@ -5222,11 +5222,31 @@ private:
                            tokenizeAndStringify(code));
     }
 
-    void cpp0xtemplate4() { // #6181
-        tokenizeAndStringify("class A; "
-                             "template <class T> class Disposer; "
-                             "template <typename T, class D = Disposer<T>> class Shim {}; "
-                             "class B : public Shim<A> {};");
+    void cpp0xtemplate4() { // #6181, #6354, #6414
+        ASSERT_THROW(tokenizeAndStringify("class A; "
+                                          "template <class T> class Disposer; "
+                                          "template <typename T, class D = Disposer<T>> class Shim {}; "
+                                          "class B : public Shim<A> {};"), InternalError);
+        tokenizeAndStringify("template <class ELFT> class ELFObjectImage {}; "
+                             "ObjectImage *createObjectImage() { "
+                             "  return new ELFObjectImage<ELFType<little>>(Obj); "
+                             "} "
+                             "void resolveX86_64Relocation() { "
+                             "  reinterpret_cast<int>(0); "
+                             "}");
+        tokenizeAndStringify("template<typename value_type, typename function_type> "
+                             "value_type Base(const value_type x, const value_type dx, function_type func, int type_deriv) { "
+                             "   return 0.0; "
+                             "}; "
+                             "namespace { "
+                             "  template<class DC> class C { "
+                             "    void Fun(int G, const double x); "
+                             "  }; "
+                             "  template<class DC> void C<DC>::Fun(int G, const double x) {"
+                             "    Base<double, CDFFunctor<DC>>(2, 2, f, 0); "
+                             "  }; "
+                             "  template<class DC> class C2 {}; "
+                             "}");
     }
 
     std::string arraySize_(const std::string &code) {


### PR DESCRIPTION
Hi,

This patch reverts what I did to fix #6181 because it caused two regressions (#6354 and #6414) that I don't have much time to look at those days. It also adds those tickets' test cases so as to track that we don't regress again when fixing again #6181. Please consider merging.

Thanks,
  Simon