### PR TITLE
Fixed #4858 (Clarify if(x = foo() && bar()) )

### DIFF
--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -48,6 +48,7 @@ public:
         CheckCondition checkCondition(tokenizer, settings, errorLogger);
         checkCondition.multiCondition();
         checkCondition.clarifyCondition();   // not simplified because ifAssign
+        checkCondition.clarifyAssignmentAndLogicalCondition();
         checkCondition.oppositeInnerCondition();
         checkCondition.checkIncorrectLogicOperator();
         checkCondition.checkInvalidTestForOverflow();
@@ -95,6 +96,9 @@ public:
     /** @brief Suspicious condition (assignment+comparison) */
     void clarifyCondition();
 
+    /** @brief Suspicious condition (assignment + logical function call) */
+    void clarifyAssignmentAndLogicalCondition();
+
     /** @brief Condition is always true/false */
     void alwaysTrueFalse();
 
@@ -122,6 +126,8 @@ private:
 
     void moduloAlwaysTrueFalseError(const Token* tok, const std::string& maxVal);
 
+    void clarifyAssignmentAndLogicalConditionError(const Token* tok);
+
     void clarifyConditionError(const Token *tok, bool assign, bool boolop);
 
     void alwaysTrueFalseError(const Token *tok, bool knownResult);
@@ -140,6 +146,7 @@ private:
         c.incorrectLogicOperatorError(nullptr, "foo > 3 && foo < 4", true, false);
         c.redundantConditionError(nullptr, "If x > 11 the condition x > 10 is always true.", false);
         c.moduloAlwaysTrueFalseError(nullptr, "1");
+        c.clarifyAssignmentAndLogicalConditionError(nullptr);
         c.clarifyConditionError(nullptr, true, false);
         c.alwaysTrueFalseError(nullptr, true);
         c.invalidTestForOverflow(nullptr, false);


### PR DESCRIPTION
new check: operator precedence of = and && in condition
cf. http://trac.cppcheck.net/ticket/4858