### PR TITLE
Ticket #6777: Basic support for 'auto' variables in CheckUnusedVar.

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -690,6 +690,9 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
                 type = Variables::pointerPointer;
             else if (i->isPointer())
                 type = Variables::pointer;
+            else if (_tokenizer->isCPP() && _settings->standards.cpp >= Standards::CPP11 &&
+                     i->typeEndToken()->str() == "auto") // Ticket #6777 (workaround until #4345 is fixed)
+                type = Variables::standard;
             else if (_tokenizer->isC() ||
                      i->typeEndToken()->isStandardType() ||
                      isRecordTypeWithoutSideEffects(i->type()) ||

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -866,6 +866,11 @@ private:
                               "    int i = 0;\n"
                               "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'i' is assigned a value that is never used.\n", errout.str());
+
+        functionVariableUsage("void foo() {\n" // #6777 - handle variables using C++ 11's auto keyword
+                              "    auto i = 0;\n"
+                              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'i' is assigned a value that is never used.\n", errout.str());
     }
 
     void localvar2() {


### PR DESCRIPTION
Hi,

cppcheck currently fails to report variables that are assigned a value but not used if they're declared 'auto'; this is due to ticket #4345, and this patch implements a workaround fix until this ticket is fixed. Thanks to consider merging.

Cheers,
  Simon