### PR TITLE
Ticket #6620, #6685: Reserved keywords cannot be function names.

### DIFF
--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1005,6 +1005,9 @@ private:
     const Scope *findNamespace(const Token * tok, const Scope * scope) const;
     Function *findFunctionInScope(const Token *func, const Scope *ns);
 
+    /** Whether iName is a keyword as defined in http://en.cppreference.com/w/c/keyword and http://en.cppreference.com/w/cpp/keyword*/
+    bool isReservedName(const std::string& iName) const;
+
 
     const Tokenizer *_tokenizer;
     const Settings *_settings;

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -78,6 +78,8 @@ private:
         TEST_CASE(garbageCode37); // #5166
         TEST_CASE(garbageCode38); // #6666
         TEST_CASE(garbageCode39); // #6686
+        TEST_CASE(garbageCode40); // #6620
+        TEST_CASE(garbageCode41); // #6685
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -453,6 +455,14 @@ private:
 
     void garbageCode39() { // #6686
         checkCode("({ (); strcat(strcat(() ()) ()) })");
+    }
+
+    void garbageCode40() { // #6620
+        ASSERT_THROW(checkCode("{ ( ) () { virtual } ; { } E } A { : { } ( ) } * const ( ) const { }"), InternalError);
+    }
+
+    void garbageCode41() { // #6685
+        ASSERT_THROW(checkCode(" { } { return } *malloc(__SIZE_TYPE__ size); *memcpy(void n); static * const () { memcpy (*slot, 3); } { (); } { }"), InternalError);
     }
 
     void garbageValueFlow() {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -805,7 +805,7 @@ private:
         ASSERT_EQUALS("\n\n##file 0\n1: else { if ( ab ) { cd } else { ef } } gh\n", elseif(code));
 
         // syntax error: assert there is no segmentation fault
-        ASSERT_EQUALS("\n\n##file 0\n1: else if ( x ) { }\n", elseif("else if (x) { }"));
+        ASSERT_THROW(elseif("else if (x) { }"), InternalError);
 
         {
             const char src[] =  "void f(int g,int f) {\n"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1919,8 +1919,7 @@ private:
     }
 
     void symboldatabase36() { // ticket #4892
-        check("void struct ( ) { if ( 1 ) } int main ( ) { }");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_THROW(check("void struct ( ) { if ( 1 ) } int main ( ) { }"), InternalError);
     }
 
     void symboldatabase37() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -1270,7 +1270,7 @@ private:
 
     void ifAddBraces15() {
         // ticket #2616 - unknown macro before if
-        ASSERT_EQUALS("{ A if ( x ) { y ( ) ; } }", tokenizeAndStringify("{A if(x)y();}", false));
+        ASSERT_THROW(tokenizeAndStringify("{A if(x)y();}", false), InternalError);
     }
 
     void ifAddBraces16() { // ticket # 2739 (segmentation fault)
@@ -6145,7 +6145,7 @@ private:
                                "operator ( ) ; "
                                "}";
 
-        ASSERT_EQUALS(result, tokenizeAndStringify(code,false));
+        ASSERT_EQUALS(result, tokenizeAndStringify(code, /*simplify=*/false, /*expand=*/true, /*platform=*/Settings::Unspecified, "test.c"));
     }
 
     void simplifyOperatorName2() {


### PR DESCRIPTION
Hi,

Both tickets are for garbage code that confuses the parser and eventually leads to a crash. In both cases the root cause is that a Function is built for a name that's reserved to the language. This patch fixes this by ensuring that we don't build function declarations when their name is reserved.

Thanks to consider merging.

Cheers,
  Simon