### PR TITLE
(Fixed #7877) Clearing values after modifying token

### DIFF
--- a/lib/token.h
+++ b/lib/token.h
@@ -76,6 +76,7 @@ public:
     void str(T&& s) {
         _str = s;
         _varId = 0;
+        values.clear();
 
         update_property_info();
     }

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -234,6 +234,8 @@ private:
 
         TEST_CASE(negativeMemoryAllocationSizeError) // #389
         TEST_CASE(negativeArraySize);
+
+        TEST_CASE(enumValueArrayBounds); // #7877        
     }
 
 
@@ -3957,6 +3959,24 @@ private:
               "int c[x?y:-1];\n");
         ASSERT_EQUALS("", errout.str());
     }
+
+    // #7877
+    void enumValueArrayBounds() {
+        check(
+            "\n enum {"
+            "\n   enum_val = 10 - 1"
+            "\n };"
+            "\n int arr[10];"
+            "\n void main()"
+            "\n {"
+            "\n   arr[enum_val] = 1;"
+            "\n }"
+            "\n"
+        , true, "test.c");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+
 };
 
 REGISTER_TEST(TestBufferOverrun)


### PR DESCRIPTION
Sometimes token had invalid value after simplifications:
`26 - 1` was simplified to `25`, but token `25` still had `26` in it's `values` array.