### PR TITLE
Mapped 17 error ids to their CWEs …

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -31,7 +31,6 @@ namespace {
 static const struct CWE CWE664(664U);
 static const struct CWE CWE788(788U);
 
-
 // Error message for bad iterator usage..
 void CheckStl::invalidIteratorError(const Token *tok, const std::string &iteratorName)
 {
@@ -625,7 +624,7 @@ void CheckStl::stlBoundariesError(const Token *tok)
     reportError(tok, Severity::error, "stlBoundaries",
                 "Dangerous comparison using operator< on iterator.\n"
                 "Iterator compared with operator<. This is dangerous since the order of items in the "
-                "container is not guaranteed. One should use operator!= instead to compare iterators.");
+                "container is not guaranteed. One should use operator!= instead to compare iterators.", CWE664, false);
 }
 
 static bool if_findCompare(const Token * const tokBack)
@@ -1079,7 +1078,7 @@ void CheckStl::string_c_strThrowError(const Token* tok)
 void CheckStl::string_c_strError(const Token* tok)
 {
     reportError(tok, Severity::error, "stlcstr", "Dangerous usage of c_str(). The value returned by c_str() is invalid after this call.\n"
-                "Dangerous usage of c_str(). The c_str() return value is only valid until its string is deleted.");
+                "Dangerous usage of c_str(). The c_str() return value is only valid until its string is deleted.", CWE664, false);
 }
 
 void CheckStl::string_c_strReturn(const Token* tok)
@@ -1210,7 +1209,7 @@ void CheckStl::autoPointerContainerError(const Token *tok)
 {
     reportError(tok, Severity::error, "useAutoPointerContainer",
                 "You can randomly lose access to pointers if you store 'auto_ptr' pointers in an STL container.\n"
-                "An element of container must be able to be copied but 'auto_ptr' does not fulfill this requirement. You should consider to use 'shared_ptr' or 'unique_ptr'. It is suitable for use in containers, because they no longer copy their values, they move them."
+                "An element of container must be able to be copied but 'auto_ptr' does not fulfill this requirement. You should consider to use 'shared_ptr' or 'unique_ptr'. It is suitable for use in containers, because they no longer copy their values, they move them.", CWE664, false
                );
 }
 
@@ -1218,7 +1217,7 @@ void CheckStl::autoPointerArrayError(const Token *tok)
 {
     reportError(tok, Severity::error, "useAutoPointerArray",
                 "Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. You should not use 'auto_ptr' for pointers obtained with operator 'new[]'.\n"
-                "Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. This means that you should only use 'auto_ptr' for pointers obtained with operator 'new'. This excludes arrays, which are allocated by operator 'new[]' and must be deallocated by operator 'delete[]'."
+                "Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. This means that you should only use 'auto_ptr' for pointers obtained with operator 'new'. This excludes arrays, which are allocated by operator 'new[]' and must be deallocated by operator 'delete[]'.", CWE664, false
                );
 }
 

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -28,6 +28,10 @@ namespace {
     CheckString instance;
 }
 
+// CWE ids used:
+static const struct CWE CWE628(628U);
+static const struct CWE CWE665(665U);
+
 
 //---------------------------------------------------------------------------
 // Writing string literal is UB
@@ -244,7 +248,7 @@ void CheckString::strPlusChar()
 
 void CheckString::strPlusCharError(const Token *tok)
 {
-    reportError(tok, Severity::error, "strPlusChar", "Unusual pointer arithmetic. A value of type 'char' is added to a string literal.");
+    reportError(tok, Severity::error, "strPlusChar", "Unusual pointer arithmetic. A value of type 'char' is added to a string literal.", CWE665, false);
 }
 
 //---------------------------------------------------------------------------
@@ -360,5 +364,5 @@ void CheckString::sprintfOverlappingDataError(const Token *tok, const std::strin
                 "s[n]printf(). The origin and destination buffers overlap. Quote from glibc (C-library) "
                 "documentation (http://www.gnu.org/software/libc/manual/html_mono/libc.html#Formatted-Output-Functions): "
                 "\"If copying takes place between objects that overlap as a result of a call "
-                "to sprintf() or snprintf(), the results are undefined.\"");
+                "to sprintf() or snprintf(), the results are undefined.\"", CWE628, false);
 }

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -33,6 +33,12 @@ namespace {
 //---------------------------------------------------------------------------
 // Checking for shift by too many bits
 //---------------------------------------------------------------------------
+//
+
+// CWE ids used:
+static const struct CWE CWE758(758U);
+static const struct CWE CWE190(190U);
+
 
 void CheckType::checkTooBigBitwiseShift()
 {
@@ -95,7 +101,7 @@ void CheckType::tooBigBitwiseShiftError(const Token *tok, int lhsbits, const Val
     errmsg << "Shifting " << lhsbits << "-bit value by " << rhsbits.intvalue << " bits is undefined behaviour";
     if (rhsbits.condition)
         errmsg << ". See condition at line " << rhsbits.condition->linenr() << ".";
-    reportError(callstack, rhsbits.condition ? Severity::warning : Severity::error, "shiftTooManyBits", errmsg.str(), CWE(0U), rhsbits.inconclusive);
+    reportError(callstack, rhsbits.condition ? Severity::warning : Severity::error, "shiftTooManyBits", errmsg.str(), CWE758, rhsbits.inconclusive);
 }
 
 //---------------------------------------------------------------------------
@@ -149,7 +155,7 @@ void CheckType::integerOverflowError(const Token *tok, const ValueFlow::Value &v
                 value.condition ? Severity::warning : Severity::error,
                 "integerOverflow",
                 msg,
-                CWE(0U),
+                CWE190,
                 value.inconclusive);
 }
 

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -35,6 +35,12 @@ namespace {
 
 //---------------------------------------------------------------------------
 
+// CWE ids used:
+static const struct CWE CWE676(676U);
+static const struct CWE CWE908(908U);
+static const struct CWE CWE825(825U);
+    
+
 void CheckUninitVar::check()
 {
     const SymbolDatabase *symbolDatabase = _tokenizer->getSymbolDatabase();
@@ -1134,17 +1140,17 @@ bool CheckUninitVar::isMemberVariableUsage(const Token *tok, bool isPointer, All
 
 void CheckUninitVar::uninitstringError(const Token *tok, const std::string &varname, bool strncpy_)
 {
-    reportError(tok, Severity::error, "uninitstring", "Dangerous usage of '" + varname + "'" + (strncpy_ ? " (strncpy doesn't always null-terminate it)." : " (not null-terminated)."));
+    reportError(tok, Severity::error, "uninitstring", "Dangerous usage of '" + varname + "'" + (strncpy_ ? " (strncpy doesn't always null-terminate it)." : " (not null-terminated)."), CWE676, false);
 }
 
 void CheckUninitVar::uninitdataError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::error, "uninitdata", "Memory is allocated but not initialized: " + varname);
+    reportError(tok, Severity::error, "uninitdata", "Memory is allocated but not initialized: " + varname, CWE908, false);
 }
 
 void CheckUninitVar::uninitvarError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::error, "uninitvar", "Uninitialized variable: " + varname);
+    reportError(tok, Severity::error, "uninitvar", "Uninitialized variable: " + varname, CWE908, false);
 }
 
 void CheckUninitVar::uninitStructMemberError(const Token *tok, const std::string &membername)
