### PR TITLE
Ticket #6713: Properly detect ternary operator in valueFlowForward.

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1043,6 +1043,8 @@ static bool valueFlowForward(Token * const               startToken,
         // If a ? is seen and it's known that the condition is true/false..
         else if (tok2->str() == "?") {
             const Token *condition = tok2->astOperand1();
+            if (!condition) // Ticket #6713
+                continue;
             std::list<ValueFlow::Value>::const_iterator it;
             for (it = values.begin(); it != values.end(); ++it) {
                 const std::map<unsigned int, MathLib::bigint> programMemory(getProgramMemory(tok2, varid, *it));

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -94,6 +94,7 @@ private:
         TEST_CASE(garbageCode53); // #6721
         TEST_CASE(garbageCode54); // #6722
         TEST_CASE(garbageCode55); // #6724
+        TEST_CASE(garbageCode56); // #6713
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -533,6 +534,10 @@ private:
 
     void garbageCode55() { // #6724
         checkCode("() __attribute__((constructor)); { } { }");
+    }
+
+    void garbageCode56() { // #6713
+        checkCode("void foo() { int a = 0; int b = ???; }");
     }
 
     void garbageValueFlow() {


### PR DESCRIPTION
Hi,

This ticket is a hang upon invalid code because valueFlowForward believes it has encountered a ternary operator (due to the ? character) and desperately tries to analyse, while it's _not_ a ternary operator. This patch fixes this by properly detecting such operators. Thanks to consider merging.

Cheers,
  Simon