### PR TITLE
Ticket #7914: Properly recognize template parameters that contains operators

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -269,7 +269,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             return 0;
 
         // num/type ..
-        if (!tok->isNumber() && tok->tokType() != Token::eChar && !tok->isName())
+        if (!tok->isNumber() && tok->tokType() != Token::eChar && !tok->isName() && !tok->isOp())
             return 0;
         tok = tok->next();
         if (!tok)
@@ -509,6 +509,12 @@ std::list<Token *> TemplateSimplifier::getTemplateInstantiations(Token *tokens)
             tok = tok->next()->findClosingBracket();
             if (!tok)
                 break;
+            // #7914
+            // Ignore template instantiations within template definitions: they will only be
+            // handled if the definition is actually instantiated
+            const Token *tok2 = Token::findmatch(tok, "{|;");
+            if (tok2 && tok2->str() == "{")
+                tok = tok2->link();
         } else if (Token::Match(tok->previous(), "[({};=] %name% <") ||
                    Token::Match(tok->previous(), "%type% %name% <") ||
                    Token::Match(tok->tokAt(-2), "[,:] private|protected|public %name% <")) {

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -915,8 +915,7 @@ private:
     }
 
     void garbageCode125() {
-        ASSERT_THROW(checkCode("{ T struct B : T valueA_AA ; } T : [ T > ( ) { B } template < T > struct A < > : ] { ( ) { return valueA_AC struct { : } } b A < int > AC ( ) a_aa.M ; ( ) ( ) }"),
-                     InternalError);
+        checkCode("{ T struct B : T valueA_AA ; } T : [ T > ( ) { B } template < T > struct A < > : ] { ( ) { return valueA_AC struct { : } } b A < int > AC ( ) a_aa.M ; ( ) ( ) }");
         ASSERT_THROW(checkCode("template < Types > struct S :{ ( S < ) S >} { ( ) { } } ( ) { return S < void > ( ) }"),
                      InternalError);
     }

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -2500,16 +2500,13 @@ private:
 
     void simplifyOperator2() {
         // #6576
-        ASSERT_EQUALS("class TClass { "
-                      "public: "
-                      "TClass & operator= ( const TClass & rhs ) ; "
+        ASSERT_EQUALS("template < class T > class SharedPtr { "
+                      "SharedPtr & operator= ( SharedPtr < Y > const & r ) ; "
                       "} ; "
-                      "TClass :: TClass ( const TClass & other ) "
-                      "{ "
-                      "operator= ( other ) ; "
-                      "} class SharedPtr < Y > { "
-                      "SharedPtr < Y > & operator= ( SharedPtr < Y > const & r ) ; "
-                      "} ;",
+                      "class TClass { "
+                      "public: TClass & operator= ( const TClass & rhs ) ; "
+                      "} ; "
+                      "TClass :: TClass ( const TClass & other ) { operator= ( other ) ; }",
                       tok("template<class T>\n"
                           "    class SharedPtr {\n"
                           "    SharedPtr& operator=(SharedPtr<Y> const & r);\n"


### PR DESCRIPTION
This ticket highlights that we would not recognise patterns like "<i == 0>" as template parameters, which is wrong.

Fixing that caused regressions all due to considering template instantiations within template definitions as instantiations. This is incorrect: they will really be instantiations (and handled correctly) only be if their enclosing template is instantiated. This patch also fixes that.