### PR TITLE
Mapped various errors, warnings, styles, etc to their CWEs ID

### DIFF
--- a/lib/check.h
+++ b/lib/check.h
@@ -33,10 +33,6 @@
 /// @addtogroup Core
 /// @{
 
-struct CWE {
-    explicit CWE(unsigned short ID) : id(ID) {}
-    unsigned short id;
-};
 
 /**
  * @brief Interface class that cppcheck uses to communicate with the checks.
@@ -135,7 +131,7 @@ protected:
     /** report an error */
     template<typename T, typename U>
     void reportError(const std::list<const Token *> &callstack, Severity::SeverityType severity, const T id, const U msg, const CWE &cwe, bool inconclusive) {
-        ErrorLogger::ErrorMessage errmsg(callstack, _tokenizer?&_tokenizer->list:0, severity, id, msg, inconclusive);
+        ErrorLogger::ErrorMessage errmsg(callstack, _tokenizer?&_tokenizer->list:0, severity, id, msg, cwe, inconclusive);
         errmsg._cwe = cwe.id;
         if (_errorLogger)
             _errorLogger->reportErr(errmsg);

--- a/lib/check64bit.cpp
+++ b/lib/check64bit.cpp
@@ -25,6 +25,10 @@
 
 //---------------------------------------------------------------------------
 
+// CWE ids used
+static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
+static const struct CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+
 // Register this check class (by creating a static instance of it)
 namespace {
     Check64BitPortability instance;
@@ -115,7 +119,7 @@ void Check64BitPortability::assignmentAddressToIntegerError(const Token *tok)
                 "Assigning a pointer to an integer (int/long/etc) is not portable across different platforms and "
                 "compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux "
                 "they are of different width. In worst case you end up assigning 64-bit address to 32-bit integer. The safe "
-                "way is to store addresses only in pointer types (or typedefs like uintptr_t).");
+                "way is to store addresses only in pointer types (or typedefs like uintptr_t).", CWE758, false);
 }
 
 void Check64BitPortability::assignmentIntegerToAddressError(const Token *tok)
@@ -126,7 +130,7 @@ void Check64BitPortability::assignmentIntegerToAddressError(const Token *tok)
                 "Assigning an integer (int/long/etc) to a pointer is not portable across different platforms and "
                 "compilers. For example in 32-bit Windows and linux they are same width, but in 64-bit Windows and linux "
                 "they are of different width. In worst case you end up assigning 64-bit integer to 32-bit pointer. The safe "
-                "way is to store addresses only in pointer types (or typedefs like uintptr_t).");
+                "way is to store addresses only in pointer types (or typedefs like uintptr_t).", CWE758, false);
 }
 
 void Check64BitPortability::returnPointerError(const Token *tok)
@@ -137,7 +141,7 @@ void Check64BitPortability::returnPointerError(const Token *tok)
                 "Returning an address value in a function with integer (int/long/etc) return type is not portable across "
                 "different platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in "
                 "64-bit Windows and Linux they are of different width. In worst case you end up casting 64-bit address down "
-                "to 32-bit integer. The safe way is to always return an integer.");
+                "to 32-bit integer. The safe way is to always return an integer.", CWE758, false);
 }
 
 void Check64BitPortability::returnIntegerError(const Token *tok)
@@ -148,5 +152,5 @@ void Check64BitPortability::returnIntegerError(const Token *tok)
                 "Returning an integer (int/long/etc) in a function with pointer return type is not portable across different "
                 "platforms and compilers. For example in 32-bit Windows and Linux they are same width, but in 64-bit Windows "
                 "and Linux they are of different width. In worst case you end up casting 64-bit integer down to 32-bit pointer. "
-                "The safe way is to always return a pointer.");
+                "The safe way is to always return a pointer.", CWE758, false);
 }

--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -25,6 +25,8 @@
 
 //---------------------------------------------------------------------------
 
