### PR TITLE
posix.cfg: Add more functions and comments

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -39,6 +39,30 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- http://man7.org/linux/man-pages/man2/access.2.html -->
+  <!-- int access(const char *pathname, int mode); -->
+  <function name="access">
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man3/adjtime.3.html -->
+  <!-- int adjtime(const struct timeval *delta, struct timeval *olddelta); -->
+  <function name="adjtime">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2"/>
+  </function>
   <!-- struct group *getgrnam(const char *name); -->
   <function name="getgrnam">
     <use-retval/>
@@ -114,6 +138,43 @@
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man2/fsync.2.html -->
+  <!-- int fdatasync(int fd); -->
+  <function name="fdatasync">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man3/fnmatch.3.html -->
+  <!-- int fnmatch(const char *pattern, const char *string, int flags); -->
+  <function name="fnmatch">
+    <pure/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-null/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man2/fsync.2.html -->
+  <!-- int fsync(int fd); -->
+  <function name="fsync">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
     </arg>
   </function>
   <!-- int truncate(const char *path, off_t length); -->
@@ -984,6 +1045,21 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-uninit/>
     </arg>
   </function>
+  <!-- http://man7.org/linux/man-pages/man2/readv.2.html -->
+  <!-- ssize_t readv(int fd, const struct iovec *iov, int iovcnt); -->
+  <function name="readv">
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
   <!-- ssize_t write(int fildes, const void *buf, size_t nbyte); -->
   <function name="write">
     <noreturn>false</noreturn>
@@ -997,6 +1073,21 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <arg nr="3">
       <not-uninit/>
       <valid>0:</valid>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man2/readv.2.html -->
+  <!-- ssize_t writev(int fd, const struct iovec *iov, int iovcnt); -->
+  <function name="writev">
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
     </arg>
   </function>
   <function name="recv">


### PR DESCRIPTION
Note: `readv()` and `writev()` uses `struct iovec` with platform-dependent size:

    struct iovec {
        void  *iov_base;    /* Starting address */
        size_t iov_len;     /* Number of bytes to transfer */
    };

I looked at the sources: Cppcheck doesn't know about this struct and assignes default value to its size (100). So, `<minsize type="argvalue" arg="3"/>` works improperly. I don't know how to fix this. Is it possible to set podtype size non-statically?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/danmar/cppcheck/767)
<!-- Reviewable:end -->
