### PR TITLE
Ticket #7068: Treat "memset(&this->member, ..." as member initialization

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -628,6 +628,18 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
             return;
         }
 
+        // Ticket #7068
+        else if (Token::Match(ftok, "::| memset ( &| this . %name%")) {
+            if (ftok->str() == "::")
+                ftok = ftok->next();
+            int offsetToMember = 4;
+            if (ftok->tokAt(ftok->strAt(2) == "&"))
+                ++offsetToMember;
+            assignVar(ftok->tokAt(offsetToMember)->varId(), scope, usage);
+            ftok = ftok->linkAt(1);
+            continue;
+        }
+
         // Clearing array..
         else if (Token::Match(ftok, "::| memset ( %name% ,")) {
             if (ftok->str() == "::")

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -2807,6 +2807,48 @@ private:
               "};");
 
         ASSERT_EQUALS("", errout.str());
+
+        // Ticket #7068
+        check("struct Foo {\n"
+              "    int * p;\n"
+              "    char c;\n"
+              "    Foo() { memset(p, 0, sizeof(int)); }\n"
+              "};");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'Foo::c' is not initialized in the constructor.\n", errout.str());
+        check("struct Foo {\n"
+              "    int i;\n"
+              "    char c;\n"
+              "    Foo() { memset(&i, 0, sizeof(int)); }\n"
+              "};");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'Foo::c' is not initialized in the constructor.\n", errout.str());
+        check("struct Foo { int f; };\n"
+              "struct Bar { int b; };\n"
+              "struct FooBar {\n"
+              "  FooBar() {\n"
+              "     memset(&foo, 0, sizeof(foo));\n"
+              "  }\n"
+              "  Foo foo;\n"
+              "  Bar bar;\n"
+              "};\n"
+              "int main() {\n"
+              "  FooBar foobar;\n"
+              "  return foobar.foo.f + foobar.bar.b;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'FooBar::bar' is not initialized in the constructor.\n", errout.str());
+        check("struct Foo { int f; };\n"
+              "struct Bar { int b; };\n"
+              "struct FooBar {\n"
+              "  FooBar() {\n"
+              "     memset(&this->foo, 0, sizeof(this->foo));\n"
+              "  }\n"
+              "  Foo foo;\n"
+              "  Bar bar;\n"
+              "};\n"
+              "int main() {\n"
+              "  FooBar foobar;\n"
+              "  return foobar.foo.f + foobar.bar.b;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'FooBar::bar' is not initialized in the constructor.\n", errout.str());
     }
 
     void privateCtor1() {


### PR DESCRIPTION
This ticket highlights that a missing kind of member initialization in CheckClass::initializeVarList. This patch fix this.