### PR TITLE
Ticket #6592: Don't mix consider "T" and "...T" as the same in template parameters

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1367,8 +1367,13 @@ void TemplateSimplifier::simplifyTemplates(
             tok->deleteThis();
 
         if (Token::simpleMatch(tok, "template <")) {
-            while (tok && tok->str() != ">")
+            while (tok && tok->str() != ">") {
+                if (Token::Match(tok, ". . . %name%")) { // Ticket #6592: The type in "typename... T" is "...T", not "T"
+                    tok->str(". . . " + tok->strAt(3));
+                    tok->deleteNext(3);
+                }
                 tok = tok->next();
+            }
             if (!tok)
                 break;
         }


### PR DESCRIPTION
Hi,

This ticket is an infinite loop upon invalid code involving a specialization with variadic templates; the reported snippet is invalid, however one pretty close and valid highlights an issue with the interpretation of the code.

The problem is that we consider "typename T" and "typename ... T" as the same, which is not the case. This patch fixes this by "renaming" T into ". . . T" in the latter case, which fixes both the invalid and valid cases. Thanks to consider merging.

Cheers,
  Simon