+// CWE ids used
+static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 
 // Register this check class (by creating a static instance of it)
 namespace {
@@ -92,7 +94,7 @@ void CheckAssert::sideEffectInAssertError(const Token *tok, const std::string& f
                 "Non-pure function: '" + functionName + "' is called inside assert statement. "
                 "Assert statements are removed from release builds so the code inside "
                 "assert statement is not executed. If the code is needed also in release "
-                "builds, this is a bug.");
+                "builds, this is a bug.", CWE398, false);
 }
 
 void CheckAssert::assignmentInAssertError(const Token *tok, const std::string& varname)
@@ -102,7 +104,7 @@ void CheckAssert::assignmentInAssertError(const Token *tok, const std::string& v
                 "Variable '" + varname + "' is modified insert assert statement. "
                 "Assert statements are removed from release builds so the code inside "
                 "assert statement is not executed. If the code is needed also in release "
-                "builds, this is a bug.");
+                "builds, this is a bug.", CWE398, false);
 }
 
 // checks if side effects happen on the variable prior to tmp

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -33,8 +33,9 @@ namespace {
     static CheckAutoVariables instance;
 }
 
-static const CWE CWE562(562U);
-static const CWE CWE590(590U);
+static const CWE CWE398(398U);  // Indicator of Poor Code Quality
+static const CWE CWE562(562U);  // Return of Stack Variable Address
+static const CWE CWE590(590U);  // Free of Memory not on the Heap
 
 bool CheckAutoVariables::isPtrArg(const Token *tok)
 {
@@ -332,7 +333,7 @@ void CheckAutoVariables::errorUselessAssignmentArg(const Token *tok)
     reportError(tok,
                 Severity::style,
                 "uselessAssignmentArg",
-                "Assignment of function parameter has no effect outside the function.");
+                "Assignment of function parameter has no effect outside the function.", CWE398, false);
 }
 
 void CheckAutoVariables::errorUselessAssignmentPtrArg(const Token *tok)
@@ -340,7 +341,7 @@ void CheckAutoVariables::errorUselessAssignmentPtrArg(const Token *tok)
     reportError(tok,
                 Severity::warning,
                 "uselessAssignmentPtrArg",
-                "Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?");
+                "Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?", CWE398, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -29,8 +29,9 @@ namespace {
     CheckBool instance;
 }
 
-static const CWE CWE571(571);
-static const CWE CWE587(587);
+static const CWE CWE398(398U);  // Indicator of Poor Code Quality
+static const CWE CWE571(571U);  // Expression is Always True
+static const CWE CWE587(587U);  // Assignment of a Fixed Address to a Pointer
 
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
@@ -60,7 +61,8 @@ void CheckBool::incrementBooleanError(const Token *tok)
         Severity::style,
         "incrementboolean",
         "Incrementing a variable of type 'bool' with postfix operator++ is deprecated by the C++ Standard. You should assign it the value 'true' instead.\n"
-        "The operand of a postfix increment operator may be of type bool but it is deprecated by C++ Standard (Annex D-1) and the operand is always set to true. You should assign it the value 'true' instead."
+        "The operand of a postfix increment operator may be of type bool but it is deprecated by C++ Standard (Annex D-1) and the operand is always set to true. You should assign it the value 'true' instead.",
+        CWE398, false
     );
 }
 
@@ -104,7 +106,7 @@ void CheckBool::bitwiseOnBooleanError(const Token *tok, const std::string &varna
 {
     reportError(tok, Severity::style, "bitwiseOnBoolean",
                 "Boolean variable '" + varname + "' is used in bitwise operation. Did you mean '" + op + "'?",
-                CWE(0),
+                CWE398,
                 true);
 }
 
@@ -214,7 +216,7 @@ void CheckBool::comparisonOfFuncReturningBoolError(const Token *tok, const std::
                 "Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.\n"
                 "The return type of function '" + expression + "' is 'bool' "
                 "and result is of type 'bool'. Comparing 'bool' value using relational (<, >, <= or >=)"
-                " operator could cause unexpected results.");
+                " operator could cause unexpected results.", CWE398, false);
 }
 
 void CheckBool::comparisonOfTwoFuncsReturningBoolError(const Token *tok, const std::string &expression1, const std::string &expression2)
