### PR TITLE
Ticket #6959: Properly handle arrays of pointers in CheckClass::constructors

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -160,7 +160,7 @@ void CheckClass::constructors()
                 }
 
                 // Check if type can't be copied
-                if (!var->isPointer() && var->typeScope()) {
+                if (!var->isPointer() && !var->isPointerArray() && var->typeScope()) {
                     if (func->type == Function::eMoveConstructor) {
                         if (canNotMove(var->typeScope()))
                             continue;

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -148,7 +148,7 @@ private:
         TEST_CASE(uninitVarArray6);
         TEST_CASE(uninitVarArray7);
         TEST_CASE(uninitVarArray8);
-        TEST_CASE(uninitVarArray9); // ticket #6957
+        TEST_CASE(uninitVarArray9); // ticket #6957, #6959
         TEST_CASE(uninitVarArray2D);
         TEST_CASE(uninitVarArray3D);
         TEST_CASE(uninitVarCpp11Init1);
@@ -2414,6 +2414,15 @@ private:
               "    IxExprListT() {}\n"
               "};");
         ASSERT_EQUALS("[test.cpp:6]: (warning) Member variable 'IxExprListT::eArr' is not initialized in the constructor.\n", errout.str());
+        check("struct sRAIUnitDefBL {\n"
+              "  sRAIUnitDefBL();\n"
+              "  ~sRAIUnitDefBL();\n"
+              "};\n"
+              "struct sRAIUnitDef {\n"
+              "  sRAIUnitDef() {}\n"
+              "  sRAIUnitDefBL *List[35];\n"
+              "};");
+        ASSERT_EQUALS("[test.cpp:6]: (warning) Member variable 'sRAIUnitDef::List' is not initialized in the constructor.\n", errout.str());
     }
 
     void uninitVarArray2D() {


### PR DESCRIPTION
Hi,

This is a follow-up to https://github.com/danmar/cppcheck/pull/661, because the ticket (thanks again @amai2012!) highlights that there's another place one needs to check for pointer arrays. This patch fixes this, and the ticket. Thanks to consider merging.

Cheers,
  Simon