### PR TITLE
Mapped 29 errors to their CWEs ID.

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -226,7 +226,7 @@ void CheckBufferOverrun::terminateStrncpyError(const Token *tok, const std::stri
 
 void CheckBufferOverrun::cmdLineArgsError(const Token *tok)
 {
-    reportError(tok, Severity::error, "insecureCmdLineArgs", "Buffer overrun possible for long command line arguments.");
+    reportError(tok, Severity::error, "insecureCmdLineArgs", "Buffer overrun possible for long command line arguments.", 119U, false);
 }
 
 void CheckBufferOverrun::bufferNotZeroTerminatedError(const Token *tok, const std::string &varname, const std::string &function)
@@ -248,7 +248,7 @@ void CheckBufferOverrun::negativeMemoryAllocationSizeError(const Token *tok)
     reportError(tok, Severity::error, "negativeMemoryAllocationSize",
                 "Memory allocation size is negative.\n"
                 "Memory allocation size is negative."
-                "Negative allocation size has no specified behaviour.");
+                "Negative allocation size has no specified behaviour.", 131U, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1144,7 +1144,7 @@ void CheckClass::mallocOnClassError(const Token* tok, const std::string &memfunc
     reportError(toks, Severity::error, "mallocOnClassError",
                 "Memory for class instance allocated with " + memfunc + "(), but class contains a " + classname + ".\n"
                 "Memory for class instance allocated with " + memfunc + "(), but class a " + classname + ". This is unsafe, "
-                "since no constructor is called and class members remain uninitialized. Consider using 'new' instead.", 0U, false);
+                "since no constructor is called and class members remain uninitialized. Consider using 'new' instead.", 665U, false);
 }
 
 void CheckClass::memsetError(const Token *tok, const std::string &memfunc, const std::string &classname, const std::string &type)
@@ -1153,12 +1153,12 @@ void CheckClass::memsetError(const Token *tok, const std::string &memfunc, const
                 "Using '" + memfunc + "' on " + type + " that contains a " + classname + ".\n"
                 "Using '" + memfunc + "' on " + type + " that contains a " + classname + " is unsafe, because constructor, destructor "
                 "and copy operator calls are omitted. These are necessary for this non-POD type to ensure that a valid object "
-                "is created.");
+                "is created.", 762U, false);
 }
 
 void CheckClass::memsetErrorReference(const Token *tok, const std::string &memfunc, const std::string &type)
 {
-    reportError(tok, Severity::error, "memsetClassReference", "Using '" + memfunc + "' on " + type + " that contains a reference.");
+    reportError(tok, Severity::error, "memsetClassReference", "Using '" + memfunc + "' on " + type + " that contains a reference.", 665U, false);
 }
 
 void CheckClass::memsetErrorFloat(const Token *tok, const std::string &type)
