### PR TITLE
Ticket #7685: Properly handle function calls as argument to a dealloc function

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -546,7 +546,11 @@ void CheckLeakAutoVar::functionCall(const Token *tok, VarInfo *varInfo, const Va
             if (!af || af->arg == argNr)
                 changeAllocStatus(varInfo, allocation, tok, arg);
         } else if (Token::Match(arg, "%name% (")) {
-            functionCall(arg, varInfo, allocation, af);
+            const Library::AllocFunc* allocFunc = _settings->library.dealloc(arg);
+            VarInfo::AllocInfo alloc(allocFunc ? allocFunc->groupId : 0, VarInfo::DEALLOC);
+            if (alloc.type == 0)
+                alloc.status = VarInfo::NOALLOC;
+            functionCall(arg, varInfo, alloc, allocFunc);
         }
         argNr++;
     }

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -66,6 +66,7 @@ private:
         TEST_CASE(doublefree3); // #4914
         TEST_CASE(doublefree4); // #5451 - FP when exit is called
         TEST_CASE(doublefree5); // #5522
+        TEST_CASE(doublefree6); // #7685
 
         // exit
         TEST_CASE(exit1);
@@ -820,6 +821,14 @@ private:
               "  free(p);\n"
               "}");
         ASSERT_EQUALS("[test.c:4]: (error) Memory pointed to by 'p' is freed twice.\n", errout.str());
+    }
+
+    void doublefree6() { // #7685
+        check("void do_wordexp(FILE *f) {\n"
+              "  free(getword(f));\n"
+              "  fclose(f);\n"
+              "}", /*cpp=*/false);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void exit1() {


### PR DESCRIPTION
Encountering such a pattern, free(some_func(p)) would lead cppcheck to believe that p was deallocated, which might be wrong. This patch fixes this.