### PR TITLE
Added several mapped CWE IDs to reportErr function calls

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -292,7 +292,7 @@ void CheckAutoVariables::errorReturnAddressToAutoVariable(const Token *tok)
 
 void CheckAutoVariables::errorReturnPointerToLocalArray(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnLocalVariable", "Pointer to local array variable returned.");
+    reportError(tok, Severity::error, "returnLocalVariable", "Pointer to local array variable returned.", 562, false);
 }
 
 void CheckAutoVariables::errorAutoVariableAssignment(const Token *tok, bool inconclusive)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -507,5 +507,5 @@ void CheckAutoVariables::errorInvalidDeallocation(const Token *tok)
                 "autovarInvalidDeallocation",
                 "Deallocation of an auto-variable results in undefined behaviour.\n"
                 "The deallocation of an auto-variable results in undefined behaviour. You should only free memory "
-                "that has been allocated dynamically.");
+                "that has been allocated dynamically.", 590U, false);
 }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -287,7 +287,7 @@ void CheckAutoVariables::returnPointerToLocalArray()
 
 void CheckAutoVariables::errorReturnAddressToAutoVariable(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnAddressOfAutoVariable", "Address of an auto-variable returned.");
+    reportError(tok, Severity::error, "returnAddressOfAutoVariable", "Address of an auto-variable returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorReturnPointerToLocalArray(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -497,7 +497,7 @@ void CheckAutoVariables::errorReturnReference(const Token *tok)
 
 void CheckAutoVariables::errorReturnTempReference(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnTempReference", "Reference to temporary returned.");
+    reportError(tok, Severity::error, "returnTempReference", "Reference to temporary returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorInvalidDeallocation(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -492,7 +492,7 @@ void CheckAutoVariables::returnReference()
 
 void CheckAutoVariables::errorReturnReference(const Token *tok)
 {
-    reportError(tok, Severity::error, "returnReference", "Reference to auto variable returned.");
+    reportError(tok, Severity::error, "returnReference", "Reference to auto variable returned.", 562U, false);
 }
 
 void CheckAutoVariables::errorReturnTempReference(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -303,7 +303,7 @@ void CheckAutoVariables::errorAutoVariableAssignment(const Token *tok, bool inco
                     "Dangerous assignment - the function parameter is assigned the address of a local "
                     "auto-variable. Local auto-variables are reserved from the stack which "
                     "is freed when the function ends. So the pointer to a local variable "
-                    "is invalid after the function ends.");
+                    "is invalid after the function ends.", 562U, false);
     } else {
         reportError(tok, Severity::error, "autoVariables",
                     "Address of local auto-variable assigned to a function parameter.\n"
@@ -311,7 +311,7 @@ void CheckAutoVariables::errorAutoVariableAssignment(const Token *tok, bool inco
                     "Local auto-variables are reserved from the stack which is freed when "
                     "the function ends. The address is invalid after the function ends and it "
                     "might 'leak' from the function through the parameter.",
-                    0U,
+                    562U,
                     true);
     }
 }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -322,7 +322,7 @@ void CheckAutoVariables::errorReturnAddressOfFunctionParameter(const Token *tok,
                 "Address of function parameter '" + varname + "' returned.\n"
                 "Address of the function parameter '" + varname + "' becomes invalid after the function exits because "
                 "function parameters are stored on the stack which is freed when the function exits. Thus the returned "
-                "value is invalid.");
+                "value is invalid.", 562U, false);
 }
 
 void CheckAutoVariables::errorUselessAssignmentArg(const Token *tok)

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -352,7 +352,7 @@ void CheckBool::checkAssignBoolToPointer()
 void CheckBool::assignBoolToPointerError(const Token *tok)
 {
     reportError(tok, Severity::error, "assignBoolToPointer",
-                "Boolean value assigned to pointer.");
+                "Boolean value assigned to pointer.", 587U, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -473,7 +473,7 @@ void CheckBool::pointerArithBoolError(const Token *tok)
                 Severity::error,
                 "pointerArithBool",
                 "Converting pointer arithmetic result to bool. The bool is always true unless there is undefined behaviour.\n"
-                "Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, and overflow is undefined behaviour. Probably a dereference is forgotten.");
+                "Converting pointer arithmetic result to bool. The boolean result is always true unless there is pointer arithmetic overflow, and overflow is undefined behaviour. Probably a dereference is forgotten.", 571U, false);
 }
 
 void CheckBool::checkAssignBoolToFloat()

