### PR TITLE
Prototype for detecting non-interlocked check after InterlockedDecrement()

### DIFF
--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -83,6 +83,7 @@ public:
 
         // --check-library : functions with nonmatching configuration
         checkOther.checkLibraryMatchFunctions();
+        checkOther.checkInterlockedDecrement();
     }
 
     /** @brief Run checks against the simplified token list */
@@ -238,6 +239,10 @@ public:
     /** @brief --check-library: warn for unconfigured function calls */
     void checkLibraryMatchFunctions();
 
+    void checkInterlockedDecrement();
+
+	void checkNewAfterDelete();
+
 private:
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &strFunctionName, const std::string &varName, const bool result);
@@ -293,6 +298,7 @@ private:
     void commaSeparatedReturnError(const Token *tok);
     void ignoredReturnValueError(const Token* tok, const std::string& function);
     void redundantPointerOpError(const Token* tok, const std::string& varname, bool inconclusive);
+    void raceAfterInterlockedDecrementError(const Token* tok);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
         CheckOther c(0, settings, errorLogger);
@@ -306,6 +312,7 @@ private:
         c.invalidPointerCastError(0, "float", "double", false);
         c.negativeBitwiseShiftError(0);
         c.checkPipeParameterSizeError(0, "varname", "dimension");
+        c.raceAfterInterlockedDecrementError(0);
 
         //performance
         c.redundantCopyError(0, "varname");
@@ -368,6 +375,7 @@ private:
                "- provide wrong dimensioned array to pipe() system command (--std=posix)\n"
                "- cast the return values of getc(),fgetc() and getchar() to character and compare it to EOF\n"
                "- invalid input values for functions\n"
+               "- race condition with non-interlocked access after InterlockedDecrement() call\n"
 
                // warning
                "- either division by zero or useless condition\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -166,6 +166,7 @@ private:
 
         TEST_CASE(redundantPointerOp);
         TEST_CASE(test_isSameExpression);
+        TEST_CASE(raceAfterInterlockedDecrement);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool runSimpleChecks=true, Settings* settings = 0) {
@@ -209,6 +210,13 @@ private:
               false,   // inconclusive
               true,    // runSimpleChecks
               &settings);
+    }
+
+    void checkInterlockedDecrement(const char code[]) {
+        Settings settings;
+        settings.platformType = Settings::Win32A;
+
+        check(code, nullptr, false, false, true, &settings);
     }
 
     void check_preprocess_suppress(const char precode[], const char *filename = nullptr) {
@@ -6227,6 +6235,206 @@ private:
               "   return  name.startswith(SRCDIR \"/com/\") || name.startswith(SRCDIR \"/uno/\");\n"
               "};", "test.cpp", false, false);
         TODO_ASSERT_EQUALS("", "[test.cpp:1] -> [test.cpp:1]: (style) Same expression on both sides of '||'.\n", errout.str());
+    }
+
+    void raceAfterInterlockedDecrement() {
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    whatever();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (counter)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (!counter)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (counter > 0)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (0 < counter)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (counter == 0)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (0 == counter)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (0 != counter)\n"
+              "        return;\n"
+              "    destroy()\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (counter != 0)\n"
+              "        return;\n"
+              "    destroy()\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (counter <= 0)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    InterlockedDecrement(&counter);\n"
+              "    if (0 >= counter)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (newCount)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (!newCount)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (newCount > 0)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (0 < newCount)\n"
+              "        return;\n"
+              "    destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (newCount == 0)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (0 == newCount)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (0 != newCount)\n"
+              "        return;\n"
+              "    destroy()\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (newCount != 0)\n"
+              "        return;\n"
+              "    destroy()\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (newCount <= 0)\n"
+              "        destroy();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkInterlockedDecrement(
+              "void f() {\n"
+              "    int counter = 0;\n"
+              "    int newCount = InterlockedDecrement(&counter);\n"
+              "    if (0 >= newCount)\n"
+              "        destroy;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
This PR contains a prototype for evaluation. I'll add tests if you like it.

A common pattern for reference counted objects goes like this:

    InterlockedDecrement(&referenceCount);
    if (referenceCount == 0)
       destroySelf();

here the problem is that the second access in not interlocked and so this allows for a race which can cause `destroySelf()` called twice.

Good code would do this instead:

    int newCount = InterlockedDecrement(&referenceCount);
    if (newCount == 0)
       destroySelf();
