### PR TITLE
Refactoring: New qt signal slot syntax

### DIFF
--- a/gui/applicationdialog.cpp
+++ b/gui/applicationdialog.cpp
@@ -34,7 +34,7 @@ ApplicationDialog::ApplicationDialog(const QString &title,
 {
     mUI.setupUi(this);
 
-    connect(mUI.mButtonBrowse, SIGNAL(clicked()), this, SLOT(browse()));
+    connect(mUI.mButtonBrowse, &QPushButton::clicked, this, &ApplicationDialog::browse);
     connect(mUI.mButtons, &QDialogButtonBox::accepted, this, &ApplicationDialog::ok);
     connect(mUI.mButtons, &QDialogButtonBox::rejected, this, &ApplicationDialog::reject);
     mUI.mPath->setText(app.getPath());

--- a/gui/file.ui
+++ b/gui/file.ui
@@ -37,22 +37,6 @@
  <connections>
   <connection>
    <sender>mButtons</sender>
-   <signal>accepted()</signal>
-   <receiver>Fileview</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mButtons</sender>
    <signal>rejected()</signal>
    <receiver>Fileview</receiver>
    <slot>reject()</slot>

--- a/gui/fileviewdialog.cpp
+++ b/gui/fileviewdialog.cpp
@@ -31,7 +31,6 @@ FileViewDialog::FileViewDialog(const QString &file,
 
 
     setWindowTitle(title);
-    connect(mUI.mButtons, SIGNAL(accepted()), this, SLOT(accept()));
     loadTextFile(file, mUI.mText);
 }
 

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -1,5 +1,11 @@
 lessThan(QT_MAJOR_VERSION, 5): error(requires >= Qt 5 (You used: $$QT_VERSION))
 
+greaterThan(QT_MAJOR_VERSION, 4) {
+   lessThan(QT_MINOR_VERSION, 7) {
+      DEFINES += QOVERLOAD_FALLBACK
+   }
+}
+
 TEMPLATE = app
 TARGET = cppcheck-gui
 CONFIG += warn_on debug

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -1,3 +1,5 @@
+lessThan(QT_MAJOR_VERSION, 5): error(requires >= Qt 5 (You used: $$QT_VERSION))
+
 TEMPLATE = app
 TARGET = cppcheck-gui
 CONFIG += warn_on debug
@@ -5,10 +7,8 @@ DEPENDPATH += . \
     ../lib
 INCLUDEPATH += . \
     ../lib
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets # In Qt 5 widgets are in separate module
-    QT += printsupport # In Qt 5 QPrinter/QPrintDialog are in separate module
-}
+QT += widgets
+QT += printsupport
 
 contains(LINKCORE, [yY][eE][sS]) {
     LIBS += -l../bin/cppcheck-core

--- a/gui/logview.cpp
+++ b/gui/logview.cpp
@@ -32,9 +32,9 @@ LogView::LogView(QWidget *parent)
     setWindowFlags(Qt::Tool);
 
     mUI.mButtonBox->button(QDialogButtonBox::Reset)->setText(tr("Clear"));
-    connect(mUI.mButtonBox->button(QDialogButtonBox::Close), SIGNAL(clicked()), this, SLOT(closeButtonClicked()));
-    connect(mUI.mButtonBox->button(QDialogButtonBox::Reset), SIGNAL(clicked()), this, SLOT(clearButtonClicked()));
-    connect(mUI.mButtonBox->button(QDialogButtonBox::Save), SIGNAL(clicked()), this, SLOT(saveButtonClicked()));
+    connect(mUI.mButtonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &LogView::closeButtonClicked);
+    connect(mUI.mButtonBox->button(QDialogButtonBox::Reset), &QPushButton::clicked, this, &LogView::clearButtonClicked);
+    connect(mUI.mButtonBox->button(QDialogButtonBox::Save), &QPushButton::clicked, this, &LogView::saveButtonClicked);
 
     QSettings settings;
     resize(settings.value(SETTINGS_LOG_VIEW_WIDTH, 400).toInt(),

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -79,11 +79,11 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
     mLineEditFilter = new QLineEdit(mUI.mToolBarFilter);
     mLineEditFilter->setPlaceholderText(tr("Quick Filter:"));
     mUI.mToolBarFilter->addWidget(mLineEditFilter);
-    connect(mLineEditFilter, SIGNAL(textChanged(const QString&)), mFilterTimer, SLOT(start()));
+    connect(mLineEditFilter, &QLineEdit::textChanged, mFilterTimer, QOverload<>::of(&QTimer::start));
     connect(mLineEditFilter, &QLineEdit::returnPressed, this, &MainWindow::filterResults);
 
-    connect(mUI.mActionPrint, SIGNAL(triggered()), mUI.mResults, SLOT(print()));
-    connect(mUI.mActionPrintPreview, SIGNAL(triggered()), mUI.mResults, SLOT(printPreview()));
+    connect(mUI.mActionPrint, &QAction::triggered, mUI.mResults, QOverload<>::of(&ResultsView::print));
+    connect(mUI.mActionPrintPreview, &QAction::triggered, mUI.mResults, &ResultsView::printPreview);
     connect(mUI.mActionQuit, &QAction::triggered, this, &MainWindow::close);
     connect(mUI.mActionAnalyzeFiles, &QAction::triggered, this, &MainWindow::analyzeFiles);
     connect(mUI.mActionAnalyzeDirectory, &QAction::triggered, this, &MainWindow::analyzeDirectory);
@@ -117,9 +117,9 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
     connect(mUI.mActionLicense, &QAction::triggered, this, &MainWindow::showLicense);
 
     // View > Toolbar menu
-    connect(mUI.mActionToolBarMain, SIGNAL(toggled(bool)), this, SLOT(toggleMainToolBar()));
-    connect(mUI.mActionToolBarView, SIGNAL(toggled(bool)), this, SLOT(toggleViewToolBar()));
-    connect(mUI.mActionToolBarFilter, SIGNAL(toggled(bool)), this, SLOT(toggleFilterToolBar()));
+    connect(mUI.mActionToolBarMain, &QAction::toggled, this, &MainWindow::toggleMainToolBar);
+    connect(mUI.mActionToolBarView, &QAction::toggled, this, &MainWindow::toggleViewToolBar);
+    connect(mUI.mActionToolBarFilter, &QAction::toggled, this, &MainWindow::toggleFilterToolBar);
 
     connect(mUI.mActionAuthors, &QAction::triggered, this, &MainWindow::showAuthors);
     connect(mThread, &ThreadHandler::done, this, &MainWindow::analysisDone);
@@ -161,8 +161,7 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
     for (int i = 0; i < MaxRecentProjects; ++i) {
         mRecentProjectActs[i] = new QAction(this);
         mRecentProjectActs[i]->setVisible(false);
-        connect(mRecentProjectActs[i], SIGNAL(triggered()),
-                this, SLOT(openRecentProject()));
+        connect(mRecentProjectActs[i], &QAction::triggered, this, &MainWindow::openRecentProject);
     }
     mRecentProjectActs[MaxRecentProjects] = nullptr; // The separator
     mUI.mActionProjectMRU->setVisible(false);
@@ -188,7 +187,7 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
         act->setCheckable(true);
         act->setActionGroup(mPlatformActions);
         mUI.mMenuAnalyze->insertAction(mUI.mActionPlatforms, act);
-        connect(act, SIGNAL(triggered()), this, SLOT(selectPlatform()));
+        connect(act, &QAction::triggered, this, &MainWindow::selectPlatform);
     }
 
     mUI.mActionC89->setActionGroup(mCStandardActions);
@@ -485,14 +484,10 @@ void MainWindow::analyzeCode(const QString& code, const QString& filename)
     // Initialize dummy ThreadResult as ErrorLogger
     ThreadResult result;
     result.setFiles(QStringList(filename));
-    connect(&result, SIGNAL(progress(int, const QString&)),
-            mUI.mResults, SLOT(progress(int, const QString&)));
-    connect(&result, SIGNAL(error(const ErrorItem &)),
-            mUI.mResults, SLOT(error(const ErrorItem &)));
-    connect(&result, SIGNAL(log(const QString &)),
-            this, SLOT(log(const QString &)));
-    connect(&result, SIGNAL(debugError(const ErrorItem &)),
-            this, SLOT(debugError(const ErrorItem &)));
+    connect(&result, &ThreadResult::progress, mUI.mResults, &ResultsView::progress);
+	connect(&result, &ThreadResult::error, mUI.mResults, &ResultsView::error);
+    connect(&result, &ThreadResult::log, this, &MainWindow::log);
+    connect(&result, &ThreadResult::debugError, this, &MainWindow::debugError);
 
     // Create CppCheck instance
     CppCheck cppcheck(result, true);

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -79,10 +79,19 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
     mLineEditFilter = new QLineEdit(mUI.mToolBarFilter);
     mLineEditFilter->setPlaceholderText(tr("Quick Filter:"));
     mUI.mToolBarFilter->addWidget(mLineEditFilter);
+#ifndef QOVERLOAD_FALLBACK
     connect(mLineEditFilter, &QLineEdit::textChanged, mFilterTimer, QOverload<>::of(&QTimer::start));
+#else
+    connect(mLineEditFilter, &QLineEdit::textChanged, mFilterTimer, static_cast<void (QTimer::*)(void)>(&QTimer::start));
+#endif
+
     connect(mLineEditFilter, &QLineEdit::returnPressed, this, &MainWindow::filterResults);
 
+#ifndef QOVERLOAD_FALLBACK
     connect(mUI.mActionPrint, &QAction::triggered, mUI.mResults, QOverload<>::of(&ResultsView::print));
+#else
+    connect(mUI.mActionPrint, &QAction::triggered, mUI.mResults, static_cast<void (ResultsView::*)(void)>(&ResultsView::print));
+#endif
     connect(mUI.mActionPrintPreview, &QAction::triggered, mUI.mResults, &ResultsView::printPreview);
     connect(mUI.mActionQuit, &QAction::triggered, this, &MainWindow::close);
     connect(mUI.mActionAnalyzeFiles, &QAction::triggered, this, &MainWindow::analyzeFiles);

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -177,6 +177,12 @@ public slots:
     /** @brief Slot for showing the library editor */
     void showLibraryEditor();
 
+	/** @brief Add new line to log. */
+	void log(const QString &logline);
+
+	/** @brief Handle new debug error. */
+	void debugError(const ErrorItem &item);
+
 protected slots:
 
     /** @brief Slot for checkthread's done signal */
@@ -205,12 +211,6 @@ protected slots:
 
     /** @brief Open help file contents */
     void openHelpContents();
-
-    /** @brief Add new line to log. */
-    void log(const QString &logline);
-
-    /** @brief Handle new debug error. */
-    void debugError(const ErrorItem &item);
 
     /** @brief Filters the results in the result list. */
     void filterResults();

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -94,13 +94,31 @@ ProjectFileDialog::ProjectFileDialog(ProjectFile *projectFile, QWidget *parent)
     connect(mUI.mBtnBrowseBuildDir, &QPushButton::clicked, this, &ProjectFileDialog::browseBuildDir);
     connect(mUI.mBtnClearImportProject, &QPushButton::clicked, this, &ProjectFileDialog::clearImportProject);
     connect(mUI.mBtnBrowseImportProject, &QPushButton::clicked, this, &ProjectFileDialog::browseImportProject);
+
+#ifndef QOVERLOAD_FALLBACK
     connect(mUI.mBtnAddCheckPath, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addCheckPath));
+#else
+    connect(mUI.mBtnAddCheckPath, &QPushButton::clicked, this, static_cast<void(ProjectFileDialog::*)(void)>(&ProjectFileDialog::addCheckPath));
+#endif
+
     connect(mUI.mBtnEditCheckPath, &QPushButton::clicked, this, &ProjectFileDialog::editCheckPath);
     connect(mUI.mBtnRemoveCheckPath, &QPushButton::clicked, this, &ProjectFileDialog::removeCheckPath);
+
+#ifndef QOVERLOAD_FALLBACK
     connect(mUI.mBtnAddInclude, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addIncludeDir));
