### PR TITLE
posix.cfg: Only pointers can be null

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -694,7 +694,6 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
-      <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
@@ -2570,10 +2569,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-uninit/>
     </arg>
     <arg nr="2">
-      <not-null/>
+      <not-uninit/>
     </arg>
     <arg nr="3">
-      <not-null/>
+      <not-uninit/>
     </arg>
   </function>
   <!-- off_t ftello(FILE *stream); -->


### PR DESCRIPTION
Idea: Library editor should do some type-checking on the arguments.