@@ -1614,7 +1614,7 @@ void CheckClass::virtualDestructor()
 void CheckClass::virtualDestructorError(const Token *tok, const std::string &Base, const std::string &Derived, bool inconclusive)
 {
     if (inconclusive)
-        reportError(tok, Severity::warning, "virtualDestructor", "Class '" + Base + "' which has virtual members does not have a virtual destructor.", 0U, true);
+        reportError(tok, Severity::warning, "virtualDestructor", "Class '" + Base + "' which has virtual members does not have a virtual destructor.", 404U, true);
     else
         reportError(tok, Severity::error, "virtualDestructor", "Class '" + Base + "' which is inherited by class '" + Derived + "' does not have a virtual destructor.\n"
                     "Class '" + Base + "' which is inherited by class '" + Derived + "' does not have a virtual destructor. "
@@ -2113,7 +2113,7 @@ void CheckClass::checkSelfInitialization()
 
 void CheckClass::selfInitializationError(const Token* tok, const std::string& varname)
 {
-    reportError(tok, Severity::error, "selfInitialization", "Member variable '" + varname + "' is initialized by itself.");
+    reportError(tok, Severity::error, "selfInitialization", "Member variable '" + varname + "' is initialized by itself.", 665U, false);
 }
 
 

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -127,14 +127,14 @@ void CheckFunctions::invalidFunctionArgError(const Token *tok, const std::string
         errmsg << ". The value is " << tok->str() << " but the valid values are '" << validstr << "'.";
     else if (tok->isComparisonOp())
         errmsg << ". The value is 0 or 1 (comparison result) but the valid values are '" << validstr << "'.";
-    reportError(tok, Severity::error, "invalidFunctionArg", errmsg.str());
+    reportError(tok, Severity::error, "invalidFunctionArg", errmsg.str(), 628U, false);
 }
 
 void CheckFunctions::invalidFunctionArgBoolError(const Token *tok, const std::string &functionName, int argnr)
 {
     std::ostringstream errmsg;
     errmsg << "Invalid " << functionName << "() argument nr " << argnr << ". A non-boolean value is required.";
-    reportError(tok, Severity::error, "invalidFunctionArgBool", errmsg.str());
+    reportError(tok, Severity::error, "invalidFunctionArgBool", errmsg.str(), 628U, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -335,26 +335,26 @@ void CheckIO::fflushOnInputStreamError(const Token *tok, const std::string &varn
 void CheckIO::ioWithoutPositioningError(const Token *tok)
 {
     reportError(tok, Severity::error,
-                "IOWithoutPositioning", "Read and write operations without a call to a positioning function (fseek, fsetpos or rewind) or fflush in between result in undefined behaviour.");
+                "IOWithoutPositioning", "Read and write operations without a call to a positioning function (fseek, fsetpos or rewind) or fflush in between result in undefined behaviour.", 664U, false);
 }
 
 void CheckIO::readWriteOnlyFileError(const Token *tok)
 {
 
     reportError(tok, Severity::error,
-                "readWriteOnlyFile", "Read operation on a file that was opened only for writing.");
+                "readWriteOnlyFile", "Read operation on a file that was opened only for writing.", 664U, false);
 }
 
 void CheckIO::writeReadOnlyFileError(const Token *tok)
 {
     reportError(tok, Severity::error,
-                "writeReadOnlyFile", "Write operation on a file that was opened only for reading.");
+                "writeReadOnlyFile", "Write operation on a file that was opened only for reading.", 664U, false);
 }
 
 void CheckIO::useClosedFileError(const Token *tok)
 {
     reportError(tok, Severity::error,
-                "useClosedFile", "Used file that is not opened.");
+                "useClosedFile", "Used file that is not opened.", 910U, false);
 }
 
 void CheckIO::seekOnAppendedFileError(const Token *tok)
@@ -1715,7 +1715,7 @@ void CheckIO::wrongPrintfScanfArgumentsError(const Token* tok,
            << (numFunction != 1 ? " are" : " is")
            << " given.";
 
-    reportError(tok, severity, "wrongPrintfScanfArgNum", errmsg.str());
+    reportError(tok, severity, "wrongPrintfScanfArgNum", errmsg.str(), 685U, false);
 }
 
 void CheckIO::wrongPrintfScanfPosixParameterPositionError(const Token* tok, const std::string& functionName,
@@ -2002,6 +2002,6 @@ void CheckIO::invalidScanfFormatWidthError(const Token* tok, unsigned int numFor
     } else {
         errmsg << "Width " << width << " given in format string (no. " << numFormat << ") is larger than destination buffer '"
                << varname << "[" << arrlen << "]', use %" << (arrlen - 1) << "s to prevent overflowing it.";
-        reportError(tok, Severity::error, "invalidScanfFormatWidth", errmsg.str(), 0U, false);
+        reportError(tok, Severity::error, "invalidScanfFormatWidth", errmsg.str(), 687U, false);
     }
 }

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -85,7 +85,7 @@ void CheckLeakAutoVar::deallocUseError(const Token *tok, const std::string &varn
 
 void CheckLeakAutoVar::deallocReturnError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::error, "deallocret", "Returning/dereferencing '" + varname + "' after it is deallocated / released");
+    reportError(tok, Severity::error, "deallocret", "Returning/dereferencing '" + varname + "' after it is deallocated / released", 672U, false);
 }
 
 void CheckLeakAutoVar::configurationInfo(const Token* tok, const std::string &functionName)