+#else
+    connect(mUI.mBtnAddInclude, &QPushButton::clicked, this, static_cast<void(ProjectFileDialog::*)(void)>(&ProjectFileDialog::addIncludeDir));
+#endif
+
     connect(mUI.mBtnEditInclude, &QPushButton::clicked, this, &ProjectFileDialog::editIncludeDir);
     connect(mUI.mBtnRemoveInclude, &QPushButton::clicked, this, &ProjectFileDialog::removeIncludeDir);
+
+#ifndef QOVERLOAD_FALLBACK
     connect(mUI.mBtnAddIgnorePath, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addExcludePath));
+#else
+    connect(mUI.mBtnAddIgnorePath, &QPushButton::clicked, this, static_cast<void (ProjectFileDialog::*)(void)>(&ProjectFileDialog::addExcludePath));
+#endif
+
     connect(mUI.mBtnEditIgnorePath, &QPushButton::clicked, this, &ProjectFileDialog::editExcludePath);
     connect(mUI.mBtnRemoveIgnorePath, &QPushButton::clicked, this, &ProjectFileDialog::removeExcludePath);
     connect(mUI.mBtnIncludeUp, &QPushButton::clicked, this, &ProjectFileDialog::moveIncludePathUp);

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -94,13 +94,13 @@ ProjectFileDialog::ProjectFileDialog(ProjectFile *projectFile, QWidget *parent)
     connect(mUI.mBtnBrowseBuildDir, &QPushButton::clicked, this, &ProjectFileDialog::browseBuildDir);
     connect(mUI.mBtnClearImportProject, &QPushButton::clicked, this, &ProjectFileDialog::clearImportProject);
     connect(mUI.mBtnBrowseImportProject, &QPushButton::clicked, this, &ProjectFileDialog::browseImportProject);
