### PR TITLE
Proper simplify delete a,b

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8726,9 +8726,8 @@ void Tokenizer::simplifyComma()
 
         if (Token::Match(tok->tokAt(-2), "delete %name% , %name% ;") &&
             tok->next()->varId() != 0) {
-            // Handle "delete a, b;"
+            // Handle "delete a, b;" - convert to delete a; b;
             tok->str(";");
-            tok->insertToken("delete");
         } else if (!inReturn && tok->tokAt(-2)) {
             bool replace = false;
             for (Token *tok2 = tok->previous(); tok2; tok2 = tok2->previous()) {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -1796,7 +1796,17 @@ private:
                                 "    char *a, *b;\n"
                                 "    delete a, b;\n"
                                 "}\n";
-            ASSERT_EQUALS("void foo ( ) { char * a ; char * b ; delete a ; delete b ; }", tok(code));
+            ASSERT_EQUALS("void foo ( ) { char * a ; char * b ; delete a ; b ; }", tok(code));
+        }
+
+        {
+            const char code[] = "void foo()\n"
+                                "{\n"
+                                "    char *a, *b;\n"
+                                "    if (x) \n"
+                                "        delete a, b;\n"
+                                "}\n";
+            ASSERT_EQUALS("void foo ( ) { char * a ; char * b ; if ( x ) { delete a ; b ; } }", tok(code));
         }
 
         {


### PR DESCRIPTION
`delete a, b` is equivalent to `(delete a), b`. Perhaps it's worth adding a warning for this case.