### PR TITLE
update Readme with info

### DIFF
--- a/htmlreport/README.txt
+++ b/htmlreport/README.txt
@@ -10,3 +10,20 @@ installed by following command:
 $ sudo apt-get install python-pygments
 
 For more information run './cppcheck-htmlreport --help'
+
+
+--- Old python compatibility ---
+The code requires python 2.7+ for collections Counter import.
+
+Quick-fix tested in Python 2.6.6 on CentOS6 is to add the following at the begininning of ./cppcheck-htmlreport:
+1)
+from future.standard_library import install_aliases
+install_aliases()
+
+2) change the line 258:
+html_unescape_table = {
+    "&quot;" : '"', 
+    "&apos;" : "'"
+}
+#{v: k for k, v in html_escape_table.items()}
+


### PR DESCRIPTION
Extra info for python2.6 compatibility. 
1) added according to http://python-future.org/imports.html requires module "future"
2) Second change is bad, no time to think about proper solution