### PR TITLE
Removed useless space in the declaration for Tokenizer::Simplifyfunctionpointers

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5241,7 +5241,7 @@ void Tokenizer::simplifyPointerToStandardType()
     }
 }
 
-void Tokenizer:: simplifyFunctionPointers()
+void Tokenizer::simplifyFunctionPointers()
 {
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         // #2873 - do not simplify function pointer usage here:


### PR DESCRIPTION
Hi,

Trivial style change: no need for a space here. Thanks to consider merging.

Cheers,
  Simon