### PR TITLE
Cache and reuse result of expensive operation

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -37,6 +37,7 @@ CheckUnusedFunctions CheckUnusedFunctions::instance;
 
 void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char FileName[], const Settings *settings)
 {
+    const bool doMarkup = settings->library.markupFile(FileName);
     const SymbolDatabase* symbolDatabase = tokenizer.getSymbolDatabase();
 
     // Function declarations..
@@ -103,7 +104,7 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char Fi
             }
         }
 
-        if (!settings->library.markupFile(FileName) // only check source files
+        if (!doMarkup // only check source files
             && settings->library.isexporter(tok->str()) && tok->next() != 0) {
             const Token * propToken = tok->next();
             while (propToken && propToken->str() != ")") {
@@ -125,8 +126,7 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char Fi
             }
         }
 
-        if (settings->library.markupFile(FileName)
-            && settings->library.isimporter(FileName, tok->str()) && tok->next()) {
+        if (doMarkup && settings->library.isimporter(FileName, tok->str()) && tok->next()) {
             const Token * propToken = tok->next();
             if (propToken->next()) {
                 propToken = propToken->next();


### PR DESCRIPTION
`markupFile()` causes rather expensive conversion to lowercase on case-insensitive systems and a lot of other manipulations on case-sensitive systems. There's no point in calling it so often in this code. This change makes `parseTokens()` about 20 percent faster on Windows.