### PR TITLE
gtk.cfg: Fix some g_variant deallocators

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -345,6 +345,8 @@
     <alloc init="true">g_inet_address_mask_to_string</alloc>
     <alloc init="true">g_variant_dup_string</alloc>
     <alloc init="true">g_variant_dup_bytestring</alloc>
+    <alloc init="true">g_variant_get_objv</alloc>
+    <alloc init="true">g_variant_get_strv</alloc>
     <alloc init="true">g_variant_print</alloc>
     <alloc init="true">g_datalist_id_dup_data</alloc>
     <alloc init="true">g_dir_make_tmp</alloc>
@@ -520,8 +522,6 @@
     <alloc init="true">g_app_launch_context_get_environment</alloc>
     <alloc init="true">g_filename_completer_get_completions</alloc>
     <alloc init="true">g_io_module_query</alloc>
-    <alloc init="true">g_variant_get_strv</alloc>
-    <alloc init="true">g_variant_get_objv</alloc>
     <alloc init="true">g_variant_dup_objv</alloc>
     <alloc init="true">g_variant_dup_bytestring_array</alloc>
     <alloc init="true">g_environ_setenv</alloc>


### PR DESCRIPTION
"This call makes a shallow copy; the return result should be released
with g_free(), but the individual strings must not be modified."

https://developer.gnome.org/glib/stable/glib-GVariant.html