### PR TITLE
Fix for bug #7866 - null pointer dereference

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -87,10 +87,13 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char Fi
         // parsing of library code to find called functions
         if (settings->library.isexecutableblock(FileName, tok->str())) {
             const Token * markupVarToken = tok->tokAt(settings->library.blockstartoffset(FileName));
+            // not found
+            if (!markupVarToken)
+            	continue;
             int scope = 0;
             bool start = true;
             // find all function calls in library code (starts with '(', not if or while etc)
-            while (scope || start) {
+            while ((scope || start) && markupVarToken) {
                 if (markupVarToken->str() == settings->library.blockstart(FileName)) {
                     scope++;
                     if (start) {


### PR DESCRIPTION
When iterating around the tokens for unused functions from other languages, the next token can return null which will be dereferenced in the next iteration of the loop.