### PR TITLE
Support system environment variables

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -123,8 +123,6 @@ static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std:
 				variables[var] = variableValue;
 			}
 			else {
-				// remember that there is no value other than the variable name
-				variables[var] = var;
 				break;
 			}
 		}

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -111,23 +111,16 @@ static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std:
 		std::map<std::string, std::string>::const_iterator it1 = variables.find(var);
 		std::string variableValue;
 		// variable was not found within defined variables
-		if (it1 != variables.end()) {
-			variableValue = it1->second;
-		}
-		// also search environment variables
-		else {
-			char const* envValue = std::getenv(var.c_str());
-			if (envValue) {
-				variableValue = std::string(envValue);
-				// also cache value for next time to reduce system access
-				variables[var] = variableValue;
-			}
-			else {
+		if (it1 == variables.end()) {
+			const char *envValue = std::getenv(var.c_str());
+			if (!envValue) {
+				//! @TODO generate a debug/info message about undefined variable
 				break;
 			}
+			variables[var] = std::string(envValue);
+			it1 = variables.find(var);
 		}
-
-		s = s.substr(0, start) + variableValue + s.substr(end + 1);
+		s = s.substr(0, start) + it1->second + s.substr(end + 1);
     }
     if (s.find("$(") != std::string::npos)
         return false;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -49,7 +49,7 @@ public:
         cppcheck::Platform::PlatformType platformType;
 
         void setDefines(std::string defs);
-        void setIncludePaths(const std::string &basepath, const std::list<std::string> &in, const std::map<std::string, std::string> &variables);
+        void setIncludePaths(const std::string &basepath, const std::list<std::string> &in, std::map<std::string, std::string> &variables);
     };
     std::list<FileSettings> fileSettings;
 
@@ -61,7 +61,7 @@ public:
 private:
     void importCompileCommands(std::istream &istr);
     void importSln(std::istream &istr, const std::string &path);
-    void importVcxproj(const std::string &filename, std::map<std::string, std::string> variables, const std::string &additionalIncludeDirectories);
+    void importVcxproj(const std::string &filename, std::map<std::string, std::string> &variables, const std::string &additionalIncludeDirectories);
 };
 
 /// @}


### PR DESCRIPTION
when parsing Microsoft Visual Studio solutions and projects.

This implements [enhancement #8110](http://trac.cppcheck.net/ticket/8110) by performing a std::getenv() lookup on cache miss for a variable. This is handy if includepaths in property sheet reference environment variables instead of absolute paths.

For this feature, the signatures of some methods had to be changed so that the parameter **variables** is `in` and `out`.

Since cppcheck ignores `-I` paths when running with `--project`, comparing the timing behavior was a bit tricky. I generated a script `runcppcheck` with calls that should resemble what the `--project` flag does (with `--verbose` enabled):

`./cppcheck.exe -I X:/gmock/gtest/include/ -I X:/gmock/include/ -D"_MSC_VER=1900;_WIN32=1;WIN32=1;_DEBUG=1;_CONSOLE=1" --platform="win32W" --verbose "/c/tmp/cppcheck/main.cpp"
./cppcheck.exe -I X:/gmock/gtest/include/ -I X:/gmock/include/ -D"_MSC_VER=1900;_WIN32=1;WIN32=1;NDEBUG=1;_CONSOLE=1" --platform="win32W" --verbose "/c/tmp/cppcheck/main.cpp"
./cppcheck.exe -I X:/gmock/gtest/include/ -I X:/gmock/include/ -D"_MSC_VER=1900;_WIN32=1;_WIN64=1;_DEBUG=1;_CONSOLE=1" --platform="win64" --verbose "/c/tmp/cppcheck/main.cpp"
./cppcheck.exe -I X:/gmock/gtest/include/ -I X:/gmock/include/ -D"_MSC_VER=1900;_WIN32=1;_WIN64=1;NDEBUG=1;_CONSOLE=1" --platform="win64" --verbose "/c/tmp/cppcheck/main.cpp"`

vs.

`./cppcheck.exe --verbose --project="/c/tmp/cppcheck/cppcheck_gtest.sln"`

and ran both a couple of times with `time` (using the real value), using **Release|x64** as target. I then compared this to same when on branch _master_.

- branch project: ~7.9s
- branch runcppcheck: ~8.1s
- master project: ~0.2s
- master runcppcheck: ~8.1s

Of course, master project is incredibly fast because it does not find the include paths correctly. Also, `runcppcheck` has some overhead of starting cppcheck multiple times. Overall performance seems fine to me.

In [commit c09227a](https://github.com/x29a/cppcheck/commit/c09227a454088d9394c5fba61b3da195e5bb2f36) I removed  the performance improvement where i also cache that no variable value was found using std::getenv(). I removed it because the gain was very small and it pollutes the **variables** cache. One could argue to put it back in since the cache is local to `importSln()`, timing improvement was:
- project: ~7.6s (about 0.3s)
- runcppcheck: ~7.9s (about 0.2s)