### PR TITLE
Make syntaxError suppressable (fixes #5917 and #7076)

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -426,7 +426,7 @@ bool CppCheck::checkFile(const std::string &code, const char FileName[], std::se
                                                e.id,
                                                false);
 
-        _errorLogger.reportErr(errmsg);
+        reportErr(errmsg);
     }
     return true;
 }


### PR DESCRIPTION
syntaxErrors were not suppressable, because they were treated as
InternalErrors which were thrown and catched during the checking,
and normal suppression rules were not applied for those.

We fix this by calling normal reportErr() function when we have
syntaxErrors. Internal errors are still kept unsuppressable.