### PR TITLE
Ticket #8031: Remove bailout and fix varid for template class member initialized in out-of-line constructor.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2910,8 +2910,10 @@ void Tokenizer::setVarIdPass2()
         for (std::list<Token *>::iterator func = allMemberFunctions.begin(); func != allMemberFunctions.end(); ++func) {
             Token *tok2 = *func;
 
-            if (!Token::Match(tok2, classname.c_str()))
-                continue;
+            if (!Token::Match(tok2, classname.c_str())) {
+                if (tok2->str() != classname) // #8031: Both could be "A < B >" and if so, one must not bail out
+                    continue;
+            }
 
             if (Token::Match(tok2, "%name% <"))
                 tok2 = tok2->next()->findClosingBracket();

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1359,11 +1359,14 @@ private:
     }
 
     // Helper function to unit test TemplateSimplifier::getTemplateNamePosition
-    int templateNamePositionHelper(const char code[], unsigned offset = 0) {
+    int templateNamePositionHelper(const char code[], unsigned offset = 0, bool onlyCreateTokens = false) {
         Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);
-        tokenizer.tokenize(istr, "test.cpp", emptyString);
+        if (onlyCreateTokens)
+            tokenizer.createTokens(istr, "test.cpp");
+        else
+            tokenizer.tokenize(istr, "test.cpp", emptyString);
 
         const Token *_tok = tokenizer.tokens();
         for (unsigned i = 0 ; i < offset ; ++i)
@@ -1398,6 +1401,11 @@ private:
                       "template<class T> unsigned A<T>::foo() { return 0; }", 19));
         ASSERT_EQUALS(9, templateNamePositionHelper("template<class T, class U> class A { unsigned foo(); }; "
                       "template<class T, class U> unsigned A<T, U>::foo() { return 0; }", 25));
+        ASSERT_EQUALS(9, templateNamePositionHelper("template<class T, class U> class A { unsigned foo(); }; "
+                      "template<class T, class U> unsigned A<T, U>::foo() { return 0; }", 25, /*onlyCreateTokens=*/true));
+        ASSERT_EQUALS(12, templateNamePositionHelper("template<class T> class v {}; "
+                                                     "template<class T, class U> class A { unsigned foo(); }; "
+                                                     "template<> unsigned A<int, v<char> >::foo() { return 0; }", 30, /*onlyCreateTokens=*/true));
     }
 
     void expandSpecialized() {


### PR DESCRIPTION
The ticket highlights two issues with out of line template constructor: a bail out and missing varid setting. This patch fixes both.