### PR TITLE
Appended test, to trigger "should be passed by reference" false positive

### DIFF
--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -199,6 +199,8 @@ private:
         TEST_CASE(funcArgNamesDifferent);
         TEST_CASE(funcArgOrderDifferent);
         TEST_CASE(cpp11FunctionArgInit); // #7846 - "void foo(int declaration = {}) {"
+
+        TEST_CASE(funcDefArgNoName);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool runSimpleChecks=true, Settings* settings = 0) {
@@ -6447,6 +6449,22 @@ private:
                         ));
         ASSERT_EQUALS("", errout.str());
     }
+
+    void funcDefArgNoName() {
+        /* Caused a false positive:
+         * [test.cpp:2]: (performance) Function parameter 'DS' should be passed by reference.
+         * While there is no problem at all
+         */
+        check("static const std::string DS = \"abcd\";\n"
+              "static void dsth(const std::string & = DS);\n"
+              "void dsth(const std::string &s) {}\n"
+              "int main(void) {\n"
+              "   dsth(\"123\");\n"
+              "   dsth();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
 };
 
 REGISTER_TEST(TestOther)

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6463,6 +6463,14 @@ private:
               "   dsth();\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("static const std::string DS = \"abcd\";\n"
+              "void dsth ( const std :: string = DS ) { }\n"
+              "int main(void) {\n"
+              "    dsth(\"123\");\n"
+              "    dsth();\n"
+              "}");
+        TODO_ASSERT_EQUALS("[test.cpp:2] (performance) Function parameter '<anonymous>' should be passed by reference.", "", errout.str());
     }
 
 };


### PR DESCRIPTION
After trying a few different things, I don't find an easy way to taking care of this.
A dirty solution would be:
```diff --git a/lib/checkother.cpp b/lib/checkother.cpp
index c2770954e..ce7e8f1d5 100644
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1456,8 +1456,12 @@ void CheckOther::checkPassByReference()
             }
         }
 
-        if (isConst)
+        if (isConst) {
+            if (var->typeEndToken()->str().compare("&=") == 0) {
+                continue;
+            }
             passedByValueError(tok, var->name(), inconclusive);
+        }
     }
```
But don't think this is a good solution.

The best solution would be the introduction of an anonymous variable. But think this would lead to a huge code change. But would take care of the false negative:
`void printIt(const std::string = DS) {}`

Maybe this should be inserted as TODO_ASSERT_EQUALS instead of the failing ASSERT_EQUALS. If so I can change the code accordingly