### PR TITLE
Fixed 7083: false positive: typedef and initialization with strings

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1502,15 +1502,21 @@ void CheckBufferOverrun::bufferOverrun2()
             varname = tok->str();
 
 
+        const Variable * const var = tok->variable();
+        if (!var)
+            continue;
+
         const Token * const strtoken = tok->getValueTokenMinStrSize();
-        if (strtoken) {
+        if (strtoken && !var->isArray()) {
+            // TODO: check for access to symbol inside the array bounds, but outside the stored string:
+            //  char arr[10] = "123"; 
+            //  arr[7] = 'x'; // warning: arr[7] is inside the array bounds, but past the string's end
+
             ArrayInfo arrayInfo(tok->varId(), varname, 1U, Token::getStrSize(strtoken));
             valueFlowCheckArrayIndex(tok->next(), arrayInfo);
         }
-
         else {
-            const Variable * const var = tok->variable();
-            if (!var || var->nameToken() == tok || !var->isArray())
+            if (var->nameToken() == tok || !var->isArray())
                 continue;
 
             // TODO: last array in struct..

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -164,6 +164,7 @@ private:
         TEST_CASE(buffer_overrun_26); // #4432 (segmentation fault)
         TEST_CASE(buffer_overrun_27); // #4444 (segmentation fault)
         TEST_CASE(buffer_overrun_28); // Out of bound char array access
+        TEST_CASE(buffer_overrun_29); // #7083: false positive: typedef and initialization with strings
         TEST_CASE(buffer_overrun_bailoutIfSwitch);  // ticket #2378 : bailoutIfSwitch
         TEST_CASE(buffer_overrun_function_array_argument);
         TEST_CASE(possible_buffer_overrun_1); // #3035
@@ -2474,6 +2475,19 @@ private:
         check("char c = \"\\0abc\"[2];");
         ASSERT_EQUALS("", errout.str());
     }
+
+
+    // #7083: false positive: typedef and initialization with strings
+    void buffer_overrun_29() {
+      check(  "typedef char testChar[10]; \n"
+              "int main(){ \n"
+              "  testChar tc1 = \"\"; \n"
+              "  tc1[5]='a'; \n"
+              "} \n"
+              );
+      ASSERT_EQUALS("", errout.str());
+    }
+
 
     void buffer_overrun_bailoutIfSwitch() {
         // No false positive


### PR DESCRIPTION
There was an unnecessary special check for array bounds when initialized with string. There is no reason for that because the array dimensions had been properly set already.

https://github.com/umanamente/cppcheck/blob/d1f06ff47cc430cd926ef3b69ca6107ffe0db302/lib/checkbufferoverrun.cpp#L1505-L1509
