### PR TITLE
Ticket #6835: Don't get confused by parentheses while detecting template parameter default values.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -572,6 +572,11 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                 continue;
             }
 
+            if (tok->str() == "(") { // Ticket #6835
+                tok = tok->link();
+                continue;
+            }
+
             if (tok->str() == "<" && templateParameters(tok))
                 ++templateParmDepth;
 

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -140,6 +140,7 @@ private:
         TEST_CASE(garbageCode98);
         TEST_CASE(garbageCode99);
         TEST_CASE(garbageCode100);
+        TEST_CASE(garbageCode101); // #6835
 
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
@@ -789,6 +790,13 @@ private:
 
     void garbageCode100() { // #6840
         checkCode("( ) { ( i< ) } int foo ( ) { int i ; ( for ( i => 1 ) ; ) }");
+    }
+
+    void garbageCode101() { // #6835
+        // Reported case
+        checkCode("template < class , =( , int) X = 1 > struct A { } ( ) { = } [ { } ] ( ) { A < void > 0 }");
+        // Reduced case
+        checkCode("template < class =( , ) X = 1> struct A {}; A<void> a;");
     }
 
     void garbageValueFlow() {


### PR DESCRIPTION
Hi,

This ticket is a crash upon invalid code due to the fact that TemplateSimplifier::useDefaultArgumentValues does not properly handle parenthesis while scanning for default values, which this patch fixes. Thanks to consider merging.

Cheers,
  Simon