### PR TITLE
Ticket #6704: Tighten pattern skipping base class declarations and fix crash upon garbage code

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2792,7 +2792,7 @@ void Tokenizer::setVarId()
 
             const Token* tokStart = tok->tokAt(2);
             while (tokStart && tokStart->str() != "{") {
-                if (Token::Match(tokStart, "public|private|protected"))
+                if (Token::Match(tokStart, "public|private|protected %name%"))
                     tokStart = tokStart->next();
                 if (tokStart->strAt(1) == "," || tokStart->strAt(1) == "{")
                     varlist[classname].insert(varlist[tokStart->str()].begin(), varlist[tokStart->str()].end());

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -82,6 +82,7 @@ private:
         TEST_CASE(garbageCode41); // #6685
         TEST_CASE(garbageCode42); // #5760
         TEST_CASE(garbageCode43); // #6703
+        TEST_CASE(garbageCode44); // #6704
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -473,6 +474,10 @@ private:
 
     void garbageCode43() { // #6703
         checkCode("int { }; struct A<void> a = { }");
+    }
+
+    void garbageCode44() { // #6704
+        ASSERT_THROW(checkCode("{ { }; }; { class A : }; public typedef b;"), InternalError);
     }
 
     void garbageValueFlow() {


### PR DESCRIPTION
Hi,

This ticket highlights that the pattern used to skip base class declarations in a class definition is not tight enough, and can trigger a crash upon malformed code. This patch fixes the pattern and the ticket. Thanks to consider merging.

Cheers,
  Simon