### PR TITLE
Resolve CID 1037075

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1469,8 +1469,8 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
             second = second->nextArgument();
             if (second)
                 second = second->tokAt(-2);
-            if (!first || !second) { // End of argument list (first or second)
-                return !first && !second;
+            if (!second) { // End of argument list (second)
+                return false;
             }
         }
 


### PR DESCRIPTION
No idea why this was marked as false positive - the analyzer is right that `first` is guaranteed to be non-null at that point, so code can be simplified.