### PR TITLE
Ticket #7017: Properly interpret operator= return type for template classes in CheckClass::operatorEq.

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1188,7 +1188,18 @@ void CheckClass::operatorEq()
                 if (func->isDelete())
                     continue;
                 // use definition for check so we don't have to deal with qualification
-                if (!(Token::Match(func->retDef, "%type% &") && func->retDef->str() == scope->className)) {
+                bool returnSelfRef = false;
+                if (func->retDef->str() == scope->className) {
+                    if (Token::Match(func->retDef, "%type% &")) {
+                        returnSelfRef = true;
+                    } else {
+                        // We might have "Self<template_parameters>&""
+                        Token *tok = func->retDef->next();
+                        if (tok && tok->str() == "<" && tok->link() && tok->link()->next() && tok->link()->next()->str() == "&")
+                            returnSelfRef = true;
+                    }
+                }
+                if (!returnSelfRef) {
                     // make sure we really have a copy assignment operator
                     if (Token::Match(func->tokenDef->tokAt(2), "const| %name% &")) {
                         if (func->tokenDef->strAt(2) == "const" &&

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -699,6 +699,13 @@ private:
                        "    void operator=(const A&)=delete;\n"
                        "};");
         ASSERT_EQUALS("", errout.str());
+
+        // Ticket #7017
+        checkOpertorEq("template<class T> struct X {\n"
+                       "  inline X(const X& Rhs);\n"
+                       "  inline X<T>& operator =(const X& Rhs);\n"
+                       "};");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void operatorEq2() {


### PR DESCRIPTION
Hi,

This trivial patch ensures we properly detect that operator= for template classes returns a reference to self. Thanks to consider merging.

Cheers,
  Simon