@@ -223,7 +225,7 @@ void CheckBool::comparisonOfTwoFuncsReturningBoolError(const Token *tok, const s
                 "Comparison of two functions returning boolean value using relational (<, >, <= or >=) operator.\n"
                 "The return type of function '" + expression1 + "' and function '" + expression2 + "' is 'bool' "
                 "and result is of type 'bool'. Comparing 'bool' value using relational (<, >, <= or >=)"
-                " operator could cause unexpected results.");
+                " operator could cause unexpected results.", CWE398, false);
 }
 
 //-------------------------------------------------------------------------------
@@ -282,7 +284,7 @@ void CheckBool::comparisonOfBoolWithBoolError(const Token *tok, const std::strin
                 "Comparison of a variable having boolean value using relational (<, >, <= or >=) operator.\n"
                 "The variable '" + expression + "' is of type 'bool' "
                 "and comparing 'bool' value using relational (<, >, <= or >=)"
-                " operator could cause unexpected results.");
+                " operator could cause unexpected results.", CWE398, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -373,10 +375,10 @@ void CheckBool::comparisonOfBoolExpressionWithIntError(const Token *tok, bool n0
 {
     if (n0o1)
         reportError(tok, Severity::warning, "compareBoolExpressionWithInt",
-                    "Comparison of a boolean expression with an integer other than 0 or 1.");
+                    "Comparison of a boolean expression with an integer other than 0 or 1.", CWE398, false);
     else
         reportError(tok, Severity::warning, "compareBoolExpressionWithInt",
-                    "Comparison of a boolean expression with an integer.");
+                    "Comparison of a boolean expression with an integer.", CWE398, false);
 }
 
 

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -44,8 +44,9 @@ namespace {
 //---------------------------------------------------------------------------
 
 // CWE ids used:
-static const CWE CWE119(119U);
 static const CWE CWE131(131U);
+static const CWE CWE398(398U);
+static const CWE CWE786(786U);
 static const CWE CWE788(788U);
 
 //---------------------------------------------------------------------------
@@ -99,7 +100,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const Arra
         std::list<const Token *> callstack;
         callstack.push_back(tok);
         callstack.push_back(condition);
-        reportError(callstack, Severity::warning, "arrayIndexOutOfBoundsCond", errmsg.str(), CWE(0U), false);
+        reportError(callstack, Severity::warning, "arrayIndexOutOfBoundsCond", errmsg.str(), CWE119, false);
     } else {
         std::ostringstream errmsg;
         errmsg << "Array '" << arrayInfo.varname();
@@ -114,7 +115,7 @@ void CheckBufferOverrun::arrayIndexOutOfBoundsError(const Token *tok, const Arra
             errmsg << " out of bounds.";
         }
 
-        reportError(tok, Severity::error, "arrayIndexOutOfBounds", errmsg.str());
+        reportError(tok, Severity::error, "arrayIndexOutOfBounds", errmsg.str(), CWE119, false);
     }
 }
 
@@ -155,12 +156,12 @@ void CheckBufferOverrun::possibleBufferOverrunError(const Token *tok, const std:
         reportError(tok, Severity::warning, "possibleBufferAccessOutOfBounds",
                     "Possible buffer overflow if strlen(" + src + ") is larger than sizeof(" + dst + ")-strlen(" + dst +").\n"
                     "Possible buffer overflow if strlen(" + src + ") is larger than sizeof(" + dst + ")-strlen(" + dst +"). "
-                    "The source buffer is larger than the destination buffer so there is the potential for overflowing the destination buffer.");
+                    "The source buffer is larger than the destination buffer so there is the potential for overflowing the destination buffer.", CWE398, false);
     else
         reportError(tok, Severity::warning, "possibleBufferAccessOutOfBounds",
                     "Possible buffer overflow if strlen(" + src + ") is larger than or equal to sizeof(" + dst + ").\n"
                     "Possible buffer overflow if strlen(" + src + ") is larger than or equal to sizeof(" + dst + "). "
-                    "The source buffer is larger than the destination buffer so there is the potential for overflowing the destination buffer.");
+                    "The source buffer is larger than the destination buffer so there is the potential for overflowing the destination buffer.", CWE398, false);
 }
 
 void CheckBufferOverrun::strncatUsageError(const Token *tok)
