### PR TITLE
Make detection of clang++ compiler more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,16 +76,16 @@ ifndef CXX
     CXX=g++
 endif
 
-ifeq ($(CXX), clang++)
+ifeq (clang++, $(findstring clang++,$(CXX)))
     CPPCHK_GLIBCXX_DEBUG=
 endif
 ifndef CXXFLAGS
     CXXFLAGS=-include lib/cxx11emu.h -pedantic -Wall -Wextra -Wabi -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wshadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar $(CPPCHK_GLIBCXX_DEBUG) -g
 endif
 
-ifeq ($(CXX), g++)
+ifeq (g++, $(findstring g++,$(CXX)))
     override CXXFLAGS += -std=c++0x
-else ifeq ($(CXX), clang++)
+else ifeq (clang++, $(findstring clang++,$(CXX)))
     override CXXFLAGS += -std=c++0x
 else ifeq ($(CXX), c++)
     ifeq ($(shell uname -s), Darwin)

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
 
     // skip "-D_GLIBCXX_DEBUG" if clang, since it breaks the build
     makeConditionalVariable(fout, "CXX", "g++");
-    fout << "ifeq ($(CXX), clang++)\n"
+    fout << "ifeq (clang++, $(findstring clang++,$(CXX)))\n"
          << "    CPPCHK_GLIBCXX_DEBUG=\n"
          << "endif\n";
 
@@ -315,9 +315,9 @@ int main(int argc, char **argv)
                                 "-g");
     }
 
-    fout << "ifeq ($(CXX), g++)\n"
+    fout << "ifeq (g++, $(findstring g++,$(CXX)))\n"
          << "    override CXXFLAGS += -std=c++0x\n"
-         << "else ifeq ($(CXX), clang++)\n"
+         << "else ifeq (clang++, $(findstring clang++,$(CXX)))\n"
          << "    override CXXFLAGS += -std=c++0x\n"
          << "else ifeq ($(CXX), c++)\n"
          << "    ifeq ($(shell uname -s), Darwin)\n"


### PR DESCRIPTION
When using a specific version of clang++ or g++ via environment variables detection of compiler in the makefile fails. For example: 
> CXX=clang++3.8 make

The command above fails because addition of "CXXFLAGS += -std=c++0x" is conditional based on compiler exact name. That is makefile only expect strict comparison "ifeq ($(CXX), clang++)" and string "clang++3.8" is not equal to "clang++".

This simple PR fixes this issue making it easier to build cppcheck with different version of compiler installed. This is especially handy with Travis CI.