### PR TITLE
CWE mapping of useAutoPointerMalloc, uselessCallsCompare, uselessCallsSwap, uselessCallsSubstr, uselessCallsEmpty, uselessCallsRemove, derefInvalidIterator, reademptycontainer, multiplySizeof, divideSizeof, stringLiteralWrite, incorrectStringCompare, literalWithCharPtrCompare, charLiteralWithCharPtrCompare, incorrectStringBooleanError, staticStringCompare, stringCompare, signConversion, truncLongCastAssignment, truncLongCastReturn, unusedFunction, unusedVariable, unusedAllocatedMemory, unreadVariable, unassignedVariable, unusedStructMember, postfixOperator, va_start_wrongParameter

### DIFF
--- a/lib/checkpostfixoperator.cpp
+++ b/lib/checkpostfixoperator.cpp
@@ -32,6 +32,11 @@ namespace {
     CheckPostfixOperator instance;
 }
 
+
+// CWE ids used
+static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
+
+
 void CheckPostfixOperator::postfixOperator()
 {
     if (!_settings->isEnabled("performance"))
@@ -74,5 +79,5 @@ void CheckPostfixOperator::postfixOperatorError(const Token *tok)
                 "Pre-increment/decrement can be more efficient than "
                 "post-increment/decrement. Post-increment/decrement usually "
                 "involves keeping a copy of the previous value around and "
-                "adds a little extra code.");
+                "adds a little extra code.", CWE398, false);
 }

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -338,7 +338,7 @@ void CheckSizeof::suspiciousSizeofCalculation()
 void CheckSizeof::multiplySizeofError(const Token *tok)
 {
     reportError(tok, Severity::warning,
-                "multiplySizeof", "Multiplying sizeof() with sizeof() indicates a logic error.", CWE(0U), true);
+                "multiplySizeof", "Multiplying sizeof() with sizeof() indicates a logic error.", CWE682, true);
 }
 
 void CheckSizeof::divideSizeofError(const Token *tok)
