### PR TITLE
Silence clang warning.

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -550,7 +550,7 @@ void CheckOther::checkRedundantAssignment()
                         varAssignments[tok->varId()] = tok;
                     memAssignments.erase(tok->varId());
                     eraseMemberAssignments(tok->varId(), membervars, varAssignments);
-                } else if (tok->next() && tok->next()->tokType() == Token::eIncDecOp || (tok->previous()->tokType() == Token::eIncDecOp && tok->strAt(1) == ";")) { // Variable incremented/decremented; Prefix-Increment is only suspicious, if its return value is unused
+                } else if ((tok->next() && tok->next()->tokType() == Token::eIncDecOp) || (tok->previous()->tokType() == Token::eIncDecOp && tok->strAt(1) == ";")) { // Variable incremented/decremented; Prefix-Increment is only suspicious, if its return value is unused
                     varAssignments[tok->varId()] = tok;
                     memAssignments.erase(tok->varId());
                     eraseMemberAssignments(tok->varId(), membervars, varAssignments);


### PR DESCRIPTION
Hi,

Trivial patch to fix a warning introduced by https://github.com/danmar/cppcheck/commit/f15f8514f67cc678a04f42a70bac5c762108c406. Thanks to consider merging.

Cheers,
  Simon