### PR TITLE
CMake: Upgrade Qt4 to Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(CppCheck)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.4)
 
 include(GNUInstallDirs)
 

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -1,4 +1,6 @@
-find_package(Qt4 4.6.1 COMPONENTS QtCore QtGui QtXML)
+set(GUI_QT_COMPONENTS Core Gui Widgets PrintSupport)
+find_package(Qt5 COMPONENTS ${GUI_QT_COMPONENTS})
+find_package(Qt5LinguistTools)
 if (HAVE_RULES)
     find_library(PCRE pcre)
     if (NOT PCRE)

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,7 +1,6 @@
 if (BUILD_GUI)
 
     set(CMAKE_AUTOMOC ON)
-    include(${QT_USE_FILE})
     if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
         add_definitions(-DQT_NO_DEBUG)
         add_definitions(-DQT_NO_DEBUG_OUTPUT)
@@ -17,16 +16,15 @@ if (BUILD_GUI)
     file(GLOB srcs "*.cpp")
     file(GLOB uis  "*.ui")
     file(GLOB tss  "*.ts")
-    QT4_WRAP_UI(uis_hdrs ${uis})
-    QT4_ADD_RESOURCES(resources "gui.qrc")
-    QT4_ADD_TRANSLATION(qms ${tss})
+    QT5_WRAP_UI(uis_hdrs ${uis})
+    QT5_ADD_RESOURCES(resources "gui.qrc")
+    QT5_ADD_TRANSLATION(qms ${tss})
 
     add_executable(cppcheck-gui ${hdrs} ${srcs} ${uis_hdrs} ${resources} ${qms} $<TARGET_OBJECTS:lib_objs> $<TARGET_OBJECTS:tinyxml_objs> $<TARGET_OBJECTS:simplecpp_objs>)
-    target_link_libraries(cppcheck-gui ${QT_LIBRARIES})
     if (HAVE_RULES)
         target_link_libraries(cppcheck-gui pcre)
     endif()
-
+    qt5_use_modules(cppcheck-gui ${GUI_QT_COMPONENTS})
 
     install(TARGETS cppcheck-gui RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)
     install(FILES ${qms} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)


### PR DESCRIPTION
The latest commit with comment "GUI: modernize connect ..." for example 5e189de95611fa3fb9eb1cef30a1340deab04bfb require Qt5.
However, the CMake build still used Qt4.

This pull request upgrades the CMake build to use Qt5 such that it can build the current sources.