@@ -346,7 +346,7 @@ void CheckSizeof::divideSizeofError(const Token *tok)
     reportError(tok, Severity::warning,
                 "divideSizeof", "Division of result of sizeof() on pointer type.\n"
                 "Division of result of sizeof() on pointer type. sizeof() returns the size of the pointer, "
-                "not the size of the memory area it points to.", CWE(0U), true);
+                "not the size of the memory area it points to.", CWE682, true);
 }
 
 void CheckSizeof::sizeofVoid()

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -30,9 +30,12 @@ namespace {
 // CWE IDs used:
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 static const struct CWE CWE597(597U);   // Use of Wrong Operator in String Comparison
+static const struct CWE CWE628(628U);   // Function Call with Incorrectly Specified Arguments
 static const struct CWE CWE664(664U);   // Improper Control of a Resource Through its Lifetime
 static const struct CWE CWE704(704U);   // Incorrect Type Conversion or Cast
+static const struct CWE CWE762(762U);   // Mismatched Memory Management Routines
 static const struct CWE CWE788(788U);   // Access of Memory Location After End of Buffer
+static const struct CWE CWE825(825U);   // Expired Pointer Dereference
 static const struct CWE CWE834(834U);   // Excessive Iteration
 
 // Error message for bad iterator usage..
@@ -1277,7 +1280,7 @@ void CheckStl::autoPointerMallocError(const Token *tok, const std::string& alloc
 {
     const std::string summary = "Object pointed by an 'auto_ptr' is destroyed using operator 'delete'. You should not use 'auto_ptr' for pointers obtained with function '" + allocFunction + "'.";
     const std::string verbose = summary + " This means that you should only use 'auto_ptr' for pointers obtained with operator 'new'. This excludes use C library allocation functions (for example '" + allocFunction + "'), which must be deallocated by the appropriate C library function.";
-    reportError(tok, Severity::error, "useAutoPointerMalloc", summary + "\n" + verbose);
+    reportError(tok, Severity::error, "useAutoPointerMalloc", summary + "\n" + verbose, CWE762, false);
 }
 
 namespace {
@@ -1341,7 +1344,7 @@ void CheckStl::uselessCallsReturnValueError(const Token *tok, const std::string 
            << "(" << varname << "." << function << "(" << varname << ")). As it is currently the "
            << "code is inefficient. It is possible either the string searched ('"
            << varname << "') or searched for ('" << varname << "') is wrong.";
-    reportError(tok, Severity::warning, "uselessCallsCompare", errmsg.str());
+    reportError(tok, Severity::warning, "uselessCallsCompare", errmsg.str(), CWE628, false);
 }
 
 void CheckStl::uselessCallsSwapError(const Token *tok, const std::string &varname)
@@ -1351,27 +1354,27 @@ void CheckStl::uselessCallsSwapError(const Token *tok, const std::string &varnam
            << "The 'swap()' function has no logical effect when given itself as parameter "
            << "(" << varname << ".swap(" << varname << ")). As it is currently the "
            << "code is inefficient. Is the object or the parameter wrong here?";
-    reportError(tok, Severity::performance, "uselessCallsSwap", errmsg.str());
+    reportError(tok, Severity::performance, "uselessCallsSwap", errmsg.str(), CWE628, false);
 }
 
 void CheckStl::uselessCallsSubstrError(const Token *tok, bool empty)
 {
     if (empty)
-        reportError(tok, Severity::performance, "uselessCallsSubstr", "Ineffective call of function 'substr' because it returns an empty string.");
+        reportError(tok, Severity::performance, "uselessCallsSubstr", "Ineffective call of function 'substr' because it returns an empty string.", CWE398, false);
     else
-        reportError(tok, Severity::performance, "uselessCallsSubstr", "Ineffective call of function 'substr' because it returns a copy of the object. Use operator= instead.");
+        reportError(tok, Severity::performance, "uselessCallsSubstr", "Ineffective call of function 'substr' because it returns a copy of the object. Use operator= instead.", CWE398, false);
 }
 
 void CheckStl::uselessCallsEmptyError(const Token *tok)
 {
-    reportError(tok, Severity::warning, "uselessCallsEmpty", "Ineffective call of function 'empty()'. Did you intend to call 'clear()' instead?");
+    reportError(tok, Severity::warning, "uselessCallsEmpty", "Ineffective call of function 'empty()'. Did you intend to call 'clear()' instead?", CWE398, false);
 }
 
 void CheckStl::uselessCallsRemoveError(const Token *tok, const std::string& function)
 {
     reportError(tok, Severity::warning, "uselessCallsRemove", "Return value of std::" + function + "() ignored. Elements remain in container.\n"
                 "The return value of std::" + function + "() is ignored. This function returns an iterator to the end of the range containing those elements that should be kept. "
-                "Elements past new end remain valid but with unspecified values. Use the erase method of the container to delete them.");
+                "Elements past new end remain valid but with unspecified values. Use the erase method of the container to delete them.", CWE762, false);
 }
 
 // Check for iterators being dereferenced before being checked for validity.
@@ -1442,7 +1445,7 @@ void CheckStl::dereferenceInvalidIteratorError(const Token* deref, const std::st
 {
     reportError(deref, Severity::warning,
                 "derefInvalidIterator", "Possible dereference of an invalid iterator: " + iterName + "\n" +
-                "Make sure to check that the iterator is valid before dereferencing it - not after.");
+                "Make sure to check that the iterator is valid before dereferencing it - not after.", CWE825, false);
 }
 
 
@@ -1557,5 +1560,5 @@ void CheckStl::readingEmptyStlContainer()
 
 void CheckStl::readingEmptyStlContainerError(const Token *tok)
 {
-    reportError(tok, Severity::style, "reademptycontainer", "Reading from empty STL container '" + (tok ? tok->str() : std::string("var")) + "'", CWE(0U), true);
+    reportError(tok, Severity::style, "reademptycontainer", "Reading from empty STL container '" + (tok ? tok->str() : std::string("var")) + "'", CWE398, true);
 }

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -34,7 +34,7 @@ static const struct CWE CWE571(571U);   // Expression is Always True
 static const struct CWE CWE595(595U);   // Comparison of Object References Instead of Object Contents
 static const struct CWE CWE628(628U);   // Function Call with Incorrectly Specified Arguments
 static const struct CWE CWE665(665U);   // Improper Initialization
-
+static const struct CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 
 //---------------------------------------------------------------------------
 // Writing string literal is UB
@@ -75,7 +75,7 @@ void CheckString::stringLiteralWriteError(const Token *tok, const Token *strValu
     }
     errmsg += " directly or indirectly is undefined behaviour.";
 
-    reportError(callstack, Severity::error, "stringLiteralWrite", errmsg);
+    reportError(callstack, Severity::error, "stringLiteralWrite", errmsg, CWE758, false);
 }
 
 //---------------------------------------------------------------------------

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -37,6 +37,7 @@ namespace {
 
 // CWE ids used:
 static const struct CWE CWE195(195U);   // Signed to Unsigned Conversion Error
+static const struct CWE CWE197(197U);   // Numeric Truncation Error
 static const struct CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 static const struct CWE CWE190(190U);   // Integer Overflow or Wraparound
 
@@ -290,7 +291,7 @@ void CheckType::longCastAssignError(const Token *tok)
                 Severity::style,
                 "truncLongCastAssignment",
                 "int result is assigned to long variable. If the variable is long to avoid loss of information, then you have loss of information.\n"
-                "int result is assigned to long variable. If the variable is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example 'l = a * b;' => 'l = (long)a * b;'.");
+                "int result is assigned to long variable. If the variable is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example 'l = a * b;' => 'l = (long)a * b;'.", CWE197, false);
 }
 
 void CheckType::longCastReturnError(const Token *tok)
@@ -299,5 +300,5 @@ void CheckType::longCastReturnError(const Token *tok)
                 Severity::style,
                 "truncLongCastReturn",
                 "int result is returned as long value. If the return value is long to avoid loss of information, then you have loss of information.\n"
