### PR TITLE
Teach CheckMemoryLeak about "alloc ; loop alloc ;" kinds of patterns.

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1964,6 +1964,10 @@ const Token *CheckMemoryLeakInFunction::findleak(const Token *tokens)
         return result->tokAt(2);
     }
 
+    if ((result = Token::findmatch(tokens, "alloc ; loop|while1 {| alloc ;")) != nullptr) {
+        return result->tokAt(3 + (result->strAt(3) == "{"));
+    }
+
     if ((result = Token::findsimplematch(tokens, "; alloc ; if assign ;")) != nullptr) {
         return result->tokAt(4);
     }

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -191,6 +191,7 @@ private:
         TEST_CASE(forwhile9);
         TEST_CASE(forwhile10);
         TEST_CASE(forwhile11);
+        TEST_CASE(forwhile12);
 
         TEST_CASE(switch2);
         TEST_CASE(switch3);
@@ -1337,7 +1338,35 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
+    void forwhile12() {
+        check("extern int bar();\n"
+              "void f() {\n"
+              "  FILE *fp = fopen(\"name\", \"r\" );\n"
+              "  while(bar()) {\n"
+              "    fp = fopen(\"name\", \"w\");\n"
+              "    fclose(fp);\n"
+              "  }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Resource leak: fp\n", errout.str());
 
+        check("void f() {\n"
+              "  FILE *fp = fopen(\"name\", \"r\" );\n"
+              "  while(1) {\n"
+              "    fp = fopen(\"name\", \"w\");\n"
+              "    fclose(fp);\n"
+              "  }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Resource leak: fp\n", errout.str());
+
+        check("void f() {\n"
+              "  FILE *fp = fopen(\"name\", \"r\" );\n"
+              "  for( ; ; ) {\n"
+              "    fp = fopen(\"name\", \"w\");\n"
+              "    fclose(fp);\n"
+              "  }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Resource leak: fp\n", errout.str());
+    }
 
 
     void switch2() {


### PR DESCRIPTION
I've noticed that the snippets that I added in that patch were not giving any leak error while they should. This patch fixes this.