### PR TITLE
Restore build on OSX, where make defines CXX as "c++" by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ ifeq ($(CXX), g++)
     override CXXFLAGS += -std=c++0x
 else ifeq ($(CXX), clang++)
     override CXXFLAGS += -std=c++0x
+else ifeq ($(CXX), c++)
+    ifeq ($(shell uname -s), Darwin)
+        override CXXFLAGS += -std=c++0x
+    endif
 endif
 
 ifeq ($(HAVE_RULES),yes)

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -359,6 +359,10 @@ int main(int argc, char **argv)
          << "    override CXXFLAGS += -std=c++0x\n"
          << "else ifeq ($(CXX), clang++)\n"
          << "    override CXXFLAGS += -std=c++0x\n"
+         << "else ifeq ($(CXX), c++)\n"
+         << "    ifeq ($(shell uname -s), Darwin)\n"
+         << "        override CXXFLAGS += -std=c++0x\n"
+         << "    endif\n"
          << "endif\n"
          << "\n";
 


### PR DESCRIPTION
Hi,

Build on OSX is broken since https://github.com/danmar/cppcheck/commit/11915f84e26204c34b5821335f82ddccff5b8aaf because make on this platform defines CXX as c++, and -std=c++0x is not appended to CXXFLAGS. This patch fixes this by handling the "CXX=c++ and OS=OSX" case appropriately. Thanks to consider merging.

Cheers,
  Simon

PS: One can find the default value make gives to CXX by issuing "make -p | grep 'CXX ='"