-                "int result is returned as long value. If the return value is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example 'return a*b;' => 'return (long)a*b'.");
+                "int result is returned as long value. If the return value is long to avoid loss of information, then there is loss of information. To avoid loss of information you must cast a calculation operand to long, for example 'return a*b;' => 'return (long)a*b'.", CWE197, false);
 }

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -30,6 +30,7 @@ namespace {
 }
 
 static const struct CWE CWE563(563U);   // Assignment to Variable without Use ('Unused Variable')
+static const struct CWE CWE665(665U);   // Improper Initialization
 
 
 /**
@@ -1205,17 +1206,17 @@ void CheckUnusedVar::unusedVariableError(const Token *tok, const std::string &va
 
 void CheckUnusedVar::allocatedButUnusedVariableError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::style, "unusedAllocatedMemory", "Variable '" + varname + "' is allocated memory that is never used.");
+    reportError(tok, Severity::style, "unusedAllocatedMemory", "Variable '" + varname + "' is allocated memory that is never used.", CWE563, false);
 }
 
 void CheckUnusedVar::unreadVariableError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::style, "unreadVariable", "Variable '" + varname + "' is assigned a value that is never used.");
+    reportError(tok, Severity::style, "unreadVariable", "Variable '" + varname + "' is assigned a value that is never used.", CWE563, false);
 }
 
 void CheckUnusedVar::unassignedVariableError(const Token *tok, const std::string &varname)
 {
-    reportError(tok, Severity::style, "unassignedVariable", "Variable '" + varname + "' is not assigned a value.");
+    reportError(tok, Severity::style, "unassignedVariable", "Variable '" + varname + "' is not assigned a value.", CWE665, false);
 }
 
 //---------------------------------------------------------------------------
@@ -1302,7 +1303,7 @@ void CheckUnusedVar::checkStructMemberUsage()
 void CheckUnusedVar::unusedStructMemberError(const Token *tok, const std::string &structname, const std::string &varname, bool isUnion)
 {
     const char* prefix = isUnion ? "union member '" : "struct member '";
-    reportError(tok, Severity::style, "unusedStructMember", std::string(prefix) + structname + "::" + varname + "' is never used.");
+    reportError(tok, Severity::style, "unusedStructMember", std::string(prefix) + structname + "::" + varname + "' is never used.", CWE563, false);
 }
 
 bool CheckUnusedVar::isRecordTypeWithoutSideEffects(const Type* type)

--- a/lib/checkvaarg.cpp
+++ b/lib/checkvaarg.cpp
@@ -32,8 +32,9 @@ namespace {
 //---------------------------------------------------------------------------
 
 // CWE ids used:
-static const struct CWE CWE664(664U);
-static const struct CWE CWE758(758U);
+static const struct CWE CWE664(664U);   // Improper Control of a Resource Through its Lifetime
+static const struct CWE CWE688(688U);   // Function Call With Incorrect Variable or Reference as Argument
+static const struct CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 
 void CheckVaarg::va_start_argument()
 {
@@ -70,7 +71,7 @@ void CheckVaarg::va_start_argument()
 void CheckVaarg::wrongParameterTo_va_start_error(const Token *tok, const std::string& paramIsName, const std::string& paramShouldName)
 {
     reportError(tok, Severity::warning,
-                "va_start_wrongParameter", "'" + paramIsName + "' given to va_start() is not last named argument of the function. Did you intend to pass '" + paramShouldName + "'?");
+                "va_start_wrongParameter", "'" + paramIsName + "' given to va_start() is not last named argument of the function. Did you intend to pass '" + paramShouldName + "'?", CWE688, false);
 }
 
 void CheckVaarg::referenceAs_va_start_error(const Token *tok, const std::string& paramName)


### PR DESCRIPTION
CWE mapping of useAutoPointerMalloc, uselessCallsCompare, uselessCallsSwap, uselessCallsSubstr, uselessCallsEmpty, uselessCallsRemove, derefInvalidIterator, reademptycontainer, multiplySizeof, divideSizeof, stringLiteralWrite, incorrectStringCompare, literalWithCharPtrCompare, charLiteralWithCharPtrCompare, incorrectStringBooleanError, staticStringCompare, stringCompare, signConversion, truncLongCastAssignment, truncLongCastReturn, unusedFunction, unusedVariable, unusedAllocatedMemory, unreadVariable, unassignedVariable, unusedStructMember, postfixOperator, va_start_wrongParameter

This is the last commit to finishing the mapping. I'll go ahead and claim CWE compatibility with the MITRE. Please confirm I can. Please also give me the lead developer email so I can CC him while asking for the compatibility claim. 

Someone with access to the continuous integration system can modify the task and automate the following task:
1.  ./cppcheck --errorlist --xml-version=2 > errorlistInAFileSomeWhere.xml
2. ./tools/listErrorsWithoutCWE.py -F errorlist.xml
3. pipe the output and send me automatically the output by email at my private email ?

That will help me maintain updated the CWE mapping for new errors without have to waint for a new release each time. 

