### PR TITLE
Remove unnecessary TODO exception safety test case.

### DIFF
--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -82,11 +82,6 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Class x is not safe, destructor throws exception\n", errout.str());
 
-        check("x::~x() {\n"
-              "    throw e;\n"
-              "}");
-        TODO_ASSERT_EQUALS("[test.cpp:3]: (warning) Class x is not safe, destructor throws exception\n", "", errout.str());
-
         // #3858 - throwing exception in try block in destructor.
         check("class x {\n"
               "    ~x() {\n"


### PR DESCRIPTION
Hi,

While looking at TODO test cases, I've noticed one for exception safety that is clearly invalid. Fixing it would require ugly (and IMHO unnecessary) changes in a part of SymbolDatabase (destructor detection) that's currently very clean... something we don't want to do. I therefore believe this test case is useless and is better removed. Thoughts?

Thanks,
  Simon