### PR TITLE
Don't call abort() in the middle of C++ code

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -446,7 +446,7 @@ static int multiComparePercent(const Token *tok, const char*& haystack, bool emp
     break;
     default:
         //unknown %cmd%, abort
-        std::abort();
+        throw InternalError( tok, "Unexpected command" );
     }
 
     if (*haystack == '|')


### PR DESCRIPTION
Calling `std::abort()` in the middle of C++ code subverts stack unwinding and makes the hosting process terminate immediately.