### PR TITLE
Ticket #5776: Simplify (&a)->b into a.b

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1886,8 +1886,17 @@ void Tokenizer::combineOperators()
                 continue;
             }
 
-            // replace "->" with "."
+            // simplify "->"
             else if (c1 == '-' && c2 == '>') {
+                // If the preceding sequence is "( & %name% )", replace it by "%name%"
+                Token *t = tok->tokAt(-4);
+                if (t && Token::Match(t, "( & %name% )")) {
+                    t->deleteThis();
+                    t->deleteThis();
+                    t->deleteNext();
+                    tok = t->next();
+                }
+                // Replace "->" with "."
                 tok->str(".");
                 tok->originalName("->");
                 tok->deleteNext();

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3547,6 +3547,15 @@ private:
                         "    x = a.m;\n"
                         "}");
         ASSERT_EQUALS("", errout.str());
+
+        // Ticket #5776
+        checkUninitVar2("typedef struct { int a, b; } AB;\n"
+                        "void f(void) {\n"
+                        "  AB ab;\n"
+                        "  ab.a = 1;\n"
+                        "  return (&ab)->b;\n"
+                        "}", "test.c");
+        ASSERT_EQUALS("[test.c:5]: (error) Uninitialized struct member: ab.b\n", errout.str());
     }
 
     void uninitvar2_while() {


### PR DESCRIPTION
Hi,

This ticket highlights that we transform (&a)->b into (&a).b, a format that is not properly handled by the uninitialised member checker. This patch ensures that it is transformed into a.b, that not only fixes the ticket but is also the correct simplification. Thanks to consider merging.

Cheers,
  Simon