### PR TITLE
Treat *.hh and *.hxx files as C++ files

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -220,6 +220,8 @@ bool Path::isCPP(const std::string &path)
         extension == ".cc" ||
         extension == ".c++" ||
         extension == ".hpp" ||
+        extension == ".hxx" ||
+        extension == ".hh" ||
         extension == ".tpp" ||
         extension == ".txx") {
         return true;


### PR DESCRIPTION
Previously they were erroneously detected as C files.

Also add *.hh and *.hxx files to be checked with the Git
pre-commit hook script.