### PR TITLE
Modified manpage to list CWE output and CWE version used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,9 @@ script:
   - make run-dmake
 #   now, if dmake modified the makefile, return false!
   - git diff --exit-code
+# check if all errors have a proper CWE and send email
+  - ./cppcheck --errorlist --xml-version=2 &> error-list.xml
+  - tools/listErrorsWithoutCWE.py -F error-list.xml | mail rmartelloni+cppcheck-cwe@gmail.com
 
 notifications:
   irc:

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -551,7 +551,7 @@ There are false positives with this option. Each result must be carefully invest
       <varlistentry>
         <term><option>--xml-version=&lt;version&gt;</option></term>
         <listitem>
-          <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1.</para>
+            <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1. Using version 2 each error will show the associate CWE using CWE dictionary version 2.9. You can find more information about CWE here: http://cwe.mitre.org/</para>
         </listitem>
       </varlistentry>
     </variablelist>


### PR DESCRIPTION
Per CWE requirement http://cwe.mitre.org/compatible/requirements.html#documentation we need to state in documentation that CWE is used and a briefly description.