### PR TITLE
dmake: Add support for mingw64

### DIFF
--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -238,7 +238,7 @@ int main(int argc, char **argv)
          << "        CPPCHK_GLIBCXX_DEBUG=\n"
          << "    endif # !CPPCHK_GLIBCXX_DEBUG\n"
          << "\n"
-         << "    ifeq ($(MSYSTEM),MINGW32)\n"
+         << "    ifeq ($(MSYSTEM),MINGW32 MINGW64)\n"
          << "        LDFLAGS=-lshlwapi\n"
          << "    else\n"
          << "        RDYNAMIC=-lshlwapi\n"


### PR DESCRIPTION
running dmake under mingw64 causes an error
the makefile will have to be recreated
under linux

error:
tools/dmake.o: In function `getCppFiles':
F:\MSYS\home\cppcheck/tools/dmake.cpp:98: undefined reference to `FileLister::addFiles(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, unsigned int> > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, PathMatch const&)'
collect2.exe: error: ld returned 1 exit status
make: *** [dmake] Error 1
sh: ./dmake: No such file or directory