### PR TITLE
Issues handling macros that don't require semicolons

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1581,7 +1581,7 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
             }
 
             // should be at a sequence point if this is a function
-            if (!Token::Match(tok1, ">|{|}|;|public:|protected:|private:") && tok1)
+            if (!Token::Match(tok1, ">|{|}|;|)|public:|protected:|private:") && tok1)
                 return false;
         }
 

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -331,6 +331,9 @@ private:
         TEST_CASE(auto7);
         TEST_CASE(auto8);
         TEST_CASE(auto9); // #8044 (segmentation fault)
+
+        TEST_CASE(macroFuncionTest1);
+        TEST_CASE(macroFuncionTest2);
     }
 
     void array() {
@@ -5183,6 +5186,42 @@ private:
                       "  }\n"
                       "}");
         ASSERT_EQUALS(true,  db != nullptr); // not null
+    }
+
+    void macroFuncionTest1() {
+        GET_SYMBOL_DB("class MacroTest\n {"
+            "public:\n"
+            "    SOME_MACRO_WITH_NO_SEMICOLON()\n"
+            "    void Init() { }\n"
+            "};\n");
+
+        // 3 scopes: Global, Class, and Function
+        ASSERT(db && db->scopeList.size() == 3);
+
+        if (!db)
+            return;
+
+        const Scope *scope = db->findScopeByName("MacroTest");
+        ASSERT(scope && scope->functionList.size() == 1);
+        ASSERT(findFunctionByName("Init", scope) != NULL);
+    }
+
+    void macroFuncionTest2() {
+        GET_SYMBOL_DB("class MacroTest\n {"
+            "public:\n"
+            "    SOME_MACRO_WITH_NO_SEMICOLON(1, 2, 3)\n"
+            "    void Init() { }\n"
+            "};\n");
+
+        // 3 scopes: Global, Class, and Function
+        ASSERT(db && db->scopeList.size() == 3);
+
+        if (!db)
+            return;
+
+        const Scope *scope = db->findScopeByName("MacroTest");
+        ASSERT(scope && scope->functionList.size() == 1);
+        ASSERT(findFunctionByName("Init", scope) != NULL);
     }
 
 };


### PR DESCRIPTION
I added test cases that catch both of these things. However, the original minimal repro causes a false positive uninitMemberVar:
```c++
struct InitTest
{
	InitTest() { Init(); }
private:
	SOME_MACRO_WITH_NO_SEMICOLON()
	void Init() { m_var = 0; }
	int m_var;
};
```