--- a/lib/checkboost.cpp
+++ b/lib/checkboost.cpp
@@ -55,6 +55,6 @@ void CheckBoost::checkBoostForeachModification()
 void CheckBoost::boostForeachError(const Token *tok)
 {
     reportError(tok, Severity::error, "boostForeachError",
-                "BOOST_FOREACH caches the end() iterator. It's undefined behavior if you modify the container inside."
+                "BOOST_FOREACH caches the end() iterator. It's undefined behavior if you modify the container inside.", 664U, false
                );
 }

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -133,13 +133,13 @@ static std::string bufferOverrunMessage(std::string varnames)
 
 void CheckBufferOverrun::bufferOverrunError(const Token *tok, const std::string &varnames)
 {
-    reportError(tok, Severity::error, "bufferAccessOutOfBounds", bufferOverrunMessage(varnames));
+    reportError(tok, Severity::error, "bufferAccessOutOfBounds", bufferOverrunMessage(varnames), 788U, false);
 }
 
 
 void CheckBufferOverrun::bufferOverrunError(const std::list<const Token *> &callstack, const std::string &varnames)
 {
-    reportError(callstack, Severity::error, "bufferAccessOutOfBounds", bufferOverrunMessage(varnames), 0U, false);
+    reportError(callstack, Severity::error, "bufferAccessOutOfBounds", bufferOverrunMessage(varnames));
 }
 
 void CheckBufferOverrun::possibleBufferOverrunError(const Token *tok, const std::string &src, const std::string &dst, bool cat)

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -177,7 +177,7 @@ void CheckBufferOverrun::outOfBoundsError(const Token *tok, const std::string &w
     if (show_size_info)
         oss << ": Supplied size " << supplied_size << " is larger than actual size " << actual_size;
     oss << '.';
-    reportError(tok, Severity::error, "outOfBounds", oss.str());
+    reportError(tok, Severity::error, "outOfBounds", oss.str(), 788U, false);
 }
 
 void CheckBufferOverrun::pointerOutOfBoundsError(const Token *tok, const Token *index, const MathLib::bigint indexvalue)

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -61,7 +61,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const Arra
 {
     std::ostringstream oss;
     makeArrayIndexOutOfBoundsError(oss, arrayInfo, index);
-    reportError(tok, Severity::error, "arrayIndexOutOfBounds", oss.str());
+    reportError(tok, Severity::error, "arrayIndexOutOfBounds", oss.str(), 788U, false);
 }
 
 void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const ArrayInfo &arrayInfo, const std::vector<ValueFlow::Value> &index)
@@ -115,7 +115,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const std::list<const Token 
 {
     std::ostringstream oss;
     makeArrayIndexOutOfBoundsError(oss, arrayInfo, index);
-    reportError(callstack, Severity::error, "arrayIndexOutOfBounds", oss.str(), 0U, false);
+    reportError(callstack, Severity::error, "arrayIndexOutOfBounds", oss.str());
 }
 
 static std::string bufferOverrunMessage(std::string varnames)


### PR DESCRIPTION
Hi, 

I messed a little with github, sorry for the load of notification you might have received. 

I've added the proper CWE to the following checks: autoVariables, returnAddressOfAutoVariable, returnLocalVariable, returnReference, returnTempReference, autovarInvalidDeallocation, returnAddressOfFunctionParameter, assignBoolToPointer, pointerArithBool, boostForeachError, arrayIndexOutOfBounds, bufferAccessOutOfBounds, outOfBounds. 

Is that fine ? How do you wants I should pull request my changes ? Please advice. 