### PR TITLE
Drop useless braces

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1147,7 +1147,7 @@ void CheckBufferOverrun::checkGlobalAndLocalVariable()
 
         for (const Token *tok = scope->classStart; tok != scope->classEnd; tok = tok->next()) {
             // if the previous token exists, it must be either a variable name or "[;{}]"
-            if (tok->previous() && (!tok->previous()->isName() && !Token::Match(tok->previous(), "[;{}]")))
+            if (tok->previous() && !tok->previous()->isName() && !Token::Match(tok->previous(), "[;{}]"))
                 continue;
 
             // size : Max array index


### PR DESCRIPTION
These braces look as if they somehow have an effect on code execution. They don't, they are just useless.