@@ -101,9 +101,9 @@ void CheckLeakAutoVar::configurationInfo(const Token* tok, const std::string &fu
 void CheckLeakAutoVar::doubleFreeError(const Token *tok, const std::string &varname, int type)
 {
     if (_settings->library.isresource(type))
-        reportError(tok, Severity::error, "doubleFree", "Resource handle '" + varname + "' freed twice.");
+        reportError(tok, Severity::error, "doubleFree", "Resource handle '" + varname + "' freed twice.", 415U, false);
     else
-        reportError(tok, Severity::error, "doubleFree", "Memory pointed to by '" + varname + "' is freed twice.");
+        reportError(tok, Severity::error, "doubleFree", "Memory pointed to by '" + varname + "' is freed twice.", 415U, false);
 }
 
 

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2701,12 +2701,12 @@ void CheckMemoryLeakNoVar::checkForUnsafeArgAlloc(const Scope *scope)
 
 void CheckMemoryLeakNoVar::functionCallLeak(const Token *loc, const std::string &alloc, const std::string &functionCall)
 {
-    reportError(loc, Severity::error, "leakNoVarFunctionCall", "Allocation with " + alloc + ", " + functionCall + " doesn't release it.");
+    reportError(loc, Severity::error, "leakNoVarFunctionCall", "Allocation with " + alloc + ", " + functionCall + " doesn't release it.", 772U, false);
 }
 
 void CheckMemoryLeakNoVar::returnValueNotUsedError(const Token *tok, const std::string &alloc)
 {
-    reportError(tok, Severity::error, "leakReturnValNotUsed", "Return value of allocation function '" + alloc + "' is not stored.");
+    reportError(tok, Severity::error, "leakReturnValNotUsed", "Return value of allocation function '" + alloc + "' is not stored.", 771U, false);
 }
 
 void CheckMemoryLeakNoVar::unsafeArgAllocError(const Token *tok, const std::string &funcName, const std::string &ptrType, const std::string& objType)

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -466,7 +466,7 @@ void CheckNullPointer::nullConstantDereference()
 
 void CheckNullPointer::nullPointerError(const Token *tok)
 {
-    reportError(tok, Severity::error, "nullPointer", "Null pointer dereference");
+    reportError(tok, Severity::error, "nullPointer", "Null pointer dereference", 476U, false);
 }
 
 void CheckNullPointer::nullPointerError(const Token *tok, const std::string &varname, bool inconclusive, bool defaultArg)
@@ -475,7 +475,7 @@ void CheckNullPointer::nullPointerError(const Token *tok, const std::string &var
         if (_settings->isEnabled("warning"))
             reportError(tok, Severity::warning, "nullPointerDefaultArg", "Possible null pointer dereference if the default parameter value is used: " + varname, 0U, inconclusive);
     } else
-        reportError(tok, Severity::error, "nullPointer", "Possible null pointer dereference: " + varname, 0U, inconclusive);
+        reportError(tok, Severity::error, "nullPointer", "Possible null pointer dereference: " + varname, 476U, inconclusive);
 }
 
 void CheckNullPointer::nullPointerError(const Token *tok, const std::string &varname, const Token* nullCheck, bool inconclusive)

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -423,7 +423,7 @@ void CheckOther::checkPipeParameterSizeError(const Token *tok, const std::string
     reportError(tok, Severity::error,
                 "wrongPipeParameterSize", "Buffer '" + strVarName + "' must have size of 2 integers if used as parameter of pipe().\n"
                 "The pipe()/pipe2() system command takes an argument, which is an array of exactly two integers.\n"
-                "The variable '" + strVarName + "' is an array of size " + strDim + ", which does not match.");
+                "The variable '" + strVarName + "' is an array of size " + strDim + ", which does not match.", 686U, false);
 }
 
 //---------------------------------------------------------------------------
@@ -1634,7 +1634,7 @@ void CheckOther::checkZeroDivision()
 
 void CheckOther::zerodivError(const Token *tok, bool inconclusive)
 {
-    reportError(tok, Severity::error, "zerodiv", "Division by zero.", 0U, inconclusive);
+    reportError(tok, Severity::error, "zerodiv", "Division by zero.", 369U, inconclusive);
 }
 
 void CheckOther::zerodivcondError(const Token *tokcond, const Token *tokdiv, bool inconclusive)
