### PR TITLE
Update TemplateSimplifier::getTemplateNamePosition to handle out-of-line template methods.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -720,6 +720,14 @@ int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
         namepos = 2;
     else if (Token::Match(tok, "> %type% %type% *|&| %type% ("))
         namepos = 3;
+    else if ((Token::Match(tok, "> %type% <") && Token::Match(tok->linkAt(2), "> :: %type% (")) ||
+             (Token::Match(tok, "> %type% %type% <") && Token::Match(tok->linkAt(3), "> :: %type% ("))) {
+        namepos = 2 + (Token::Match(tok, "> %type% %type%"));
+        const Token *end = tok->linkAt(namepos);
+        for(const Token *tok2 = tok->tokAt(namepos) ; tok2 != end ; tok2 = tok2->next())
+            ++namepos;
+        namepos += 2;
+    }
     else if (Token::Match(tok, "> %type% *|&| %type% :: %type% (")) {
         namepos = 4;
         starAmpPossiblePosition = 2;

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1372,8 +1372,14 @@ private:
         TODO_ASSERT_EQUALS(7, -1, templateNamePositionHelper("class A { class B { template<class T> const unsigned foo(); }; } ; "
                            "template<class T> const unsigned A::B::foo() { return 0; }", 25));
         // Template class member
-        TODO_ASSERT_EQUALS(7, -1, templateNamePositionHelper("template<class T> class A { unsigned foo(); }; "
-                           "template<class T> unsigned A<T>::foo() { return 0; }", 19));
+        ASSERT_EQUALS(6, templateNamePositionHelper("template<class T> class A { A(); }; "
+                                                    "template<class T> A<T>::A() {}", 18));
+        ASSERT_EQUALS(8, templateNamePositionHelper("template<class T, class U> class A { A(); }; "
+                                                    "template<class T, class U> A<T, U>::A() {}", 24));
+        ASSERT_EQUALS(7, templateNamePositionHelper("template<class T> class A { unsigned foo(); }; "
+                                                    "template<class T> unsigned A<T>::foo() { return 0; }", 19));
+        ASSERT_EQUALS(9, templateNamePositionHelper("template<class T, class U> class A { unsigned foo(); }; "
+                                                    "template<class T, class U> unsigned A<T, U>::foo() { return 0; }", 25));
     }
 
     void expandSpecialized() {


### PR DESCRIPTION
While investigating http://trac.cppcheck.net/ticket/7942 I noticed that getTemplateNamePosition does not properly support out-of-line definitions of template methods. This patch fixes this.