### PR TITLE
Ticket #7820: Properly report leaks with conditional deallocations followed by a return.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1968,8 +1968,8 @@ const Token *CheckMemoryLeakInFunction::findleak(const Token *tokens)
         return result->tokAt(4);
     }
 
-    if (((result = Token::findsimplematch(tokens, "; alloc ; if dealloc ; }")) != nullptr) &&
-        !result->tokAt(7)) {
+    if (((result = Token::findsimplematch(tokens, "; alloc ; if dealloc ; }")) != nullptr) ||
+        ((result = Token::findsimplematch(tokens, "; alloc ; if dealloc ; return ;")) != nullptr)) {
         return result->tokAt(6);
     }
 


### PR DESCRIPTION
This ticket shows that the leak detector can be confused by "return", and this patch fixes this.

I've removed line 1972 because I could not understand why it's needed (it will still leak when we're towards the EOF...), and the test suite keeps passing without it.
