### PR TITLE
check if simplifyPath changes the capitalization of paths as stated

### DIFF
--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -75,6 +75,8 @@ private:
         ASSERT_EQUALS("a/index.h", Path::simplifyPath("a/../a/index.h"));
         ASSERT_EQUALS(".", Path::simplifyPath("a/.."));
         ASSERT_EQUALS(".", Path::simplifyPath("./a/.."));
+		ASSERT_EQUALS("C:/foo.cpp", Path::simplifyPath("C:/foo.cpp"));
+		ASSERT_EQUALS("c:/foo.cpp", Path::simplifyPath("c:/foo.cpp"));
         ASSERT_EQUALS("../../src/test.cpp", Path::simplifyPath("../../src/test.cpp"));
         ASSERT_EQUALS("../../../src/test.cpp", Path::simplifyPath("../../../src/test.cpp"));
         ASSERT_EQUALS("src/test.cpp", Path::simplifyPath(".//src/test.cpp"));


### PR DESCRIPTION
in [issue #85](https://github.com/danmar/simplecpp/issues/85) of simplecpp.

This test verifies that the case of paths is not altered which in turn then breaks e.g. [suppressions.](https://ci.appveyor.com/project/danmar/cppcheck/history).