### PR TITLE
Pre-check to reduce number of match checks

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -188,7 +188,7 @@ void CheckFunctions::checkMathFunctions()
         for (const Token* tok = scope->classStart->next(); tok != scope->classEnd; tok = tok->next()) {
             if (tok->varId())
                 continue;
-            if (printWarnings) {
+            if (printWarnings && Token::Match(tok, "%name% ( !!)")) {
                 if (tok->strAt(-1) != "."
                     && Token::Match(tok, "log|logf|logl|log10|log10f|log10l ( %num% )")) {
                     const std::string& number = tok->strAt(2);


### PR DESCRIPTION
The pre-check ensures that the pattern at least looks like a function call. This reduces number of `Match()` calls three times compared to what would mostly be a check-fail-check-fail-check sequence. Performance is improved for pattern version of `Match()` and should be even better for pre-compiled version.