### PR TITLE
Remove unneded deep copy, make reference const

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -570,11 +570,11 @@ static void eraseNotLocalArg(std::map<unsigned int, const Token*>& container, co
     }
 }
 
-static void eraseMemberAssignments(const unsigned int varId, std::map<unsigned int, std::set<unsigned int> > &membervars, std::map<unsigned int, const Token*> &varAssignments)
+static void eraseMemberAssignments(const unsigned int varId, const std::map<unsigned int, std::set<unsigned int> > &membervars, std::map<unsigned int, const Token*> &varAssignments)
 {
     const std::map<unsigned int, std::set<unsigned int> >::const_iterator it = membervars.find(varId);
     if (it != membervars.end()) {
-        const std::set<unsigned int> v = it->second;
+        const std::set<unsigned int>& v = it->second;
         for (std::set<unsigned int>::const_iterator vit = v.begin(); vit != v.end(); ++vit) {
             varAssignments.erase(*vit);
             if (*vit != varId)


### PR DESCRIPTION
I see no reason for deep copy of that `std::set` inside the function. Also the parameter reference should be const.