### PR TITLE
#8240 support for cygwin with directory separator in stripDirectoryPart method

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -228,7 +228,7 @@ std::string Path::getAbsoluteFilePath(const std::string& filePath)
 
 std::string Path::stripDirectoryPart(const std::string &file)
 {
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__CYGWIN__)
     const char native = '\\';
 #else
     const char native = '/';


### PR DESCRIPTION
This will hopefully fix the issue from ticket 8240.

FYI: The method I copied it from (Path::toNativeSeparators) should then also not work under Cygwin.
This might have slipped through or never been used...

Thanks Hexcoder