### PR TITLE
Run all Python code through autopep8

### DIFF
--- a/tools/daca2-addons.py
+++ b/tools/daca2-addons.py
@@ -89,14 +89,14 @@ def removeAllExceptResults():
                     shutil.rmtree(filename, onerror=handleRemoveReadonly)
                 elif filename != 'results.txt':
                     os.remove(filename)
-        except WindowsError, err:
+        except WindowsError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')
                 print(err)
                 sys.exit(1)
             continue
-        except OSError, err:
+        except OSError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')

--- a/tools/daca2-download.py
+++ b/tools/daca2-download.py
@@ -90,14 +90,14 @@ def removeAll():
                     shutil.rmtree(filename, onerror=handleRemoveReadonly)
                 else:
                     os.remove(filename)
-        except WindowsError, err:
+        except WindowsError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')
                 print(err)
                 sys.exit(1)
             continue
-        except OSError, err:
+        except OSError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')

--- a/tools/daca2.py
+++ b/tools/daca2.py
@@ -89,14 +89,14 @@ def removeAllExceptResults():
                     shutil.rmtree(filename, onerror=handleRemoveReadonly)
                 elif filename != 'results.txt':
                     os.remove(filename)
-        except WindowsError, err:
+        except WindowsError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')
                 print(err)
                 sys.exit(1)
             continue
-        except OSError, err:
+        except OSError as err:
             time.sleep(30)
             if count == 0:
                 print('Failed to cleanup files/folders')

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -84,7 +84,7 @@ class MatchCompiler:
         if tok == '%any%':
             return 'true'
         elif tok == '%assign%':
-			return 'tok->isAssignmentOp()'
+            return 'tok->isAssignmentOp()'
         elif tok == '%bool%':
             return 'tok->isBoolean()'
         elif tok == '%char%':

--- a/tools/rundaca2.py
+++ b/tools/rundaca2.py
@@ -59,14 +59,12 @@ def daca2(foldernum):
     # run cppcheck addons
     subprocess.call(['rm', '-rf', os.path.expanduser('~/daca2/' + folder)])
     subprocess.call(['nice', '--adjustment=19', 'python', os.path.expanduser('~/cppcheck/tools/daca2-addons.py'), folder, '--rev=' + rev])
-    upload(os.path.expanduser('~/daca2/'+folder+'/results.txt'), 'evidente/addons-'+folder+'.txt')
+    upload(os.path.expanduser('~/daca2/' + folder + '/results.txt'), 'evidente/addons-' + folder + '.txt')
     subprocess.call(['rm', '-rf', os.path.expanduser('~/daca2/lib' + folder)])
     subprocess.call(['nice', '--adjustment=19', 'python', os.path.expanduser('~/cppcheck/tools/daca2-addons.py'), 'lib' + folder, '--rev=' + rev])
-    upload(os.path.expanduser('~/daca2/lib'+folder+'/results.txt'), 'evidente/addons-lib'+folder+'.txt')
+    upload(os.path.expanduser('~/daca2/lib' + folder + '/results.txt'), 'evidente/addons-lib' + folder + '.txt')
 
 foldernum = 0
 while True:
     daca2(foldernum)
     foldernum = foldernum + 1
-
-


### PR DESCRIPTION
Run all Python code through autopep8 as follows:

	autopep8 -ri --ignore=E261,E262 .

E261 or E262 would cause spaces after a comment's hash sign
to be squashed. Since some of the comments in cppcheck's
Python code have space-indented code examples, not ignoring
E261 or E262 would wreck the formatting of those examples.