### PR TITLE
fix ticket #8072

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1600,8 +1600,7 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
     }
 
     // UNKNOWN_MACRO(a,b) { ... }
-    else if (outerScope->type == Scope::eGlobal &&
-             Token::Match(tok, "%name% (") &&
+    else if (Token::Match(tok, "%name% (") &&
              tok->isUpperCaseName() &&
              Token::simpleMatch(tok->linkAt(1), ") {") &&
              (!tok->previous() || Token::Match(tok->previous(), "[;{}]"))) {


### PR DESCRIPTION
by not limiting MACROs to the global scope (see minimum example attached to [ticket #8072](http://trac.cppcheck.net/ticket/8072))

Builds with Visual Studio 2017 (v141) x64 and Win32.

Testing Complete
Number of tests: 3053
Number of todos: 204
Tests failed: 0
