### PR TITLE
also support absolute project paths

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -253,8 +253,10 @@ void ImportProject::importSln(std::istream &istr, const std::string &path)
         const std::string::size_type pos1 = line.rfind('\"',pos);
         if (pos == std::string::npos)
             continue;
-        const std::string vcxproj(line.substr(pos1+1, pos-pos1+7));
-        importVcxproj(path + Path::fromNativeSeparators(vcxproj), variables, emptyString);
+        std::string vcxproj(line.substr(pos1+1, pos-pos1+7));
+		if (!Path::isAbsolute(vcxproj))
+			vcxproj = path + vcxproj;
+        importVcxproj(Path::fromNativeSeparators(vcxproj), variables, emptyString);
     }
 }
 


### PR DESCRIPTION
because always prepending the path (base of where solution is stored) breaks absolute paths as project paths.

The signature was changed slightly in order to pass the solution basedir along so if the path can not be resolved directly, the relative approach is still tried.