@@ -1705,7 +1705,7 @@ void CheckOther::checkMisusedScopedObject()
 void CheckOther::misusedScopeObjectError(const Token *tok, const std::string& varname)
 {
     reportError(tok, Severity::style,
-                "unusedScopedObject", "Instance of '" + varname + "' object is destroyed immediately.");
+                "unusedScopedObject", "Instance of '" + varname + "' object is destroyed immediately.", 563U, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -2251,9 +2251,9 @@ void CheckOther::checkNegativeBitwiseShift()
 void CheckOther::negativeBitwiseShiftError(const Token *tok, int op)
 {
     if (op == 1) // LHS
-        reportError(tok, Severity::error, "shiftNegative", "Shifting a negative value is undefined behaviour");
+        reportError(tok, Severity::error, "shiftNegative", "Shifting a negative value is undefined behaviour", 758U, false);
     else // RHS
-        reportError(tok, Severity::error, "shiftNegative", "Shifting by a negative value is undefined behaviour");
+        reportError(tok, Severity::error, "shiftNegative", "Shifting by a negative value is undefined behaviour", 758U, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -31,12 +31,12 @@ namespace {
 // Error message for bad iterator usage..
 void CheckStl::invalidIteratorError(const Token *tok, const std::string &iteratorName)
 {
-    reportError(tok, Severity::error, "invalidIterator1", "Invalid iterator: " + iteratorName);
+    reportError(tok, Severity::error, "invalidIterator1", "Invalid iterator: " + iteratorName, 664U, false);
 }
 
 void CheckStl::iteratorsError(const Token *tok, const std::string &container1, const std::string &container2)
 {
-    reportError(tok, Severity::error, "iterators", "Same iterator is used with different containers '" + container1 + "' and '" + container2 + "'.");
+    reportError(tok, Severity::error, "iterators", "Same iterator is used with different containers '" + container1 + "' and '" + container2 + "'.", 664U, false);
 }
 
 // Error message used when dereferencing an iterator that has been erased..
@@ -49,12 +49,12 @@ void CheckStl::dereferenceErasedError(const Token *erased, const Token* deref, c
         reportError(callstack, Severity::error, "eraseDereference",
                     "Iterator '" + itername + "' used after element has been erased.\n"
                     "The iterator '" + itername + "' is invalid after the element it pointed to has been erased. "
-                    "Dereferencing or comparing it with another iterator is invalid operation.");
+                    "Dereferencing or comparing it with another iterator is invalid operation.", 664U, false);
     } else {
         reportError(deref, Severity::error, "eraseDereference",
                     "Invalid iterator '" + itername + "' used.\n"
                     "The iterator '" + itername + "' is invalid before being assigned. "
-                    "Dereferencing or comparing it with another iterator is invalid operation.");
+                    "Dereferencing or comparing it with another iterator is invalid operation.", 664U, false);
     }
 }
 
@@ -235,7 +235,7 @@ void CheckStl::iterators()
 // Error message for bad iterator usage..
 void CheckStl::mismatchingContainersError(const Token *tok)
 {
-    reportError(tok, Severity::error, "mismatchingContainers", "Iterators of different containers are used together.");
+    reportError(tok, Severity::error, "mismatchingContainers", "Iterators of different containers are used together.", 664U, false);
 }
 
 namespace {
@@ -376,9 +376,9 @@ void CheckStl::stlOutOfBounds()
 void CheckStl::stlOutOfBoundsError(const Token *tok, const std::string &num, const std::string &var, bool at)
 {
     if (at)
-        reportError(tok, Severity::error, "stlOutOfBounds", "When " + num + "==" + var + ".size(), " + var + ".at(" + num + ") is out of bounds.");
+        reportError(tok, Severity::error, "stlOutOfBounds", "When " + num + "==" + var + ".size(), " + var + ".at(" + num + ") is out of bounds.", 788U, false);
     else
-        reportError(tok, Severity::error, "stlOutOfBounds", "When " + num + "==" + var + ".size(), " + var + "[" + num + "] is out of bounds.");
+        reportError(tok, Severity::error, "stlOutOfBounds", "When " + num + "==" + var + ".size(), " + var + "[" + num + "] is out of bounds.", 788U, false);
 }
 
 void CheckStl::erase()
@@ -581,14 +581,14 @@ void CheckStl::pushback()
 // Error message for bad iterator usage..
 void CheckStl::invalidIteratorError(const Token *tok, const std::string &func, const std::string &iterator_name)
 {
-    reportError(tok, Severity::error, "invalidIterator2", "After " + func + "(), the iterator '" + iterator_name + "' may be invalid.");
+    reportError(tok, Severity::error, "invalidIterator2", "After " + func + "(), the iterator '" + iterator_name + "' may be invalid.", 664U, false);
 }
 
 
 // Error message for bad iterator usage..
 void CheckStl::invalidPointerError(const Token *tok, const std::string &func, const std::string &pointer_name)
 {
-    reportError(tok, Severity::error, "invalidPointer", "Invalid pointer '" + pointer_name + "' after " + func + "().");
+    reportError(tok, Severity::error, "invalidPointer", "Invalid pointer '" + pointer_name + "' after " + func + "().", 664U, false);
 }
 
 


### PR DESCRIPTION
Added propers CWEs to insecureCmdLineArgs, negativeMemoryAllocationSize, memsetClass, memsetClassReference, IOWithoutPositioning, readWriteOnlyFile, writeReadOnlyFile, useClosedFile, wrongPrintfScanfArgNum, invalidScanfFormatWidth, deallocret, leakNoVarFunctionCall, leakReturnValNotUsed, nullPointer, invalidFunctionArg, invalidFunctionArgBool, zerodiv, unusedScopedObject, doubleFree, shiftNegative, wrongPipeParameterSize, invalidIterator1, iterators, mismatchingContainers, eraseDereference, stlOutOfBounds, mallocOnClassError, virtualDestructor, 
selfInitialization. 