### PR TITLE
Deduplicate a multislash test

### DIFF
--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -54,7 +54,7 @@ private:
         ASSERT_EQUALS("../../src/test.cpp", Path::simplifyPath("../../src/test.cpp"));
         ASSERT_EQUALS("../../../src/test.cpp", Path::simplifyPath("../../../src/test.cpp"));
         ASSERT_EQUALS("src/test.cpp", Path::simplifyPath(".//src/test.cpp"));
-        ASSERT_EQUALS("src/test.cpp", Path::simplifyPath(".//src/test.cpp"));
+        ASSERT_EQUALS("src/test.cpp", Path::simplifyPath(".///src/test.cpp"));
 
         // Handling of UNC paths on Windows
         ASSERT_EQUALS("//src/test.cpp", Path::simplifyPath("//src/test.cpp"));


### PR DESCRIPTION
Earlier commit included the same test twice. That's not what was intended.