### PR TITLE
Make MISRA C 2012 12.2 work on C++

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -587,7 +587,7 @@ def misra_12_2(data):
             continue
         maxval = 0
         for val in token.astOperand2.values:
-            if val.intvalue > maxval:
+            if val.intvalue and val.intvalue > maxval:
                 maxval = val.intvalue
         if maxval == 0:
             continue


### PR DESCRIPTION
Hello!

I'm not quite sure if your intention was to make MISRA C 2012 addon (`addons/misra.py`) work with C++ codes or not, current `misra.py` addon work well with C++ codes.

I found it is highly useful to detect some rules of MISRA C++ 2008, specifically intersection of MISRA C and C++ .

To make current `misra.py` work with C++ smoothly, I made a subtle change.
Followings are the reason of my change.

If you try to analyze below code with current `misra.py`,
```
#include <iostream>

int main(void)
{
  std::cout<<"Hello"<<"World!"<<std::endl;
  return 0;
}
```

You will encounter following error.
```
Checking test.cpp.dump...
Traceback (most recent call last):
  File "addons/misra.py", line 1107, in <module>
    misra_12_2(cfg)
  File "addons/misra.py", line 590, in misra_12_2
    if val.intvalue > maxval:
TypeError: unorderable types: NoneType > int
```