### PR TITLE
Ticket #7912: Properly preprocess files with decreasing line numbers, due to #line directives

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -615,7 +615,7 @@ std::string Preprocessor::getcode(const simplecpp::TokenList &tokens1, const std
             line = tok->location.line;
         }
 
-        if (tok->previous && line == tok->location.line)
+        if (tok->previous && line >= tok->location.line) // #7912
             ret << ' ';
         bool newline = false;
         while (tok->location.line > line) {

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -240,6 +240,8 @@ private:
         TEST_CASE(testDirectiveIncludeTypes);
         TEST_CASE(testDirectiveIncludeLocations);
         TEST_CASE(testDirectiveIncludeComments);
+
+        TEST_CASE(testSameLine);  // #7912
     }
 
     void preprocess(const char* code, std::map<std::string, std::string>& actual, const char filename[] = "file.c") {
@@ -2292,6 +2294,19 @@ private:
         preprocessor.getcode(filedata, "", "test.c");
         preprocessor.dump(ostr);
         ASSERT_EQUALS(dumpdata, ostr.str());
+    }
+
+    void testSameLine() { // Ticket #7912
+        const char code[] = "#line 1 \"bench/btl/libs/BLAS/blas_interface_impl.hh\" \n"
+                            "template < > class blas_interface < float > : public c_interface_base < float > \n"
+                            "{ } ;\n"
+                            "#line 1 \"bench/btl/libs/BLAS/blas_interface_impl.hh\" \n"
+                            "template < > class blas_interface < double > : public c_interface_base < double > \n"
+                            "{ } ;";
+        const char exp[]  = "template < > class blas_interface < float > : public c_interface_base < float >\n"
+                            "{ } ; template < > class blas_interface < double > : public c_interface_base < double > { } ;";
+        Preprocessor preprocessor(settings0, this);
+        ASSERT_EQUALS(exp, preprocessor.getcode(code, "", "test.cpp"));
     }
 
 };


### PR DESCRIPTION
This ticket shows that we don't preprocess files that have "decreasing line numbers" (due to using #line): we don't properly space separate tokens in Preprocessor::getcode(), and end up doing "use after free"... This patch fixes this.