### PR TITLE
cppcheck-gui: Add CFGDIR to the default list of library paths.

### DIFF
--- a/gui/erroritem.h
+++ b/gui/erroritem.h
@@ -76,7 +76,7 @@ public:
     QString message;
 };
 
-Q_DECLARE_METATYPE(ErrorItem);
+Q_DECLARE_METATYPE(ErrorItem)
 
 /**
 * @brief A class containing error data for one shown error line.

--- a/gui/librarydialog.cpp
+++ b/gui/librarydialog.cpp
@@ -96,7 +96,7 @@ void LibraryDialog::openCfg()
             ui->buttonSaveAs->setEnabled(true);
             ui->filter->clear();
             ui->functions->clear();
-            for (struct CppcheckLibraryData::Function &function : data.functions) {
+            for (CppcheckLibraryData::Function &function : data.functions) {
                 ui->functions->addItem(new FunctionListItem(ui->functions,
                                        &function,
                                        false));
@@ -246,7 +246,7 @@ void LibraryDialog::sortFunctions(bool sort)
         ignoreChanges = true;
         CppcheckLibraryData::Function *selfunction = currentFunction();
         ui->functions->clear();
-        for (struct CppcheckLibraryData::Function &function : data.functions) {
+        for (CppcheckLibraryData::Function &function : data.functions) {
             ui->functions->addItem(new FunctionListItem(ui->functions,
                                    &function,
                                    selfunction == &function));

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -645,6 +645,19 @@ Library::Error MainWindow::LoadLibrary(Library *library, QString filename)
     if (ret.errorcode != Library::ErrorCode::FILE_NOT_FOUND)
         return ret;
 
+#ifdef CFGDIR
+    // Try to load the library from CFGDIR..
+    const QString cfgdir = CFGDIR;
+    if (!cfgdir.isEmpty()) {
+        ret = library->load(NULL, (cfgdir+"/"+filename).toLatin1());
+        if (ret.errorcode != Library::ErrorCode::FILE_NOT_FOUND)
+            return ret;
+        ret = library->load(NULL, (cfgdir+"/cfg/"+filename).toLatin1());
+        if (ret.errorcode != Library::ErrorCode::FILE_NOT_FOUND)
+            return ret;
+    }
+#endif
+
     // Try to load the library from the cfg subfolder..
     const QString datadir = mSettings->value("DATADIR", QString()).toString();
     if (!datadir.isEmpty()) {

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -47,9 +47,16 @@ ProjectFileDialog::ProjectFileDialog(const QString &path, QWidget *parent)
     const QString applicationFilePath = QCoreApplication::applicationFilePath();
     const QString appPath = QFileInfo(applicationFilePath).canonicalPath();
     QSettings settings;
+#ifdef CFGDIR
+    const QString cfgdir = CFGDIR;
+#endif
     const QString datadir = settings.value("DATADIR",QString()).toString();
     QStringList searchPaths;
     searchPaths << appPath << appPath + "/cfg" << inf.canonicalPath();
+#ifdef CFGDIR
+    if (!cfgdir.isEmpty())
+        searchPaths << cfgdir << cfgdir + "/cfg";
+#endif
     if (!datadir.isEmpty())
         searchPaths << datadir << datadir + "/cfg";
     QStringList libs;

--- a/gui/translationhandler.cpp
+++ b/gui/translationhandler.cpp
@@ -127,7 +127,6 @@ bool TranslationHandler::SetLanguage(const QString &code)
         translationFile = appPath + "/" + mTranslations[index].mFilename + ".qm";
 
     if (!mTranslator->load(translationFile) && !failure) {
-        translationFile += ".qm";
         //If it failed, lets check if the default file exists
         if (!QFile::exists(translationFile)) {
             error = QObject::tr("Language file %1 not found!");


### PR DESCRIPTION
For a long time, cppcheck-gui on Gentoo (and possibly other distros) hasn't been able to find the path to the standard library configurations. It turns out that cppcheck-gui doesn't check CFGDIR; instead, it expects you to manually set the DATADIR variable in the configuration file by running `cppcheck --data-dir=DATADIR`. This isn't very intuitive, and it should "just work" out of the box.

This pull request adds CFGDIR to the default list of paths to check if it was defined during the build.

Other changes:
- Don't add ".qm" to the translation filename when it already ends in ".qm".
- Small set of warning fixes.
