### PR TITLE
Fixed #8142 (false positive: The class 'B' has 'copy constructor' but…

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2383,7 +2383,13 @@ void CheckClass::checkCopyCtorAndEqOperator()
     for (std::size_t i = 0; i < classes; ++i) {
         const Scope * scope = symbolDatabase->classAndStructScopes[i];
 
-        if (scope->varlist.empty())
+        // count the number of non-static variables
+        int vars = 0;
+        for (std::list<Variable>::const_iterator var = scope->varlist.begin(); var != scope->varlist.end(); ++var) {
+            if (!var->isStatic())
+                vars++;
+        }
+        if (vars == 0)
             continue;
 
         int hasCopyCtor = 0;

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -254,6 +254,26 @@ private:
                                    "    int x;\n"
                                    "};");
         ASSERT_EQUALS("", errout.str());
+
+        checkCopyCtorAndEqOperator("class A {\n"
+                                   "public:\n"
+                                   "    A() : x(0) { }\n"
+                                   "    A(const A & a) { x = a.x; }\n"
+                                   "    A & operator = (const A & a) {\n"
+                                   "        x = a.x;\n"
+                                   "        return *this;\n"
+                                   "    }\n"
+                                   "private:\n"
+                                   "    int x;\n"
+                                   "};\n"
+                                   "class B : public A {\n"
+                                   "public:\n"
+                                   "    B() { }\n"
+                                   "    B(const B & b) :A(b) { }\n"
+                                   "private:\n"
+                                   "    static int i;\n"
+                                   "};");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkExplicitConstructors(const char code[]) {


### PR DESCRIPTION
… lack of 'operator='.)

Do not count static member variables when trying to figure out if
'operator =' is needed.