### PR TITLE
Properly categorize "return free(" in CheckMemoryLeak.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1139,6 +1139,11 @@ Token *CheckMemoryLeakInFunction::getcode(const Token *tok, std::list<const Toke
                 tok = tok->tokAt(2);
             }
 
+            else if (varid && Token::Match(tok, "return free|fclose|pclose|closedir ( %varid% )", varid)) {
+                addtoken(&rettail, tok, "dealloc");
+                tok = tok->tokAt(4);
+            }
+
             else {
                 bool use = false;
 
@@ -2079,6 +2084,7 @@ void CheckMemoryLeakInFunction::checkScope(const Token *startTok, const std::str
         bool noerr = false;
         noerr = noerr || Token::simpleMatch(first, "alloc ; }");
         noerr = noerr || Token::simpleMatch(first, "alloc ; dealloc ; }");
+        noerr = noerr || Token::simpleMatch(first, "alloc ; return dealloc ; }");
         noerr = noerr || Token::simpleMatch(first, "alloc ; return use ; }");
         noerr = noerr || Token::simpleMatch(first, "alloc ; use ; }");
         noerr = noerr || Token::simpleMatch(first, "alloc ; use ; return ; }");

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -455,7 +455,9 @@ private:
         ASSERT_EQUALS(";;dealloc;", getcode("void *p; foo(fclose(p));", "p"));
         ASSERT_EQUALS(";;dealloc;", getcode("void *p; foo(close(p));", "p"));
         ASSERT_EQUALS(";;;;", getcode("FILE *f1; FILE *f2; fclose(f1);", "f2"));
-        ASSERT_EQUALS(";;returnuse;", getcode("FILE *f; return fclose(f) == EOF ? 1 : 2;", "f"));
+        ASSERT_EQUALS(";;returndealloc;", getcode("FILE *f; return fclose(f) == EOF ? 1 : 2;", "f"));
+        ASSERT_EQUALS(";;alloc;returndealloc;", getcode("char *c = (char*) malloc(10); return free(c);", "c"));
+        ASSERT_EQUALS(";;returndealloc;", getcode("DIR* d; return closedir(d);", "d"));
         ASSERT_EQUALS(";;dealloc;", getcode("char *s; s ? free(s) : 0;", "s"));
 
         // if..


### PR DESCRIPTION
While investigating ticket 7820, I noticed CheckMemoryLeak categorizes "return free()" as a "return use", which is wrong. This patch fixes this.