### PR TITLE
Ticket #6347: Fix use after delete when simplifying template instantiations

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1052,8 +1052,8 @@ bool TemplateSimplifier::simplifyCalculations(Token *_tokens)
                     ret = true;
                 } else if (Token::Match(tok->previous(), "[=([,] 0 [+|]") ||
                            Token::Match(tok->previous(), "return|case 0 [+|]")) {
-                    tok->deleteNext();
-                    tok->deleteThis();
+                    tok = tok->previous();
+                    tok->deleteNext(2);
                     ret = true;
                 } else if (Token::Match(tok->previous(), "[=[(,] 0 * %name% ,|]|)|;|=|%cop%") ||
                            Token::Match(tok->previous(), "[=[(,] 0 * %num% ,|]|)|;|%op%") ||
@@ -1232,7 +1232,6 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
                 break;
             }
         }
-
         Token * const tok2 = *iter2;
         if (tok2->str() != name)
             continue;

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -82,6 +82,7 @@ private:
         TEST_CASE(template49);  // #6237 - template instantiation
         TEST_CASE(template50);  // #4272 - simple partial specialization
         TEST_CASE(template51);  // #6172 - crash upon valid code
+        TEST_CASE(template52);  // #6437 - crash upon valid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -925,6 +926,16 @@ private:
             "void bar() { "
             "  A<0>::foo(); "
             "}");
+    }
+
+    void template52() { // #6437
+        tok("template <int value> int sum() { "
+            "  return value + sum<value/2>(); "
+            "} "
+            "template<int x, int y> int calculate_value() { "
+            "  return sum<x - y>(); "
+            "} "
+            "int value = calculate_value<1,1>();");
     }
 
     void template_default_parameter() {


### PR DESCRIPTION
Hi,

This ticket highlights the fact that the way we simplify "0 + ..." expressions might delete tokens we have a reference to, leading to a crash. This patch fixes this by reviewing how the 0 and + tokens are removed. Thanks to consider merging.

Cheers,
  Simon