### PR TITLE
Ticket #6703: Rewrite pattern in SymbolDatabase to avoid crash upon garbage code

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -75,7 +75,7 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                     if (tok2->next()->str() == ";")
                         tok = tok2->next();
                     else if (Token::simpleMatch(tok2->next(), "= {") &&
-                             tok2->linkAt(2)->next()->str() == ";")
+                             Token::simpleMatch(tok2->linkAt(2), "} ;"))
                         tok = tok2->linkAt(2)->next();
                     else if (Token::Match(tok2->next(), "(|{") &&
                              tok2->next()->link()->strAt(1) == ";")

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -81,6 +81,7 @@ private:
         TEST_CASE(garbageCode40); // #6620
         TEST_CASE(garbageCode41); // #6685
         TEST_CASE(garbageCode42); // #5760
+        TEST_CASE(garbageCode43); // #6703
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -468,6 +469,10 @@ private:
 
     void garbageCode42() { // #5760
         ASSERT_THROW(checkCode("{  } * const ( ) { }"), InternalError);
+    }
+
+    void garbageCode43() { // #6703
+        checkCode("int { }; struct A<void> a = { }");
     }
 
     void garbageValueFlow() {


### PR DESCRIPTION
Hi,

This trivial patch fixes the ticket by rewriting a pattern to avoid dereferencing some possibly null pointer. Thanks to consider merging.

Cheers,
  Simon