### PR TITLE
Ticket #6587: Do not consider template expressions in decltype as instantiations

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -812,7 +812,7 @@ const Token * Token::findClosingBracket() const
         for (closing = this; closing != nullptr; closing = closing->next()) {
             if (Token::Match(closing, "{|[|("))
                 closing = closing->link();
-            else if (Token::Match(closing, "}|]|)|;|="))
+            else if (Token::Match(closing, "}|]|)|;"))
                 break;
             else if (closing->str() == "<")
                 ++depth;

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -84,6 +84,7 @@ private:
         TEST_CASE(template51);  // #6172 - crash upon valid code
         TEST_CASE(template52);  // #6437 - crash upon valid code
         TEST_CASE(template53);  // #4335 - bail out for valid code
+        TEST_CASE(template54);  // #6587 - memory corruption upon valid code
         TEST_CASE(template_unhandled);
         TEST_CASE(template_default_parameter);
         TEST_CASE(template_default_type);
@@ -951,6 +952,15 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
+    void template54() { // #6587
+        tok("template<typename _Tp> _Tp* fn(); "
+            "template <class T> struct A { "
+            "  template <class U, class S = decltype(fn<T>())> "
+            "  struct B { }; "
+            "}; "
+            "A<int> a;");
+    }
+
     void template_default_parameter() {
         {
             const char code[] = "template <class T, int n=3>\n"
@@ -1036,8 +1046,8 @@ private:
                                 "template<class T1 = A, typename T2 = B<A>> class D { };";
             ASSERT_EQUALS("class A { } ; "
                           "template < class T > class B { } ; "
-                          "template < class T1 , class T2 > class C { } ; "
-                          "template < class T1 , typename T2 > class D { } ;", tok(code));
+                          "template < class T1 , class T2 = B < T1 > > class C { } ; "
+                          "template < class T1 = A , typename T2 = B < A > > class D { } ;", tok(code));
         }
     }
 


### PR DESCRIPTION
Hi,

The code in this ticket triggers a memory corruption because we end up considering the default value of a template parameter as an instantiation, that's deleted by useDefaultArgumentValues but still referenced as an instantiation and therefore read later.

The code that computes the list of instantiations is supposed to skip template parameter default values, but does not because Token::findClosingBracket considers "=" as a closing bracket, for no obvious nor good reason (I tracked this down to https://github.com/danmar/cppcheck/commit/c283bc414d71d4f63c35254f31fa148b9d0e7814). This patch fixes findClosingBracket, and the ticket. Thanks to consider merging.

Cheers,
  Si,mon