### PR TITLE
Separate dump from checks and optimize tokenizing

### DIFF
--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -145,14 +145,22 @@ private:
     unsigned int processFile(const std::string& filename, std::istream& fileStream);
 
     /**
-     * @brief Check file
-     * @param code
-     * @param FileName
-     * @param checksums
-     * @param[out] internalErrorFound will be set to true if an internal has been caught, false else
-     * @return false if file has been checked before, true else !?
+     * @brief Check raw tokens
+     * @param tokenizer
      */
-    bool checkFile(const std::string &code, const char FileName[], std::set<unsigned long long>& checksums, bool& internalErrorFound);
+    void checkRawTokens(const Tokenizer &tokenizer);
+
+    /**
+     * @brief Check normal tokens
+     * @param tokenizer
+     */
+    void checkNormalTokens(const Tokenizer &tokenizer);
+
+    /**
+     * @brief Check simplified tokens
+     * @param tokenizer
+     */
+    void checkSimplifiedTokens(const Tokenizer &tokenizer);
 
     /**
      * @brief Execute rules, if any

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1710,23 +1710,24 @@ void Tokenizer::simplifyMulAndParens()
     }
 }
 
-bool Tokenizer::tokenize(std::istream &code,
-                         const char FileName[],
-                         const std::string &configuration,
-                         bool noSymbolDB_AST)
+bool Tokenizer::createTokens(std::istream &code,
+                             const char FileName[])
 {
     // make sure settings specified
     assert(_settings);
 
+    return list.createTokens(code, Path::getRelativePath(Path::simplifyPath(FileName), _settings->_basePaths));
+}
+
+bool Tokenizer::simplifyTokens1(const std::string &configuration,
+                                bool noSymbolDB_AST)
+{
     // Fill the map _typeSize..
     fillTypeSizes();
 
     _configuration = configuration;
 
-    if (!list.createTokens(code, Path::getRelativePath(Path::simplifyPath(FileName), _settings->_basePaths)))
-        cppcheckError(nullptr);
-
-    if (simplifyTokenList1(FileName)) {
+    if (simplifyTokenList1(list.getFiles()[0].c_str())) {
         if (!noSymbolDB_AST) {
             createSymbolDatabase();
 
@@ -1753,6 +1754,17 @@ bool Tokenizer::tokenize(std::istream &code,
         return true;
     }
     return false;
+}
+
+bool Tokenizer::tokenize(std::istream &code,
+                         const char FileName[],
+                         const std::string &configuration,
+                         bool noSymbolDB_AST)
+{
+    if (!createTokens(code, FileName))
+        return false;
+
+    return simplifyTokens1(configuration, noSymbolDB_AST);
 }
 //---------------------------------------------------------------------------
 

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -75,6 +75,11 @@ public:
      */
     bool IsScopeNoReturn(const Token *endScopeToken, bool *unknown = nullptr) const;
 
+    bool createTokens(std::istream &code,
+                      const char FileName[]);
+
+    bool simplifyTokens1(const std::string &configuration,
+                         bool noSymbolDB_AST = false);
     /**
      * Tokenize code
      * @param code input stream for code, e.g.


### PR DESCRIPTION
Move dump generation from `CppCheck::checkFile()` to `CppCheck::processFile()` including Tokenizer, then optimize tokeninzing by removing duplicate token creations.