### PR TITLE
Fix multiple config dumps

### DIFF
--- a/addons/findcasts.py
+++ b/addons/findcasts.py
@@ -12,25 +12,29 @@ for arg in sys.argv[1:]:
     print('Checking ' + arg + '...')
     data = cppcheckdata.parsedump(arg)
 
-    for token in data.tokenlist:
-        if token.str != '(' or not token.astOperand1 or token.astOperand2:
-            continue
+    for cfg in data.configurations:
+        if len(data.configurations) > 1:
+            print('Checking ' + arg + ', config "' + cfg.name + '"...')
+        for token in cfg.tokenlist:
+            if token.str != '(' or not token.astOperand1 or token.astOperand2:
+                continue
 
-        # we probably have a cast.. if there is something inside the parentheses
-        # there is a cast. Otherwise this is a function call.
-        typetok = token.next
-        if not typetok.isName:
-            continue
+            # we probably have a cast.. if there is something inside the parentheses
+            # there is a cast. Otherwise this is a function call.
+            typetok = token.next
+            if not typetok.isName:
+                continue
 
-        # cast number => skip output
-        if token.astOperand1.isNumber:
-            continue
+            # cast number => skip output
+            if token.astOperand1.isNumber:
+                continue
 
-        # void cast => often used to suppress compiler warnings
-        if typetok.str == 'void':
-            continue
+            # void cast => often used to suppress compiler warnings
+            if typetok.str == 'void':
+                continue
 
-        msg = '[' + token.file + ':' + str(token.linenr) + '] (information) findcasts.py: found a cast\n'
-        if not msg in messages:
-            messages.append(msg)
-            sys.stderr.write(msg)
+            msg = '[' + token.file + ':' + str(
+                token.linenr) + '] (information) findcasts.py: found a cast\n'
+            if not msg in messages:
+                messages.append(msg)
+                sys.stderr.write(msg)

--- a/addons/naming.py
+++ b/addons/naming.py
@@ -21,21 +21,27 @@ for arg in sys.argv[1:]:
 
 
 def reportError(token, severity, msg):
-    sys.stderr.write('[' + token.file + ':' + str(token.linenr) + '] (' + severity + ') naming.py: ' + msg + '\n')
+    sys.stderr.write(
+        '[' + token.file + ':' + str(token.linenr) + '] (' + severity + ') naming.py: ' + msg + '\n')
 
 for arg in sys.argv[1:]:
     if not arg[-5:] == '.dump':
         continue
     print('Checking ' + arg + '...')
     data = cppcheckdata.parsedump(arg)
-    if RE_VARNAME:
-        for var in data.variables:
-            res = re.match(RE_VARNAME, var.nameToken.str)
-            if not res:
-                reportError(var.typeStartToken, 'style', 'Variable ' + var.nameToken.str + ' violates naming convention')
-    if RE_FUNCTIONNAME:
-        for scope in data.scopes:
-            if scope.type == 'Function':
-                res = re.match(RE_FUNCTIONNAME, scope.className)
+    for cfg in data.configurations:
+        if len(data.configurations) > 1:
+            print('Checking ' + arg + ', config "' + cfg.name + '"...')
+        if RE_VARNAME:
+            for var in cfg.variables:
+                res = re.match(RE_VARNAME, var.nameToken.str)
                 if not res:
-                    reportError(scope.classStart, 'style', 'Function ' + scope.className + ' violates naming convention')
+                    reportError(var.typeStartToken, 'style', 'Variable ' +
+                                var.nameToken.str + ' violates naming convention')
+        if RE_FUNCTIONNAME:
+            for scope in cfg.scopes:
+                if scope.type == 'Function':
+                    res = re.match(RE_FUNCTIONNAME, scope.className)
+                    if not res:
+                        reportError(
+                            scope.classStart, 'style', 'Function ' + scope.className + ' violates naming convention')

--- a/addons/threadsafety.py
+++ b/addons/threadsafety.py
@@ -9,7 +9,8 @@ import sys
 
 
 def reportError(token, severity, msg):
-    sys.stderr.write('[' + token.file + ':' + str(token.linenr) + '] (' + severity + ') threadsafety.py: ' + msg + '\n')
+    sys.stderr.write(
+        '[' + token.file + ':' + str(token.linenr) + '] (' + severity + ') threadsafety.py: ' + msg + '\n')
 
 
 def checkstatic(data):
@@ -20,4 +21,7 @@ def checkstatic(data):
 for arg in sys.argv[1:]:
     print('Checking ' + arg + '...')
     data = cppcheckdata.parsedump(arg)
-    checkstatic(data)
+    for cfg in data.configurations:
+        if len(data.configurations) > 1:
+            print('Checking ' + arg + ', config "' + cfg.name + '"...')
+        checkstatic(cfg)

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -143,6 +143,17 @@ unsigned int CppCheck::processFile(const std::string& filename, std::istream& fi
             }
         }
 
+        // write dump file xml prolog
+        std::ofstream fdump;
+        if (_settings.dump) {
+            const std::string dumpfile(filename + ".dump");
+            fdump.open(dumpfile.c_str());
+            if (fdump.is_open()) {
+                fdump << "<?xml version=\"1.0\"?>" << std::endl;
+                fdump << "<dumps>" << std::endl;
+            }
+        }
+
         std::set<unsigned long long> checksums;
         unsigned int checkCount = 0;
         for (std::list<std::string>::const_iterator it = configurations.begin(); it != configurations.end(); ++it) {
@@ -203,11 +214,9 @@ unsigned int CppCheck::processFile(const std::string& filename, std::istream& fi
                 if (!result)
                     continue;
 
-                // dump xml
+                // dump xml if --dump
                 if (_settings.dump) {
-                    std::ofstream fdump((filename + ".dump").c_str());
                     if (fdump.is_open()) {
-                        fdump << "<?xml version=\"1.0\"?>" << std::endl;
                         fdump << "<dump cfg=\"" << cfg << "\">" << std::endl;
                         _tokenizer.dump(fdump);
                         fdump << "</dump>" << std::endl;
@@ -264,6 +273,10 @@ unsigned int CppCheck::processFile(const std::string& filename, std::istream& fi
                 reportErr(errmsg);
             }
         }
+
+        // dumped all configs, close root </dumps> element now
+        if (_settings.dump && fdump.is_open())
+            fdump << "</dumps>" << std::endl;
 
     } catch (const std::runtime_error &e) {
         internalError(filename, e.what());


### PR DESCRIPTION
This PR moves dump generation from CppCheck::checkFile() to CppCheck::processFile() then fixes multiple-configuration XML dumps so that all configurations are dumped, not only the last one. The new behavior is obtained with the new option **`--dump=all`**(original option `--dump` retains original behavior).