### PR TITLE
Ticket #6675: Fixed pattern detecting C++ 11 delegated constructors.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1198,7 +1198,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                 func->functionScope->functionOf && func->arg && func->arg->link()->strAt(1) == ":") {
                 const Token * tok = func->arg->link()->tokAt(2);
                 while (tok && tok != func->functionScope->classStart) {
-                    if (Token::Match(tok, "%name% {")) {
+                    if (Token::Match(tok, "%name% {|(")) {
                         if (tok->str() == func->tokenDef->str()) {
                             const_cast<Token *>(tok)->function(func->functionScope->functionOf->findFunction(tok));
                             break;

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1044,6 +1044,16 @@ private:
               "    A() { number = 42; }\n"
               "};");
         ASSERT_EQUALS("", errout.str());
+
+        // Ticket #6675
+        check("struct Foo {\n"
+              "  Foo();\n"
+              "  Foo(int foo);\n"
+              "  int foo_;\n"
+              "};\n"
+              "Foo::Foo() : Foo(0) {}\n"
+              "Foo::Foo(int foo) : foo_(foo) {}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
Hi,

This ticket highlights that the pattern currently used to recognise C++ 11 delegated constructors is incomplete: it detects ": Foo {" but not ": Foo (". This patch fixes this by tweaking the regular expression. Thanks to consider merging.

Cheers,
  Simon