### PR TITLE
Don't generate invalid syntax for out of line template class constructors during instantiation

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -818,8 +818,12 @@ void TemplateSimplifier::expandTemplate(
 
             // replace name..
             if (Token::Match(tok3, (name + " !!<").c_str())) {
-                tokenlist.addtoken(newName, tok3->linenr(), tok3->fileIndex());
-                continue;
+                if (Token::Match(tok3->tokAt(-2), "> :: %name% ( )")) {
+                    ; // Ticket #7942: Replacing for out-of-line constructors generates invalid syntax
+                } else {
+                    tokenlist.addtoken(newName, tok3->linenr(), tok3->fileIndex());
+                    continue;
+                }
             }
 
             // copy

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -183,6 +183,7 @@ private:
         TEST_CASE(uninitConstVar);
         TEST_CASE(constructors_crash1);    // ticket #5641
         TEST_CASE(classWithOperatorInName);// ticket #2827
+        TEST_CASE(templateConstructor);    // ticket #7942
     }
 
 
@@ -3346,6 +3347,16 @@ private:
               "public:\n"
               "  operatorX() : mValue(0) {}\n"
               "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void templateConstructor() { // ticket #7942
+        check("template <class T> struct Containter {\n"
+              "  Containter();\n"
+              "  T* mElements;\n"
+              "};\n"
+              "template <class T> Containter<T>::Containter() : mElements(nullptr) {}\n"
+              "Containter<int> intContainer;");
         ASSERT_EQUALS("", errout.str());
     }
 };

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -184,7 +184,7 @@ private:
         const char expected[] = "template < class T > Fred < T > :: Fred ( ) { } " // <- TODO: this should be removed
                                 "Fred < float > fred ; "
                                 "class Fred < float > { } ; "
-                                "Fred < float > :: Fred < float > ( ) { }";
+                                "Fred < float > :: Fred ( ) { }";
 
         ASSERT_EQUALS(expected, tok(code));
     }


### PR DESCRIPTION
This ticket highlights that we don't properly instantiate out of line template class constructors, which confuses the class analyser. The patch fixes this, and the ticket.