### PR TITLE
Ticket #6957: Properly handle arrays of pointers in CheckClass::constructors

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -148,7 +148,7 @@ void CheckClass::constructors()
                     continue;
 
                 // Check if this is a class constructor
-                if (!var->isPointer() && var->isClass() && func->type == Function::eConstructor) {
+                if (!var->isPointer() && !var->isPointerArray() && var->isClass() && func->type == Function::eConstructor) {
                     // Unknown type so assume it is initialized
                     if (!var->type())
                         continue;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1422,6 +1422,10 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
     return false;
 }
 
+bool Variable::isPointerArray() const {
+    return isArray() && nameToken() && nameToken()->previous() && (nameToken()->previous()->str() == "*");
+}
+
 const Token * Variable::declEndToken() const
 {
     Token const * declEnd = typeStartToken();

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -394,6 +394,12 @@ public:
     }
 
     /**
+     * Is variable an array of pointers
+     * @return true if array or pointers, false otherwise
+     */
+    bool isPointerArray() const;
+
+    /**
      * Is array or pointer variable.
      * @return true if pointer or array, false otherwise
      */

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -148,6 +148,7 @@ private:
         TEST_CASE(uninitVarArray6);
         TEST_CASE(uninitVarArray7);
         TEST_CASE(uninitVarArray8);
+        TEST_CASE(uninitVarArray9); // ticket #6957
         TEST_CASE(uninitVarArray2D);
         TEST_CASE(uninitVarArray3D);
         TEST_CASE(uninitVarCpp11Init1);
@@ -2402,6 +2403,17 @@ private:
               "    Foo() { ::ZeroMemory(a); }\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void uninitVarArray9() { // #6957
+        check("class BaseGDL;\n"
+              "struct IxExprListT {\n"
+              "private:\n"
+              "    BaseGDL* eArr[3];\n"
+              "public:\n"
+              "    IxExprListT() {}\n"
+              "};");
+        ASSERT_EQUALS("[test.cpp:6]: (warning) Member variable 'IxExprListT::eArr' is not initialized in the constructor.\n", errout.str());
     }
 
     void uninitVarArray2D() {

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -113,6 +113,7 @@ private:
         TEST_CASE(test_isVariableDeclarationIdentifiesDeclarationWithIndirection);
         TEST_CASE(test_isVariableDeclarationIdentifiesDeclarationWithMultipleIndirection);
         TEST_CASE(test_isVariableDeclarationIdentifiesArray);
+        TEST_CASE(test_isVariableDeclarationIdentifiesPointerArray);
         TEST_CASE(test_isVariableDeclarationIdentifiesOfArrayPointers);
         TEST_CASE(isVariableDeclarationIdentifiesTemplatedPointerVariable);
         TEST_CASE(isVariableDeclarationIdentifiesTemplatedPointerToPointerVariable);
@@ -491,6 +492,22 @@ private:
         Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings.library);
         ASSERT(true == v.isArray());
         ASSERT(false == v.isPointer());
+        ASSERT(false == v.isPointerArray());
+        ASSERT(false == v.isReference());
+    }
+
+    void test_isVariableDeclarationIdentifiesPointerArray() {
+        reset();
+        givenACodeSampleToTokenize arr("A *a[5];");
+        bool result = si.isVariableDeclaration(arr.tokens(), vartok, typetok);
+        ASSERT_EQUALS(true, result);
+        ASSERT_EQUALS("a", vartok->str());
+        ASSERT_EQUALS("A", typetok->str());
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings.library);
+        ASSERT(false == v.isPointer());
+        ASSERT(true == v.isArray());
+        ASSERT(false == v.isPointerToArray());
+        ASSERT(true == v.isPointerArray());
         ASSERT(false == v.isReference());
     }
 
@@ -505,6 +522,7 @@ private:
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointerToArray());
+        ASSERT(false == v.isPointerArray());
         ASSERT(false == v.isReference());
     }
 


### PR DESCRIPTION
Hi,

This is another follow-up to https://github.com/danmar/cppcheck/pull/651, and @amai2012 showed (thanks!) that we need to keep track of the fact that a variable is an array of pointers, and use this information in CheckClass::constructors. Thanks to consider merging.

Cheers,
  Simon