### PR TITLE
Unique includes

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -127,7 +127,7 @@ void ImportProject::FileSettings::setIncludePaths(const std::string &basepath, c
     uniqueIncludePaths.sort();
     uniqueIncludePaths.unique();
 
-    for (std::list<std::string>::const_iterator it = uniqueIncludePaths.begin(); uniqueIncludePaths != in.end(); ++it) {
+    for (std::list<std::string>::const_iterator it = uniqueIncludePaths.begin(); it != uniqueIncludePaths.end(); ++it) {
         if (it->empty())
             continue;
         if (it->compare(0,2,"%(")==0)

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -122,7 +122,12 @@ static bool simplifyPathWithVariables(std::string &s, const std::map<std::string
 void ImportProject::FileSettings::setIncludePaths(const std::string &basepath, const std::list<std::string> &in, const std::map<std::string, std::string> &variables)
 {
     std::list<std::string> I;
-    for (std::list<std::string>::const_iterator it = in.begin(); it != in.end(); ++it) {
+    // only parse each includePath once - so remove duplicates
+    std::list<std::string> uniqueIncludePaths = in;
+    uniqueIncludePaths.sort();
+    uniqueIncludePaths.unique();
+
+    for (std::list<std::string>::const_iterator it = uniqueIncludePaths.begin(); uniqueIncludePaths != in.end(); ++it) {
         if (it->empty())
             continue;
         if (it->compare(0,2,"%(")==0)


### PR DESCRIPTION
While parsing Visual Studio solutions, include paths are collected from all projects and their property sheets so it is quite likely that the same include path occurs multiple times.

This PR removes duplicate entries before setting the includes.

It would have been better to change the behavior higher up in the callstack but since the includepaths are handled as a string there, its a bigger change for some other time.

This PR will help when implementing [enhancement # 8110](http://trac.cppcheck.net/ticket/8110) because less variables will have to be evaluated.