-    connect(mUI.mBtnAddCheckPath, SIGNAL(clicked()), this, SLOT(addCheckPath()));
+    connect(mUI.mBtnAddCheckPath, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addCheckPath));
     connect(mUI.mBtnEditCheckPath, &QPushButton::clicked, this, &ProjectFileDialog::editCheckPath);
     connect(mUI.mBtnRemoveCheckPath, &QPushButton::clicked, this, &ProjectFileDialog::removeCheckPath);
-    connect(mUI.mBtnAddInclude, SIGNAL(clicked()), this, SLOT(addIncludeDir()));
+    connect(mUI.mBtnAddInclude, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addIncludeDir));
     connect(mUI.mBtnEditInclude, &QPushButton::clicked, this, &ProjectFileDialog::editIncludeDir);
     connect(mUI.mBtnRemoveInclude, &QPushButton::clicked, this, &ProjectFileDialog::removeIncludeDir);
-    connect(mUI.mBtnAddIgnorePath, SIGNAL(clicked()), this, SLOT(addExcludePath()));
+    connect(mUI.mBtnAddIgnorePath, &QPushButton::clicked, this, QOverload<>::of(&ProjectFileDialog::addExcludePath));
     connect(mUI.mBtnEditIgnorePath, &QPushButton::clicked, this, &ProjectFileDialog::editExcludePath);
     connect(mUI.mBtnRemoveIgnorePath, &QPushButton::clicked, this, &ProjectFileDialog::removeExcludePath);
     connect(mUI.mBtnIncludeUp, &QPushButton::clicked, this, &ProjectFileDialog::moveIncludePathUp);

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -579,12 +579,20 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
             menu.addAction(start);
 
             //Connect the signal to signal mapper
