### PR TITLE
gnu.cfg: Few improvements in backtrace* functions support

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -57,7 +57,7 @@
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-null/>
-      <not-uninit/>
+      <minsize type="argvalue" arg="2"/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -70,6 +70,7 @@
     <arg nr="1">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="2"/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -81,6 +82,7 @@
     <arg nr="1">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="2"/>
     </arg>
     <arg nr="2">
       <not-uninit/>


### PR DESCRIPTION
    * first argument of backtrace() can be uninitialized
    * treat second argument as size