### PR TITLE
Factorize toxml() into a single member function

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -421,3 +421,36 @@ std::string ErrorLogger::ErrorMessage::FileLocation::stringify() const
     oss << ']';
     return oss.str();
 }
+
+std::string ErrorLogger::toxml(const std::string &str)
+{
+    std::ostringstream xml;
+    const bool isstring(str[0] == '\"');
+    for (std::size_t i = 0U; i < str.length(); i++) {
+        char c = str[i];
+        switch (c) {
+        case '<':
+            xml << "&lt;";
+            break;
+        case '>':
+            xml << "&gt;";
+            break;
+        case '&':
+            xml << "&amp;";
+            break;
+        case '\"':
+            xml << "&quot;";
+            break;
+        case '\0':
+            xml << "\\0";
+            break;
+        default:
+            if (!isstring || (c >= ' ' && c <= 'z'))
+                xml << c;
+            else
+                xml << 'x';
+            break;
+        }
+    }
+    return xml.str();
+}

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -311,6 +311,13 @@ public:
     void reportUnmatchedSuppressions(const std::list<Suppressions::SuppressionEntry> &unmatched);
 
     static std::string callStackToString(const std::list<ErrorLogger::ErrorMessage::FileLocation> &callStack);
+
+    /**
+     * Convert XML-sensitive characters into XML entities
+     * @param str The input string containing XML-sensitive characters
+     * @return The ouput string containing XML entities
+     */
+    static std::string toxml(const std::string &str);
 };
 
 /// @}

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2452,32 +2452,6 @@ void SymbolDatabase::printOut(const char *title) const
     std::cout << std::resetiosflags(std::ios::boolalpha);
 }
 
-static std::string toxml(const std::string &str)
-{
-    std::ostringstream xml;
-    for (std::size_t i = 0U; i < str.length(); i++) {
-        char c = str[i];
-        switch (c) {
-        case '<':
-            xml << "&lt;";
-            break;
-        case '>':
-            xml << "&gt;";
-            break;
-        case '&':
-            xml << "&amp;";
-            break;
-        case '\"':
-            xml << "&quot;";
-            break;
-        default:
-            xml << c;
-            break;
-        }
-    }
-    return xml.str();
-}
-
 void SymbolDatabase::printXml(std::ostream &out) const
 {
     out << std::setiosflags(std::ios::boolalpha);
@@ -2488,7 +2462,7 @@ void SymbolDatabase::printXml(std::ostream &out) const
         out << " id=\"" << &*scope << "\"";
         out << " type=\"" << scope->type << "\"";
         if (!scope->className.empty())
-            out << " className=\"" << toxml(scope->className) << "\"";
+            out << " className=\"" << ErrorLogger::toxml(scope->className) << "\"";
         if (scope->classStart)
             out << " classStart=\"" << scope->classStart << '\"';
         if (scope->classEnd)
@@ -2504,7 +2478,7 @@ void SymbolDatabase::printXml(std::ostream &out) const
             if (!scope->functionList.empty()) {
                 out << "      <functionList>" << std::endl;
                 for (std::list<Function>::const_iterator function = scope->functionList.begin(); function != scope->functionList.end(); ++function) {
-                    out << "        <function id=\"" << &*function << "\" tokenDef=\"" << function->tokenDef << "\" name=\"" << toxml(function->name()) << '\"';
+                    out << "        <function id=\"" << &*function << "\" tokenDef=\"" << function->tokenDef << "\" name=\"" << ErrorLogger::toxml(function->name()) << '\"';
                     if (function->argCount() == 0U)
                         out << "/>" << std::endl;
                     else {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3911,39 +3911,6 @@ void Tokenizer::printDebugOutput(unsigned int simplification) const
     }
 }
 
-static std::string toxml(const std::string &str)
-{
-    std::ostringstream xml;
-    const bool isstring(str[0] == '\"');
-    for (std::size_t i = 0U; i < str.length(); i++) {
-        char c = str[i];
-        switch (c) {
-        case '<':
-            xml << "&lt;";
-            break;
-        case '>':
-            xml << "&gt;";
-            break;
-        case '&':
-            xml << "&amp;";
-            break;
-        case '\"':
-            xml << "&quot;";
-            break;
-        case '\0':
-            xml << "\\0";
-            break;
-        default:
-            if (!isstring || (c >= ' ' && c <= 'z'))
-                xml << c;
-            else
-                xml << 'x';
-            break;
-        }
-    }
-    return xml.str();
-}
-
 void Tokenizer::dump(std::ostream &out) const
 {
     // Create a xml data dump.
@@ -3953,8 +3920,8 @@ void Tokenizer::dump(std::ostream &out) const
     // tokens..
     out << "  <tokenlist>" << std::endl;
     for (const Token *tok = list.front(); tok; tok = tok->next()) {
-        out << "    <token id=\"" << tok << "\" file=\"" << toxml(list.file(tok)) << "\" linenr=\"" << tok->linenr() << '\"';
-        out << " str=\"" << toxml(tok->str()) << '\"';
+        out << "    <token id=\"" << tok << "\" file=\"" << ErrorLogger::toxml(list.file(tok)) << "\" linenr=\"" << tok->linenr() << '\"';
+        out << " str=\"" << ErrorLogger::toxml(tok->str()) << '\"';
         out << " scope=\"" << tok->scope() << '\"';
         if (tok->isName())
             out << " type=\"name\"";


### PR DESCRIPTION
lib/symboldatabase.cpp and lib/tokenize.cpp both
define a static toxml() function. Make it a single
static ErrorLogger::toxml() member function.