### PR TITLE
Pygments is a required package

### DIFF
--- a/htmlreport/requirements.txt
+++ b/htmlreport/requirements.txt
@@ -1,0 +1,1 @@
+Pygments

--- a/htmlreport/setup.py
+++ b/htmlreport/setup.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python
-from distutils.core import setup
 
-if __name__ == '__main__':
-    setup(
-        name="cppcheck",
-        scripts=[
-            "cppcheck-htmlreport",
-        ]
-    )
+from setuptools import setup
+
+with open('README.txt') as f:
+    readme = f.read()
+
+setup(
+    name="cppcheck",
+    description='Python script to parse the XML (version 2) output of '
+    + 'cppcheck and generate an HTML report using Pygments for syntax '
+    + 'highlighting.',
+    long_description=readme,
+    author='Henrik Nilsson',
+    url='https://github.com/danmar/cppcheck',
+    license='GPL',
+    scripts=[
+        "cppcheck-htmlreport",
+    ],
+    install_requires=['Pygments']
+)


### PR DESCRIPTION
I noticed for umpteenth time that I had forgotten to install Pygments before install cppcheck-htmlreport. I figured it was about time to fix the dependency in the setup.py. Please consider this pull request that adds the file requirements.text and changes the setup.py to have Pygments be an install requirement.