### PR TITLE
Continue encoding on UnicodeEncodeError

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -520,10 +520,12 @@ if __name__ == '__main__':
 
             if options.source_encoding:
                 lexer.encoding = options.source_encoding
-
-            output_file.write(
-                highlight(content, lexer, htmlFormatter).decode(
-                    options.source_encoding))
+            
+            # exclude the non ascii characters from the output rather than crashing miserably
+            # refer to: https://sourceforge.net/p/cppcheck/discussion/general/thread/f24a2007/
+            variable = highlight(content, lexer, htmlFormatter).decode(options.source_encoding)
+            variable = ''.join([i if ord(i) < 128 else '' for i in variable])
+            output_file.write(variable)
 
             output_file.write(HTML_FOOTER % contentHandler.versionCppcheck)
 


### PR DESCRIPTION
Sometimes the script crashes due to a UnicodeEncodeError with a message like 'UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd' in position 20'. I did inspect the files which were being complained about but didn't come across a non-ascii character, so, I'm not quite sure what is exactly happening but other people are clearly complaining about it too.

The patch is poached from 'https://sourceforge.net/p/cppcheck/discussion/general/thread/f24a2007/' and it probably can be fixed in a better way but I think it is a lot better than having a crash.