### PR TITLE
Ticket #6680: Members can be initialized by operator>>.

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1886,6 +1886,8 @@ bool CheckUninitVar::isMemberVariableAssignment(const Token *tok, const std::str
             return true;
         else if (Token::Match(tok->tokAt(-2), "[(,=] &"))
             return true;
+        else if (Token::Match(tok->tokAt(-2), "%name% >>") && Token::Match(tok->tokAt(3), ";|>>")) // #6680
+            return true;
         else if ((tok->previous() && tok->previous()->isConstOp()) || Token::Match(tok->previous(), "[|="))
             ; // member variable usage
         else if (tok->tokAt(3)->isConstOp())


### PR DESCRIPTION
Hi,

This ticket shows that the check for uninitialised member variables does not take into account that they might be initialised by operator>>. This patch fixes this. Thanks to consider merging.

Cheers,
  Simon