### PR TITLE
(Fixed #7895) C++11 brace initialization

### DIFF
--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -175,6 +175,7 @@ private:
 
         TEST_CASE(lambdaFunction); // #5078
         TEST_CASE(namespaces); // #7557
+        TEST_CASE(bracesInitCpp11);// #7895 - "int var{123}" initialization
     }
 
     void checkStructMemberUsage(const char code[]) {
@@ -4099,6 +4100,17 @@ private:
                               "     return value;\n"
                               "  }\n"
                               "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void bracesInitCpp11() {
+        functionVariableUsage(
+            "int fun() {\n"
+            " static int fpUnread{0};\n"
+            " const int var{fpUnread++};\n"
+            " return var;\n"
+            "}\n"
+        );
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
- Added support for C++11 style initialization:
  `int var{123}; // instead of int var = {123};`
- Fixed http://trac.cppcheck.net/ticket/7895
- Added test.

I'm not sure how to handle `--std=c11` option here.