### PR TITLE
Ticket #6795: Make float parsing locale insensitive.

### DIFF
--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -138,15 +138,19 @@ MathLib::bigint MathLib::toLongNumber(const std::string & str)
 
 double MathLib::toDoubleNumber(const std::string &str)
 {
+    const std::string::size_type strLen = str.size();
+    std::string::size_type numTrailingNotDigit = 0; // Number of trailing characters that are not digits
     if (isHex(str))
         return static_cast<double>(toLongNumber(str));
     // nullcheck
     else if (isNullValue(str))
         return 0.0;
-    else if (isFloat(str)) // Workaround libc++ bug at http://llvm.org/bugs/show_bug.cgi?id=17782
-        return std::strtod(str.c_str(), 0);
+    else if (isFloat(str)) { // Workaround libc++ bug at http://llvm.org/bugs/show_bug.cgi?id=17782
+        while (!isdigit(str[strLen - numTrailingNotDigit - 1]))
+            ++numTrailingNotDigit;
+    }
     // otherwise, convert to double
-    std::istringstream istr(str);
+    std::istringstream istr(str.substr(0, strLen - numTrailingNotDigit));
     double ret;
     istr >> ret;
     return ret;

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -18,6 +18,7 @@
 
 #include "mathlib.h"
 #include "testsuite.h"
+#include <clocale>
 
 
 class TestMathLib : public TestFixture {
@@ -311,6 +312,14 @@ private:
         ASSERT_EQUALS_DOUBLE(0.0   , MathLib::toDoubleNumber("+0."));
         ASSERT_EQUALS_DOUBLE(0.0   , MathLib::toDoubleNumber("-0.0"));
         ASSERT_EQUALS_DOUBLE(0.0   , MathLib::toDoubleNumber("+0.0"));
+
+        // Ticket #6795
+        std::setlocale(LC_NUMERIC, "de_DE") ||
+        std::setlocale(LC_NUMERIC, "de_DE.ISO8859-1") ||
+        std::setlocale(LC_NUMERIC, "de_DE.ISO8859-15") ||
+        std::setlocale(LC_NUMERIC, "de_DE.UTF8");
+        ASSERT_EQUALS_DOUBLE(10.1  , MathLib::toDoubleNumber("10.1"));
+        std::setlocale(LC_NUMERIC, "");
 
         // verify: string --> double --> string conversion
         ASSERT_EQUALS("1.0" , MathLib::toString(MathLib::toDoubleNumber("1.0f")));


### PR DESCRIPTION
Hi,

The workaround for Mac OS's C++ library bug with float parsing (see details in https://github.com/danmar/cppcheck/pull/589) causes issues - ticket #6795 - depending on the locale used because strtod is locale sensitive... This patch makes sure we use the "C" locale before calls to strtod, which fixes the ticket. Thanks to consider merging.

Cheers,
  Simon