### PR TITLE
added python script to list in CSV format all errors without a CWE

### DIFF
--- a/tools/listErrorsWithoutCWE.py
+++ b/tools/listErrorsWithoutCWE.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+import argparse
+import xml.etree.ElementTree as ET
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="List all error without a CWE assigned in CSV format")
+    parser.add_argument("-F", metavar="filename", required=True, help="XML file containing output from: ./cppcheck --errorlist --xml-version=2")
+    parsed = parser.parse_args()
+
+    tree = ET.parse(vars(parsed)["F"])
+    root = tree.getroot()
+    for child in root.iter("error"):
+
+        if "cwe" not in child.attrib:
+            print child.attrib["id"], ",", child.attrib["severity"], ",", child.attrib["verbose"]
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script once I've finished to maps all current missing errors (67) I would like that will be integrated into the continuous integration to send me an email when new errors will not have a CWE assigned and so promptly follow up with the mapping during normal development. 