### PR TITLE
Ticket #6536: Properly handle variables whose name is that of an allocation function.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2745,7 +2745,7 @@ void CheckMemoryLeakNoVar::check()
 void CheckMemoryLeakNoVar::checkForUnusedReturnValue(const Scope *scope)
 {
     for (const Token *tok = scope->classStart; tok != scope->classEnd; tok = tok->next()) {
-        if (Token::Match(tok, "%name% (") && (!tok->next()->astParent() || tok->next()->astParent()->str() == "!" || tok->next()->astParent()->isComparisonOp()) && tok->next()->astOperand1() == tok) {
+        if (!tok->varId() && Token::Match(tok, "%name% (") && (!tok->next()->astParent() || tok->next()->astParent()->str() == "!" || tok->next()->astParent()->isComparisonOp()) && tok->next()->astOperand1() == tok) {
             const AllocType allocType = getAllocationType(tok, 0);
             if (allocType != No)
                 returnValueNotUsedError(tok, tok->str());

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -6194,6 +6194,7 @@ private:
 
     void run() {
         settings.inconclusive = true;
+        settings.standards.posix = true;
         settings.addEnabled("warning");
 
         LOAD_LIB_2(settings.library, "gtk.cfg");
@@ -6372,6 +6373,13 @@ private:
         check("FOO* factory() {\n"
               "    FOO* foo = new (std::nothrow) FOO;\n"
               "    return foo;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // Ticket #6536
+        check("struct S { S(int) {} };\n"
+              "void foo(int i) {\n"
+              "  S socket(i);\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
Hi,

This ticket shows that the leak checker can get confused by variables called the same as an allocation function. This patch fixes this by only considering tokens with no varId as possible allocation functions.

Cheers,
  Simon