### PR TITLE
Remove theoretical qt4 support for gui projects

### DIFF
--- a/gui/readme.txt
+++ b/gui/readme.txt
@@ -5,11 +5,12 @@ with cppcheck and shows list of found errors.
 
 Running
 -------
-You need Qt4 or Qt5 libraries installed in your system. Packages/files to install
+You need Qt5 libraries installed in your system. Packages/files to install
 depends on your operating system:
 - Windows: download Qt from http://www.qt.io/download/
 - Linux: install Qt using your package manager, look for packages having Qt
-  in their name, e.g. for Ubuntu install libqt4-core and libqt4-gui.
+  in their name, e.g. for Ubuntu install libqt5core5a, libqt5gui5, libqt5widgets5 
+  and libqt5printsupport5.
 
 Compiling
 ---------
@@ -26,11 +27,7 @@ Windows:
 Linux:
 - Install Qt development packages (make sure qmake -tool gets installed!). The
   names depend on distribution, but e.g. for Ubuntu the needed packages are:
-  * libqt4-core
-  * libqt4-gui
-  * libqt4-dev
-  * qt4-dev-tools
-  * qt4-qmake
+  * qt5-default 
 
 After you have needed libraries and tools installed, open command
 prompt/console, go to gui directory and run command:

--- a/gui/test/common.pri
+++ b/gui/test/common.pri
@@ -1,8 +1,7 @@
-CONFIG += qtestlib
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets # In Qt 5 widgets are in separate module
-    QT += printsupport # In Qt 5 QPrinter/QPrintDialog are in separate module
-}
+Qt += testlib
+QT += widgets
+QT += printsupport
+
 INCLUDEPATH += $${PWD}/..
 
 LIBS += -L$$PWD/../../externals

--- a/gui/test/test.pro
+++ b/gui/test/test.pro
@@ -1,3 +1,5 @@
+#lessThan(QT_MAJOR_VERSION, 5): error(requires >= Qt 5 (You used: $$QT_VERSION))
+
 CONFIG  += ordered
 TEMPLATE = subdirs
 


### PR DESCRIPTION
Update readme instruction to install and build with qt5 only. Remove version check for newer version as qt4.