### PR TITLE
Add a dynamic rule enable/disable system

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -641,7 +641,7 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
         else if (std::strncmp(argv[i], "--rule=", 7) == 0) {
             Settings::Rule rule;
             rule.pattern = 7 + argv[i];
-            _settings->rules.push_back(rule);
+            _settings->rules[rule.id] = rule;
         }
 
         // Rule file
@@ -674,10 +674,36 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
                         tinyxml2::XMLElement *summary = message->FirstChildElement("summary");
                         if (summary)
                             rule.summary = summary->GetText() ? summary->GetText() : "";
+
                     }
 
+		    tinyxml2::XMLElement *state = node->FirstChildElement("state");
+		    if (state) {
+			std::string rule_state = state->GetText();
+			if (rule_state == "enabled")
+			    rule.enabled = true;
+			else if (rule_state == "disabled")
+			    rule.enabled = false;
+		        else {
+			    std::string msg("cppcheck: error: unrecognized rule state: \"");
+                            msg += rule_state;
+			    msg +=  "\". Supported states: disable, enable.";
+			    PrintMessage(msg);
+		        }
+		    }
+
+		    tinyxml2::XMLElement *disabled = node->FirstChildElement("disable");
+		    if (disabled) {
+			rule.disable_rules = disabled->GetText();
+		    }
+
+		    tinyxml2::XMLElement *enabled = node->FirstChildElement("enable");
+		    if (enabled) {
+			rule.enable_rules = enabled->GetText();
+		    }
+
                     if (!rule.pattern.empty())
-                        _settings->rules.push_back(rule);
+                        _settings->rules[rule.id] = rule;
                 }
             }
         }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <iostream>
 #include <stdexcept>
 #include "timer.h"
 #include "version.h"
@@ -168,8 +169,8 @@ unsigned int CppCheck::processFile(const std::string& filename, std::istream& fi
         }
 
         // Run rules on this code
-        for (std::list<Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
-            if (it->tokenlist == "define") {
+        for (std::map<std::string, Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
+            if (it->second.enabled && it->second.tokenlist == "define") {
                 Tokenizer tokenizer2(&_settings, this);
                 std::istringstream istr2(filedata);
                 tokenizer2.list.createTokens(istr2, filename);
@@ -320,8 +321,8 @@ bool CppCheck::checkFile(const std::string &code, const char FileName[], std::se
         _tokenizer.setTimerResults(&S_timerResults);
     try {
         // Execute rules for "raw" code
-        for (std::list<Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
-            if (it->tokenlist == "raw") {
+        for (std::map<std::string, Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
+            if (it->second.enabled && it->second.tokenlist == "raw") {
                 Tokenizer tokenizer2(&_settings, this);
                 std::istringstream istr(code);
                 tokenizer2.list.createTokens(istr, FileName);
@@ -439,8 +440,8 @@ void CppCheck::executeRules(const std::string &tokenlist, const Tokenizer &token
 #ifdef HAVE_RULES
     // Are there rules to execute?
     bool isrule = false;
-    for (std::list<Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
-        if (it->tokenlist == tokenlist)
+    for (std::map<std::string, Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
+        if (it->second.enabled && it->second.tokenlist == tokenlist)
             isrule = true;
     }
 
@@ -454,9 +455,9 @@ void CppCheck::executeRules(const std::string &tokenlist, const Tokenizer &token
         ostr << " " << tok->str();
     const std::string str(ostr.str());
 
-    for (std::list<Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
-        const Settings::Rule &rule = *it;
-        if (rule.pattern.empty() || rule.id.empty() || rule.severity.empty() || rule.tokenlist != tokenlist)
+    for (std::map<std::string, Settings::Rule>::const_iterator it = _settings.rules.begin(); it != _settings.rules.end(); ++it) {
+        const Settings::Rule &rule = it->second;
+        if (rule.pattern.empty() || rule.id.empty() || rule.severity.empty() || rule.tokenlist != tokenlist || !rule.enabled)
             continue;
 
         const char *error = nullptr;
@@ -511,6 +512,26 @@ void CppCheck::executeRules(const std::string &tokenlist, const Tokenizer &token
 
             // Report error
             reportErr(errmsg);
+
+	    // Disable rules that must be disabled
+	    std::istringstream disable(rule.disable_rules);
+	    do {
+		std::string rule_to_disable;
+		disable >> rule_to_disable;
+		if (rule_to_disable != "") {
+		    _settings.rules[rule_to_disable].enabled = false;
+	        }
+	    } while (disable);
+
+	    // Enable rules that must be enabled
+	    std::istringstream enable(rule.enable_rules);
+	    do {
+		std::string rule_to_enable;
+		enable >> rule_to_enable;
+		if (rule_to_enable != "") {
+		    _settings.rules[rule_to_enable].enabled = true;
+	        }
+	    } while (enable);
         }
 
         pcre_free(re);

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -218,7 +218,10 @@ public:
         Rule()
             : tokenlist("simple") // use simple tokenlist
             , id("rule")          // default id
-            , severity("style") { // default severity
+            , severity("style")   // default severity
+            , disable_rules("")   // default disabled rules
+            , enable_rules("")    // default enabled rules
+	    , enabled(true) {
         }
 
         std::string tokenlist;
@@ -226,12 +229,15 @@ public:
         std::string id;
         std::string severity;
         std::string summary;
+        std::string disable_rules;
+        std::string enable_rules;
+	bool enabled;
     };
 
     /**
      * @brief Extra rules
      */
-    std::list<Rule> rules;
+    std::map<std::string, Rule> rules;
 
     /** Is the 'configuration checking' wanted? */
     bool checkConfiguration;


### PR DESCRIPTION
First, each rule now has a "state" attribute:

<rule>
	<state>enabled</state> => rule is enabled
	...
</rule>

<rule>
	<state>disabled</state> => rule is disabled.
	...
</rule>

Second, each rule has a list of IDs of rules to
disable and a list of rules to enable if fired:

<rule>
	...
	<disable>thatrule</disable>
	<enable>thisrule</enable>
</rule>

<rule>
	<state>disabled</state>
	<message>
		<id>thisrule</id>
	...

<rule>
	<message>
		<id>thatrule</id>
	...
</rule>

Initially, the first and third rule are enabled. When
the first rule gets fired, then the third rule becomes
disabled and the second rule becomes enabled.

Note that the behavior of this system is undefined when
the rule to be enabled or disabled should fire on the same
source fragment which fired the controlling rule.