### PR TITLE
Ticket #5776: Since the fix is in Tokenizer, write a Tokenizer unit test

### DIFF
--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -692,6 +692,7 @@ private:
         ASSERT_EQUALS("void f ( ) { int p ; if ( ! p ) { } }", tok("void f(){int p; if ((p) == 0) {}}"));
         ASSERT_EQUALS("void f ( ) { int * p ; * p = 1 ; }", tok("void f(){int *p; *(p) = 1;}"));
         ASSERT_EQUALS("void f ( ) { int p ; if ( p ) { } p = 1 ; }", tok("void f(){int p; if ( p ) { } (p) = 1;}"));
+        ASSERT_EQUALS("void f ( ) { a . b ; }", tok("void f ( ) { ( & a ) -> b ; }")); // Ticket #5776
 
         // keep parentheses..
         ASSERT_EQUALS("b = a ;", tok("b = (char)a;"));

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3547,15 +3547,6 @@ private:
                         "    x = a.m;\n"
                         "}");
         ASSERT_EQUALS("", errout.str());
-
-        // Ticket #5776
-        checkUninitVar2("typedef struct { int a, b; } AB;\n"
-                        "void f(void) {\n"
-                        "  AB ab;\n"
-                        "  ab.a = 1;\n"
-                        "  return (&ab)->b;\n"
-                        "}", "test.c");
-        ASSERT_EQUALS("[test.c:5]: (error) Uninitialized struct member: ab.b\n", errout.str());
     }
 
     void uninitvar2_while() {


### PR DESCRIPTION
Hi,

As highlighter by amai in https://github.com/danmar/cppcheck/pull/623, it makes more sense to write a Tokenizer unit test for this fix that's purely in Tokenizer. This patch does exactly this. Thanks to consider merging.

Cheers,
  Simon