+#ifndef QOVERLOAD_FALLBACK
             connect(start, &QAction::triggered, signalMapper, QOverload<>::of(&QSignalMapper::map));
+#else
+            connect(start, &QAction::triggered, signalMapper, static_cast<void (QSignalMapper::*)(void)>(&QSignalMapper::map));
+#endif
 
             //Add a new mapping
             signalMapper->setMapping(start, defaultApplicationIndex);
 
+#ifndef QOVERLOAD_FALLBACK
             connect(signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &ResultsTree::context);
+#else
+            connect(signalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &ResultsTree::context);
+#endif
         }
 
         // Add menuitems to copy full path/filename to clipboard
@@ -658,10 +666,19 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
                 //Disconnect all signals
                 for (int i = 0; i < actions.size(); i++) {
 
+#ifndef QOVERLOAD_FALLBACK
                     disconnect(actions[i], &QAction::triggered, signalMapper, QOverload<>::of(&QSignalMapper::map));
+#else
+                    disconnect(actions[i], &QAction::triggered, signalMapper, static_cast<void (QSignalMapper::*)(void)>(&QSignalMapper::map));
+#endif
                 }
 
+#ifndef QOVERLOAD_FALLBACK
                 disconnect(signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &ResultsTree::context);
+#else
+                disconnect(signalMapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped), this, &ResultsTree::context);
+#endif
+
                 //And remove the signal mapper
                 delete signalMapper;
             }

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -576,13 +576,12 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
             menu.addAction(start);
 
             //Connect the signal to signal mapper
-            connect(start, SIGNAL(triggered()), signalMapper, SLOT(map()));
+            connect(start, &QAction::triggered, signalMapper, QOverload<>::of(&QSignalMapper::map));
 
             //Add a new mapping
             signalMapper->setMapping(start, defaultApplicationIndex);
 
-            connect(signalMapper, SIGNAL(mapped(int)),
-                    this, SLOT(context(int)));
+            connect(signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &ResultsTree::context);
         }
 
         // Add menuitems to copy full path/filename to clipboard
