### PR TITLE
Passing string literals into printf as %p is fine

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1275,7 +1275,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                                 break;
                             case 'p':
                                 if (argInfo.typeToken->tokType() == Token::eString)
-                                    invalidPrintfArgTypeError_p(tok, numFormat, &argInfo);
+                                    ;// string literals are passed as pointers to literal start, okay
                                 else if (argInfo.isKnownType() && !argInfo.isArrayOrPointer())
                                     invalidPrintfArgTypeError_p(tok, numFormat, &argInfo);
                                 done = true;

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -1576,6 +1576,17 @@ private:
                       "[test.cpp:4]: (warning) %p in format string (no. 1) requires an address but the argument type is 'char'.\n", errout.str());
 
         check("class foo {};\n"
+              "void foo(char* pc, const char* cpc, wchar_t* pwc, const wchar_t* cpwc) {\n"
+              "    printf(\"%p\", pc);\n"
+              "    printf(\"%p\", cpc);\n"
+              "    printf(\"%p\", pwc);\n"
+              "    printf(\"%p\", cpwc);\n"
+              "    printf(\"%p\", \"s4\");\n"
+              "    printf(\"%p\", L\"s5W\");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("class foo {};\n"
               "void foo(const int* cpi, foo f, bar b, bar* bp, double d) {\n"
               "    printf(\"%e\", f);\n"
               "    printf(\"%E\", \"s4\");\n"


### PR DESCRIPTION
@danmar Could you please take a look on this? I can pass a string literal into `strlen()` and so I should be able to print its address with `printf("%p", "literal"). gcc with -Wformat is just fine with that.