### PR TITLE
readdir_r is deprecated in glibc 2.24

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -184,13 +184,12 @@ static void addFiles2(std::map<std::string, std::size_t> &files,
             if (!dir)
                 return;
 
-            dirent entry;
             dirent * dir_result;
 
             std::string new_path;
             new_path.reserve(path.length() + 100);// prealloc some memory to avoid constant new/deletes in loop
 
-            while ((readdir_r(dir, &entry, &dir_result) == 0) && (dir_result != NULL)) {
+            while ((dir_result = readdir(dir)) != NULL) {
 
                 if ((std::strcmp(dir_result->d_name, ".") == 0) ||
                     (std::strcmp(dir_result->d_name, "..") == 0))


### PR DESCRIPTION
Replace readdir_r with readdir since it has been marked for deprecation
since glibc 2.24.

See:
https://sourceware.org/ml/libc-alpha/2016-02/msg00093.html
https://womble.decadent.org.uk/readdir_r-advisory.html
