### PR TITLE
No need to use std::min() in normalizeCharacterLiteral.

### DIFF
--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -393,7 +393,7 @@ std::string MathLib::normalizeCharacterLiteral(const std::string& iLiteral)
             continue;
         }
         // Single digit octal number
-        if (1 == std::min<unsigned>(3, iLiteralLen - idx)) {
+        if (1 == iLiteralLen - idx) {
             switch (iLiteral[idx]) {
             case '0':
             case '1':


### PR DESCRIPTION
Hi,

Another follow-up to https://github.com/danmar/cppcheck/pull/794: I don't know why and how I ended up writing "1 == std::min<unsigned>(3, iLiteralLen - idx)", but it can definitely be simplified as proposed here.

Simon