### PR TITLE
Remove repeated search, clearer code

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3133,11 +3133,12 @@ bool Tokenizer::simplifySizeof()
 
         // sizeof( a )
         else if (Token::Match(tok->next(), "( %var% )")) {
-            if (sizeOfVar.find(tok->tokAt(2)->varId()) != sizeOfVar.end()) {
+            std::map<unsigned int, unsigned int>::const_iterator sizeOfVarPos = sizeOfVar.find(tok->tokAt(2)->varId());
+            if (sizeOfVarPos != sizeOfVar.end()) {
                 tok->deleteNext();
                 tok->deleteThis();
                 tok->deleteNext();
-                tok->str(MathLib::toString(sizeOfVar[tok->varId()]));
+                tok->str(MathLib::toString(sizeOfVarPos->second));
                 ret = true;
             } else {
                 // don't try to replace size of variable if variable has


### PR DESCRIPTION
The current code not only does the same map lookup twice, it also accesses `tokAt(2)`, then deletes some tokens and accesses the very same token as previously but now it's not `tokAt(2)` anymore - this isn't trivial. This change makes it clearer by removing the second lookup.