### PR TITLE
Include cmath for std::fabs

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -22,6 +22,7 @@
 
 #include "checkfunctions.h"
 #include "symboldatabase.h"
+#include <cmath>
 
 //---------------------------------------------------------------------------
 


### PR DESCRIPTION
Since `std::fabs` is defined in `cmath` we should include it.

Otherwise this fails to compile for me with a trunk version of libc++ under OS X.