### PR TITLE
Ticket #4544: Also handle Foo<struct Bar> constructs.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1303,7 +1303,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
                 typeForPatternMatch += tok3->str();
             }
             // add additional type information
-            if (!constconst && tok3->str() != "class") {
+            if (!constconst && !Token::Match(tok3, "class|struct|enum")) {
                 if (tok3->isUnsigned())
                     typeForNewName += "unsigned";
                 else if (tok3->isSigned())

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -766,12 +766,30 @@ private:
     }
 
     void template37() { // #4544 - A<class B> a;
-        const char code[] = "class A { };\n"
-                            "template<class T> class B {};\n"
-                            "B<class A> b1;\n"
-                            "B<A> b2;";
-        ASSERT_EQUALS("class A { } ; B < A > b1 ; B < A > b2 ; class B < A > { } ;",
-                      tok(code));
+        {
+            const char code[] = "class A { };\n"
+                                "template<class T> class B {};\n"
+                                "B<class A> b1;\n"
+                                "B<A> b2;";
+            ASSERT_EQUALS("class A { } ; B < A > b1 ; B < A > b2 ; class B < A > { } ;",
+                          tok(code));
+        }
+        {
+            const char code[] = "struct A { };\n"
+                                "template<class T> class B {};\n"
+                                "B<struct A> b1;\n"
+                                "B<A> b2;";
+            ASSERT_EQUALS("struct A { } ; B < A > b1 ; B < A > b2 ; class B < A > { } ;",
+                          tok(code));
+        }
+        {
+            const char code[] = "enum A { };\n"
+                                "template<class T> class B {};\n"
+                                "B<enum A> b1;\n"
+                                "B<A> b2;";
+            ASSERT_EQUALS("enum A { } ; B < A > b1 ; B < A > b2 ; class B < A > { } ;",
+                          tok(code));
+        }
     }
 
     void template_unhandled() {


### PR DESCRIPTION
I've noticed that the fix for http://trac.cppcheck.net/ticket/4544 is not complete, in that it handles class but not struct. This patch fixes it.