### PR TITLE
 	build with a previous version of gcc 4.6

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -72,7 +72,11 @@ static void AddInclPathsToList(const std::string& FileList, std::list<std::strin
                 PathName = Path::fromNativeSeparators(PathName);
 
                 // If path doesn't end with / or \, add it
+#if GCC_VERSION >= 40600
                 if (PathName.back() != '/')
+#else
+                if (PathName[PathName.size() - 1] != '/')
+#endif
                     PathName += '/';
 
                 PathNames->push_back(PathName);
@@ -411,7 +415,11 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
                 path = Path::fromNativeSeparators(path);
 
                 // If path doesn't end with / or \, add it
+#if GCC_VERSION >= 40600
                 if (path.back() != '/')
+#else
+                if (path[path.size() - 1] != '/')
+#endif
                     path += '/';
 
                 _settings->includePaths.push_back(path);
@@ -465,7 +473,11 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
 
                     if (FileLister::isDirectory(path)) {
                         // If directory name doesn't end with / or \, add it
+#if GCC_VERSION >= 40600
                         if (path.back() != '/')
+#else
+                        if (path[path.size() - 1] != '/')
+#endif
                             path += '/';
                     }
                     _ignoredPaths.push_back(path);

--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -223,7 +223,11 @@ void FileLister::addFiles(std::map<std::string, std::size_t> &files, const std::
 {
     if (!path.empty()) {
         std::string corrected_path = path;
+#if GCC_VERSION >= 40600
         if (corrected_path.back() == '/')
+#else
+        if (corrected_path[corrected_path.size() - 1] == '/')
+#endif
             corrected_path.erase(corrected_path.end() - 1);
 
         addFiles2(files, corrected_path, extra, recursive, ignored);

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1701,7 +1701,13 @@ void CheckClass::checkConst()
                         continue;
                 } else if (func->isOperator() && Token::Match(previous, ";|{|}|public:|private:|protected:")) { // Operator without return type: conversion operator
                     const std::string& opName = func->tokenDef->str();
-                    if (opName.compare(8, 5, "const") != 0 && opName.back() == '&')
+                    if (opName.compare(8, 5, "const") != 0 && 
+#if GCC_VERSION >= 40600
+                        opName.back() == '&'
+#else
+                        opName[opName.size() -1] == '&'
+#endif
+                    )
                         continue;
                 } else {
                     // don't warn for unknown types..

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -775,7 +775,14 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
         }
 
         // templates
-        if (tok->isName() && tok->str().back() == '>') {
+        if (tok->isName() && 
+#if GCC_VERSION >= 40600
+            tok->str().back() == '>'
+#else
+            tok->str()[tok->str().size() - 1] == '>'
+#endif
+        )
+        {
             // TODO: This is a quick fix to handle when constants are used
             // as template parameters. Try to handle this better, perhaps
             // only remove constants.

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -116,7 +116,11 @@ void ErrorLogger::ErrorMessage::setmsg(const std::string &msg)
     // as an empty message to the user if --verbose is used.
     // Even this doesn't cause problems with messages that have multiple
     // lines, none of the the error messages should end into it.
+#if GCC_VERSION >= 40600
     assert(!(msg.back() =='\n'));
+#else
+    assert(!(msg[msg.size() - 1] =='\n'));
+#endif
 
     // The summary and verbose message are separated by a newline
     // If there is no newline then both the summary and verbose messages

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -338,7 +338,11 @@ MathLib::biguint MathLib::toULongNumber(const std::string & str)
 
 static unsigned int encodeMultiChar(const std::string& str)
 {
+#if GCC_VERSION >= 40600
     unsigned int retval(str.front());
+#else
+    unsigned int retval(str[0]);
+#endif
     for (std::string::const_iterator it=str.begin()+1; it!=str.end(); ++it) {
         retval = retval<<8 | *it;
     }

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -387,7 +387,13 @@ std::string Preprocessor::preprocessCleanupDirectives(const std::string &process
         // Trim lines..
         if (!line.empty() && line[0] == ' ')
             line.erase(0, line.find_first_not_of(" "));
-        if (!line.empty() && line.back() == ' ')
+        if (!line.empty() && 
+#if GCC_VERSION >= 40600
+            line.back() == ' '
+#else
+            line[line.size() - 1] == ' '
+#endif
+        )
             line.erase(line.find_last_not_of(" ") + 1);
 
         // Preprocessor
@@ -1500,7 +1506,13 @@ std::list<std::string> Preprocessor::getcfgs(const std::string &filedata, const 
             while (cfg.length() > 0 && cfg[0] == ';')
                 cfg.erase(0, 1);
 
-            while (cfg.length() > 0 && cfg.back() == ';')
+            while (cfg.length() > 0 &&
+#if GCC_VERSION >= 40600
+                   cfg.back() == ';'
+#else
+                   cfg[cfg.size() - 1] == ';'
+#endif
+            )
                 cfg.erase(cfg.length() - 1);
 
             std::string::size_type pos = 0;
@@ -2554,7 +2566,14 @@ static void getparams(const std::string &line,
         // spaces are only added if needed
         else if (line[pos] == ' ') {
             // Add space only if it is needed
-            if (par.size() && std::isalnum((unsigned char)par.back())) {
+            if (par.size() && 
+#if GCC_VERSION >= 40600
+                std::isalnum((unsigned char)par.back())
+#else
+                std::isalnum((unsigned char)par[par.size() - 1])
+#endif
+            )
+            {
                 par += ' ';
             }
         }
@@ -2613,7 +2632,14 @@ private:
         for (std::size_t ipar = 0; ipar < params1.size(); ++ipar) {
             const std::string s(innerMacroName + "(");
             const std::string param(params1[ipar]);
-            if (param.compare(0,s.length(),s)==0 && param.back() == ')') {
+            if (param.compare(0,s.length(),s)==0 &&
+#if GCC_VERSION >= 40600
+                param.back() == ')'
+#else
+                param[param.size() - 1] == ')'
+#endif
+            )
+            {
                 std::vector<std::string> innerparams;
                 std::string::size_type pos = s.length() - 1;
                 unsigned int num = 0;

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -72,9 +72,21 @@ void Token::update_property_info()
                 _tokType = eName;
         } else if (std::isdigit((unsigned char)_str[0]) || (_str.length() > 1 && _str[0] == '-' && std::isdigit((unsigned char)_str[1])))
             _tokType = eNumber;
-        else if (_str.length() > 1 && _str[0] == '"' && _str.back() == '"')
+        else if (_str.length() > 1 && _str[0] == '"' &&
+#if GCC_VERSION >= 40600
+                _str.back() == '"'
+#else
+                _str[_str.size() - 1] == '"'
+#endif
+        )
             _tokType = eString;
-        else if (_str.length() > 1 && _str[0] == '\'' && _str.back() == '\'')
+        else if (_str.length() > 1 && _str[0] == '\'' && 
+#if GCC_VERSION >= 40600
+                _str.back() == '\''
+#else
+                _str[_str.size() - 1] == '\''
+#endif
+        )
             _tokType = eChar;
         else if (_str == "=" || _str == "<<=" || _str == ">>=" ||
                  (_str.size() == 2U && _str[1] == '=' && std::strchr("+-*/%&^|", _str[0])))

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -297,8 +297,13 @@ bool TokenList::createTokens(std::istream &code, const std::string& file0)
         } else if (std::strchr("+-", ch) &&
                    CurrentToken.length() > 0 &&
                    std::isdigit((unsigned char)CurrentToken[0]) &&
+#if GCC_VERSION >= 40600
                    (CurrentToken.back() == 'e' ||
                     CurrentToken.back() == 'E') &&
+#else
+                   (CurrentToken[CurrentToken.size() - 1] == 'e' ||
+                    CurrentToken[CurrentToken.size() - 1] == 'E') &&
+#endif
                    !MathLib::isIntHex(CurrentToken)) {
             // Don't separate doubles "4.2e+10"
         } else if (CurrentToken.empty() && ch == '.' && std::isdigit((unsigned char)code.peek())) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -25,6 +25,9 @@
 #include "token.h"
 #include "tokenlist.h"
 #include <stack>
+#if GCC_VERSION < 40600
+#include <limits>
+#endif
 
 namespace {
     struct ProgramMemory {


### PR DESCRIPTION
I have add some preprocessor rules to be able to build cppcheck with gcc version older than 4.6.
all STL method with are only in C++11 are replaced by equivalent STD method in C++98