### PR TITLE
[RFC] testrunner: remove non-gcc-style output format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ test:	all
 	./testrunner
 
 check:	all
-	./testrunner -g -q
+	./testrunner -q
 
 checkcfg:	cppcheck
 	./test/cfg/runtests.sh

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -19,10 +19,8 @@
 options::options(int argc, const char* argv[])
     :_options(argv + 1, argv + argc)
     ,_which_test("")
-    ,_gcc_style_errors(_options.count("-g") != 0)
     ,_quiet(_options.count("-q") != 0)
 {
-    _options.erase("-g");
     _options.erase("-q");
     if (! _options.empty()) {
         _which_test = *_options.rbegin();
@@ -32,11 +30,6 @@ options::options(int argc, const char* argv[])
 bool options::quiet() const
 {
     return _quiet;
-}
-
-bool options::gcc_style_errors() const
-{
-    return _gcc_style_errors;
 }
 
 const std::string& options::which_test() const

--- a/test/options.h
+++ b/test/options.h
@@ -31,9 +31,6 @@ public:
     options(int argc, const char* argv[]);
     /** Don't print the name of each method being tested. */
     bool quiet() const;
-    /** __FILE__:__LINE__: Error message. Makes it easier for editors to find
-     * failing tests/ */
-    bool gcc_style_errors() const;
     /** Which test should be run. Empty string means 'all tests' */
     const std::string& which_test() const;
 
@@ -45,7 +42,6 @@ private:
 private:
     std::set<std::string> _options;
     std::string _which_test;
-    const bool _gcc_style_errors;
     const bool _quiet;
 };
 

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -32,7 +32,6 @@ private:
         TEST_CASE(no_test_method);
         TEST_CASE(not_quiet);
         TEST_CASE(quiet);
-        TEST_CASE(gcc_errors);
         TEST_CASE(multiple_testcases);
         TEST_CASE(invalid_switches);
     }
@@ -73,11 +72,6 @@ private:
     }
 
 
-    void gcc_errors() const {
-        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-g"};
-        options args(sizeof argv / sizeof argv[0], argv);
-        ASSERT_EQUALS(true, args.gcc_style_errors());
-    }
 
 
     void multiple_testcases() const {
@@ -88,10 +82,9 @@ private:
 
 
     void invalid_switches() const {
-        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-a", "-v", "-q", "-g"};
+        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-a", "-v", "-q"};
         options args(sizeof argv / sizeof argv[0], argv);
         ASSERT_EQUALS("TestClass::TestMethod", args.which_test());
-        ASSERT_EQUALS(true, args.gcc_style_errors());
         ASSERT_EQUALS(true, args.quiet());
     }
 };

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -68,7 +68,6 @@ std::set<std::string> TestFixture::missingLibs;
 
 TestFixture::TestFixture(const std::string &_name)
     :classname(_name)
