### PR TITLE
Maped arrayIndexOutOfBounds error id to CWE 788

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -507,5 +507,5 @@ void CheckAutoVariables::errorInvalidDeallocation(const Token *tok)
                 "autovarInvalidDeallocation",
                 "Deallocation of an auto-variable results in undefined behaviour.\n"
                 "The deallocation of an auto-variable results in undefined behaviour. You should only free memory "
-                "that has been allocated dynamically.");
+                "that has been allocated dynamically.", 590U, false);
 }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -287,7 +287,7 @@ void CheckAutoVariables::returnPointerToLocalArray()
 
 void CheckAutoVariables::errorReturnAddressToAutoVariable(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnAddressOfAutoVariable", "Address of an auto-variable returned.");
+    reportError(tok, Severity::error, "returnAddressOfAutoVariable", "Address of an auto-variable returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorReturnPointerToLocalArray(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -497,7 +497,7 @@ void CheckAutoVariables::errorReturnReference(const Token *tok)
 
 void CheckAutoVariables::errorReturnTempReference(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnTempReference", "Reference to temporary returned.");
+    reportError(tok, Severity::error, "returnTempReference", "Reference to temporary returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorInvalidDeallocation(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -492,7 +492,7 @@ void CheckAutoVariables::returnReference()
 
 void CheckAutoVariables::errorReturnReference(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnReference", "Reference to auto variable returned.");
+    reportError(tok, Severity::error, "returnReference", "Reference to auto variable returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorReturnTempReference(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -303,7 +303,7 @@ void CheckAutoVariables::errorAutoVariableAssignment(const Token *tok, bool inco
                     "Dangerous assignment - the function parameter is assigned the address of a local "
                     "auto-variable. Local auto-variables are reserved from the stack which "
                     "is freed when the function ends. So the pointer to a local variable "
-                    "is invalid after the function ends.");
+                    "is invalid after the function ends.", 562U, false);
     } else {
         reportError(tok, Severity::error, "autoVariables",
                     "Address of local auto-variable assigned to a function parameter.\n"
@@ -311,7 +311,7 @@ void CheckAutoVariables::errorAutoVariableAssignment(const Token *tok, bool inco
                     "Local auto-variables are reserved from the stack which is freed when "
                     "the function ends. The address is invalid after the function ends and it "
                     "might 'leak' from the function through the parameter.",
-                    0U,
+                    562U,
                     true);
     }
 }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -322,7 +322,7 @@ void CheckAutoVariables::errorReturnAddressOfFunctionParameter(const Token *tok,
                 "Address of function parameter '" + varname + "' returned.\n"
                 "Address of the function parameter '" + varname + "' becomes invalid after the function exits because "
                 "function parameters are stored on the stack which is freed when the function exits. Thus the returned "
-                "value is invalid.");
+                "value is invalid.", 562U, false);
 }
 
 void CheckAutoVariables::errorUselessAssignmentArg(const Token *tok)

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -352,7 +352,7 @@ void CheckBool::checkAssignBoolToPointer()
 void CheckBool::assignBoolToPointerError(const Token *tok)
 {
     reportError(tok, Severity::error, "assignBoolToPointer",
-                "Boolean value assigned to pointer.");
+                "Boolean value assigned to pointer.", 587U, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -473,7 +473,7 @@ void CheckBool::pointerArithBoolError(const Token *tok)
                 Severity::error,
                 "pointerArithBool",
                 "Converting pointer arithmetic result to bool. The bool is always true unless there is undefined behaviour.\n"
-                "Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, and overflow is undefined behaviour. Probably a dereference is forgotten.");
+                "Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, and overflow is undefined behaviour. Probably a dereference is forgotten.", 571U, false);
 }
 
 void CheckBool::checkAssignBoolToFloat()

--- a/lib/checkboost.cpp
+++ b/lib/checkboost.cpp
@@ -55,6 +55,6 @@ void CheckBoost::checkBoostForeachModification()
 void CheckBoost::boostForeachError(const Token *tok)
 {
     reportError(tok, Severity::error, "boostForeachError",
-                "BOOST_FOREACH caches the end() iterator. It's undefined behavior if you modify the container inside."
+                "BOOST_FOREACH caches the end() iterator. It's undefined behavior if you modify the container inside.", 664U, false
                );
 }

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -61,7 +61,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const Arra
 {
     std::ostringstream oss;
     makeArrayIndexOutOfBoundsError(oss, arrayInfo, index);
-    reportError(tok, Severity::error, "arrayIndexOutOfBounds", oss.str());
+    reportError(tok, Severity::error, "arrayIndexOutOfBounds", oss.str(), 788U, false);
 }
 
 void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const ArrayInfo &arrayInfo, const std::vector<ValueFlow::Value> &index)
@@ -115,7 +115,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const std::list<const Token 
 {
     std::ostringstream oss;
     makeArrayIndexOutOfBoundsError(oss, arrayInfo, index);
-    reportError(callstack, Severity::error, "arrayIndexOutOfBounds", oss.str(), 0U, false);
+    reportError(callstack, Severity::error, "arrayIndexOutOfBounds", oss.str());
 }
 
 static std::string bufferOverrunMessage(std::string varnames)


### PR DESCRIPTION
Hi, 

I mapped various errors ID to their respective CWEs.


In regards to arrayIndexOutOfBounds error id to CWE 788 I had to substitute a little more of what you have done to have the CWE shown in --xml-version=2 -errorlist. 

Looks like that reportError you suggested to use (the one with 0U argument) was not the right one. 

I hope I'm not messing around too much with github, pull requests and branches. It's either the first time that I collaborate on a FOSS and first time time that I do it on github. 

Many Thanks.

P.S. Looking on how the pull requests are appearing I think I did. :/