### PR TITLE
Fix search-replace

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -302,7 +302,14 @@ void ErrorLogger::ErrorMessage::findAndReplace(std::string &source, const std::s
     std::string::size_type index = 0;
     while ((index = source.find(searchFor, index)) != std::string::npos) {
         source.replace(index, searchFor.length(), replaceWith);
-        index = (std::string::difference_type)index + (std::string::difference_type)replaceWith.length() - (std::string::difference_type)searchFor.length() + 1;
+
+        std::string::size_type advanceBy;
+        if (searchFor.length() >= replaceWith.length())
+            advanceBy = replaceWith.length();
+        else
+            advanceBy = (replaceWith.length() - searchFor.length()) + 1;
+
+        index += advanceBy;
     }
 }
 

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -32,6 +32,7 @@ private:
     const ErrorLogger::ErrorMessage::FileLocation barCpp8;
 
     void run() {
+        TEST_CASE(PatternSearchReplace);
         TEST_CASE(FileLocationDefaults);
         TEST_CASE(FileLocationSetFile);
         TEST_CASE(ErrorMessageConstruct);
@@ -58,6 +59,41 @@ private:
         TEST_CASE(SerializeSanitize);
 
         TEST_CASE(suppressUnmatchedSuppressions);
+    }
+
+    void TestPatternSearchReplace(const std::string& idPlaceholder, const std::string& id) const {
+        const std::string plainText = "text";
+
+        ErrorLogger::ErrorMessage message;
+        message._id = id;
+
+        std::string serialized = message.toString(true, idPlaceholder + plainText + idPlaceholder);
+        ASSERT_EQUALS(id + plainText + id, serialized);
+
+        serialized = message.toString(true, idPlaceholder + idPlaceholder);
+        ASSERT_EQUALS(id + id, serialized);
+
+        serialized = message.toString(true, plainText + idPlaceholder + plainText);
+        ASSERT_EQUALS(plainText + id + plainText, serialized);
+    }
+
+    void PatternSearchReplace() const {
+        const std::string idPlaceholder = "{id}";
+
+        const std::string empty;
+        TestPatternSearchReplace(idPlaceholder, empty);
+
+        const std::string shortIdValue = "ID";
+        ASSERT_EQUALS(true, shortIdValue.length() < idPlaceholder.length());
+        TestPatternSearchReplace(idPlaceholder, shortIdValue);
+
+        const std::string mediumIdValue = "_ID_";
+        ASSERT_EQUALS(mediumIdValue.length(), idPlaceholder.length());
+        TestPatternSearchReplace(idPlaceholder, mediumIdValue);
+
+        const std::string longIdValue = "longId";
+        ASSERT_EQUALS(true, longIdValue.length() > idPlaceholder.length());
+        TestPatternSearchReplace(idPlaceholder, longIdValue);
     }
 
     void FileLocationDefaults() const {


### PR DESCRIPTION
The current code is broken.

Start with `source = "{file}{file}"` and try to replace `{file}` with `c`. First, `index` is set to zero, then `0 + 1 - 6 + 1` is computed which yields `-4` which is then flipped into unsigned variable and turns into `npos - 3` and the loop terminates instead of proceeding to the next match.