### PR TITLE
Write HTML report as UTF-8

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -497,8 +497,7 @@ if __name__ == '__main__':
                                               encoding=options.source_encoding)
         htmlFormatter.errors = errors
 
-        with io.open(os.path.join(options.report_dir, htmlfile),
-                     'w') as output_file:
+        with io.open(os.path.join(options.report_dir, htmlfile), 'w', encoding='utf-8') as output_file:
             output_file.write(HTML_HEAD %
                               (options.title,
                                htmlFormatter.get_style_defs('.highlight'),


### PR DESCRIPTION
When source code contains non-ASCII characters, `cppcheck-htmlreport` currently dies with an error like:
```
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 80673: ordinal not in range(128)
```
This is because even though the source code is read as UTF-8, and `HTML_HEAD` specifies that the file should be read as UTF-8, the output file is opened with the default encoding (ascii).

This should fix all of the cases that #869 fixes, in a better way (by actually writing non-ASCII characters properly as UTF-8 rather than skipping them).