### PR TITLE
Ticket #7452: Properly interpret escape sequences in character literals.

### DIFF
--- a/lib/mathlib.h
+++ b/lib/mathlib.h
@@ -31,6 +31,8 @@
 /** @brief simple math functions that uses operands stored in std::string. useful when performing math on tokens. */
 
 class CPPCHECKLIB MathLib {
+    friend class TestMathLib;
+
 public:
     /** @brief value class */
     class value {
@@ -120,6 +122,12 @@ public:
      * */
     static MathLib::bigint characterLiteralToLongNumber(const std::string& str);
 
+private:
+    /*
+     * \param iLiteral A character literal
+     * \return The equivalent character literal with all escapes interpreted
+     */
+    static std::string normalizeCharacterLiteral(const std::string& iLiteral);
 };
 
 MathLib::value operator+(const MathLib::value &v1, const MathLib::value &v2);


### PR DESCRIPTION
This ticket highlights that we don't properly parse character literals when they contain escape sequences and are not made of a single one of those. This patch fixes this.

Thanks to consider merging,
   Simon