### PR TITLE
Fixed #5028  Fix parsing of C++11 raw string literals

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -690,7 +690,7 @@ std::string Preprocessor::removeComments(const std::string &str, const std::stri
             else if (str.compare(i,2,"R\"")==0) {
                 std::string delim;
                 for (std::string::size_type i2 = i+2; i2 < str.length(); ++i2) {
-                    if (i2 > 16 ||
+                    if (i2 > 16 + i ||
                         std::isspace(str[i2]) ||
                         std::iscntrl(str[i2]) ||
                         str[i2] == ')' ||
@@ -713,7 +713,9 @@ std::string Preprocessor::removeComments(const std::string &str, const std::stri
                         } else if (std::iscntrl((unsigned char)str[p]) ||
                                    std::isspace((unsigned char)str[p])) {
                             code << " ";
-                        } else if (str[p] == '\"' || str[p] == '\'') {
+                        } else if (str[p] == '\\') {
+                            code << "\\\\";
+                        } else if (str[p] == '\"') {
                             code << "\\" << (char)str[p];
                         } else {
                             code << (char)str[p];

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -316,12 +316,12 @@ private:
     }
 
     void readCode2() {
-        const char code[] = "R\"( \" /* abc */ \n)\";";
+        const char code[] = "R\"( \" \\ ' /* abc */ \n)\";";
         Settings settings;
         Preprocessor preprocessor(settings, this);
         std::istringstream istr(code);
         std::string codestr(preprocessor.read(istr,"test.c"));
-        ASSERT_EQUALS("\" \\\" /* abc */ \\n\"\n;", codestr);
+        ASSERT_EQUALS("\" \\\" \\\\ ' /* abc */ \\n\"\n;", codestr);
     }
 
     void readCode3() {


### PR DESCRIPTION
Parsing of C++11 raw string literals only worked in the first 16 bytes of a file.
Backslashes in raw string literals were not escaped.
Single quotes in raw string literals were escaped unnecessarily.