### PR TITLE
freopen does not allocate

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -4407,7 +4407,6 @@
     <dealloc>fclose</dealloc>
     <alloc init="true">fopen</alloc>
     <alloc init="true">tmpfile</alloc>
-    <alloc init="true">freopen</alloc>
   </resource>
   <!-- char * strcat(char *deststr, const char *srcstr); -->
   <function name="strcat">


### PR DESCRIPTION
freopen either returns the FILE* it was given, or returns NULL.
It does not allocate a new FILE*.