### PR TITLE
Ticket #6793: Added basic unit test showing that basic integer shift length check is run even for templates.

### DIFF
--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -85,6 +85,15 @@ private:
               "  someList << 300;\n"
               "}", &settings);
         ASSERT_EQUALS("", errout.str());
+
+        // Ticket #6793
+        check("template<int I> int foo(int x) { return x << I; }\n"
+              "const int f = foo<31>(1);\n"
+              "const int g = foo<100>(1);\n"
+              "template<int I> int hoo(int x) { return x << 32; }\n"
+              "const int h = hoo<100>(1);", &settings);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n"
+                      "[test.cpp:1]: (error) Shifting 32-bit value by 100 bits is undefined behaviour\n", errout.str());
     }
 
     void checkIntegerOverflow() {


### PR DESCRIPTION
Hi,

This ticket is a claim (not justified by any snipped, just code read) that the check for too large right shifts is not run on template code. This patch adds some unit tests showing that it does (at least basic cases; will check more advanced ones later). Thanks to consider merging.

Cheers,
  Simon