### PR TITLE
#7428 assigned enhancement

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -281,7 +281,7 @@ void CheckCondition::comparison()
         return;
 
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "==|!=")) {
+        if (Token::Match(tok, "==|!=|>|>=|<|<=")) {
             const Token *expr1 = tok->astOperand1();
             const Token *expr2 = tok->astOperand2();
             if (!expr1 || !expr2)
@@ -301,10 +301,24 @@ void CheckCondition::comparison()
                 const MathLib::bigint num1 = *num;
                 if (num1 < 0)
                     continue;
-                if ((expr1->str() == "&" && (num1 & num2) != num2) ||
-                    (expr1->str() == "|" && (num1 | num2) != num2)) {
-                    const std::string& op(tok->str());
-                    comparisonError(expr1, expr1->str(), num1, op, num2, op=="==" ? false : true);
+                if (Token::Match(tok, "==|!=|>=|<=")) {
+                    if ((expr1->str() == "&" && (num1 & num2) != num2) ||
+                        (expr1->str() == "|" && (num1 | num2) != num2)) {
+                        const std::string& op(tok->str());
+                        comparisonError(expr1, expr1->str(), num1, op, num2, op!="!=" ? false : true);
+                    }
+                }
+                else if (Token::simpleMatch(tok, ">")) {
+                    if ((expr1->str() == "&" && (num1 <= num2))) {
+                        const std::string& op(tok->str());
+                        comparisonError(expr1, expr1->str(), num1, op, num2, false);
+                    }
+                }
+                else if (Token::simpleMatch(tok, "<")) {
+                    if ((expr1->str() == "|" && (num1 >= num2))) {
+                        const std::string& op(tok->str());
+                        comparisonError(expr1, expr1->str(), num1, op, num2, false);
+                    }
                 }
             }
         }

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -1622,6 +1622,29 @@ private:
               "  assert(x == 0);\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        //TRAC #7428 false negative: Statement is always false
+        check("void f() {\n"
+              "assert( (a & 0x07) == 8U );\n" // statement always false, because 7 == 8 is false
+              "assert( (a & 0x07) >  7U );\n" // statement always false, because 7 > 7 is false
+              "assert( (a | 0x07) <  7U );\n" // statement always false, because 7 < 7 is false
+              "assert( (a & 0x07) >  8U );\n" // statement always false, because 7 > 8 is false
+              "assert( (a | 0x07) <  6U );\n" // statement always false, because 7 < 6 is false
+              "assert( (a & 0x07) >= 7U );\n" // statement correct
+              "assert( (a | 0x07) <= 7U );\n" // statement correct
+              "assert( (a & 0x07) >= 8U );\n" // statement always false, because 7 >= 8 is false
+              "assert( (a | 0x07) <= 6U );\n" // statement always false, because 7 <= 6 is false
+              "assert( (a & 0x07) >  3U );\n" // statement correct
+              "assert( (a | 0x07) <  9U );\n" // statement correct
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Expression '(X & 0x7) == 0x8' is always false.\n"
+                      "[test.cpp:3]: (style) Expression '(X & 0x7) > 0x7' is always false.\n"
+                      "[test.cpp:4]: (style) Expression '(X | 0x7) < 0x7' is always false.\n"
+                      "[test.cpp:5]: (style) Expression '(X & 0x7) > 0x8' is always false.\n"
+                      "[test.cpp:6]: (style) Expression '(X | 0x7) < 0x6' is always false.\n"
+                      "[test.cpp:9]: (style) Expression '(X & 0x7) >= 0x8' is always false.\n"
+                      "[test.cpp:10]: (style) Expression '(X | 0x7) <= 0x6' is always false.\n",
+                      errout.str());
     }
 
     void checkInvalidTestForOverflow() {


### PR DESCRIPTION
This is a fix proposal for TRAC #7428
http://trac.cppcheck.net/ticket/7428

 Tested with file:
```
void main(int a)
{
    if( (a & 0x07) == 8U ) // statement always false, because 7 == 8 is false
    if( (a & 0x07) > 7U ) // statement always false, because 7 > 7 is false
    if( (a | 0x07) < 7U ) // statement always false, because 7 < 7 is false
    if( (a & 0x07) > 8U ) // statement always false, because 7 > 8 is false
    if( (a | 0x07) < 6U ) // statement always false, because 7 < 6 is false
    if( (a & 0x07) >= 7U ) // statement correct
    if( (a | 0x07) <= 7U ) // statement correct
    if( (a & 0x07) >= 8U ) // statement always false, because 7 >= 8 is false
    if( (a | 0x07) <= 6U ) // statement always false, because 7 <= 6 is false
    if( (a & 0x07) > 3U ) // statement correct
    if( (a | 0x07) < 9U ) // statement correct
}
```
test result:
```
../cppcheck --enable=all testcase_7428.cpp
Checking testcase_7428.cpp...
[testcase_7428.cpp:3]: (style) Expression '(X & 0x7) == 0x8' is always false.
[testcase_7428.cpp:4]: (style) Expression '(X & 0x7) > 0x7' is always false.
[testcase_7428.cpp:5]: (style) Expression '(X | 0x7) < 0x7' is always false.
[testcase_7428.cpp:6]: (style) Expression '(X & 0x7) > 0x8' is always false.
[testcase_7428.cpp:7]: (style) Expression '(X | 0x7) < 0x6' is always false.
[testcase_7428.cpp:10]: (style) Expression '(X & 0x7) >= 0x8' is always false.
[testcase_7428.cpp:11]: (style) Expression '(X | 0x7) <= 0x6' is always false.
```