### PR TITLE
Check classEnd for scope

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -150,6 +150,10 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                 new_scope->classDef = tok;
                 new_scope->classStart = tok2;
                 new_scope->classEnd = tok2->link();
+                // make sure we have valid code
+                if (!new_scope->classEnd) {
+                    _tokenizer->syntaxError(tok);
+                }
                 scope = new_scope;
                 tok = tok2;
             } else {


### PR DESCRIPTION
This comes as PR for evaluation.

@danmar Could you please take a look? It looks like every time a "scope" is set up its `classEnd` is altered and then immediately checked for being not null. This is not the case in the code I changed - no check in there. Does this have any use or it it likely a bug?