### PR TITLE
CWE mapping of invalidLengthModifierError, leakUnsafeArgAlloc, nullPointerDefaultArg, nullPointerRedundantCheck, raceAfterInterlockedDecrement.

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -40,6 +40,7 @@ static const CWE CWE664(664U);  // Improper Control of a Resource Through its Li
 static const CWE CWE685(685U);  // Function Call With Incorrect Number of Arguments
 static const CWE CWE686(686U);  // Function Call With Incorrect Argument Type
 static const CWE CWE687(687U);  // Function Call With Incorrectly Specified Argument Value
+static const CWE CWE704(704U);	// Incorrect Type Conversion or Cast
 static const CWE CWE910(910U);  // Use of Expired File Descriptor
 
 //---------------------------------------------------------------------------
@@ -2019,7 +2020,7 @@ void CheckIO::invalidLengthModifierError(const Token* tok, unsigned int numForma
         return;
     std::ostringstream errmsg;
     errmsg << "'" << modifier << "' in format string (no. " << numFormat << ") is a length modifier and cannot be used without a conversion specifier.";
-    reportError(tok, Severity::warning, "invalidLengthModifierError", errmsg.str());
+    reportError(tok, Severity::warning, "invalidLengthModifierError", errmsg.str(), CWE704, false);
 }
 
 void CheckIO::invalidScanfFormatWidthError(const Token* tok, unsigned int numFormat, int width, const Variable *var, char c)

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -39,9 +39,10 @@ namespace {
 }
 
 // CWE ID used:
-static const CWE CWE398(398U);
-static const CWE CWE771(771U);
-static const CWE CWE772(772U);
+static const CWE CWE398(398U);	// Indicator of Poor Code Quality
+static const CWE CWE401(401U);	// Improper Release of Memory Before Removing Last Reference ('Memory Leak')
+static const CWE CWE771(771U);	// Missing Reference to Active Allocated Resource
+static const CWE CWE772(772U);	// Missing Release of Resource after Effective Lifetime
 
 /**
  * Count function parameters
@@ -2749,6 +2750,6 @@ void CheckMemoryLeakNoVar::unsafeArgAllocError(const Token *tok, const std::stri
     const std::string factoryFunc = ptrType == "shared_ptr" ? "make_shared" : "make_unique";
     reportError(tok, Severity::warning, "leakUnsafeArgAlloc",
                 "Unsafe allocation. If " + funcName + "() throws, memory could be leaked. Use " + factoryFunc + "<" + objType + ">() instead.",
-                CWE(0U),
+                CWE401,
                 true); // Inconclusive because funcName may never throw
 }

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -30,7 +30,7 @@ namespace {
     CheckNullPointer instance;
 }
 
-static const CWE CWE476(476U);
+static const CWE CWE476(476U);	// NULL Pointer Dereference
 
 //---------------------------------------------------------------------------
 
@@ -477,7 +477,7 @@ void CheckNullPointer::nullPointerError(const Token *tok, const std::string &var
 {
     if (defaultArg) {
         if (_settings->isEnabled("warning"))
-            reportError(tok, Severity::warning, "nullPointerDefaultArg", "Possible null pointer dereference if the default parameter value is used: " + varname, CWE(0U), inconclusive);
+            reportError(tok, Severity::warning, "nullPointerDefaultArg", "Possible null pointer dereference if the default parameter value is used: " + varname, CWE476, inconclusive);
     } else if (possible) {
         if (_settings->isEnabled("warning"))
             reportError(tok, Severity::warning, "nullPointer", "Possible null pointer dereference: " + varname, CWE476, inconclusive);
@@ -491,5 +491,5 @@ void CheckNullPointer::nullPointerError(const Token *tok, const std::string &var
     callstack.push_back(tok);
     callstack.push_back(nullCheck);
     const std::string errmsg(ValueFlow::eitherTheConditionIsRedundant(nullCheck) + " or there is possible null pointer dereference: " + varname + ".");
-    reportError(callstack, Severity::warning, "nullPointerRedundantCheck", errmsg, CWE(0U), inconclusive);
+    reportError(callstack, Severity::warning, "nullPointerRedundantCheck", errmsg, CWE476, inconclusive);
 }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -34,7 +34,8 @@ namespace {
 }
 
 static const struct CWE CWE197(197U);   // Numeric Truncation Error
-static const struct CWE CWE369(369U);
+static const struct CWE CWE362(362U);	// Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
+static const struct CWE CWE369(369U);	// Divide By Zero
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 static const struct CWE CWE475(475U);   // Undefined Behavior for Input to API
 static const struct CWE CWE561(561U);   // Dead Code
@@ -2554,7 +2555,7 @@ void CheckOther::checkInterlockedDecrement()
 void CheckOther::raceAfterInterlockedDecrementError(const Token* tok)
 {
     reportError(tok, Severity::error, "raceAfterInterlockedDecrement",
-                "Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.");
+                "Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.", CWE362, false);
 }
 
 void CheckOther::checkUnusedLabel()


### PR DESCRIPTION
CWE mapping of invalidLengthModifierError, leakUnsafeArgAlloc, nullPointerDefaultArg, nullPointerRedundantCheck, raceAfterInterlockedDecrement.