### PR TITLE
Ticket #7964: Don't crash on valid code using function pointers named strcpy or strcat in main()

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1756,7 +1756,11 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                 // Match common patterns that can result in a buffer overrun
                 // e.g. strcpy(buffer, argv[0])
                 if (Token::Match(tok, "strcpy|strcat (")) {
-                    tok = tok->tokAt(2)->nextArgument();
+                    const Token *nextArgument = tok->tokAt(2)->nextArgument();
+                    if (nextArgument)
+                        tok = nextArgument;
+                    else
+                        continue; // Ticket #7964
                     if (Token::Match(tok, "* %varid%", varid) || Token::Match(tok, "%varid% [", varid))
                         cmdLineArgsError(tok);
                 }

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3731,6 +3731,16 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Buffer overrun possible for long command line arguments.\n"
                       "[test.cpp:4]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());
+
+        // #7964
+        check("int main(int argc, char *argv[]) {\n"
+              "  char *strcpy();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        check("int main(int argc, char *argv[]) {\n"
+              "  char *strcat();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkBufferAllocatedWithStrlen() {


### PR DESCRIPTION
Trivial fix for a crash on valid.