### PR TITLE
Fix for ticket #7429

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -562,7 +562,12 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
         }
 
         // Before a new statement there is "[{};()=[]" or ::
-        if (! Token::Match(ftok, "{|}|;|(|)|=|[|::"))
+        // We can also have a new statement after any operators or comparisons
+        if (! Token::Match(ftok, "%op%|%comp%|{|}|;|(|)|=|[|::"))
+            continue;
+
+        // If assignment comes after an && or || this is really inconclusive because of short circuiting
+        if (Token::Match(ftok, "%oror%|&&"))
             continue;
 
         if (Token::simpleMatch(ftok, "( !"))

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -184,6 +184,10 @@ private:
         TEST_CASE(constructors_crash1);    // ticket #5641
         TEST_CASE(classWithOperatorInName);// ticket #2827
         TEST_CASE(templateConstructor);    // ticket #7942
+
+        TEST_CASE(uninitAssignmentWithOperator);  // ticket #7429
+        TEST_CASE(uninitCompoundAssignment);      // ticket #7429
+        TEST_CASE(uninitComparisonAssignment);    // ticket #7429
     }
 
 
@@ -3357,6 +3361,317 @@ private:
               "};\n"
               "template <class T> Containter<T>::Containter() : mElements(nullptr) {}\n"
               "Containter<int> intContainer;");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void uninitAssignmentWithOperator()
+    {
+        check("struct C {\n"
+              "    int x;\n"
+              "    C() {\n"
+              "        bool b = false;\n"
+              "        b = b && SetValue();\n"
+              "    }\n"
+              "    bool SetValue() {\n"
+              "        x = 1;\n"
+              "        return true;\n"
+              "    }\n"
+              "};", true);
+        TODO_ASSERT_EQUALS("[test.cpp:3]: (warning, inconclusive) Member variable 'C::x' is not initialized in the constructor.\n",
+            "[test.cpp:3]: (warning) Member variable 'C::x' is not initialized in the constructor.\n", errout.str());
+    
+        check("struct C {\n"
+              "    int x;\n"
+              "    C() {\n"
+              "        bool b = false;\n"
+              "        b = true || SetValue();\n"
+              "    }\n"
+              "    bool SetValue() {\n"
+              "        x = 1;\n"
+              "        return true;\n"
+              "    }\n"
+              "};", true);
+        TODO_ASSERT_EQUALS("[test.cpp:3]: (warning, inconclusive) Member variable 'C::x' is not initialized in the constructor.\n",
+            "[test.cpp:3]: (warning) Member variable 'C::x' is not initialized in the constructor.\n", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = true;\n"
+            "        b = b & SetValue();\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = false;\n"
+            "        b = true | SetValue();\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i * SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i / SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i % SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i + SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i - SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i << SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i >> SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i = i ^ SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void uninitCompoundAssignment()
+    {
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = true;\n"
+            "        b &= SetValue();\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = false;\n"
+            "        b |= SetValue();\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i *= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i /= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i %= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i += SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i -= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i <<= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i >>= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        int i = 0;\n"
+            "        i ^= SetValue();\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void uninitComparisonAssignment()
+    {
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = true;\n"
+            "        b = (true == SetValue());\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = false;\n"
+            "        b |= (true != SetValue());\n"
+            "    }\n"
+            "    bool SetValue() {\n"
+            "        x = 1;\n"
+            "        return true;\n"
+            "    }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = (0 < SetValue());\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = (0 <= SetValue());\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = (0 > SetValue());\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct C {\n"
+            "    int x;\n"
+            "    C() {\n"
+            "        bool b = (0 >= SetValue());\n"
+            "    }\n"
+            "    int SetValue() { return x = 1; }\n"
+            "};");
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
This resolves false positives for uninitialized member variable when assignment comes after an operator, compound assignment, or comparison. Note that some of the tests can be done without the assignment being done in a separate function, however not all of them. This is because some of the tests would require additional parentheses which due to the parsing logic would allow the test to pass.

I left the TODO assert in there for when the assignment comes after && or || operators to be inconclusive because these could potentially be uninitialized or they could cause initialization depending on values and short circuiting. However, in general I would say it's probably bad practice to leave it up to specific conditions for your member variables to be assigned.

I do have some changes that I could post that would actually return the expected inconclusive result there, but they're much more involved and I wasn't sure it was worth it.