### PR TITLE
Ticket #6181: Normalize '>>' into '> >' when it's closing a C++11 template parameter list

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2315,6 +2315,14 @@ void Tokenizer::simplifyTemplates()
             tok3->deleteNext(4);
             tok3->insertToken(MathLib::toString(sizeOfResult));
         }
+        // Ticket #6181: normalize C++11 template parameter list closing syntax
+        if (tok->str() == "<" && TemplateSimplifier::templateParameters(tok)) {
+            Token *endTok = tok->findClosingBracket();
+            if (endTok && endTok->str() == ">>") {
+                endTok->str(">");
+                endTok->insertToken(">");
+            }
+        }
     }
 
     TemplateSimplifier::simplifyTemplates(

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1009,12 +1009,14 @@ private:
             TODO_ASSERT_EQUALS(wanted, current, tok(code));
         }
         {
-            const char code[] = "template<class T, class T2 = A<T>> class B {};\n"
-                                "template<class B = A, typename C = C<B>> class C {};\n"
-                                "template<class B, typename C> class D { };\n";
-            ASSERT_EQUALS("template < class T , class T2 > class B { } ; "
-                          "template < class B , typename C > class C { } ; "
-                          "template < class B , typename C > class D { } ;", tok(code));
+            const char code[] = "class A { }; "
+                                "template<class T> class B { }; "
+                                "template<class T1, class T2 = B<T1>> class C { }; "
+                                "template<class T1 = A, typename T2 = B<A>> class D { };";
+            ASSERT_EQUALS("class A { } ; "
+                          "template < class T > class B { } ; "
+                          "template < class T1 , class T2 > class C { } ; "
+                          "template < class T1 , typename T2 > class D { } ;", tok(code));
         }
     }
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -828,7 +828,7 @@ private:
                             "void z() {\n"
                             "    vector<int> VI;\n"
                             "}\n";
-        ASSERT_THROW(tokenizeAndStringify(code, true), InternalError);
+        tokenizeAndStringify(code, true);
     }
 
     void tokenize34() { // #6121
@@ -5185,10 +5185,10 @@ private:
     }
 
     void cpp0xtemplate4() { // #6181, #6354, #6414
-        ASSERT_THROW(tokenizeAndStringify("class A; "
-                                          "template <class T> class Disposer; "
-                                          "template <typename T, class D = Disposer<T>> class Shim {}; "
-                                          "class B : public Shim<A> {};"), InternalError);
+        tokenizeAndStringify("class A; "
+                             "template <class T> class Disposer; "
+                             "template <typename T, class D = Disposer<T>> class Shim {}; "
+                             "class B : public Shim<A> {};");
         tokenizeAndStringify("template <class ELFT> class ELFObjectImage {}; "
                              "ObjectImage *createObjectImage() { "
                              "  return new ELFObjectImage<ELFType<little>>(Obj); "


### PR DESCRIPTION
Hi,

This patch is another fix for this ticket, where C++11's ">>" closing parameter list syntax is not properly handled (previous attempt was in https://github.com/danmar/cppcheck/pull/484). The idea is to turn this syntax into the legacy one early enough so that we don't need "Token::Match(..., ">|>>")" constructs all over the place (I plan to work on code cleanup via a separate PR).

Note that I reworked one test in TestSimplifyTemplate that was completely invalid, with the same identifier used as a template parameter, its default value and the template class being defined...

Thanks to consider merging.

Cheers,
  Simon