### PR TITLE
fix build on OpenBSD

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -41,7 +41,7 @@
 #   define _XOPEN_SOURCE // ucontext.h APIs can only be used on Mac OSX >= 10.7 if _XOPEN_SOURCE is defined
 #   include <ucontext.h>
 #   undef _XOPEN_SOURCE
-#else
+#elif !defined(__OpenBSD__)
 #   include <ucontext.h>
 #endif
 #ifdef __linux__


### PR DESCRIPTION
fix build on OpenBSD:
cli/cppcheckexecutor.cpp:45:25: fatal error: ucontext.h: No such file or directory

OpenBSD doesn't have ucontext.h, ucontext_t is a typedef to struct sigcontext in signal.h