### PR TITLE
Determine if path is directory for XFS filesystem

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -198,7 +198,7 @@ static void addFiles2(std::map<std::string, std::size_t> &files,
 
                 new_path = path + '/' + dir_result->d_name;
 
-                if (dir_result->d_type == DT_DIR) {
+                if (dir_result->d_type == DT_DIR || (dir_result->d_type == DT_UNKNOWN && FileLister::isDirectory(new_path))) {
                     if (recursive && !ignored.Match(new_path)) {
                         addFiles2(files, new_path, extra, recursive, ignored);
                     }


### PR DESCRIPTION
I have tried to update from cppcheck 1.69 to 1.72 but failed because cppcheck failed to load files to verify recursively. Turns out that the reason is that I am using the XFS file system and the readdir_r dirent->d_type is set to DT_UNKNOWN instead of DT_DIR.

I have created a small patch to let cppcheck handle the DT_UNKNOWN situation by using the FileLister::isDirectory for this special case.