### PR TITLE
Ticket #6708: Check that a function name is not a reserved keyword in SymbolDatabase::isFunction instead of later.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -745,8 +745,6 @@ SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *setti
                         // save function prototype in database
                         if (newFunc) {
                             Function* func = addGlobalFunctionDecl(scope, tok, argStart, funcStart);
-                            if (!func)
-                                break;
 
                             if (Token::Match(argStart->link(), ") const| noexcept")) {
                                 int arg = 2;
@@ -1301,7 +1299,7 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
     }
 
     // regular function?
-    else if (Token::Match(tok, "%name% (") && tok->previous() &&
+    else if (Token::Match(tok, "%name% (") && !isReservedName(tok->str()) && tok->previous() &&
              (tok->previous()->isName() || tok->strAt(-1) == ">" || tok->strAt(-1) == "&" || tok->strAt(-1) == "*" || // Either a return type in front of tok
               tok->strAt(-1) == "::" || tok->strAt(-1) == "~" || // or a scope qualifier in front of tok
               outerScope->isClassOrStruct())) { // or a ctor/dtor
@@ -1660,9 +1658,6 @@ Function* SymbolDatabase::addGlobalFunction(Scope*& scope, const Token*& tok, co
     if (!function)
         function = addGlobalFunctionDecl(scope, tok, argStart, funcStart);
 
-    if (!function)
-        return 0;
-
     function->arg = argStart;
     function->token = funcStart;
     function->hasBody(true);
@@ -1688,8 +1683,6 @@ Function* SymbolDatabase::addGlobalFunctionDecl(Scope*& scope, const Token *tok,
     function.access = Public;
 
     // save the function name location
-    if (funcStart && isReservedName(funcStart->str()))
-        return 0;
     function.tokenDef = funcStart;
 
     function.isInline(false);

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1001,7 +1001,7 @@ private:
     Function *addGlobalFunctionDecl(Scope*& scope, const Token* tok, const Token *argStart, const Token* funcStart);
     Function *addGlobalFunction(Scope*& scope, const Token*& tok, const Token *argStart, const Token* funcStart);
     void addNewFunction(Scope **info, const Token **tok);
-    static bool isFunction(const Token *tok, const Scope* outerScope, const Token **funcStart, const Token **argStart);
+    bool isFunction(const Token *tok, const Scope* outerScope, const Token **funcStart, const Token **argStart);
     const Type *findTypeInNested(const Token *tok, const Scope *startScope) const;
     const Scope *findNamespace(const Token * tok, const Scope * scope) const;
     Function *findFunctionInScope(const Token *func, const Scope *ns);

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -462,15 +462,15 @@ private:
     }
 
     void garbageCode40() { // #6620
-        ASSERT_THROW(checkCode("{ ( ) () { virtual } ; { } E } A { : { } ( ) } * const ( ) const { }"), InternalError);
+        checkCode("{ ( ) () { virtual } ; { } E } A { : { } ( ) } * const ( ) const { }");
     }
 
     void garbageCode41() { // #6685
-        ASSERT_THROW(checkCode(" { } { return } *malloc(__SIZE_TYPE__ size); *memcpy(void n); static * const () { memcpy (*slot, 3); } { (); } { }"), InternalError);
+        checkCode(" { } { return } *malloc(__SIZE_TYPE__ size); *memcpy(void n); static * const () { memcpy (*slot, 3); } { (); } { }");
     }
 
     void garbageCode42() { // #5760
-        ASSERT_THROW(checkCode("{  } * const ( ) { }"), InternalError);
+        checkCode("{  } * const ( ) { }");
     }
 
     void garbageCode43() { // #6703

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -805,7 +805,7 @@ private:
         ASSERT_EQUALS("\n\n##file 0\n1: else { if ( ab ) { cd } else { ef } } gh\n", elseif(code));
 
         // syntax error: assert there is no segmentation fault
-        ASSERT_THROW(elseif("else if (x) { }"), InternalError);
+        ASSERT_EQUALS("\n\n##file 0\n1: else if ( x ) { }\n", elseif("else if (x) { }"));
 
         {
             const char src[] =  "void f(int g,int f) {\n"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1920,7 +1920,8 @@ private:
     }
 
     void symboldatabase36() { // ticket #4892
-        ASSERT_THROW(check("void struct ( ) { if ( 1 ) } int main ( ) { }"), InternalError);
+        check("void struct ( ) { if ( 1 ) } int main ( ) { }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void symboldatabase37() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -336,6 +336,7 @@ private:
         TEST_CASE(cpp0xtemplate2);
         TEST_CASE(cpp0xtemplate3);
         TEST_CASE(cpp0xtemplate4); // Ticket #6181: Mishandled C++11 syntax
+        TEST_CASE(cpp14template); // Ticket #6708
 
         TEST_CASE(arraySize);
 
@@ -1270,7 +1271,7 @@ private:
 
     void ifAddBraces15() {
         // ticket #2616 - unknown macro before if
-        ASSERT_THROW(tokenizeAndStringify("{A if(x)y();}", false), InternalError);
+        ASSERT_EQUALS("{ A if ( x ) { y ( ) ; } }", tokenizeAndStringify("{A if(x)y();}", false));
     }
 
     void ifAddBraces16() { // ticket # 2739 (segmentation fault)
@@ -5262,6 +5263,11 @@ private:
                              "  }; "
                              "  template<class DC> class C2 {}; "
                              "}");
+    }
+
+    void cpp14template() { // Ticket #6708
+        tokenizeAndStringify("template <typename T> "
+                             "decltype(auto) forward(T& t) { return 0; }");
     }
 
     std::string arraySize_(const std::string &code) {


### PR DESCRIPTION
Hi,

This is a follow-up to https://github.com/danmar/cppcheck/pull/596 that actually caused a regression as highlighted by @amai2012 in ticket #6708. The problem is that the initial PR checked that a function's name is not a reserved keyword while building a Function instance, while it's better to do it in isFunction.

Thanks to consider merging.

Cheers,
  Simon