### PR TITLE
Ticket #7548: Properly detect the end of template parameter default values during instantiation

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -627,7 +627,7 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<Token *> &temp
                     tok = tok->next();
                     const Token *from = (*it)->next();
                     std::stack<Token *> links;
-                    while (from && (!links.empty() || (from->str() != "," && (indentlevel || from->str() != ">")))) {
+                    while (from && (!links.empty() || indentlevel || !Token::Match(from, ",|>"))) {
                         if (from->str() == "<")
                             ++indentlevel;
                         else if (from->str() == ">")

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1144,6 +1144,19 @@ private:
                           "template < class T1 , class T2 = B < T1 > > class C { } ; "
                           "template < class T1 = A , typename T2 = B < A > > class D { } ;", tok(code));
         }
+        {
+            // #7548
+            const char code[] = "template<class T, class U> class DefaultMemory {}; "
+                                "template<class Key, class Val, class Mem=DefaultMemory<Key,Val> > class thv_table_c  {}; "
+                                "thv_table_c<void *,void *> id_table_m;";
+            const char exp [] = "template < class T , class U > class DefaultMemory { } ; "
+                                "thv_table_c<void*,void*,DefaultMemory<void*,void*>> id_table_m ; "
+                                "class thv_table_c<void*,void*,DefaultMemory<void*,void*>> { } ;";
+            const char curr[] = "template < class T , class U > class DefaultMemory { } ; "
+                                "thv_table_c<void*,void*,DefaultMemory<Key,Val>> id_table_m ; "
+                                "class thv_table_c<void*,void*,DefaultMemory<Key,Val>> { } ;";
+            TODO_ASSERT_EQUALS(exp, curr, tok(code));
+        }
     }
 
     void template_default_type() {


### PR DESCRIPTION
This patch fixes how we detect the end of a template parameter default value when instantiating: the logic was flawed and would stop at the first comma. This is wrong if the default value is a template with multiple parameters.

I've added a TODO because we don't properly expand the default value if it depends on other template parameters of the template being instantiated. That's for another patch.