### PR TITLE
Ticket #6810: Avoid infinite loop upon invalid typed enum declaration.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7597,11 +7597,16 @@ void Tokenizer::simplifyEnum()
                 typeTokenEnd = 0;
 
                 while (tok->next() && Token::Match(tok->next(), "::|%type%")) {
+                    // Ticket #6810: Avoid infinite loop upon invalid enum definition
+                    if (enumType && enumType->str() == tok->strAt(1)) {
+                        typeTokenEnd = 0;
+                        break;
+                    }
                     typeTokenEnd = tok->next();
                     tok = tok->next();
                 }
 
-                if (!tok->next() || !typeTokenEnd) {
+                if (!tok->next() || tok->str() == "::" || !typeTokenEnd) {
                     syntaxError(tok);
                     return; // can't recover
                 }

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -3188,6 +3188,13 @@ private:
             ASSERT_EQUALS(expected, checkSimplifyEnum(code, false)); // Compile as C code: enum has name 'class'
             checkSimplifyEnum(code, true); // Compile as C++ code: Don't crash
         }
+
+        {
+            // Ticket #6810
+            ASSERT_THROW(checkSimplifyEnum("enum x : enum x {} :"), InternalError);
+            ASSERT_THROW(checkSimplifyEnum("enum x : enum x {} () :"), InternalError);
+            ASSERT_THROW(checkSimplifyEnum("enum x : :: {} () :"), InternalError);
+        }
     }
 
     void enum16() { // ticket #1988


### PR DESCRIPTION
Hi,

In this ticket, we end up simplifying a faulty enum declaration until memory is exhausted because we're too permissive in typed enumeration declarations. This trivial patch fixes the issue by detecting such recursive definitions. We could definitely be more strict on such definitions, however I don't think it's worth the pain.

Thanks to consider merging.

Cheers,
  Simon