### PR TITLE
Fix #7789 (Missing error messages in repeated check on compile_comman…

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -84,7 +84,7 @@ unsigned int CppCheck::check(const std::string &path, const std::string &content
 
 unsigned int CppCheck::check(const ImportProject::FileSettings &fs)
 {
-    CppCheck temp(*this, _useGlobalSuppressions);
+    CppCheck temp(_errorLogger, _useGlobalSuppressions);
     temp._settings = _settings;
     temp._settings.userDefines = fs.defines;
     temp._settings.includePaths = fs.includePaths;


### PR DESCRIPTION
…ds.json in cppcheck-gui)

The problem is that in ```CppCheck::check``` during the call of ```temp.processFile``` the error list ```temp._errorList``` is cleared. However the error list of ```this``` is not cleaned. This has the effect that the error list of ```this``` is also used for subsequent calls of ```CppCheck::check``` to filter duplicated error messages.

What exactly is the purpose of them temporary ```CppCheck``` instance ```temp``` inside ```CppCheck::check```?

If its only purpose is not to overwrite the global settings the fix of this pull request solves the problem.
