### PR TITLE
Wrong type parsing for library functions (from /cfg)

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5189,6 +5189,7 @@ void SymbolDatabase::setValueTypeInTokenList()
                 if (tokenList.createTokens(istr)) {
                     ValueType vt;
                     assert(tokenList.front());
+                    tokenList.simplifyStdType();
                     if (parsedecl(tokenList.front(), &vt, defaultSignedness, _settings)) {
                         setValueType(tok, vt);
                     }

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -260,12 +260,6 @@ public:
     void simplifyPlatformTypes();
 
     /**
-     * Collapse compound standard types into a single token.
-     * unsigned long long int => long _isUnsigned=true,_isLong=true
-     */
-    void simplifyStdType();
-
-    /**
      * Simplify easy constant '?:' operation
      * Example: 0 ? (2/0) : 0 => 0
      * @return true if something is modified

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1173,3 +1173,65 @@ bool TokenList::validateToken(const Token* tok) const
     }
     return false;
 }
+
+void TokenList::simplifyStdType()
+{
+    for (Token *tok = front(); tok; tok = tok->next()) {
+        if (Token::Match(tok, "char|short|int|long|unsigned|signed|double|float") || (_settings->standards.c >= Standards::C99 && Token::Match(tok, "complex|_Complex"))) {
+            bool isFloat= false;
+            bool isSigned = false;
+            bool isUnsigned = false;
+            bool isComplex = false;
+            unsigned int countLong = 0;
+            Token* typeSpec = nullptr;
+
+            Token* tok2 = tok;
+            for (; tok2->next(); tok2 = tok2->next()) {
+                if (tok2->str() == "long") {
+                    countLong++;
+                    if (!isFloat)
+                        typeSpec = tok2;
+                } else if (tok2->str() == "short") {
+                    typeSpec = tok2;
+                } else if (tok2->str() == "unsigned")
+                    isUnsigned = true;
+                else if (tok2->str() == "signed")
+                    isSigned = true;
+                else if (Token::Match(tok2, "float|double")) {
+                    isFloat = true;
+                    typeSpec = tok2;
+                } else if (_settings->standards.c >= Standards::C99 && Token::Match(tok2, "complex|_Complex"))
+                    isComplex = !isFloat || tok2->str() == "_Complex" || Token::Match(tok2->next(), "*|&|%name%"); // Ensure that "complex" is not the variables name
+                else if (Token::Match(tok2, "char|int")) {
+                    if (!typeSpec)
+                        typeSpec = tok2;
+                } else
+                    break;
+            }
+
+            if (!typeSpec) { // unsigned i; or similar declaration
+                if (!isComplex) { // Ensure that "complex" is not the variables name
+                    tok->str("int");
+                    tok->isSigned(isSigned);
+                    tok->isUnsigned(isUnsigned);
+                }
+            } else {
+                typeSpec->isLong(typeSpec->isLong() || (isFloat && countLong == 1) || countLong > 1);
+                typeSpec->isComplex(typeSpec->isComplex() || (isFloat && isComplex));
+                typeSpec->isSigned(typeSpec->isSigned() || isSigned);
+                typeSpec->isUnsigned(typeSpec->isUnsigned() || isUnsigned);
+
+                // Remove specifiers
+                const Token* tok3 = tok->previous();
+                tok2 = tok2->previous();
+                while (tok3 != tok2) {
+                    if (tok2 != typeSpec &&
+                        (isComplex || !Token::Match(tok2, "complex|_Complex")))  // Ensure that "complex" is not the variables name
+                        tok2->deleteThis();
+                    tok2 = tok2->previous();
+                }
+            }
+        }
+    }
+}
+

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -156,6 +156,12 @@ public:
      */
     bool validateToken(const Token* tok) const;
 
+    /**
+     * Collapse compound standard types into a single token.
+     * unsigned long long int => long _isUnsigned=true,_isLong=true
+     */
+    void simplifyStdType();
+
 private:
 
     /** Disable copy constructor, no implementation */

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -68,6 +68,7 @@ private:
 
         TEST_CASE(testAstType); // #7014
         TEST_CASE(testPrintf0WithSuffix); // ticket #7069
+        TEST_CASE(testReturnValueTypeStdLib);
     }
 
     void check(const char* code, bool inconclusive = false, bool portability = false, Settings::PlatformType platform = Settings::Unspecified) {
@@ -2975,6 +2976,14 @@ private:
               "    printf(\"%u %lu %llu\", 0u, 0ul, 0ull);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void testReturnValueTypeStdLib() {
+       check("void f() {\n"
+             "   const char *s = \"0\";\n"
+             "   printf(\"%ld%lld\", atol(s), atoll(s));\n"
+             "}");
+       ASSERT_EQUALS("", errout.str());
     }
 
 };


### PR DESCRIPTION
I have observed a false positive while analyzing my project. An example of code caused cppcheck warnings:
`void f() {
   const char *s = "0";
   printf("%ld%lld", atol(s), atoll(s));
}`
And warnings themselves:
`[test.cpp:3]: (warning) %ld in format string (no. 1) requires 'long' but the argument type is 'signed int'.`
`[test.cpp:3]: (warning) %lld in format string (no. 2) requires 'long long' but the argument type is 'signed int'.`

Configuration for functions in std.cfg were ok: return value type for atol - long int, for atoll - long long int. Further reading of source code led to the conclusion that cppcheck uses only last keyword in the configured string - int, because return value type was not rolled up as it is done in the tokenizer for the analized file.
In my patch I suggest to move method Tokenizer.simplifyStdType to the TokenList class and to use it just before the parsing of declararion for standard library function.
I have added example of code written above as IO unit test. I am not sure that is a good place for it, probably test should be rewritten in some other way.