### PR TITLE
Ticket #6588: Properly detect whether the condition in a ternary operator is constant on C input

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4858,9 +4858,9 @@ bool Tokenizer::simplifyConstTernaryOp()
         const int offset = (tok->previous()->str() == ")") ? 2 : 1;
 
         bool inTemplateParameter = false;
-        if (!isC() && tok->strAt(-2*offset) == "<") {
-            if (!TemplateSimplifier::templateParameters(tok->tokAt(-2*offset)))
-                continue;
+        if (tok->strAt(-2*offset) == "<") {
+            if (isC() || !TemplateSimplifier::templateParameters(tok->tokAt(-2*offset)))
+                continue; // '<' is less than; the condition is not a constant
             inTemplateParameter = true;
         }
 

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -136,7 +136,17 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
-        // ticket #6588
+        // ticket #6588 (c mode)
+        check("struct MpegEncContext { int *q_intra_matrix, *q_chroma_intra_matrix; };\n"
+              "void dnxhd_10bit_dct_quantize(MpegEncContext *ctx, int n, int qscale) {\n"
+              "  const int *qmat = n < 4;\n" /* KO */
+              "  const int *rmat = n < 4 ? " /* OK */
+              "                       ctx->q_intra_matrix :"
+              "                       ctx->q_chroma_intra_matrix;\n"
+              "}", /*experimental=*/false, "test.c");
+        ASSERT_EQUALS("[test.c:3]: (error) Boolean value assigned to pointer.\n", errout.str());
+
+        // ticket #6588 (c++ mode)
         check("struct MpegEncContext { int *q_intra_matrix, *q_chroma_intra_matrix; };\n"
               "void dnxhd_10bit_dct_quantize(MpegEncContext *ctx, int n, int qscale) {\n"
               "  const int *qmat = n < 4;\n" /* KO */


### PR DESCRIPTION
Hi,

This is a follow-up to https://github.com/danmar/cppcheck/pull/606 where I wrongly assumed the ticket was fixed, while it still existed in C mode. The issue is that simplifyConstTernaryOp wrongly handled the '<' character in C mode ("n < 4 ? foo : bar" was turned into "n < foo", a bool hence the warning). This is fixed in the attached patch. Thanks to consider merging.

Cheers,
  Simon