### PR TITLE
Function parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ endif
 $(SRCDIR)/analyzerinfo.o: lib/analyzerinfo.cpp lib/cxx11emu.h lib/analyzerinfo.h lib/config.h lib/errorlogger.h lib/suppressions.h lib/path.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CFG) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o $(SRCDIR)/analyzerinfo.o $(SRCDIR)/analyzerinfo.cpp
 
-$(SRCDIR)/astutils.o: lib/astutils.cpp lib/cxx11emu.h lib/astutils.h lib/symboldatabase.h lib/config.h lib/token.h lib/valueflow.h lib/mathlib.h lib/tokenize.h lib/errorlogger.h lib/suppressions.h lib/tokenlist.h
+$(SRCDIR)/astutils.o: lib/astutils.cpp lib/cxx11emu.h lib/astutils.h lib/settings.h lib/config.h lib/library.h lib/mathlib.h lib/standards.h lib/errorlogger.h lib/suppressions.h lib/platform.h lib/importproject.h lib/timer.h lib/symboldatabase.h lib/token.h lib/valueflow.h lib/tokenize.h lib/tokenlist.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CFG) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o $(SRCDIR)/astutils.o $(SRCDIR)/astutils.cpp
 
 $(SRCDIR)/check.o: lib/check.cpp lib/cxx11emu.h lib/check.h lib/config.h lib/token.h lib/valueflow.h lib/mathlib.h lib/tokenize.h lib/errorlogger.h lib/suppressions.h lib/tokenlist.h lib/settings.h lib/library.h lib/standards.h lib/platform.h lib/importproject.h lib/timer.h

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -25,6 +25,7 @@
 #include <set>
 #include <string>
 
+class Settings;
 class Token;
 
 /** Is expression a 'signed char' if no promotion is used */
@@ -71,8 +72,18 @@ bool isWithoutSideEffects(bool cpp, const Token* tok);
 /** Is scope a return scope (scope will unconditionally return) */
 bool isReturnScope(const Token *endToken);
 
+/** Is variable changed by function call?
+ * In case the anser of the question is inconclusive, e.g. because the function declaration is not known
+ * the return value is false and the output parameter inconclusive is set to true
+ *
+ * @param tok           token of varible in function call
+ * @param settings      program settings
+ * @param inconclusive pointer to output variable which indicates that the answer of the question is inconclusive
+ */
+bool isVariableChangedByFunctionCall(const Token *tok, const Settings *settings, bool *inconclusive);
+
 /** Is variable changed in block of code? */
-bool isVariableChanged(const Token *start, const Token *end, const unsigned int varid);
+bool isVariableChanged(const Token *start, const Token *end, const unsigned int varid, const Settings *settings);
 
 /** Determines the number of arguments - if token is a function call or macro
  * @param start token which is supposed to be the function/macro name.

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -151,7 +151,7 @@ bool CheckCondition::assignIfParseScope(const Token * const assignTok,
                 // is variable changed in loop?
                 const Token *bodyStart = tok2->linkAt(1)->next();
                 const Token *bodyEnd   = bodyStart ? bodyStart->link() : nullptr;
-                if (!bodyEnd || bodyEnd->str() != "}" || isVariableChanged(bodyStart, bodyEnd, varid))
+                if (!bodyEnd || bodyEnd->str() != "}" || isVariableChanged(bodyStart, bodyEnd, varid, _settings))
                     continue;
             }
 

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -77,11 +77,7 @@ namespace ValueFlow {
             /** This value is possible, other unlisted values may also be possible */
             Possible,
             /** Only listed values are possible */
-            Known,
-            /** Max value. Greater values are impossible. */
-            Max,
-            /** Min value. Smaller values are impossible. */
-            Min
+            Known
         } valueKind;
 
         void setKnown() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -193,6 +193,26 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
+        check("void g(int x);\n"
+              "void f(int x) {\n"
+              "    int a = 100;\n"
+              "    while (x) {\n"
+              "        int y = 16 | a;\n"
+              "        while (y != 0) g(y);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:6]: (style) Condition 'y!=0' is always true\n[test.cpp:5] -> [test.cpp:6]: (style) Mismatching assignment and comparison, comparison 'y!=0' is always true.\n", errout.str());
+
+        check("void g(int &x);\n"
+              "void f(int x) {\n"
+              "    int a = 100;\n"
+              "    while (x) {\n"
+              "        int y = 16 | a;\n"
+              "        while (y != 0) g(y);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
         // calling function
         check("void f(int x) {\n"
               "    int y = x & 7;\n"
@@ -293,6 +313,33 @@ private:
               "  }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    int x = 100;\n"
+              "    while (x) {\n"
+              "        g(x);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void g(int x);\n"
+              "void f() {\n"
+              "    int x = 100;\n"
+              "    while (x) {\n"
+              "        g(x);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void g(int & x);\n"
+              "void f() {\n"
+              "    int x = 100;\n"
+              "    while (x) {\n"
+              "        g(x);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
     }
 
     void mismatchingBitAnd() {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2503,7 +2503,7 @@ private:
 
     void ticket6505() {
         check("void foo(MythSocket *socket) {\n"
-              "  bool do_write=false;\n"
+              "  bool do_write=0;\n"
               "  if (socket) {\n"
               "    do_write=something();\n"
               "  }\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -1865,6 +1865,34 @@ private:
                "}\n";
         ASSERT(isNotKnownValues(code, "<"));
 
+        code = "void dostuff(int x);\n"
+               "void f() {\n"
+               "  int x = 0;\n"
+               "  dostuff(x);\n"
+               "  if (x < 0) {}\n"
+               "}\n";
+        value = valueOfTok(code, "<");
+        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT(value.isKnown());
+
+        code = "void dostuff(int & x);\n"
+               "void f() {\n"
+               "  int x = 0;\n"
+               "  dostuff(x);\n"
+               "  if (x < 0) {}\n"
+               "}\n";
+        ASSERT(isNotKnownValues(code, "<"));
+
+        code = "void dostuff(const int & x);\n"
+               "void f() {\n"
+               "  int x = 0;\n"
+               "  dostuff(x);\n"
+               "  if (x < 0) {}\n"
+               "}\n";
+        value = valueOfTok(code, "<");
+        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT(value.isKnown());
+
         code = "void f() {\n"
                "  int x = 0;\n"
                "  do {\n"


### PR DESCRIPTION
In astutils::isVariableChanged there is a comment "TODO: check if function parameter is const".
I want to put the following changes under discussion by this pull request.

This pull request removes the TODO by having a common function astutils::isVariableChangedByFunctionCall.
The algorithm used is the one from valueflow::bailoutFunctionPar (which handles const parameters correctly).

With this pull request astutils::isVariableChangedByFunctionCall is used in valueflow, too.

(As a minor change it contains a commit which removes the unused ValueKind::Min and ValueKind::Max.)

The question is know if the naming of the function isVariableChangedByFunctionCall is OK and if the location for this function in astutils is OK.
