### PR TITLE
Ticket #7745: Simplify "alloc ; dealloc ;" blocks that we don't have any value for CheckMemoryLeak's analysis.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1696,6 +1696,13 @@ void CheckMemoryLeakInFunction::simplifycode(Token *tok) const
                 done = false;
             }
 
+            // Ticket #7745
+            // Delete "if (!var) { alloc ; dealloc }" blocks
+            if (Token::simpleMatch(tok2->next(), "if(!var) { alloc ; dealloc ; }")) {
+                tok2->deleteNext(7);
+                done = false;
+            }
+
             // Reduce "do { alloc ; } " => "alloc ;"
             /** @todo If the loop "do { alloc ; }" can be executed twice, reduce it to "loop alloc ;" */
             if (Token::simpleMatch(tok2->next(), "do { alloc ; }")) {

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -184,6 +184,7 @@ private:
         TEST_CASE(if9);     // if (realloc)
         TEST_CASE(if10);    // else if (realloc)
         TEST_CASE(if11);
+        TEST_CASE(if12);    // Ticket #7745
 
         TEST_CASE(forwhile5);
         TEST_CASE(forwhile6);
@@ -1232,6 +1233,16 @@ private:
                            "", errout.str());
     }
 
+    void if12() { // #7745
+        check("void f() {\n"
+              "  FILE *fp = fopen(\"name\", \"r\");\n"
+              "  if (!fp) {\n"
+              "    fp = fopen(\"name\", \"w\");\n"
+              "    fclose(fp);\n"
+              "  }\n"
+              "}", /*c=*/true, /*posix=*/false);
+        ASSERT_EQUALS("[test.c:7]: (error) Resource leak: fp\n", errout.str());
+    }
 
     void forwhile5() {
         check("void f(const char **a)\n"


### PR DESCRIPTION
This patch fixes the ticket by removing blocks that are of no use for the analysis: they're conditioned by the variable being not set, and allocate + deallocate.