### PR TITLE
Ticket #7445: Properly represent integer types smaller than int in CheckIO::ArgumentInfo.

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1389,9 +1389,7 @@ CheckIO::ArgumentInfo::ArgumentInfo(const Token * tok, const Settings *settings,
                 tempToken->insertToken("a");
                 tempToken = tempToken->next();
             }
-            if (valuetype->pointer == 0U && valuetype->type <= ValueType::INT)
-                tempToken->str("int");
-            else if (valuetype->type == ValueType::BOOL)
+            if (valuetype->type == ValueType::BOOL)
                 tempToken->str("bool");
             else if (valuetype->type == ValueType::CHAR)
                 tempToken->str("char");

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -2187,6 +2187,12 @@ private:
         ASSERT_EQUALS("[test.cpp:9]: (warning) %u in format string (no. 1) requires 'unsigned int' but the argument type is 'int'.\n"
                       "[test.cpp:9]: (warning) %u in format string (no. 2) requires 'unsigned int' but the argument type is 'float'.\n", errout.str());
 
+        // Ticket #7445
+        check("struct S { unsigned short x; } s = {0};\n"
+              "void foo() {\n"
+              "    printf(\"%d\", s.x);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void testPosixPrintfScanfParameterPosition() { // #4900  - No support for parameters in format strings


### PR DESCRIPTION
This ticket highlights an issue in https://github.com/danmar/cppcheck/commit/b77203a277c37ff008b9205636e0c47927316acb, that effectively considers as int any argument with an integral type smaller than int . This patch fixes this and the ticket.

Thanks to consider merging.