### PR TITLE
Fix typo causing two expressions being identical

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -223,7 +223,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
     // in c++, a+b might be different to b+a, depending on the type of a and b
     if (cpp && tok1->str() == "+") {
         const ValueType* vt1 = tok1->astOperand1()->valueType();
-        const ValueType* vt2 = tok1->astOperand1()->valueType();
+        const ValueType* vt2 = tok1->astOperand2()->valueType();
         if (!(vt1 && (vt1->type >= ValueType::VOID || vt1->pointer) && vt2 && (vt2->type >= ValueType::VOID || vt2->pointer)))
             return false;
     }


### PR DESCRIPTION
This is PR to see how tests pass. Will push the change myself if it's good.