### PR TITLE
Added unit test involving function reference for TemplateSimplifier::templateParameters

### DIFF
--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1175,6 +1175,8 @@ private:
         ASSERT_EQUALS(1U, templateParameters("<class... T> x;"));
         ASSERT_EQUALS(0U, templateParameters("<class, typename T...> x;")); // Invalid syntax
         ASSERT_EQUALS(2U, templateParameters("<class, typename... T> x;"));
+        ASSERT_EQUALS(2U, templateParameters("<int(&)(), class> x;"));
+        ASSERT_EQUALS(3U, templateParameters("<char, int(*)(), bool> x;"));
         TODO_ASSERT_EQUALS(1U, 0U, templateParameters("<int...> x;")); // Mishandled valid syntax
         TODO_ASSERT_EQUALS(2U, 0U, templateParameters("<class, typename...> x;")); // Mishandled valid syntax
     }


### PR DESCRIPTION
Hi,

While investigating Ticket #6601, I saw that we don't have any test involving function pointers and referenced for TemplateSimplifier::templateParameters. This patch adds some. Thanks to consider merging.

Cheers,
  Simon