### PR TITLE
Restore build on Mac OS X

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1255,7 +1255,7 @@ void CheckStl::checkAutoPointer()
                     }
                     if (Token::Match(tok3, "( %var%")) {
                         std::map<unsigned int, const std::string>::const_iterator it = mallocVarId.find(tok3->next()->varId());
-                        if (it != mallocVarId.cend()) {
+                        if (it != mallocVarId.end()) {
                             // pointer on the memory allocated by malloc used in the auto pointer constructor -> error
                             autoPointerMallocError(tok2->next(), it->second);
                         }


### PR DESCRIPTION
Hi,

This is similar to https://github.com/danmar/cppcheck/pull/228, where cend() cannot be used on Mac OS X because
 - If one uses clang + libc++ (default), we get a lot of test suite failures due to http://llvm.org/bugs/show_bug.cgi?id=17782
 - To have the test suite succeed, one needs to use GNU's libstdc++ instead of libc++... but it does not provide cbegin() / cend(), and cppcheck does not build

It's really too bad we have to do this but at the same time I believe it's not that big a deal in that case and it's good to have cppcheck build on as many environments as possible.

Thanks to consider merging,
  Simon