### PR TITLE
Extend command line to support --xml-results=<file> option

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -285,6 +285,12 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
                 _settings->xml = true;
             }
 
+            else if (std::strncmp(argv[i], "--xml-results=", 14) == 0) {
+                // Enable also XML if version is set
+                _settings->xml_results = std::string(argv[i]+14);
+                _settings->xml = true;
+            }
+
             // Only print something when there are errors
             else if (std::strcmp(argv[i], "-q") == 0 || std::strcmp(argv[i], "--quiet") == 0)
                 _settings->quiet = true;
@@ -965,6 +971,8 @@ void CmdLineParser::PrintHelp()
               "    --xml-version=<version>\n"
               "                         Select the XML file version. Currently versions 1 and\n"
               "                         2 are available. The default version is 1."
+              "    --xml-results==<file>\n"
+              "                         Write XML results to file, rather than standard error.\n"
               "\n"
               "Example usage:\n"
               "  # Recursively check the current folder. Print the progress on the screen and\n"

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -68,7 +68,7 @@
 /*static*/ FILE* CppCheckExecutor::exceptionOutput = stdout;
 
 CppCheckExecutor::CppCheckExecutor()
-    : _settings(0), time1(0), errorlist(false)
+    : _settings(0), time1(0), xmlResults(0), errorlist(false)
 {
 }
 
@@ -799,7 +799,16 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck, int /*argc*/, const cha
         time1 = std::time(0);
 
     if (settings.xml) {
-        reportErr(ErrorLogger::ErrorMessage::getXMLHeader(settings.xml_version));
+        if (settings.xml_results.length()) {
+            xmlResults = new std::ofstream(settings.xml_results);
+        }
+        std::string xmlHeader = ErrorLogger::ErrorMessage::getXMLHeader(settings.xml_version);
+        if (xmlResults) {
+            *xmlResults << xmlHeader << "\n";
+        }
+        else {
+            reportErr(xmlHeader);
+        }
     }
 
     unsigned int returnValue = 0;
@@ -877,7 +886,16 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck, int /*argc*/, const cha
     }
 
     if (settings.xml) {
-        reportErr(ErrorLogger::ErrorMessage::getXMLFooter(settings.xml_version));
+        std::string xmlFooter = ErrorLogger::ErrorMessage::getXMLFooter(settings.xml_version);
+        if (xmlResults) {
+            *xmlResults << xmlFooter << "\n";
+            xmlResults->close();
+            delete xmlResults;
+            xmlResults = 0;
+        }
+        else {
+            reportErr(xmlFooter);
+        }
     }
 
     _settings = 0;
@@ -947,7 +965,13 @@ void CppCheckExecutor::reportErr(const ErrorLogger::ErrorMessage &msg)
     if (errorlist) {
         reportOut(msg.toXML(false, _settings->xml_version));
     } else if (_settings->xml) {
-        reportErr(msg.toXML(_settings->verbose, _settings->xml_version));
+        std::string xmlMessage = msg.toXML(_settings->verbose, _settings->xml_version);
+        if (xmlResults) {
+            *xmlResults << xmlMessage << "\n";
+        }
+        else {
+            reportErr(xmlMessage);
+        }
     } else {
         reportErr(msg.toString(_settings->verbose, _settings->outputFormat));
     }

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -24,6 +24,7 @@
 #include <ctime>
 #include <set>
 #include <string>
+#include <fstream>
 
 class CppCheck;
 class Settings;
@@ -173,6 +174,11 @@ private:
      * Output file name for exception handler
      */
     static FILE* exceptionOutput;
+
+    /**
+     * Output file for XML results
+     */
+    std::ofstream* xmlResults;
 
     /**
      * Has --errorlist been given?

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -120,6 +120,9 @@ public:
     /** @brief XML version (--xmlver=..) */
     int xml_version;
 
+    /** @brief XML results file (--xmlresults=...) */
+    std::string xml_results;
+
     /** @brief How many processes/threads should do checking at the same
         time. Default is 1. (-j N) */
     unsigned int jobs;

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -554,6 +554,12 @@ There are false positives with this option. Each result must be carefully invest
           <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>--xml-results=&lt;file&gt;</option></term>
+        <listitem>
+          <para>Write XML results to file, rather than standard error.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
   <refsect1 id="author">


### PR DESCRIPTION
For integration with `cmake` and `jenkins` for a large-scale codebase, we'd like the XML results to be written to a specific file, rather than going to standard error.
