### PR TITLE
Fix #6180 (Usage of variable after std::move or std::forward)

### DIFF
--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -94,6 +94,7 @@ public:
         checkOther.checkRedundantCopy();
         checkOther.checkSuspiciousEqualityComparison();
         checkOther.checkComparisonFunctionIsAlwaysTrueOrFalse();
+        checkOther.checkAccessOfMovedVariable();
     }
 
     /** @brief Clarify calculation for ".. a * b ? .." */
@@ -203,6 +204,9 @@ public:
     /** @brief %Check for expression that depends on order of evaluation of side effects */
     void checkEvaluationOrder();
 
+    /** @brief %Check for access of moved or forwarded variable */
+    void checkAccessOfMovedVariable();
+
 private:
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &strFunctionName, const std::string &varName, const bool result);
@@ -252,6 +256,8 @@ private:
     void raceAfterInterlockedDecrementError(const Token* tok);
     void unusedLabelError(const Token* tok, bool inSwitch);
     void unknownEvaluationOrder(const Token* tok);
+    static bool isMovedParameterAllowedForInconclusiveFunction(const Token * tok);
+    void accessMovedError(const Token *tok, const std::string &varname, ValueFlow::Value::MoveKind moveKind, bool inconclusive);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const {
         CheckOther c(nullptr, settings, errorLogger);
@@ -308,6 +314,8 @@ private:
         c.unusedLabelError(nullptr,  true);
         c.unusedLabelError(nullptr,  false);
         c.unknownEvaluationOrder(nullptr);
+        c.accessMovedError(nullptr, "v", ValueFlow::Value::MovedVariable, false);
+        c.accessMovedError(nullptr, "v", ValueFlow::Value::ForwardedVariable, false);
     }
 
     static std::string myName() {
@@ -331,6 +339,7 @@ private:
                // warning
                "- either division by zero or useless condition\n"
                "- memset() with a value out of range as the 2nd parameter\n"
+               "- access of moved or forwarded variable.\n"
 
                // performance
                "- redundant data copying for const variable\n"

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -31,10 +31,10 @@
  */
 struct Standards {
     /** C code C89/C99/C11 standard */
-    enum cstd_t { C89, C99, C11 } c;
+    enum cstd_t { C89, C99, C11, CLatest=C11 } c;
 
     /** C++ code standard */
-    enum cppstd_t { CPP03, CPP11 } cpp;
+    enum cppstd_t { CPP03, CPP11, CPPLatest=CPP11 } cpp;
 
     /** Code is posix */
     bool posix;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1838,6 +1838,15 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
     return false;
 }
 
+const Token * Function::constructorMemberInitialization() const
+{
+    if (!isConstructor() || !functionScope || !functionScope->classStart)
+        return nullptr;
+    if (Token::Match(token, "%name% (") && Token::simpleMatch(token->linkAt(1), ") :"))
+        return token->linkAt(1)->next();
+    return nullptr;
+}
+
 Function* SymbolDatabase::addGlobalFunction(Scope*& scope, const Token*& tok, const Token *argStart, const Token* funcStart)
 {
     Function* function = nullptr;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -857,6 +857,12 @@ public:
 
     static bool argsMatch(const Scope *info, const Token *first, const Token *second, const std::string &path, unsigned int depth);
 
+    /**
+     * @return token to ":" if the function is a constructor
+     * and it contains member initialization otherwise a nullptr is returned
+     */
+    const Token * constructorMemberInitialization() const;
+
 private:
     bool isImplicitlyVirtual_rec(const ::Type* baseType, bool& safe) const;
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1335,6 +1335,9 @@ void Token::printValueFlow(bool xml, std::ostream &out) const
                 case ValueFlow::Value::FLOAT:
                     out << "floatvalue=\"" << it->floatValue << '\"';
                     break;
+                case ValueFlow::Value::MOVED:
+                    out << "movedvalue=\"" << ValueFlow::Value::toString(it->moveKind) << '\"';
+                    break;
                 }
                 if (it->condition)
                     out << " condition-line=\"" << it->condition->linenr() << '\"';
@@ -1357,6 +1360,9 @@ void Token::printValueFlow(bool xml, std::ostream &out) const
                     break;
                 case ValueFlow::Value::FLOAT:
                     out << it->floatValue;
+                    break;
+                case ValueFlow::Value::MOVED:
+                    out << ValueFlow::Value::toString(it->moveKind);
                     break;
                 }
             }

