### PR TITLE
Modified man page and listErrorsWithoutCWE.py teak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,9 @@ script:
 # check --dump
   - ./cppcheck test/testpreprocessor.cpp --dump
   - xmllint --noout test/testpreprocessor.cpp.dump
+# Send list of errors without a CWE 
+  - ./cppcheck --error-exitcode=1 --errorlist --xml-version=2 > errors.xml
+  - ./tools/listErrorsWithoutCWE.py -F errors.xml
 # check if Makefile needs to be regenerated
   - git clean -dfx
   - make dmake

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -551,7 +551,7 @@ There are false positives with this option. Each result must be carefully invest
       <varlistentry>
         <term><option>--xml-version=&lt;version&gt;</option></term>
         <listitem>
-          <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1.</para>
+            <para>Select the XML file version. Currently versions 1 and 2 are available. The default version is 1. With version 2, for each software weakness found by the tool, you also find the associated Common Weakness Enumeration (CWE) ID based on CWE dictionary version 2.9. You can find more information about CWE at http://cwe.mitre.org/ .</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/tools/listErrorsWithoutCWE.py
+++ b/tools/listErrorsWithoutCWE.py
@@ -1,20 +1,46 @@
 #!/usr/bin/python
-import argparse
-import xml.etree.ElementTree as ET
+
+try:
+    import argparse
+    import xml.etree.ElementTree as ET
+    import httplib
+    import urllib
+    import sys
+
+except ImportError as ImportErrorMsg:
+    print("Unable to find needed modules.: {}".format(ImportErrorMsg))
+    sys.exit(0)
 
 
 def main():
-
     parser = argparse.ArgumentParser(description="List all error without a CWE assigned in CSV format")
-    parser.add_argument("-F", metavar="filename", required=True, help="XML file containing output from: ./cppcheck --errorlist --xml-version=2")
+    parser.add_argument("-F", metavar="filename", required=True,
+                        help="XML file containing output from: ./cppcheck --errorlist --xml-version=2")
     parsed = parser.parse_args()
 
-    tree = ET.parse(vars(parsed)["F"])
-    root = tree.getroot()
-    for child in root.iter("error"):
+    try:
+        tree = ET.parse(vars(parsed)["F"])
+        root = tree.getroot()
+    except ET.ParseError as ETerrorMsg:
+        print("Unable to parse XML file {}: {}".format(vars(parsed)["F"], ETerrorMsg))
+        sys.exit(0)
 
-        if "cwe" not in child.attrib:
-            print child.attrib["id"], ",", child.attrib["severity"], ",", child.attrib["verbose"]
+    try:
+        lines = str()
+        for child in root.iter("error"):
+            if "cwe" not in child.attrib:
+                lines += ("{}, {}, {}".format(child.attrib["id"], child.attrib["severity"], child.attrib["verbose"] + "\n"))
+
+        params = urllib.urlencode({"data": lines})
+        headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+        conn = httplib.HTTPSConnection("usa.boos.core-dumped.info:443")
+        conn.request("POST", "/cgi-bin/cppcheck-cwe-mapping-check", params, headers)
+        conn.close()
+
+    except Exception:
+        print("Unable to parse XML file {}: {}".format(vars(parsed)["F"], error))
+        sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Modified man page to list how to turn on XML with CWE output.
- Send list of errors without CWE to the maintainer.
