### PR TITLE
Explicit continue instead of fall through with a check

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3200,7 +3200,7 @@ bool Tokenizer::simplifySizeof()
                         tok2 = tok2->linkAt(1);
                     }
                     if (Token::simpleMatch(tok2, "] ["))
-                        sz = 0;
+                        continue;
                 }
             } else if (nametok->strAt(1) == "[" && nametok->isStandardType()) {
                 sz = sizeOfType(nametok);


### PR DESCRIPTION
The current code first sets `sz`, then falls through, then checks `sz` and proceeds to the next iteration. It's more explicit to just use `continue`.