### PR TITLE
CWE mapping of functionConst, functionStatic, initializerList, badBitmaskCheck, knownConditionTrueFalse, invalidTestForOverflow, unhandledExceptionSpecification, coutCerrMisusage,  invalidPrintfArgType_int

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -35,11 +35,11 @@ namespace {
     CheckClass instance;
 }
 
-static const CWE CWE398(398U);
-static const CWE CWE404(404U);
-static const CWE CWE665(665U);
-static const CWE CWE758(758U);
-static const CWE CWE762(762U);
+static const CWE CWE398(398U);	// Indicator of Poor Code Quality
+static const CWE CWE404(404U);	// Improper Resource Shutdown or Release
+static const CWE CWE665(665U);	// Improper Initialization
+static const CWE CWE758(758U);	// Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+static const CWE CWE762(762U);	// Mismatched Memory Management Routines
 
 static const char * getFunctionTypeName(Function::Type type)
 {
@@ -2010,7 +2010,7 @@ void CheckClass::checkConstError2(const Token *tok1, const Token *tok2, const st
                     "function. Making this function 'const' should not cause compiler errors. "
                     "Even though the function can be made const function technically it may not make "
                     "sense conceptually. Think about your design and the task of the function first - is "
-                    "it a function that must not change object internal state?", CWE(0U), true);
+                    "it a function that must not change object internal state?", CWE398, true);
     else
         reportError(toks, Severity::performance, "functionStatic",
                     "Technically the member function '" + classname + "::" + funcname + "' can be static.\n"
@@ -2018,7 +2018,7 @@ void CheckClass::checkConstError2(const Token *tok1, const Token *tok2, const st
                     "function. Making a function static can bring a performance benefit since no 'this' instance is "
                     "passed to the function. This change should not cause compiler errors but it does not "
                     "necessarily make sense conceptually. Think about your design and the task of the function first - "
-                    "is it a function that must not access members of class instances?", CWE(0U), true);
+                    "is it a function that must not access members of class instances?", CWE398, true);
 }
 
 //---------------------------------------------------------------------------
@@ -2105,7 +2105,7 @@ void CheckClass::initializerListError(const Token *tok1, const Token *tok2, cons
                 "Members are initialized in the order they are declared, not in the "
                 "order they are in the initializer list.  Keeping the initializer list "
                 "in the same order that the members were declared prevents order dependent "
-                "initialization errors.", CWE(0U), true);
+                "initialization errors.", CWE398, true);
 }
 
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -29,9 +29,9 @@
 #include <stack>
 
 // CWE ids used
-static const struct CWE CWE398(398U);
-static const struct CWE CWE570(570U);
-static const struct CWE CWE571(571U);
+static const struct CWE CWE398(398U);	// Indicator of Poor Code Quality
+static const struct CWE CWE570(570U);	// Expression is Always False
+static const struct CWE CWE571(571U);	// Expression is Always True
 
 //---------------------------------------------------------------------------
 
@@ -272,7 +272,7 @@ void CheckCondition::checkBadBitmaskCheck()
 
 void CheckCondition::badBitmaskCheckError(const Token *tok)
 {
-    reportError(tok, Severity::warning, "badBitmaskCheck", "Result of operator '|' is always true if one operand is non-zero. Did you intend to use '&'?");
+    reportError(tok, Severity::warning, "badBitmaskCheck", "Result of operator '|' is always true if one operand is non-zero. Did you intend to use '&'?", CWE571, false);
 }
 
 void CheckCondition::comparison()
@@ -1023,7 +1023,8 @@ void CheckCondition::alwaysTrueFalseError(const Token *tok, bool knownResult)
     reportError(tok,
                 Severity::style,
                 "knownConditionTrueFalse",
-                "Condition '" + expr + "' is always " + (knownResult ? "true" : "false"));
+                "Condition '" + expr + "' is always " + (knownResult ? "true" : "false"),
+				(knownResult ? CWE571 : CWE570), false);
 }
 
 void CheckCondition::checkInvalidTestForOverflow()
@@ -1087,5 +1088,5 @@ void CheckCondition::invalidTestForOverflow(const Token* tok, bool result)
              "'. Condition is always " +
              std::string(result ? "true" : "false") +
              " unless there is overflow, and overflow is UB.";
-    reportError(tok, Severity::warning, "invalidTestForOverflow", errmsg);
+    reportError(tok, Severity::warning, "invalidTestForOverflow", errmsg, (result ? CWE571 : CWE570), false);
 }

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -27,6 +27,7 @@
 
 // CWE ID used:
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
+static const struct CWE CWE703(703U);	// Improper Check or Handling of Exceptional Conditions
 
 
 /// @addtogroup Checks
@@ -124,7 +125,7 @@ private:
         reportError(locationList, Severity::style, "unhandledExceptionSpecification",
                     "Unhandled exception specification when calling function " + str1 + "().\n"
                     "Unhandled exception specification when calling function " + str1 + "(). "
-                    "Either use a try/catch around the function call, or add a exception specification for " + funcname + "() also.", CWE(0U), true);
+                    "Either use a try/catch around the function call, or add a exception specification for " + funcname + "() also.", CWE703, true);
     }
 
     /** Generate all possible errors (for --errorlist) */

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -69,7 +69,7 @@ void CheckIO::checkCoutCerrMisusage()
 
 void CheckIO::coutCerrMisusageError(const Token* tok, const std::string& streamName)
 {
-    reportError(tok, Severity::error, "coutCerrMisusage", "Invalid usage of output stream: '<< std::" + streamName + "'.");
+    reportError(tok, Severity::error, "coutCerrMisusage", "Invalid usage of output stream: '<< std::" + streamName + "'.", CWE398, false);
 }
 
 //---------------------------------------------------------------------------
@@ -1923,7 +1923,7 @@ void CheckIO::invalidPrintfArgTypeError_int(const Token* tok, unsigned int numFo
     errmsg << " but the argument type is ";
     argumentType(errmsg, argInfo);
     errmsg << ".";
-    reportError(tok, Severity::warning, "invalidPrintfArgType_int", errmsg.str());
+    reportError(tok, Severity::warning, "invalidPrintfArgType_int", errmsg.str(), CWE686, false);
 }
 void CheckIO::invalidPrintfArgTypeError_uint(const Token* tok, unsigned int numFormat, const std::string& specifier, const ArgumentInfo* argInfo)
 {


### PR DESCRIPTION
CWE mapping of functionConst, functionStatic, initializerList, badBitmaskCheck, knownConditionTrueFalse, invalidTestForOverflow, unhandledExceptionSpecification, coutCerrMisusage,  invalidPrintfArgType_int.

functionConst, functionStatic, initializerList mapped to **Indicator of Poor Code Quality - (398)** without any doubt is a strong assignment but remember that proposal is to use CWE398 as the catch-all CWE case.  

50 issue to have the full mapping in release v1.75! 