### PR TITLE
Ticket #6567: Handle member functions in TemplateSimplifier::getTemplateNamePosition

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -699,18 +699,24 @@ bool TemplateSimplifier::instantiateMatch(const Token *instance, const std::stri
 int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
 {
     // get the position of the template name
-    int namepos = 0;
+    int namepos = 0, starAmpPossiblePosition = 0;
     if (Token::Match(tok, "> class|struct %type% {|:"))
         namepos = 2;
     else if (Token::Match(tok, "> %type% *|&| %type% ("))
         namepos = 2;
     else if (Token::Match(tok, "> %type% %type% *|&| %type% ("))
         namepos = 3;
-    else {
+    else if (Token::Match(tok, "> %type% *|&| %type% :: %type% (")) {
+        namepos = 4;
+        starAmpPossiblePosition = 2;
+    } else if (Token::Match(tok, "> %type% %type% *|&| %type% :: %type% (")) {
+        namepos = 5;
+        starAmpPossiblePosition = 3;
+    } else {
         // Name not found
         return -1;
     }
-    if ((tok->strAt(namepos) == "*" || tok->strAt(namepos) == "&"))
+    if (Token::Match(tok->tokAt(starAmpPossiblePosition ? starAmpPossiblePosition : namepos), "*|&"))
         ++namepos;
 
     return namepos;


### PR DESCRIPTION
Hi,

Even though the initial issue reported in this ticket was fixed via https://github.com/danmar/cppcheck/pull/539, there was still a "bailiing out" debug trace emitted due to the fact that TemplateSimplifier::getTemplateNamePosition does not support template member functions. This patch fixes this and removes the warning in that particular case.

There are still cases I need to work on (nested class members and template class members), hence two TODO tests, however I believe this patch is already an improvement. Thanks to consider merging.

Cheers,
  Simon