--- a/lib/token.h
+++ b/lib/token.h
@@ -774,6 +774,15 @@ public:
         return ret;
     }
 
+    const ValueFlow::Value * getMovedValue() const {
+        std::list<ValueFlow::Value>::const_iterator it;
+        for (it = values.begin(); it != values.end(); ++it) {
+            if (it->isMovedValue())
+                return &(*it);
+        }
+        return nullptr;
+    }
+
     const ValueFlow::Value * getValueLE(const MathLib::bigint val, const Settings *settings) const;
     const ValueFlow::Value * getValueGE(const MathLib::bigint val, const Settings *settings) const;
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1811,9 +1811,15 @@ static void valueFlowAfterAssign(TokenList *tokenlist, SymbolDatabase* symboldat
                 start = memberInitializationTok;
         }
 
+        const Token * isInForCondition = nullptr;   // if in for condition then pointer to end of for condition
         for (Token* tok = const_cast<Token*>(start); tok != scope->classEnd; tok = tok->next()) {
+            if (tok == isInForCondition)
+                isInForCondition = nullptr;
+            if (Token::simpleMatch(tok, "for ("))
+                isInForCondition = tok->linkAt(1);
             if (tok->str() != "=" || tok->astParent())
                 continue;
+
             // Lhs should be a variable
             if (!tok->astOperand1() || !tok->astOperand1()->varId())
                 continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1286,7 +1286,7 @@ static bool valueFlowForward(Token * const               startToken,
         }
 
         // conditional block of code that assigns variable..
-        else if (Token::Match(tok2, "%name% (") && Token::simpleMatch(tok2->linkAt(1), ") {")) {
+        else if (!tok2->varId() && Token::Match(tok2, "%name% (") && Token::simpleMatch(tok2->linkAt(1), ") {")) {
             // is variable changed in condition?
             if (isVariableChanged(tok2->next(), tok2->next()->link(), varid, settings)) {
                 if (settings->debugwarnings)
@@ -1675,6 +1675,19 @@ static bool valueFlowForward(Token * const               startToken,
                     it->changeKnownToPossible();
                 }
             }
+            if (tok2->strAt(1) == "." && tok2->next()->originalName() != "->") {
+                if (settings->inconclusive) {
+                    std::list<ValueFlow::Value>::iterator it;
+                    for (it = values.begin(); it != values.end(); ++it) {
+                        it->inconclusive = true;
+                        it->changeKnownToPossible();
+                    }
+                } else {
+                    if (settings->debugwarnings)
+                        bailout(tokenlist, errorLogger, tok2, "possible assignment of " + tok2->str() + " by member function");
+                    return false;
+                }
+            }
         }
 
         // Lambda function
@@ -1692,16 +1705,115 @@ static bool valueFlowForward(Token * const               startToken,
     return true;
 }
 
+static bool isStdMoveOrStdForwarded(Token * tok, ValueFlow::Value::MoveKind * moveKind, Token ** varTok = nullptr)
+{
+    if (tok->str() != "std")
+        return false;
+    bool isMovedOrForwarded = false;
+    ValueFlow::Value::MoveKind kind = ValueFlow::Value::MovedVariable;
+    Token * variableToken = nullptr;
+    if (Token::Match(tok, "std :: move ( %var% )")) {
+        variableToken = tok->tokAt(4);
+        isMovedOrForwarded = true;
+        kind = ValueFlow::Value::MovedVariable;
+    } else if (Token::simpleMatch(tok, "std :: forward <")) {
+        Token * leftAngle = tok->tokAt(3);
+        Token * rightAngle = leftAngle->link();
+        if (Token::Match(rightAngle, "> ( %var% )")) {
+            variableToken = rightAngle->tokAt(2);
+            isMovedOrForwarded = true;
+            kind = ValueFlow::Value::ForwardedVariable;
+        }
+    }
+    if (!isMovedOrForwarded)
+        return false;
+    if (variableToken->strAt(2) == ".") // Only partially moved
+        return false;
+
+    if (moveKind != nullptr)
+        *moveKind = kind;
+    if (varTok != nullptr)
+        *varTok = variableToken;
+    return true;
+}
+
+static void valueFlowAfterMove(TokenList *tokenlist, SymbolDatabase* symboldatabase, ErrorLogger *errorLogger, const Settings *settings)
+{
+    bool isAtLeastCpp11 = tokenlist->isCPP() && settings->standards.cpp >= Standards::CPP11;
+    if (!isAtLeastCpp11)
+        return;
+    const std::size_t functions = symboldatabase->functionScopes.size();
+    for (std::size_t i = 0; i < functions; ++i) {
+        const Scope * scope = symboldatabase->functionScopes[i];
+        if (!scope)
+            continue;
+        const Token * start = scope->classStart;
+        if (scope->function) {
+            const Token * memberInitializationTok = scope->function->constructorMemberInitialization();
+            if (memberInitializationTok)
+                start = memberInitializationTok;
+        }
+
+        for (Token* tok = const_cast<Token*>(start); tok != scope->classEnd; tok = tok->next()) {
+            Token * varTok;
+            ValueFlow::Value::MoveKind moveKind;
+            if (!isStdMoveOrStdForwarded(tok, &moveKind, &varTok))
+                continue;
+            // x is not MOVED after assignment if code is:  x = ... std::move(x) .. ;
+            const Token *parent = tok->astParent();
+            while (parent && parent->str() != "=" && parent->str() != "return")
+                parent = parent->astParent();
+            if (parent && parent->str() == "return") // MOVED in return statement
+                continue;
+            if (parent && parent->astOperand1()->str() == varTok->str())
+                continue;
+            const unsigned int varid = varTok->varId();
+            const Variable *var = varTok->variable();
+            if (!var)
+                continue;
+            const Token * const endOfVarScope = var->typeStartToken()->scope()->classEnd;
+
+            ValueFlow::Value value;
+            value.valueType = ValueFlow::Value::MOVED;
+            value.moveKind = moveKind;
+            value.setKnown();
+            std::list<ValueFlow::Value> values;
+            values.push_back(value);
+
+            valueFlowForward(varTok->next(), endOfVarScope, var, varid, values, false, tokenlist, errorLogger, settings);
+        }
+    }
+}
+
+static const Token * nextAfterAstRightmostLeaf(Token const * tok)
+{
+    const Token * rightmostLeaf = tok;
+    if (!rightmostLeaf || !rightmostLeaf->astOperand1())
+        return nullptr;
+    do {
+        if (rightmostLeaf->astOperand2())
+            rightmostLeaf = rightmostLeaf->astOperand2();
+        else
+            rightmostLeaf = rightmostLeaf->astOperand1();
+    } while (rightmostLeaf->astOperand1());
+    return rightmostLeaf->next();
+}
+
 static void valueFlowAfterAssign(TokenList *tokenlist, SymbolDatabase* symboldatabase, ErrorLogger *errorLogger, const Settings *settings)
 {
     const std::size_t functions = symboldatabase->functionScopes.size();
     for (std::size_t i = 0; i < functions; ++i) {
         const Scope * scope = symboldatabase->functionScopes[i];
-        for (Token* tok = const_cast<Token*>(scope->classStart); tok != scope->classEnd; tok = tok->next()) {
-            // Assignment
-            if ((tok->str() != "=") || (tok->astParent()))
-                continue;
+        const Token * start = scope->classStart;
+        if (scope->function) {
+            const Token * memberInitializationTok = scope->function->constructorMemberInitialization();
+            if (memberInitializationTok)
+                start = memberInitializationTok;
+        }
 
+        for (Token* tok = const_cast<Token*>(start); tok != scope->classEnd; tok = tok->next()) {
+            if (tok->str() != "=" || tok->astParent())
+                continue;
             // Lhs should be a variable
             if (!tok->astOperand1() || !tok->astOperand1()->varId())
                 continue;
@@ -1727,17 +1839,9 @@ static void valueFlowAfterAssign(TokenList *tokenlist, SymbolDatabase* symboldat
             }
 
             // Skip RHS
-            const Token *nextExpression = tok->astOperand2();
-            for (;;) {
-                if (nextExpression->astOperand2())
-                    nextExpression = nextExpression->astOperand2();
-                else if (nextExpression->isUnaryPreOp())
-                    nextExpression = nextExpression->astOperand1();
-                else break;
-            }
-            nextExpression = nextExpression->next();
+            const Token * tokEndOfAssignment = nextAfterAstRightmostLeaf(tok);
 
-            valueFlowForward(const_cast<Token *>(nextExpression), endOfVarScope, var, varid, values, constValue, tokenlist, errorLogger, settings);
+            valueFlowForward(const_cast<Token *>(tokEndOfAssignment), endOfVarScope, var, varid, values, constValue, tokenlist, errorLogger, settings);
         }
     }
 }
@@ -2625,6 +2729,7 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
     valueFlowOppositeCondition(symboldatabase, settings);
     valueFlowForLoop(tokenlist, symboldatabase, errorLogger, settings);
     valueFlowBeforeCondition(tokenlist, symboldatabase, errorLogger, settings);
+    valueFlowAfterMove(tokenlist, symboldatabase, errorLogger, settings);
     valueFlowAfterAssign(tokenlist, symboldatabase, errorLogger, settings);
     valueFlowAfterCondition(tokenlist, symboldatabase, errorLogger, settings);
     valueFlowSwitchVariable(tokenlist, symboldatabase, errorLogger, settings);

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -33,8 +33,8 @@ class Settings;
 namespace ValueFlow {
     class CPPCHECKLIB Value {
     public:
-        explicit Value(long long val = 0) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), varvalue(val), condition(0), varId(0U), conditional(false), inconclusive(false), defaultArg(false), valueKind(ValueKind::Possible) {}
-        Value(const Token *c, long long val) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), varvalue(val), condition(c), varId(0U), conditional(false), inconclusive(false), defaultArg(false), valueKind(ValueKind::Possible) {}
+        explicit Value(long long val = 0) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), moveKind(MovedVariable), varvalue(val), condition(0), varId(0U), conditional(false), inconclusive(false), defaultArg(false), valueKind(ValueKind::Possible) {}
+        Value(const Token *c, long long val) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), moveKind(MovedVariable), varvalue(val), condition(c), varId(0U), conditional(false), inconclusive(false), defaultArg(false), valueKind(ValueKind::Possible) {}
 
         bool operator==(const Value &rhs) const {
             if (valueType != rhs.valueType)
@@ -53,6 +53,10 @@ namespace ValueFlow {
                 if (floatValue > rhs.floatValue || floatValue < rhs.floatValue)
                     return false;
                 break;
+            case MOVED:
+                if (moveKind != rhs.moveKind)
+                    return false;
+                break;
             };
 
             return varvalue == rhs.varvalue &&
@@ -64,7 +68,7 @@ namespace ValueFlow {
                    valueKind == rhs.valueKind;
         }
 
-        enum ValueType { INT, TOK, FLOAT } valueType;
+        enum ValueType { INT, TOK, FLOAT, MOVED } valueType;
         bool isIntValue() const {
             return valueType == INT;
         }
@@ -73,6 +77,9 @@ namespace ValueFlow {
         }
         bool isFloatValue() const {
             return valueType == FLOAT;
+        }
+        bool isMovedValue() const {
+            return valueType == MOVED;
         }
 
         /** int value */
@@ -83,6 +90,9 @@ namespace ValueFlow {
 
         /** float value */
         double floatValue;
+
+        /** kind of moved  */
+        enum MoveKind {MovedVariable, ForwardedVariable} moveKind;
 
         /** For calculated values - variable value that calculated value depends on */
         long long varvalue;
@@ -101,6 +111,16 @@ namespace ValueFlow {
 
         /** Is this value passed as default parameter to the function? */
         bool defaultArg;
+
+        static const char * toString(MoveKind moveKind) {
+            switch (moveKind) {
+            case MovedVariable:
+                return "MovedVariable";
+            case ForwardedVariable:
+                return "ForwardedVariable";
+            }
+            return "";
+        }
 
         /** How known is this value */
         enum ValueKind {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -187,6 +187,7 @@ private:
         TEST_CASE(moveAndClear);
         TEST_CASE(movedPointer);
         TEST_CASE(partiallyMoved);
+        TEST_CASE(moveAndLambda);
         TEST_CASE(forwardAndUsed);
     }
 
@@ -6254,6 +6255,15 @@ private:
               "    A a;\n"
               "    gx(std::move(a).x());\n"
               "    gy(std::move(a).y());\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void moveAndLambda() {
+        check("void f() {\n"
+              "    A a;\n"
+              "    auto h = [a=std::move(a)](){return g(std::move(a));};"
+              "    b = a;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
I want to put this pull request under discussion.
It is a first version and there are still open questions.

The proposed version finds access of moved or forwarded variables.

Some examples can be seen in test/testmove.cpp.

Furthermore I want to discuss the outcome at some real world code, i.e. facebook/folly.
In folly the developers have a lot of test whether the result of a moved variable has the expected results after the move. This is OK for tests but in ordinary code a user should not rely on the outcome of a moved variable.
``` c++
TEST(small_vector, NonCopyableType) {
  folly::small_vector<NontrivialType,2> vec;

  for (int i = 0; i < 10; ++i) {
    vec.emplace(vec.begin(), 13);
  }
  EXPECT_EQ(vec.size(), 10);
  auto vec2 = std::move(vec);
  EXPECT_EQ(vec.size(), 0);				// <- Access of moved variable vec.
  EXPECT_EQ(vec2.size(), 10);
  vec2.clear();

  folly::small_vector<NoncopyableCounter,3> vec3;
  for (int i = 0; i < 10; ++i) {
    EXPECT_EQ(vec3.size(), i);
    EXPECT_EQ(NoncopyableCounter::alive, i);
    vec3.insert(vec3.begin(), NoncopyableCounter());
  }
  EXPECT_EQ(vec3.size(), 10);
  EXPECT_EQ(NoncopyableCounter::alive, 10);

  vec3.insert(vec3.begin() + 3, NoncopyableCounter());
  EXPECT_EQ(NoncopyableCounter::alive, 11);
  auto vec4 = std::move(vec3);
  EXPECT_EQ(NoncopyableCounter::alive, 11);
  vec4.resize(30);
  EXPECT_EQ(NoncopyableCounter::alive, 30);
  vec4.erase(vec4.begin(), vec4.end());
  EXPECT_EQ(vec4.size(), 0);
  EXPECT_EQ(NoncopyableCounter::alive, 0);
}
```

Another example is the following. Also here one can see a test of the variable after it has been moved. Additionally, there is a the assign of the vector. The proposed commit does not know that by the assign function the vector is totally overwritten independent of its content.
``` c++
TEST(fbvector, move_construction) {
  fbvector<int> v1(100, 100);
  fbvector<int> v2;
  EXPECT_EQ(v1.size(), 100);
  EXPECT_EQ(v1.front(), 100);
  EXPECT_EQ(v2.size(), 0);
  v2 = std::move(v1);
  EXPECT_EQ(v1.size(), 0);			// <- Access of moved variable v1.
  EXPECT_EQ(v2.size(), 100);
  EXPECT_EQ(v2.front(), 100);

  v1.assign(100, 100);				// <- Access of moved variable v1.
  auto other = std::move(v1);			// <- Access of moved variable v1.
  EXPECT_EQ(v1.size(), 0);
  EXPECT_EQ(other.size(), 100);
  EXPECT_EQ(other.front(), 100);
}
```
There are a lot of error messages to code like this in folly.

Now follows two really strange examples (which work in folly only due to the special usage of the functions).

``` c++
template<class C>
void testRangeFunc(C&& x, size_t n) {
  const auto& cx = x;
  // type, conversion checks
  Range<int*> r1 = range(std::forward<C>(x));
  Range<const int*> r2 = range(std::forward<C>(x));   // <- Access of moved variable x.
  Range<const int*> r3 = range(cx);                   // <- Access of moved variable x.
  Range<const int*> r5 = range(std::move(cx));        // <- Access of moved variable x.
  EXPECT_EQ(r1.begin(), dataPtr(x));
  EXPECT_EQ(r1.end(), dataPtr(x) + n);
  EXPECT_EQ(n, r1.size());
  EXPECT_EQ(n, r2.size());
  EXPECT_EQ(n, r3.size());
  EXPECT_EQ(n, r5.size());
}
```
``` c++
template<class F, class Tuple>
struct GuardObj : GuardObjBase {
  explicit GuardObj(F&& f, Tuple&& args)
    : f_(std::forward<F>(f))
    , args_(std::forward<Tuple>(args))
  {}
  GuardObj(GuardObj&& g) noexcept
    : GuardObjBase(std::move(g))
    , f_(std::move(g.f_))				// <- Access of moved variable g.
    , args_(std::move(g.args_))				// <- Access of moved variable g.
  {}

  ~GuardObj() {
    folly::applyTuple(f_, args_);
  }

  GuardObj(const GuardObj&) = delete;
  GuardObj& operator=(const GuardObj&) = delete;

private:
  F f_;
  Tuple args_;
};
```

Finally, I want to show an example, where the check cannot know that ```tryPutMessageNoThrow``` only take over the moved variable when it returns ```true```.
``` c++
void AsyncServerSocket::dispatchError(const char *msgstr, int errnoValue) {
  uint32_t startingIndex = callbackIndex_;
  CallbackInfo *info = nextCallback();

  // Create a message to send over the notification queue
  QueueMessage msg;
  msg.type = MessageType::MSG_ERROR;
  msg.err = errnoValue;
  msg.msg = std::move(msgstr);

  while (true) {
    // Short circuit if the callback is in the primary EventBase thread
    if (info->eventBase == nullptr) {
      std::runtime_error ex(
        std::string(msgstr) +  folly::to<std::string>(errnoValue));
      info->callback->acceptError(ex);
      return;
    }

    if (info->consumer->getQueue()->tryPutMessageNoThrow(std::move(msg))) {
      return;
    }
    // Fall through and try another callback

    if (callbackIndex_ == startingIndex) {
      // The notification queues for all of the callbacks were full.
      // We can't really do anything at this point.
      LOG(ERROR) << "failed to dispatch accept error: all accept callback "
        "queues are full: error msg:  " <<
        msg.msg.c_str() << errnoValue;	                                    // <- Access of moved variable msg. 
      return;
    }
    info = nextCallback();
  }
}
```

Now, to the questions I want to discuss:
1. Should the error message distinguish between moved and forwarded variables?
2. Should the error message distinguish between moved and possibly moved variables, i.e. variables which were moved only in an if branch?
3. Which functions should be detected as moves (and forward, respectively)?
 a. Any function named move
 b. Only std::move
 c. std::move or move but not name::move or name.move (I do not know if it is possible to see the active namespaces)
4. I have added the detection of the move to ```valueFlowAfterAssign``` since the behavior is very similar. I treat a move as an assignment with a for the user unknown value, since the user cannot rely on the result after the move. Is this OK?
5. I have added the move check to a completely new source, i.e. checkmove.cpp. Unfortunately, the check requires an iteration through the whole source. Should the check be included into another already existing iteration though the source?
6. For which settings the check should be activated?
7. How should the message be classified error/style/... ?