@@ -1152,7 +1158,7 @@ void CheckUninitVar::uninitStructMemberError(const Token *tok, const std::string
     reportError(tok,
                 Severity::error,
                 "uninitStructMember",
-                "Uninitialized struct member: " + membername);
+                "Uninitialized struct member: " + membername, CWE908, false);
 }
 
 void CheckUninitVar::deadPointer()
@@ -1186,5 +1192,5 @@ void CheckUninitVar::deadPointerError(const Token *pointer, const Token *alias)
     reportError(pointer,
                 Severity::error,
                 "deadpointer",
-                "Dead pointer usage. Pointer '" + strpointer + "' is dead if it has been assigned '" + stralias + "' at line " + MathLib::toString(alias ? alias->linenr() : 0U) + ".");
+                "Dead pointer usage. Pointer '" + strpointer + "' is dead if it has been assigned '" + stralias + "' at line " + MathLib::toString(alias ? alias->linenr() : 0U) + ".", CWE825, false);
 }

--- a/lib/checkvaarg.cpp
+++ b/lib/checkvaarg.cpp
@@ -31,6 +31,10 @@ namespace {
 // Ensure that correct parameter is passed to va_start()
 //---------------------------------------------------------------------------
 
+// CWE ids used:
+static const struct CWE CWE664(664U);
+static const struct CWE CWE758(758U);
+
 void CheckVaarg::va_start_argument()
 {
     const SymbolDatabase* const symbolDatabase = _tokenizer->getSymbolDatabase();
@@ -72,7 +76,7 @@ void CheckVaarg::wrongParameterTo_va_start_error(const Token *tok, const std::st
 void CheckVaarg::referenceAs_va_start_error(const Token *tok, const std::string& paramName)
 {
     reportError(tok, Severity::error,
-                "va_start_referencePassed", "Using reference '" + paramName + "' as parameter for va_start() results in undefined behaviour.");
+                "va_start_referencePassed", "Using reference '" + paramName + "' as parameter for va_start() results in undefined behaviour.", CWE758, false);
 }
 
 //---------------------------------------------------------------------------
@@ -136,17 +140,17 @@ void CheckVaarg::va_list_usage()
 void CheckVaarg::va_end_missingError(const Token *tok, const std::string& varname)
 {
     reportError(tok, Severity::error,
-                "va_end_missing", "va_list '" + varname + "' was opened but not closed by va_end().");
+                "va_end_missing", "va_list '" + varname + "' was opened but not closed by va_end().", CWE664, false);
 }
 
 void CheckVaarg::va_list_usedBeforeStartedError(const Token *tok, const std::string& varname)
 {
     reportError(tok, Severity::error,
-                "va_list_usedBeforeStarted", "va_list '" + varname + "' used before va_start() was called.");
+                "va_list_usedBeforeStarted", "va_list '" + varname + "' used before va_start() was called.", CWE664, false);
 }
 
 void CheckVaarg::va_start_subsequentCallsError(const Token *tok, const std::string& varname)
 {
     reportError(tok, Severity::error,
-                "va_start_subsequentCalls", "va_start() or va_copy() called subsequently on '" + varname + "' without va_end() in between.");
+                "va_start_subsequentCalls", "va_start() or va_copy() called subsequently on '" + varname + "' without va_end() in between.", CWE664, false);
 }


### PR DESCRIPTION
Mapped stlBoundaries, stlcstr, useAutoPointerContainer, useAutoPointerArray, sprintfOverlappingData, strPlusChar, shiftTooManyBits, integerOverflow, uninitstring, uninitdata, uninitvar, uninitStructMember, deadpointer, va_start_referencePassed, va_end_missing, va_list_usedBeforeStarted, va_start_subsequentCalls to their CWEs.

P.S. could you check preprocessorErrorDirective error id ? ReportErr is managed differently than usual and I don't know how to map CWE664 without breaking anythin.