### PR TITLE
Fixes preprocessor regression causing hang

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -217,6 +217,10 @@ static std::string readcondition(const simplecpp::Token *iftok, const std::set<s
 
 static bool hasDefine(const std::string &userDefines, const std::string &cfg)
 {
+    if (cfg.empty()) {
+        return false;
+    }
+
     std::string::size_type pos = 0;
     while (pos < userDefines.size()) {
         pos = userDefines.find(cfg, pos);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -224,6 +224,7 @@ private:
         TEST_CASE(getConfigsU4);
         TEST_CASE(getConfigsU5);
         TEST_CASE(getConfigsU6);
+        TEST_CASE(getConfigsU7);
 
         TEST_CASE(validateCfg);
 
@@ -2120,6 +2121,14 @@ private:
         ASSERT_EQUALS("\nX=0\n", getConfigsStr(filedata, "-UX"));
         ASSERT_EQUALS("\nX=0\n", getConfigsStr(filedata));
     }
+
+    void getConfigsU7() {
+        const char code[] = "#ifndef Y\n"
+                            "#else\n"
+                            "#endif\n";
+        ASSERT_EQUALS("\nY\n", getConfigsStr(code, "-DX"));
+    }
+
 
     void validateCfg() {
         Settings settings;


### PR DESCRIPTION
Cppcheck 1.76 introduced a regression in preprocessor which causes
the following code to hang:

    $ cat > test.c << EOF
    #ifndef Y
    #else
    #endif
    EOF
    $ cppcheck -D BAR --force test.c
    Checking test.c ...
    ^C

This used to work with version 1.75. Git bisect reveals that this
regression was caused by commit:
ff036c8742e8f3a0a54d36dbbbb9845af7d22c53

This commit fixes the regression by avoiding infinite loop in
hasDefine(). If cfg is empty string "", we can skip the whole loop
and exit early.