### PR TITLE
Ticket #6998: Properly handle "typedef unsigned T;" constructs.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -704,7 +704,8 @@ void Tokenizer::simplifyTypedef()
         } else if (Token::Match(tokOffset, "%type%")) {
             typeStart = tokOffset;
 
-            while (Token::Match(tokOffset, "const|signed|unsigned|struct|enum %type%") ||
+            while (Token::Match(tokOffset, "const|struct|enum %type%") ||
+                   (Token::Match(tokOffset, "signed|unsigned %type%") && tokOffset->next()->isStandardType()) ||
                    (tokOffset->next() && tokOffset->next()->isStandardType()))
                 tokOffset = tokOffset->next();
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -151,6 +151,7 @@ private:
         TEST_CASE(simplifyTypedef112); // ticket #6048
         TEST_CASE(simplifyTypedef113); // ticket #7030
         TEST_CASE(simplifyTypedef114); // ticket #7058 - skip "struct", AB::..
+        TEST_CASE(simplifyTypedef115); // ticket #6998
 
         TEST_CASE(simplifyTypedefFunction1);
         TEST_CASE(simplifyTypedefFunction2); // ticket #1685
@@ -2420,6 +2421,16 @@ private:
                             "x=AB::B;";
         const char expected[] = "struct AB { } ; x = 1 ;";
         ASSERT_EQUALS(expected, tok(code));
+    }
+
+    void simplifyTypedef115() {     // ticket #6998
+        const char code[] = "typedef unsigned unsignedTypedef;\n"
+                            "unsignedTypedef t1 ;\n"
+                            "unsigned t2 ;";
+        const char expected[] = "unsigned int t1 ; "
+                                "unsigned int t2 ;";
+        ASSERT_EQUALS(expected, tok(code, false));
+        ASSERT_EQUALS("", errout.str());
     }
 
     void simplifyTypedefFunction1() {


### PR DESCRIPTION
Hi,

This ticket highlights that the typedef simplifier does not properly handle "typedef unsigned T;" constructs. This patch fixes this. Thanks to consider merging.

Cheers,
  Simon