@@ -205,7 +206,7 @@ void CheckBufferOverrun::pointerOutOfBoundsError(const Token *tok, const Token *
     }
     std::string verbosemsg(errmsg + ". From chapter 6.5.6 in the C specification:\n"
                            "\"When an expression that has integer type is added to or subtracted from a pointer, ..\" and then \"If both the pointer operand and the result point to elements of the same array object, or one past the last element of the array object, the evaluation shall not produce an overflow; otherwise, the behavior is undefined.\"");
-    reportError(tok, Severity::portability, "pointerOutOfBounds", errmsg + ".\n" + verbosemsg);
+    reportError(tok, Severity::portability, "pointerOutOfBounds", errmsg + ".\n" + verbosemsg, CWE398, false);
     /*
          "Undefined behaviour: The result of this pointer arithmetic does not point into
          or just one element past the end of the " + object + ".
@@ -247,7 +248,7 @@ void CheckBufferOverrun::bufferNotZeroTerminatedError(const Token *tok, const st
 
 void CheckBufferOverrun::argumentSizeError(const Token *tok, const std::string &functionName, const std::string &varname)
 {
-    reportError(tok, Severity::warning, "argumentSize", "The array '" + varname + "' is too small, the function '" + functionName + "' expects a bigger one.");
+    reportError(tok, Severity::warning, "argumentSize", "The array '" + varname + "' is too small, the function '" + functionName + "' expects a bigger one.", CWE398, false);
 }
 
 void CheckBufferOverrun::negativeMemoryAllocationSizeError(const Token *tok)
@@ -1727,7 +1728,7 @@ void CheckBufferOverrun::negativeIndexError(const Token *tok, MathLib::bigint in
 {
     std::ostringstream ostr;
     ostr << "Array index " << index << " is out of bounds.";
-    reportError(tok, Severity::error, "negativeIndex", ostr.str());
+    reportError(tok, Severity::error, "negativeIndex", ostr.str(), CWE786, false);
 }
 
 void CheckBufferOverrun::negativeIndexError(const Token *tok, const ValueFlow::Value &index)
@@ -1736,7 +1737,7 @@ void CheckBufferOverrun::negativeIndexError(const Token *tok, const ValueFlow::V
     ostr << "Array index " << index.intvalue << " is out of bounds.";
     if (index.condition)
         ostr << " Otherwise there is useless condition at line " << index.condition->linenr() << ".";
-    reportError(tok, index.condition ? Severity::warning : Severity::error, "negativeIndex", ostr.str(), CWE(0U), index.inconclusive);
+    reportError(tok, index.condition ? Severity::warning : Severity::error, "negativeIndex", ostr.str(), CWE786, index.inconclusive);
 }
 
 CheckBufferOverrun::ArrayInfo::ArrayInfo()
@@ -1870,7 +1871,7 @@ void CheckBufferOverrun::arrayIndexThenCheckError(const Token *tok, const std::s
                 "Defensive programming: The variable '" + indexName + "' is used as an array index before it "
                 "is checked that is within limits. This can mean that the array might be accessed out of bounds. "
                 "Reorder conditions such as '(a[i] && i < 10)' to '(i < 10 && a[i])'. That way the array will "
-                "not be accessed if the index is out of limits.");
+                "not be accessed if the index is out of limits.", CWE398, false);
 }
 
 Check::FileInfo* CheckBufferOverrun::getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const
@@ -1962,7 +1963,7 @@ void CheckBufferOverrun::analyseWholeProgram(const std::list<Check::FileInfo*> &
                                                    Severity::error,
                                                    ostr.str(),
                                                    "arrayIndexOutOfBounds",
-                                                   false);
+                                                   CWE788, false);
             errorLogger.reportErr(errmsg);
         }
     }

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -25,9 +25,13 @@
 #include "config.h"
 #include "check.h"
 #include "mathlib.h"
+
 #include <list>
 #include <vector>
 #include <string>
+
+// CWE ids used
+static const struct CWE CWE119(119U); // Improper Restriction of Operations within the Bounds of a Memory Buffer
 
 class Variable;
 
@@ -256,7 +260,7 @@ public:
         c.argumentSizeError(0, "function", "array");
         c.negativeMemoryAllocationSizeError(0);
         c.negativeArraySizeError(0);
-        c.reportError(nullptr, Severity::warning, "arrayIndexOutOfBoundsCond", "Array 'x[10]' accessed at index 20, which is out of bounds. Otherwise condition 'y==20' is redundant.");
+        c.reportError(nullptr, Severity::warning, "arrayIndexOutOfBoundsCond", "Array 'x[10]' accessed at index 20, which is out of bounds. Otherwise condition 'y==20' is redundant.", CWE119, false);
     }
 private:
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -28,6 +28,11 @@
 #include <limits>
 #include <stack>
 
+// CWE ids used 
+static const struct CWE CWE398(398U);
+static const struct CWE CWE570(570U);
+static const struct CWE CWE571(571U);
+
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)
@@ -191,7 +196,7 @@ void CheckCondition::assignIfError(const Token *tok1, const Token *tok2, const s
     reportError(locations,
                 Severity::style,
                 "assignIfError",
-                "Mismatching assignment and comparison, comparison '" + condition + "' is always " + std::string(result ? "true" : "false") + ".");
+                "Mismatching assignment and comparison, comparison '" + condition + "' is always " + std::string(result ? "true" : "false") + ".", CWE398, false);
 }
 
 
@@ -208,7 +213,7 @@ void CheckCondition::mismatchingBitAndError(const Token *tok1, const MathLib::bi
     reportError(locations,
                 Severity::style,
                 "mismatchingBitAnd",
-                msg.str());
+                msg.str(), CWE398, false);
 }
 
 
@@ -317,7 +322,7 @@ void CheckCondition::comparisonError(const Token *tok, const std::string &bitop,
                              "spot sometimes. In case of complex expression it might help to split it to "
                              "separate expressions.");
 
-    reportError(tok, Severity::style, "comparisonError", errmsg);
+    reportError(tok, Severity::style, "comparisonError", errmsg, CWE398, false);
 }
 
 bool CheckCondition::isOverlappingCond(const Token * const cond1, const Token * const cond2, const std::set<std::string> &constFunctions) const
@@ -395,7 +400,7 @@ void CheckCondition::multiConditionError(const Token *tok, unsigned int line1)
     errmsg << "Expression is always false because 'else if' condition matches previous condition at line "
            << line1 << ".";
 
-    reportError(tok, Severity::style, "multiCondition", errmsg.str());
+    reportError(tok, Severity::style, "multiCondition", errmsg.str(), CWE398, false);
 }
 
 //---------------------------------------------------------------------------
@@ -481,7 +486,7 @@ void CheckCondition::oppositeInnerConditionError(const Token *tok1, const Token*
     std::list<const Token*> callstack;
     callstack.push_back(tok1);
     callstack.push_back(tok2);
-    reportError(callstack, Severity::warning, "oppositeInnerCondition", "Opposite conditions in nested 'if' blocks lead to a dead code block.");
+    reportError(callstack, Severity::warning, "oppositeInnerCondition", "Opposite conditions in nested 'if' blocks lead to a dead code block.", CWE398, false);
 }
 
 //---------------------------------------------------------------------------
@@ -805,17 +810,17 @@ void CheckCondition::incorrectLogicOperatorError(const Token *tok, const std::st
         reportError(tok, Severity::warning, "incorrectLogicOperator",
                     "Logical disjunction always evaluates to true: " + condition + ".\n"
                     "Logical disjunction always evaluates to true: " + condition + ". "
-                    "Are these conditions necessary? Did you intend to use && instead? Are the numbers correct? Are you comparing the correct variables?");
+                    "Are these conditions necessary? Did you intend to use && instead? Are the numbers correct? Are you comparing the correct variables?", CWE571, false);
     else
         reportError(tok, Severity::warning, "incorrectLogicOperator",
                     "Logical conjunction always evaluates to false: " + condition + ".\n"
                     "Logical conjunction always evaluates to false: " + condition + ". "
-                    "Are these conditions necessary? Did you intend to use || instead? Are the numbers correct? Are you comparing the correct variables?");
+                    "Are these conditions necessary? Did you intend to use || instead? Are the numbers correct? Are you comparing the correct variables?", CWE570, false);
 }
 
 void CheckCondition::redundantConditionError(const Token *tok, const std::string &text)
 {
-    reportError(tok, Severity::style, "redundantCondition", "Redundant condition: " + text);
+    reportError(tok, Severity::style, "redundantCondition", "Redundant condition: " + text, CWE398, false);
 }
 
 //-----------------------------------------------------------------------------
@@ -854,7 +859,7 @@ void CheckCondition::checkModuloAlwaysTrueFalse()
 void CheckCondition::moduloAlwaysTrueFalseError(const Token* tok, const std::string& maxVal)
 {
     reportError(tok, Severity::warning, "moduloAlwaysTrueFalse",
-                "Comparison of modulo result is predetermined, because it is always less than " + maxVal + ".");
+                "Comparison of modulo result is predetermined, because it is always less than " + maxVal + ".", CWE398, false);
 }
 
 //---------------------------------------------------------------------------
@@ -955,7 +960,7 @@ void CheckCondition::clarifyConditionError(const Token *tok, bool assign, bool b
     reportError(tok,
                 Severity::style,
                 "clarifyCondition",
-                errmsg);
+                errmsg, CWE398, false);
 }
 
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -40,6 +40,9 @@ static const char ExtraVersion[] = "";
 
 static TimerResults S_timerResults;
 
+// CWE ids used
+static const CWE CWE398(398U);  // Indicator of Poor Code Quality
+
 CppCheck::CppCheck(ErrorLogger &errorLogger, bool useGlobalSuppressions)
     : _errorLogger(errorLogger), exitcode(0), _useGlobalSuppressions(useGlobalSuppressions), tooManyConfigs(false), _simplify(true)
 {
@@ -523,7 +526,7 @@ void CppCheck::tooManyConfigsError(const std::string &file, const std::size_t nu
     ErrorLogger::ErrorMessage errmsg(loclist,
                                      Severity::information,
                                      msg.str(),
-                                     "toomanyconfigs",
+                                     "toomanyconfigs", CWE398,
                                      false);
 
     reportErr(errmsg);

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -58,8 +58,40 @@ ErrorLogger::ErrorMessage::ErrorMessage(const std::list<FileLocation> &callStack
     setmsg(msg);
 }
 
+
+
+ErrorLogger::ErrorMessage::ErrorMessage(const std::list<FileLocation> &callStack, Severity::SeverityType severity, const std::string &msg, const std::string &id, const CWE &cwe, bool inconclusive) :
+    _callStack(callStack), // locations for this error message
+    _id(id),               // set the message id
+    _severity(severity),   // severity for this error message
+    _cwe(cwe.id),
+    _inconclusive(inconclusive)
+{
+    // set the summary and verbose messages
+    setmsg(msg);
+}
+
 ErrorLogger::ErrorMessage::ErrorMessage(const std::list<const Token*>& callstack, const TokenList* list, Severity::SeverityType severity, const std::string& id, const std::string& msg, bool inconclusive)
     : _id(id), _severity(severity), _cwe(0U), _inconclusive(inconclusive)
+{
+    // Format callstack
+    for (std::list<const Token *>::const_iterator it = callstack.begin(); it != callstack.end(); ++it) {
+        // --errorlist can provide null values here
+        if (!(*it))
+            continue;
+
+        _callStack.push_back(ErrorLogger::ErrorMessage::FileLocation(*it, list));
+    }
+
+    if (list && !list->getFiles().empty())
+        file0 = list->getFiles()[0];
+
+    setmsg(msg);
+}
+
+
+ErrorLogger::ErrorMessage::ErrorMessage(const std::list<const Token*>& callstack, const TokenList* list, Severity::SeverityType severity, const std::string& id, const std::string& msg, const CWE &cwe, bool inconclusive)
+    : _id(id), _severity(severity), _cwe(cwe.id), _inconclusive(inconclusive)
 {
     // Format callstack
     for (std::list<const Token *>::const_iterator it = callstack.begin(); it != callstack.end(); ++it) {

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -27,6 +27,13 @@
 #include <list>
 #include <string>
 
+struct CWE {
+        explicit CWE(unsigned short ID) : id(ID) {}
+            unsigned short id;
+};
+
+
+
 class Token;
 class TokenList;
 
@@ -198,7 +205,9 @@ public:
         };
 
         ErrorMessage(const std::list<FileLocation> &callStack, Severity::SeverityType severity, const std::string &msg, const std::string &id, bool inconclusive);
+        ErrorMessage(const std::list<FileLocation> &callStack, Severity::SeverityType severity, const std::string &msg, const std::string &id, const CWE &cwe, bool inconclusive);
         ErrorMessage(const std::list<const Token*>& callstack, const TokenList* list, Severity::SeverityType severity, const std::string& id, const std::string& msg, bool inconclusive);
+        ErrorMessage(const std::list<const Token*>& callstack, const TokenList* list, Severity::SeverityType severity, const std::string& id, const std::string& msg, const CWE &cwe, bool inconclusive);
         ErrorMessage();
 
         /**


### PR DESCRIPTION
Hi, 

I expanded errorLogger interface to include CWE as parameters. 
I had to move the CWE struct definition otherwise I was not able to used it inside errorlogger.h 
I mapped below list ID to their CWEs ID. 

I have only one minor doubt about the assignment of CWE  to arrayIndexOutOfBounds**Cond** error.
When is it triggered ? I've not been able to find the test case to dig more and therefore at the moment it has the same CWE as arrayIndexOutOfBounds.

toomanyconfigs
AssignmentAddressToInteger
AssignmentIntegerToAddress
CastIntegerToAddressAtReturn
CastAddressToIntegerAtReturn
assertWithSideEffect
assignmentInAssert
uselessAssignmentArg
uselessAssignmentPtrArg
comparisonOfFuncReturningBoolError
comparisonOfTwoFuncsReturningBoolError
comparisonOfBoolWithBoolError
incrementboolean
comparisonOfBoolWithInt
compareBoolExpressionWithInt
negativeIndex
pointerOutOfBounds
arrayIndexThenCheck
possibleBufferAccessOutOfBounds
argumentSize
arrayIndexOutOfBoundsCond
noConstructor
copyCtorPointerCopying
noCopyConstructor
uninitMemberVar
operatorEqVarError
unusedPrivateFunction
memsetClassFloat
mallocOnClassWarning
operatorEq
thisSubtraction
operatorEqRetRefThis
operatorEqToSelf
useInitializationList
duplInheritedMember
assignIfError
comparisonError
multiCondition
mismatchingBitAnd
oppositeInnerCondition
incorrectLogicOperator
redundantCondition
moduloAlwaysTrueFalse