### PR TITLE
windows.cfg: Added support for sprintf_s and other functions.

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3571,4 +3571,60 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
+  <!-- int sprintf_s(char *buffer, size_t sizeOfBuffer, const char *format [, argument] ...); -->
+  <function name="sprintf_s">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+      <minsize type="argvalue" arg="2"/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
+    <formatstr/>
+    <arg nr="3">
+      <formatstr/>
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- char *_strupr(char *str); -->
+  <!-- char *_strlwr(char * str); -->
+  <!-- wchar_t *_wcsupr(wchar_t *str); -->
+  <!-- wchar_t *_wcslwr(wchar_t * str); -->
+  <function name="_strupr,_strlwr,_wcsupr,_wcslwr">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+      <strz/>
+    </arg>
+  </function>
+  <!-- char *_itoa(int value, char *str, int radix); -->
+  <!-- char *_i64toa(__int64 value, char *str, int radix); -->
+  <!-- char *_ui64toa(unsigned _int64 value, char *str, int radix); -->
+  <!-- wchar_t *_itow(int value, wchar_t *str, int radix); -->
+  <!-- wchar_t *_i64tow(__int64 value, wchar_t *str, int radix); -->
+  <!-- wchar_t *_ui64tow(unsigned __int64 value, wchar_t *str, int radix); -->
+  <function name="_itoa,_i64toa,_ui64toa,_itow,_i64tow,_ui64tow">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1"/>
+    <arg nr="2">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+      <valid>2:36</valid>
+    </arg>
+  </function>
 </def>


### PR DESCRIPTION
Added support for the following functions: sprintf_s, _strupr, _strlwr,
_wcsupr, _wcslwr, _itoa, _i64toa, _ui64toa, _itow, _i64tow, _ui64tow.