### PR TITLE
add missing change from "GUI: Rename methods in FileList and PathMatch"

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -134,7 +134,7 @@ void FileLister::recursiveAddFiles(std::map<std::string, std::size_t> &files, co
             }
         } else {
             // Directory
-            if (!ignored.Match(fname))
+            if (!ignored.match(fname))
                 FileLister::recursiveAddFiles(files, fname, extra, ignored);
         }
     } while (FindNextFileA(hFind, &ffd) != FALSE);


### PR DESCRIPTION
which should fix the build again

this is missing from [this commit](https://github.com/danmar/cppcheck/commit/c4bd70210c40bcab84d10a1261fe170a8af5792e) by @danmar