### PR TITLE
Corrected noexcept constructor delegating handling

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1176,9 +1176,18 @@ void SymbolDatabase::createSymbolDatabaseSetFunctionPointers(bool firstPass)
     for (std::list<Scope>::iterator it = scopeList.begin(); it != scopeList.end(); ++it) {
         for (std::list<Function>::const_iterator func = it->functionList.begin(); func != it->functionList.end(); ++func) {
             // look for initializer list
-            if (func->type == Function::eConstructor && func->functionScope &&
-                func->functionScope->functionOf && func->arg && func->arg->link()->strAt(1) == ":") {
-                const Token * tok = func->arg->link()->tokAt(2);
+            if (func->type == Function::eConstructor && func->functionScope && func->functionScope->functionOf && func->arg) {
+                const Token * tok = func->arg->link()->next();
+                if (tok->str() == "noexcept") {
+                    if (!tok->linkAt(1) || !tok->linkAt(1)->next()) {
+                        continue;
+                    }
+                    tok = tok->linkAt(1)->next();
+                }
+                if (tok->str() != ":") {
+                    continue;
+                }
+                tok = tok->next();
                 while (tok && tok != func->functionScope->classStart) {
                     if (Token::Match(tok, "%name% {|(")) {
                         if (tok->str() == func->tokenDef->str()) {

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1074,6 +1074,18 @@ private:
               "Foo::Foo() : Foo(0) {}\n"
               "Foo::Foo(int foo) : foo_(foo) {}\n");
         ASSERT_EQUALS("", errout.str());
+
+        // Noexcept ctors
+        check("class A {\n"
+              "private:\n"
+              "    int _a;\n"
+              "public:\n"
+              "    A(const int a) noexcept : _a{a} {}\n"
+              "    A() noexcept;\n"
+              "};\n"
+              "\n"
+              "A::A() noexcept: A(0) {}");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
Corrects a false positive related to the handling of noexcept constructors. Without the patch, the delegating ctor call is not recognized as a function. The function pointer seems to be set, but is not marked with the the releted eType accordingly.