### PR TITLE
Resolve CID 1365360

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -496,8 +496,13 @@ bool CmdLineParser::ParseFromArgs(int argc, const char* const argv[])
             // --project
             else if (std::strncmp(argv[i], "--project=", 10) == 0) {
                 _settings->project.import(argv[i]+10);
-                if (std::strstr(argv[i], ".sln") || std::strstr(argv[i], ".vcxproj"))
-                    CppCheckExecutor::tryLoadLibrary(_settings->library, argv[0], "windows");
+                if (std::strstr(argv[i], ".sln") || std::strstr(argv[i], ".vcxproj")) {
+                    if (!CppCheckExecutor::tryLoadLibrary(_settings->library, argv[0], "windows.cfg")) {
+                        // This shouldn't happen normally.
+                        PrintMessage("cppcheck: Failed to load 'windows.cfg'. Your Cppcheck installation is broken. Please re-install.");
+                        return false;
+                    }
+                }
             }
 
             // Report progress


### PR DESCRIPTION
@danmar I'm not fully sure so could you please review this?

It looks like this `tryLoadLibrary()` call tries to load windows.cfg which should never fail in normal scenarios. However the current code ignores the result and silently continues execution. This doesn't look good at all.