### PR TITLE
Make DB2MAN overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ endif
 BIN=$(DESTDIR)$(PREFIX)/bin
 
 # For 'make man': sudo apt-get install xsltproc docbook-xsl docbook-xml on Linux
-DB2MAN=/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl
+DB2MAN?=/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl
 XP=xsltproc -''-nonet -''-param man.charmap.use.subset "0"
 MAN_SOURCE=man/cppcheck.1.xml
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -366,7 +366,7 @@ int main(int argc, char **argv)
 
     fout << "BIN=$(DESTDIR)$(PREFIX)/bin\n\n";
     fout << "# For 'make man': sudo apt-get install xsltproc docbook-xsl docbook-xml on Linux\n";
-    fout << "DB2MAN=/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl\n";
+    fout << "DB2MAN?=/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl\n";
     fout << "XP=xsltproc -''-nonet -''-param man.charmap.use.subset \"0\"\n";
     fout << "MAN_SOURCE=man/cppcheck.1.xml\n\n";
 


### PR DESCRIPTION
On different systems it may point to different locations, e.g. FreeBSD uses ${LOCALBASE}/share/xsl/docbook/manpages/docbook.xsl