### PR TITLE
Fix cppcheck warning (instead of suppressing it)

### DIFF
--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -7,8 +7,6 @@ passedByValue:lib/symboldatabase.h
 passedByValue:lib/library.h
 knownConditionTrueFalse:lib/platform.cpp
 knownConditionTrueFalse:build/*
-useInitializationList:lib/errorlogger.cpp
-useInitializationList:build/errorlogger.cpp
 
 *:gui/test*
 *:test/test.cxx


### PR DESCRIPTION
This pull request fixes the code according to the warning about lib/errorlogger.cpp given by cppcheck instead of suppressing it.

(Note: I have not tested the code.)