### PR TITLE
Resolve CID 1312126 and maybe also CID 1288510

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -580,22 +580,22 @@ static void PrintCallstack(FILE* f, PEXCEPTION_POINTERS ex)
 static void writeMemoryErrorDetails(FILE* f, PEXCEPTION_POINTERS ex, const char* description)
 {
     fputs(description, f);
-    fprintf(f, " (instruction: 0x%X) ", ex->ExceptionRecord->ExceptionAddress);
+    fprintf(f, " (instruction: 0x%p) ", ex->ExceptionRecord->ExceptionAddress);
     // Using %p for ULONG_PTR later on, so it must have size identical to size of pointer
     // This is not the universally portable solution but good enough for Win32/64
     C_ASSERT(sizeof(void*) == sizeof(ex->ExceptionRecord->ExceptionInformation[1]));
     switch (ex->ExceptionRecord->ExceptionInformation[0]) {
     case 0:
-        fprintf(f, "reading from 0x%X",
-                ex->ExceptionRecord->ExceptionInformation[1]);
+        fprintf(f, "reading from 0x%p",
+                reinterpret_cast<void*>(ex->ExceptionRecord->ExceptionInformation[1]));
         break;
     case 1:
-        fprintf(f, "writing to 0x%X",
-                ex->ExceptionRecord->ExceptionInformation[1]);
+        fprintf(f, "writing to 0x%p",
+                reinterpret_cast<void*>(ex->ExceptionRecord->ExceptionInformation[1]));
         break;
     case 8:
-        fprintf(f, "data execution prevention at 0x%X",
-                ex->ExceptionRecord->ExceptionInformation[1]);
+        fprintf(f, "data execution prevention at 0x%p",
+                reinterpret_cast<void*>(ex->ExceptionRecord->ExceptionInformation[1]));
         break;
     default:
         break;


### PR DESCRIPTION
Commit https://github.com/danmar/cppcheck/commit/8b97f04de4a7ecfa1b52c4b94f3321057e1e495a first, breaks the code Coverity wasn't even unhappy about (on line 583) and also effectively breaks previously corrected code without making Coverity happier.

This fixes both problems and most likely makes Coverity happy with a cast between `ULONG_PTR` and a pointer as suggested in this comment https://github.com/danmar/cppcheck/commit/8b97f04de4a7ecfa1b52c4b94f3321057e1e495a#commitcomment-12267821