### PR TITLE
Ticket #6666: Don't crash upon garbage code in CheckLeakAutoVar::checkScope

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -150,8 +150,11 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
     // Parse all tokens
     const Token * const endToken = startToken->link();
     for (const Token *tok = startToken; tok && tok != endToken; tok = tok->next()) {
-        if (!tok->scope()->isExecutable())
+        if (!tok->scope()->isExecutable()) {
             tok = tok->scope()->classEnd;
+            if (!tok) // Ticket #6666 (crash upon invalid code)
+                break;
+        }
 
         // Deallocation and then dereferencing pointer..
         if (tok->varId() > 0) {

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -76,6 +76,7 @@ private:
         TEST_CASE(garbageCode35); // #2599, #2604
         TEST_CASE(garbageCode36); // #6334
         TEST_CASE(garbageCode37); // #5166
+        TEST_CASE(garbageCode38); // #6666
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -443,6 +444,10 @@ private:
     void garbageCode37() {
         // #5166 segmentation fault (invalid code) in lib/checkother.cpp:329 ( void * f { } void b ( ) { * f } )
         checkCode("void * f { } void b ( ) { * f }");
+    }
+
+    void garbageCode38() { // Ticket #6666
+        checkCode("{ f2 { } } void f3 () { delete[] } { }");
     }
 
     void garbageValueFlow() {


### PR DESCRIPTION
Hi,

This trivial patch fixes this ticket, where we crash upon garbage code as we end up dereferencing a null pointer. Thanks to consider merging.

Cheers,
  Simon