### PR TITLE
Silent clang -Wshadow warning.

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1772,17 +1772,17 @@ CheckBufferOverrun::ArrayInfo::ArrayInfo()
 {
 }
 
-CheckBufferOverrun::ArrayInfo::ArrayInfo(const Variable *var, const SymbolDatabase * symbolDatabase, const unsigned int forcedeclid)
+CheckBufferOverrun::ArrayInfo::ArrayInfo(const Variable *var, const SymbolDatabase * symDb, const unsigned int forcedeclid)
     : _varname(var->name()), _declarationId((forcedeclid == 0U) ? var->declarationId() : forcedeclid)
 {
     for (std::size_t i = 0; i < var->dimensions().size(); i++)
         _num.push_back(var->dimension(i));
     if (var->typeEndToken()->str() == "*")
-        _element_size = symbolDatabase->sizeOfType(var->typeEndToken());
+        _element_size = symDb->sizeOfType(var->typeEndToken());
     else if (var->typeStartToken()->str() == "struct")
         _element_size = 100;
     else {
-        _element_size = symbolDatabase->sizeOfType(var->typeEndToken());
+        _element_size = symDb->sizeOfType(var->typeEndToken());
     }
 }
 


### PR DESCRIPTION
Hi,

symboldDatabase, as a parameter to CheckBufferOverrun::ArrayInfo::ArrayInfo, shadows CheckBufferOverrun::symboldDatabase, and clang rightfully warns about it. This patch fixes it. Thanks to consider merging.

Simon