### PR TITLE
CWE mapping of incorrectStringCompare, literalWithCharPtrCompare, charLiteralWithCharPtrCompare, incorrectStringBooleanError, staticStringCompare, stringCompare, signConversion, unusedFunction, unusedVariable

### DIFF
--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -29,8 +29,11 @@ namespace {
 }
 
 // CWE ids used:
-static const struct CWE CWE628(628U);
-static const struct CWE CWE665(665U);
+static const struct CWE CWE570(570U);	// Expression is Always False
+static const struct CWE CWE571(571U);	// Expression is Always True
+static const struct CWE CWE595(595U);	// Comparison of Object References Instead of Object Contents
+static const struct CWE CWE628(628U);	// Function Call with Incorrectly Specified Arguments
+static const struct CWE CWE665(665U);	// Improper Initialization
 
 
 //---------------------------------------------------------------------------
@@ -130,7 +133,7 @@ void CheckString::alwaysTrueFalseStringCompareError(const Token *tok, const std:
     reportError(tok, Severity::warning, "staticStringCompare",
                 "Unnecessary comparison of static strings.\n"
                 "The compared strings, '" + string1 + "' and '" + string2 + "', are always " + (str1==str2?"identical":"unequal") + ". "
-                "Therefore the comparison is unnecessary and looks suspicious.");
+                "Therefore the comparison is unnecessary and looks suspicious.", (str1==str2)?CWE571:CWE570, false);
 }
 
 void CheckString::alwaysTrueStringVariableCompareError(const Token *tok, const std::string& str1, const std::string& str2)
@@ -138,7 +141,7 @@ void CheckString::alwaysTrueStringVariableCompareError(const Token *tok, const s
     reportError(tok, Severity::warning, "stringCompare",
                 "Comparison of identical string variables.\n"
                 "The compared strings, '" + str1 + "' and '" + str2 + "', are identical. "
-                "This could be a logic bug.");
+                "This could be a logic bug.", CWE571, false);
 }
 
 
@@ -210,13 +213,13 @@ void CheckString::checkSuspiciousStringCompare()
 void CheckString::suspiciousStringCompareError(const Token* tok, const std::string& var)
 {
     reportError(tok, Severity::warning, "literalWithCharPtrCompare",
-                "String literal compared with variable '" + var + "'. Did you intend to use strcmp() instead?");
+                "String literal compared with variable '" + var + "'. Did you intend to use strcmp() instead?", CWE595, false);
 }
 
 void CheckString::suspiciousStringCompareError_char(const Token* tok, const std::string& var)
 {
     reportError(tok, Severity::warning, "charLiteralWithCharPtrCompare",
-                "Char literal compared with pointer '" + var + "'. Did you intend to dereference it?");
+                "Char literal compared with pointer '" + var + "'. Did you intend to dereference it?", CWE595, false);
 }
 
 
@@ -306,12 +309,12 @@ void CheckString::checkIncorrectStringCompare()
 
 void CheckString::incorrectStringCompareError(const Token *tok, const std::string& func, const std::string &string)
 {
-    reportError(tok, Severity::warning, "incorrectStringCompare", "String literal " + string + " doesn't match length argument for " + func + "().");
+    reportError(tok, Severity::warning, "incorrectStringCompare", "String literal " + string + " doesn't match length argument for " + func + "().", CWE570, false);
 }
 
 void CheckString::incorrectStringBooleanError(const Token *tok, const std::string& string)
 {
-    reportError(tok, Severity::warning, "incorrectStringBooleanError", "Conversion of string literal " + string + " to bool always evaluates to true.");
+    reportError(tok, Severity::warning, "incorrectStringBooleanError", "Conversion of string literal " + string + " to bool always evaluates to true.", CWE571, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -36,8 +36,9 @@ namespace {
 //
 
 // CWE ids used:
-static const struct CWE CWE758(758U);
-static const struct CWE CWE190(190U);
+static const struct CWE CWE195(195U);	// Signed to Unsigned Conversion Error
+static const struct CWE CWE758(758U);	// Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+static const struct CWE CWE190(190U);	// Integer Overflow or Wraparound
 
 
 void CheckType::checkTooBigBitwiseShift()
@@ -207,7 +208,7 @@ void CheckType::signConversionError(const Token *tok, const bool constvalue)
                 "signConversion",
                 (constvalue) ?
                 "Suspicious code: sign conversion of " + varname + " in calculation because '" + varname + "' has a negative value" :
-                "Suspicious code: sign conversion of " + varname + " in calculation, even though " + varname + " can have a negative value");
+                "Suspicious code: sign conversion of " + varname + " in calculation, even though " + varname + " can have a negative value", CWE195, false);
 }
 
 

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -30,6 +30,8 @@
 // Register this check class
 CheckUnusedFunctions CheckUnusedFunctions::instance;
 
+static const struct CWE CWE561(561U);	// Dead Code
+
 
 //---------------------------------------------------------------------------
 // FUNCTION USAGE - Check for unused functions etc
@@ -250,7 +252,7 @@ void CheckUnusedFunctions::unusedFunctionError(ErrorLogger * const errorLogger,
         locationList.push_back(fileLoc);
     }
 
-    const ErrorLogger::ErrorMessage errmsg(locationList, Severity::style, "The function '" + funcname + "' is never used.", "unusedFunction", false);
+    const ErrorLogger::ErrorMessage errmsg(locationList, Severity::style, "The function '" + funcname + "' is never used.", "unusedFunction", CWE561, false);
     if (errorLogger)
         errorLogger->reportErr(errmsg);
     else

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -29,6 +29,9 @@ namespace {
     CheckUnusedVar instance;
 }
 
+static const struct CWE CWE563(563U);	// Assignment to Variable without Use ('Unused Variable')
+
+
 /**
  * @brief This class is used create a list of variables within a function.
  */
@@ -1192,7 +1195,7 @@ void CheckUnusedVar::checkFunctionVariableUsage()
 
 void CheckUnusedVar::unusedVariableError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::style, "unusedVariable", "Unused variable: " + varname);
+    reportError(tok, Severity::style, "unusedVariable", "Unused variable: " + varname, CWE563, false);
 }
 
 void CheckUnusedVar::allocatedButUnusedVariableError(const Token *tok, const std::string &varname)


### PR DESCRIPTION
CWE mapping of incorrectStringCompare, literalWithCharPtrCompare, charLiteralWithCharPtrCompare, incorrectStringBooleanError, staticStringCompare, stringCompare, signConversion, unusedFunction, unusedVariable