### PR TITLE
Merge identical matches

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -189,16 +189,19 @@ void CheckAutoVariables::autoVariables()
                     errorAutoVariableAssignment(tok->next(), false);
             }
             // Critical return
-            else if (Token::Match(tok, "return & %var% ;") && isAutoVar(tok->tokAt(2))) {
-                errorReturnAddressToAutoVariable(tok);
+            else if (Token::Match(tok, "return & %var% ;")) {
+                const Token* varTok = tok->tokAt(2);
+                if (isAutoVar(varTok))
+                    errorReturnAddressToAutoVariable(tok);
+                else if (varTok->varId()) {
+                    const Variable * var1 = varTok->variable();
+                    if (var1 && var1->isArgument() && var1->typeEndToken()->str() != "&")
+                        errorReturnAddressOfFunctionParameter(tok, varTok->str());
+                }
             } else if (Token::Match(tok, "return & %var% [") &&
                        Token::simpleMatch(tok->linkAt(3), "] ;") &&
                        isAutoVarArray(tok->tokAt(2))) {
                 errorReturnAddressToAutoVariable(tok);
-            } else if (Token::Match(tok, "return & %var% ;") && tok->tokAt(2)->varId()) {
-                const Variable * var1 = tok->tokAt(2)->variable();
-                if (var1 && var1->isArgument() && var1->typeEndToken()->str() != "&")
-                    errorReturnAddressOfFunctionParameter(tok, tok->strAt(2));
             }
             // Invalid pointer deallocation
             else if ((Token::Match(tok, "%name% ( %var% ) ;") && _settings->library.dealloc(tok)) ||


### PR DESCRIPTION
Benchmark shows that `Match()` calls are reduced by 8 percent and the whole function gets about 5 percent faster on some random pile of code.