### PR TITLE
Show template instantiation and not definition location in template instantiation debug message

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1271,9 +1271,9 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
 
         if (typeForNewName.empty() || typeParametersInDeclaration.size() != typesUsedInTemplateInstantiation.size()) {
             if (_settings->debugwarnings && errorlogger) {
-                std::list<const Token *> callstack(1, tok);
+                std::list<const Token *> callstack(1, tok2);
                 errorlogger->reportErr(ErrorLogger::ErrorMessage(callstack, &tokenlist, Severity::debug, "debug",
-                                       "Failed to instantiate template. The checking continues anyway.", false));
+                                       "Failed to instantiate template \"" + name + "\". The checking continues anyway.", false));
             }
             if (typeForNewName.empty())
                 continue;


### PR DESCRIPTION
Hi,

While investigating the comment mathiaskrgr did in https://github.com/danmar/cppcheck/pull/586, I've noticed that the "Failed to instantiate template" debug message does not name the template that we fail on, and also gives as location where the template was defined, not where it actually is instantiated. This trivial patch fixes that. Thanks to consider merging.

Cheers,
  Simon