### PR TITLE
Ticket #7805: Ignore enumerators when simplifying known variables.

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -179,6 +179,7 @@ private:
         TEST_CASE(simplifyKnownVariables58);    // ticket #5268
         TEST_CASE(simplifyKnownVariables59);    // skip for header
         TEST_CASE(simplifyKnownVariables60);    // #6829
+        TEST_CASE(simplifyKnownVariables61);    // #7805
         TEST_CASE(simplifyKnownVariablesBailOutAssign1);
         TEST_CASE(simplifyKnownVariablesBailOutAssign2);
         TEST_CASE(simplifyKnownVariablesBailOutAssign3); // #4395 - nested assignments
@@ -532,7 +533,6 @@ private:
         // result..
         return tokenizer.tokens()->stringifyList(true,true,true,true,false);
     }
-
 
     void tokenize1() {
         const char code[] = "void f ( )\n"
@@ -2651,6 +2651,19 @@ private:
                       "std :: cout << i << std :: endl ;\n"
                       "std :: cout << & i << std :: endl ;\n"
                       "}", tokenizeAndStringify(code, true));
+    }
+
+    void simplifyKnownVariables61() { // #7805
+        tokenizeAndStringify("static const int XX = 0;\n"
+                             "enum E { XX };\n"
+                             "struct s {\n"
+                             "  enum Bar {\n"
+                             "    XX,\n"
+                             "    Other\n"
+                             "  };\n"
+                             "  enum { XX };\n"
+                             "};", /*simplify=*/true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void simplifyKnownVariablesBailOutAssign1() {


### PR DESCRIPTION
Known variable simplification must be aware of enumerators and leave them untouched even if they are called the same as a constant variable.