### PR TITLE
Resolve CID 1288510

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -596,17 +596,20 @@ static void PrintCallstack(FILE* f, PEXCEPTION_POINTERS ex)
 static void writeMemoryErrorDetails(FILE* f, PEXCEPTION_POINTERS ex, const char* description)
 {
     fputs(description, f);
+    // Using %p for ULONG_PTR later on, so it must have size identical to size of pointer
+    // This is not the universally portable solution but good enough for Win32/64
+    C_ASSERT(sizeof(void*) == sizeof(ex->ExceptionRecord->ExceptionInformation[1]));
     switch (ex->ExceptionRecord->ExceptionInformation[0]) {
     case 0:
-        fprintf(f, " reading from 0x%x",
+        fprintf(f, " reading from 0x%p",
                 ex->ExceptionRecord->ExceptionInformation[1]);
         break;
     case 1:
-        fprintf(f, " writing at 0x%x",
+        fprintf(f, " writing at 0x%p",
                 ex->ExceptionRecord->ExceptionInformation[1]);
         break;
     case 8:
-        fprintf(f, " data execution prevention at 0x%x",
+        fprintf(f, " data execution prevention at 0x%p",
                 ex->ExceptionRecord->ExceptionInformation[1]);
         break;
     default:


### PR DESCRIPTION
`%x` is for `int`, so the original code would only print half of pointer when compiled for x64. The new code is not perfect (`%p` can only be used for valid pointers) but will do for Windows.