### PR TITLE
Ticket #7680: Properly handle ::delete during memory leak checks.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -908,6 +908,9 @@ Token *CheckMemoryLeakInFunction::getcode(const Token *tok, std::list<const Toke
             }
 
             if (Token::Match(tok->previous(), "%op%|;|{|}|) ::| %name%") || (Token::Match(tok->previous(), "( ::| %name%") && (!rettail || rettail->str() != "loop"))) {
+                if (tok->str() == "::")
+                    tok = tok->next();
+
                 if (Token::Match(tok, "%varid% ?", varid))
                     tok = tok->tokAt(2);
 

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1048,7 +1048,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
         return tok->linkAt(1);
 
     if (tok->str() == "return" || !tok->previous() || Token::Match(tok, "%name% %op%|(|[|.|::|<|?|;") || Token::Match(tok->previous(), "[;{}] %cop%|++|--|( !!{")) {
-        if (cpp && Token::Match(tok->tokAt(-2), "[;{}] new|delete %name%"))
+        if (cpp && (Token::Match(tok->tokAt(-2), "[;{}] new|delete %name%") || Token::Match(tok->tokAt(-3), "[;{}] :: new|delete %name%")))
             tok = tok->previous();
 
         Token * const tok1 = tok;

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -365,6 +365,7 @@ private:
         TEST_CASE(gnucfg);
         TEST_CASE(trac3991);
         TEST_CASE(crash);
+        TEST_CASE(trac7680);
     }
 
     std::string getcode(const char code[], const char varname[], bool classfunc=false) {
@@ -3928,6 +3929,14 @@ private:
               "    ComponentDC *cdc = dynamic_cast<ComponentDC *>(childNode);\n"
               "    if (cdc)\n"
               "        ::Component *c = cdc->getComponent();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void trac7680() {
+        check("void foo() {\n"
+              "  int *i = ::new int;\n"
+              "  ::delete i;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
Using ::delete instead of delete confuses the memory leak checker, and this patch fixes this. Thanks to consider merging.