@@ -623,14 +622,14 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
             menu.addAction(hideallid);
             menu.addAction(opencontainingfolder);
 
-            connect(recheckSelectedFiles, SIGNAL(triggered()), this, SLOT(recheckSelectedFiles()));
-            connect(copyfilename, SIGNAL(triggered()), this, SLOT(copyFilename()));
-            connect(copypath, SIGNAL(triggered()), this, SLOT(copyFullPath()));
-            connect(copymessage, SIGNAL(triggered()), this, SLOT(copyMessage()));
-            connect(copymessageid, SIGNAL(triggered()), this, SLOT(copyMessageId()));
-            connect(hide, SIGNAL(triggered()), this, SLOT(hideResult()));
-            connect(hideallid, SIGNAL(triggered()), this, SLOT(hideAllIdResult()));
-            connect(opencontainingfolder, SIGNAL(triggered()), this, SLOT(openContainingFolder()));
+            connect(recheckSelectedFiles, &QAction::triggered, this, &ResultsTree::recheckSelectedFiles);
+            connect(copyfilename, &QAction::triggered, this, &ResultsTree::copyFilename);
+            connect(copypath, &QAction::triggered, this, &ResultsTree::copyFullPath);
+            connect(copymessage, &QAction::triggered, this, &ResultsTree::copyMessage);
+            connect(copymessageid, &QAction::triggered, this, &ResultsTree::copyMessageId);
+            connect(hide, &QAction::triggered, this, &ResultsTree::hideResult);
+            connect(hideallid, &QAction::triggered, this, &ResultsTree::hideAllIdResult);
+            connect(opencontainingfolder, &QAction::triggered, this, &ResultsTree::openContainingFolder);
 
             menu.addSeparator();
             QAction *fp       = new QAction(tr("False positive"), &menu);
@@ -653,11 +652,10 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
                 //Disconnect all signals
                 for (int i = 0; i < actions.size(); i++) {
 
-                    disconnect(actions[i], SIGNAL(triggered()), signalMapper, SLOT(map()));
+                    disconnect(actions[i], &QAction::triggered, signalMapper, QOverload<>::of(&QSignalMapper::map));
                 }
 
-                disconnect(signalMapper, SIGNAL(mapped(int)),
-                           this, SLOT(context(int)));
+                disconnect(signalMapper, QOverload<int>::of(&QSignalMapper::mapped), this, &ResultsTree::context);
                 //And remove the signal mapper
                 delete signalMapper;
             }

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -212,7 +212,7 @@ void ResultsView::printPreview()
 {
     QPrinter printer;
     QPrintPreviewDialog dialog(&printer, this);
-    connect(&dialog, SIGNAL(paintRequested(QPrinter*)), SLOT(print(QPrinter*)));
+    connect(&dialog, &QPrintPreviewDialog::paintRequested, this, QOverload<QPrinter*>::of(&ResultsView::print));
     dialog.exec();
 }
 

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -216,7 +216,12 @@ void ResultsView::printPreview()
 {
     QPrinter printer;
     QPrintPreviewDialog dialog(&printer, this);
+#ifndef QOVERLOAD_FALLBACK
     connect(&dialog, &QPrintPreviewDialog::paintRequested, this, QOverload<QPrinter*>::of(&ResultsView::print));
+#else
+    connect(&dialog, &QPrintPreviewDialog::paintRequested, this, static_cast<void (ResultsView::*)(QPrinter*)>(&ResultsView::print));
+#endif
+
     dialog.exec();
 }
 

