### PR TITLE
Do not warn when unique pointers are passed by value

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1379,7 +1379,7 @@ void CheckOther::checkPassByReference()
         const Token* const tok = var->typeStartToken();
         if (var->isStlStringType()) {
             ;
-        } else if (var->isStlType() && Token::Match(tok, "std :: %type% <") && !Token::simpleMatch(tok->linkAt(3), "> ::") && !Token::Match(tok->tokAt(2), "initializer_list|weak_ptr|auto_ptr")) {
+        } else if (var->isStlType() && Token::Match(tok, "std :: %type% <") && !Token::simpleMatch(tok->linkAt(3), "> ::") && !Token::Match(tok->tokAt(2), "initializer_list|weak_ptr|auto_ptr|unique_ptr")) {
             ;
         } else if (var->type() && !var->type()->isEnumType()) { // Check if type is a struct or class.
             // Ensure that it is a large object.

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1371,6 +1371,9 @@ private:
         check("void f(const std::string str) {}");
         ASSERT_EQUALS("[test.cpp:1]: (performance) Function parameter 'str' should be passed by reference.\n", errout.str());
 
+        check("void f(std::unique_ptr<std::string> ptr) {}");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f(const std::string::size_type x) {}");
         ASSERT_EQUALS("", errout.str());
 


### PR DESCRIPTION
A unique pointer should only be passed by value or by const reference.
Passing by value means transferring ownership it makes no sense to have a pass by value Warning for unique_ptr.

Signed-off-by: Andreas Pokorny <andreas.pokorny@siemens.com>