### PR TITLE
Replace match call with explicit comparison

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -784,7 +784,7 @@ static void valueFlowReverse(TokenList *tokenlist,
             if (!var->isLocal()) {
                 if (!Token::Match(tok2->previous(), ")|else|do {"))
                     break;
-                if (Token::simpleMatch(tok2->previous(), ") {") &&
+                if ((tok2->previous()->str() == ")") &&
                     !Token::Match(tok2->linkAt(-1)->previous(), "if|for|while ("))
                     break;
             }


### PR DESCRIPTION
Here the second match checks for a subset of a previous match. All is needed is actually comparing the first token - that's easier to read and not slower.