--- a/gui/scratchpad.cpp
+++ b/gui/scratchpad.cpp
@@ -26,7 +26,7 @@ ScratchPad::ScratchPad(MainWindow& mainWindow)
 {
     mUI.setupUi(this);
 
-    connect(mUI.mCheckButton, SIGNAL(clicked()), this, SLOT(checkButtonClicked()));
+    connect(mUI.mCheckButton, &QPushButton::clicked, this, &ScratchPad::checkButtonClicked);
 }
 
 void ScratchPad::checkButtonClicked()

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -56,22 +56,14 @@ SettingsDialog::SettingsDialog(ApplicationList *list,
 
     connect(mUI.mButtons, &QDialogButtonBox::accepted, this, &SettingsDialog::ok);
     connect(mUI.mButtons, &QDialogButtonBox::rejected, this, &SettingsDialog::reject);
-    connect(mUI.mBtnAddApplication, SIGNAL(clicked()),
-            this, SLOT(addApplication()));
-    connect(mUI.mBtnRemoveApplication, SIGNAL(clicked()),
-            this, SLOT(removeApplication()));
-    connect(mUI.mBtnEditApplication, SIGNAL(clicked()),
-            this, SLOT(editApplication()));
-    connect(mUI.mBtnDefaultApplication, SIGNAL(clicked()),
-            this, SLOT(defaultApplication()));
-    connect(mUI.mListWidget, SIGNAL(itemDoubleClicked(QListWidgetItem *)),
-            this, SLOT(editApplication()));
-    connect(mUI.mBtnAddIncludePath, SIGNAL(clicked()),
-            this, SLOT(addIncludePath()));
-    connect(mUI.mBtnRemoveIncludePath, SIGNAL(clicked()),
-            this, SLOT(removeIncludePath()));
-    connect(mUI.mBtnEditIncludePath, SIGNAL(clicked()),
-            this, SLOT(editIncludePath()));
+    connect(mUI.mBtnAddApplication, &QPushButton::clicked, this, &SettingsDialog::addApplication);
+    connect(mUI.mBtnRemoveApplication, &QPushButton::clicked, this, &SettingsDialog::removeApplication);
+    connect(mUI.mBtnEditApplication, &QPushButton::clicked, this, &SettingsDialog::editApplication);
+    connect(mUI.mBtnDefaultApplication, &QPushButton::clicked, this, &SettingsDialog::defaultApplication);
+    connect(mUI.mListWidget, &QListWidget::itemDoubleClicked, this, &SettingsDialog::editApplication);
+    connect(mUI.mBtnAddIncludePath, &QPushButton::clicked, this, QOverload<>::of(&SettingsDialog::addIncludePath));
+    connect(mUI.mBtnRemoveIncludePath, &QPushButton::clicked, this, &SettingsDialog::removeIncludePath);
+    connect(mUI.mBtnEditIncludePath, &QPushButton::clicked, this, &SettingsDialog::editIncludePath);
 
     mUI.mListWidget->setSortingEnabled(false);
     populateApplicationList();
@@ -333,6 +325,10 @@ void SettingsDialog::addIncludePath()
 void SettingsDialog::removeIncludePath()
 {
     const int row = mUI.mListIncludePaths->currentRow();
+
+    if (row < 0)
+	    return;
+
     QListWidgetItem *item = mUI.mListIncludePaths->takeItem(row);
     delete item;
 }
@@ -340,5 +336,9 @@ void SettingsDialog::removeIncludePath()
 void SettingsDialog::editIncludePath()
 {
     QListWidgetItem *item = mUI.mListIncludePaths->currentItem();
+
+    if (item == nullptr)
+        return;
+
     mUI.mListIncludePaths->editItem(item);
 }

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -70,7 +70,13 @@ SettingsDialog::SettingsDialog(ApplicationList *list,
     connect(mUI.mBtnEditApplication, &QPushButton::clicked, this, &SettingsDialog::editApplication);
     connect(mUI.mBtnDefaultApplication, &QPushButton::clicked, this, &SettingsDialog::defaultApplication);
     connect(mUI.mListWidget, &QListWidget::itemDoubleClicked, this, &SettingsDialog::editApplication);
+
+#ifndef QOVERLOAD_FALLBACK
     connect(mUI.mBtnAddIncludePath, &QPushButton::clicked, this, QOverload<>::of(&SettingsDialog::addIncludePath));
+#else
+    connect(mUI.mBtnAddIncludePath, &QPushButton::clicked, this, static_cast<void (SettingsDialog::*)(void)>(&SettingsDialog::addIncludePath));
+#endif
+
     connect(mUI.mBtnRemoveIncludePath, &QPushButton::clicked, this, &SettingsDialog::removeIncludePath);
     connect(mUI.mBtnEditIncludePath, &QPushButton::clicked, this, &SettingsDialog::editIncludePath);
 


### PR DESCRIPTION
Refactored all (except used by designer) Qt signal/slots to the new syntax.

In this step i removed support for Qt4, because the already used new signal/slot syntax not supported by Qt4. Add blockade that qt4 qmake don't allow generate a project file. 

**Other little special changes are:**
mainwindow/threadhandler:
- Moved needed slots to public
- Type safe connect to MainWindow

file.ui/fileviewdialog:
- Removed not used connect. The QDialogButtonBox are contain only a close button with the RejectRole. There are no button that need/used the AcceptRole.

settingsdialog:
- Corrected debug output if no element is selected.