-    ,gcc_style_errors(false)
     ,quiet_tests(false)
 {
     TestRegistry::theInstance().addTest(this);
@@ -121,11 +120,8 @@ void TestFixture::assert_(const char *filename, unsigned int linenr, bool condit
 {
     if (!condition) {
         ++fails_counter;
-        if (gcc_style_errors) {
-            errmsg << filename << ':' << linenr << ": Assertion failed." << std::endl;
-        } else {
-            errmsg << "Assertion failed in " << filename << " at line " << linenr << std::endl << "_____" << std::endl;
-        }
+        errmsg << filename << ':' << linenr << ": Assertion failed." << std::endl << "_____" << std::endl;
+
     }
 }
 
@@ -133,26 +129,16 @@ void TestFixture::assertEquals(const char *filename, unsigned int linenr, const 
 {
     if (expected != actual) {
         ++fails_counter;
-        if (gcc_style_errors) {
-            errmsg << filename << ':' << linenr << ": Assertion failed. "
-                   << "Expected: "
-                   << writestr(expected, true)
-                   << ". Actual: "
-                   << writestr(actual, true)
-                   << '.'
-                   << std::endl;
-            if (!msg.empty())
-                errmsg << msg << std::endl;
-        } else {
-            errmsg << "Assertion failed in " << filename << " at line " << linenr << std::endl
-                   << "Expected:" << std::endl
-                   << writestr(expected) << std::endl
-                   << "Actual:" << std::endl
-                   << writestr(actual) << std::endl;
-            if (!msg.empty())
-                errmsg << "Hint:" << std::endl << msg << std::endl;
-            errmsg << "_____" << std::endl;
-        }
+        errmsg << filename << ':' << linenr << ": Assertion failed. " << std::endl
+               << "Expected: " <<  std::endl
+               << writestr(expected)  << std::endl
+               << "Actual: " << std::endl
+               << writestr(actual) << std::endl;
+        if (!msg.empty())
+            errmsg << "Hint:" << std::endl <<  msg << std::endl;
+        errmsg << "_____" << std::endl;
+
+
     }
 }
 void TestFixture::assertEquals(const char *filename, unsigned int linenr, const char expected[], const std::string& actual, const std::string &msg) const
@@ -192,13 +178,9 @@ void TestFixture::todoAssertEquals(const char *filename, unsigned int linenr,
                                    const std::string &actual) const
 {
     if (wanted == actual) {
-        if (gcc_style_errors) {
-            errmsg << filename << ':' << linenr << ": Assertion succeeded unexpectedly. "
-                   << "Result: " << writestr(wanted, true) << "." << std::endl;
-        } else {
-            errmsg << "Assertion succeeded unexpectedly in " << filename << " at line " << linenr << std::endl
-                   << "Result:" << std::endl << writestr(wanted) << std::endl << "_____" << std::endl;
-        }
+        errmsg << filename << ':' << linenr << ": Assertion succeeded unexpectedly. "
+               << "Result: " << writestr(wanted, true)  << std::endl << "_____" << std::endl;
+
         ++succeeded_todos_counter;
     } else {
         assertEquals(filename, linenr, current, actual);
@@ -218,37 +200,25 @@ void TestFixture::todoAssertEquals(const char *filename, unsigned int linenr, lo
 void TestFixture::assertThrow(const char *filename, unsigned int linenr) const
 {
     ++fails_counter;
-    if (gcc_style_errors) {
-        errmsg << filename << ':' << linenr << " Assertion succeeded. "
-               << "The expected exception was thrown" << std::endl;
-    } else {
-        errmsg << "Assertion succeeded in " << filename << " at line " << linenr << std::endl
-               << "The expected exception was thrown" << std::endl << "_____" << std::endl;
-    }
+    errmsg << filename << ':' << linenr << ": Assertion succeeded. "
+           << "The expected exception was thrown" << std::endl << "_____" << std::endl;
+
 }
 
 void TestFixture::assertThrowFail(const char *filename, unsigned int linenr) const
 {
     ++fails_counter;
-    if (gcc_style_errors) {
-        errmsg << filename << ':' << linenr << " Assertion failed. "
-               << "The expected exception was not thrown" << std::endl;
-    } else {
-        errmsg << "Assertion failed in " << filename << " at line " << linenr << std::endl
-               << "The expected exception was not thrown" << std::endl << "_____" << std::endl;
-    }
+    errmsg << filename << ':' << linenr << ": Assertion failed. "
+           << "The expected exception was not thrown"  << std::endl << "_____" << std::endl;
+
 }
 
 void TestFixture::assertNoThrowFail(const char *filename, unsigned int linenr) const
 {
     ++fails_counter;
-    if (gcc_style_errors) {
-        errmsg << filename << ':' << linenr << " Assertion failed. "
-               << "Unexpected exception was thrown" << std::endl;
-    } else {
-        errmsg << "Assertion failed in " << filename << " at line " << linenr << std::endl
-               << "Unexpected exception was thrown" << std::endl << "_____" << std::endl;
-    }
+    errmsg << filename << ':' << linenr << ": Assertion failed. "
+           << "Unexpected exception was thrown"  << std::endl << "_____" << std::endl;
+
 }
 
 void TestFixture::complainMissingLib(const char* libname) const
@@ -272,7 +242,6 @@ void TestFixture::run(const std::string &str)
 void TestFixture::processOptions(const options& args)
 {
     quiet_tests = args.quiet();
-    gcc_style_errors = args.gcc_style_errors();
 }
 
 std::size_t TestFixture::runTests(const options& args)

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -38,7 +38,6 @@ private:
 protected:
     std::string classname;
     std::string testToRun;
-    bool gcc_style_errors;
     bool quiet_tests;
     std::string currentTest;
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
     fout << "test:\tall\n";
     fout << "\t./testrunner\n\n";
     fout << "check:\tall\n";
-    fout << "\t./testrunner -g -q\n\n";
+    fout << "\t./testrunner -q\n\n";
     fout << "checkcfg:\tcppcheck\n";
     fout << "\t./test/cfg/runtests.sh\n\n";
     fout << "dmake:\ttools/dmake.o cli/filelister.o lib/pathmatch.o lib/path.o\n";


### PR DESCRIPTION
I made this pull request to spark a discussion/make sure the majority of contributors are ok with the change.
The changeset removes the non-gcc-style error message from the testrunner and makes the gcc style ones be the default.

non-gcc:
````
Assertion failed in test/testcondition.cpp at line 365
````
gcc:
````
test/testcondition.cpp:365: Assertion failed.
````

The advantage of the gcc style messages is (in my eyes) that they are more condensed and you can simply copy and paste the "test/testcondition.cpp:365" into a terminal to open with an editor and in most cases the editor will automatically scroll to that line.
With the other format, you either have to search for the line manually or merge the filename and line number by hand.

Note that the gcc-style message was already default for "make check" (but not for "make test").
The gcc style message was invoked by ````testrunner -g````, I removed the flag. 