### PR TITLE
Restore build with libc++ and revert PR#228 and PR#562.

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -533,7 +533,7 @@ void CheckIO::checkWrongPrintfScanfArguments()
 
             if (Token::Match(tok->next(), "( %any%") && _settings->library.formatstr_function(tok->str())) {
                 const std::map<int, Library::ArgumentChecks>& argumentChecks = _settings->library.argumentChecks.at(tok->str());
-                for (std::map<int, Library::ArgumentChecks>::const_iterator i = argumentChecks.begin(); i != argumentChecks.end(); ++i) {
+                for (std::map<int, Library::ArgumentChecks>::const_iterator i = argumentChecks.cbegin(); i != argumentChecks.cend(); ++i) {
                     if (i->second.formatstr) {
                         formatStringArgNo = i->first - 1;
                         break;

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1260,7 +1260,7 @@ void CheckStl::checkAutoPointer()
                     }
                     if (Token::Match(tok3, "( %var%")) {
                         std::map<unsigned int, const std::string>::const_iterator it = mallocVarId.find(tok3->next()->varId());
-                        if (it != mallocVarId.end()) {
+                        if (it != mallocVarId.cend()) {
                             // pointer on the memory allocated by malloc used in the auto pointer constructor -> error
                             autoPointerMallocError(tok2->next(), it->second);
                         }

--- a/lib/library.h
+++ b/lib/library.h
@@ -107,7 +107,7 @@ public:
     }
 
     bool formatstr_function(const std::string& funcname) const {
-        return _formatstr.find(funcname) != _formatstr.end();
+        return _formatstr.find(funcname) != _formatstr.cend();
     }
 
     bool formatstr_scan(const std::string& funcname) const {

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -143,6 +143,8 @@ double MathLib::toDoubleNumber(const std::string &str)
     // nullcheck
     else if (isNullValue(str))
         return 0.0;
+    else if (isFloat(str)) // Workaround libc++ bug at http://llvm.org/bugs/show_bug.cgi?id=17782
+        return std::strtod(str.c_str(), 0);
     // otherwise, convert to double
     std::istringstream istr(str);
     double ret;

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -170,20 +170,12 @@ void TestFixture::assertEquals(const char *filename, unsigned int linenr, const 
 
 void TestFixture::assertEquals(const char *filename, unsigned int linenr, long long expected, long long actual, const std::string &msg) const
 {
-    std::ostringstream ostr1;
-    ostr1 << expected;
-    std::ostringstream ostr2;
-    ostr2 << actual;
-    assertEquals(filename, linenr, ostr1.str(), ostr2.str(), msg);
+    assertEquals(filename, linenr, MathLib::toString(expected), MathLib::toString(actual), msg);
 }
 
 void TestFixture::assertEqualsDouble(const char *filename, unsigned int linenr, double expected, double actual, const std::string &msg) const
 {
-    std::ostringstream ostr1;
-    ostr1 << expected;
-    std::ostringstream ostr2;
-    ostr2 << actual;
-    assertEquals(filename, linenr, ostr1.str(), ostr2.str(), msg);
+    assertEquals(filename, linenr, MathLib::toString(expected), MathLib::toString(actual), msg);
 }
 
 void TestFixture::todoAssertEquals(const char *filename, unsigned int linenr,
@@ -301,7 +293,7 @@ std::size_t TestFixture::runTests(const options& args)
 
     if (!missingLibs.empty()) {
         std::cerr << "Missing libraries: ";
-        for (std::set<std::string>::const_iterator i = missingLibs.begin(); i != missingLibs.end(); ++i)
+        for (std::set<std::string>::const_iterator i = missingLibs.cbegin(); i != missingLibs.cend(); ++i)
             std::cerr << *i << "  ";
         std::cerr << std::endl << std::endl;
     }


### PR DESCRIPTION
Hi,

This patch works around https://llvm.org/bugs/show_bug.cgi?id=17782, a bug in libc++ that forced to use GNU's STL when building on Mac OS X, and therefore prevented the use of cbegin() and cend() (hence https://github.com/danmar/cppcheck/pull/228 and https://github.com/danmar/cppcheck/pull/562, that are reverted as well here).

The idea is to detect cases where conversion to double will fail due to that bug and directly call strtod.

Thanks to consider merging.

Cheers,
  Simon