### PR TITLE
Fix matchcompiler failure in case of parallel build

### DIFF
--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -22,6 +22,7 @@ import sys
 import re
 import glob
 import argparse
+import errno
 
 
 class MatchCompiler:
@@ -667,8 +668,16 @@ def main():
         sys.exit(-1)
 
     # Create build directory if needed
-    if not os.path.exists(build_dir):
+    try:
         os.makedirs(build_dir)
+    except OSError as e:
+        # due to race condition in case of parallel build,
+        # makedirs may fail. Ignore that; if there's actual
+        # problem with directory creation, it'll be caught
+        # by the following isdir check
+        if e.errno != errno.EEXIST:
+            raise
+
     if not os.path.isdir(build_dir):
         raise Exception(build_dir + ' is not a directory')
 


### PR DESCRIPTION
During parallel build, multiple processes will try to create build_dir in parallel, so the build will fail. Fix that by calling makedirs unconditionally and ignoring errors from it. If there's actual problem with directory creation, it'll be caught later by isdir() check.

Actual build error:

```
Traceback (most recent call last):                                                                                                                                                                                                                              
  File "/wrkdirs/usr/ports/devel/cppcheck/work/cppcheck-1.79/tools/matchcompiler.py", line 692, in <module>                                                                                                                                                     
    main()                                                                                                                                                                                                                                                      
  File "/wrkdirs/usr/ports/devel/cppcheck/work/cppcheck-1.79/tools/matchcompiler.py", line 671, in main                                                                                                                                                         
    os.makedirs(build_dir)                                                                                                                                                                                                                                      
  File "/usr/local/lib/python2.7/os.py", line 157, in makedirs                                                                                                                                                                                                  
    mkdir(name, mode)                                                                                                                                                                                                                                           
OSError: [Errno 17] File exists: 'build'                                                                                                                                                                                                                        
```

Unfortunately, `exist_ok` argument of os.makedirs is only available in python3, so we have to use rather ugly hack with ignoring exceptions here. Alternative fix would be to create build directory from e.g. cmake.