### PR TITLE
testrunner proposal: add new testrunner option to silence stdout output

### DIFF
--- a/test/options.cpp
+++ b/test/options.cpp
@@ -21,9 +21,13 @@
 options::options(int argc, const char* argv[])
     :_options(argv + 1, argv + argc)
     ,_which_test("")
-    ,_quiet(_options.count("-q") != 0)
+    ,_verbosity(
+          _options.count("-Q") != 0 ? verbosity_t::Mute
+        : _options.count("-q") != 0 ? verbosity_t::Quiet
+        :                             verbosity_t::Verbose)
 {
     _options.erase("-q");
+    _options.erase("-Q");
     if (! _options.empty()) {
         _which_test = *_options.rbegin();
     }
@@ -31,7 +35,12 @@ options::options(int argc, const char* argv[])
 
 bool options::quiet() const
 {
-    return _quiet;
+    return _verbosity == verbosity_t::Quiet;
+}
+
+bool options::mute() const
+{
+    return _verbosity == verbosity_t::Mute;
 }
 
 const std::string& options::which_test() const

--- a/test/options.h
+++ b/test/options.h
@@ -31,9 +31,12 @@ public:
     options(int argc, const char* argv[]);
     /** Don't print the name of each method being tested. */
     bool quiet() const;
+    /** Don't print anything for each method being tested on stdout. */
+    bool mute() const;
     /** Which test should be run. Empty string means 'all tests' */
     const std::string& which_test() const;
 
+    enum verbosity_t { Verbose, Quiet, Mute };
 private:
     options();
     options(const options& non_copy);
@@ -42,7 +45,7 @@ private:
 private:
     std::set<std::string> _options;
     std::string _which_test;
-    const bool _quiet;
+    const verbosity_t _verbosity;
 };
 
 #endif

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -32,6 +32,7 @@ private:
         TEST_CASE(no_test_method);
         TEST_CASE(not_quiet);
         TEST_CASE(quiet);
+        TEST_CASE(mute);
         TEST_CASE(multiple_testcases);
         TEST_CASE(invalid_switches);
     }
@@ -70,6 +71,13 @@ private:
         options args(sizeof argv / sizeof argv[0], argv);
         ASSERT_EQUALS(true, args.quiet());
     }
+
+    void mute() const {
+        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-Q"};
+        options args(sizeof argv / sizeof argv[0], argv);
+        ASSERT_EQUALS(true, args.mute());
+    }
+
 
 
 

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -70,6 +70,7 @@ std::set<std::string> TestFixture::missingLibs;
 TestFixture::TestFixture(const char* _name)
     :classname(_name)
     ,quiet_tests(false)
+    ,mute_tests(false)
 {
     TestRegistry::theInstance().addTest(this);
 }
@@ -81,7 +82,9 @@ bool TestFixture::prepareTest(const char testname[])
     if (testToRun.empty() || testToRun == testname) {
         // Tests will be executed - prepare them
         ++countTests;
-        if (quiet_tests) {
+        if (mute_tests) {
+            // suppress test names on stdout
+        } else if (quiet_tests) {
             std::putchar('.'); // Use putchar to write through redirection of std::cout/cerr
             std::fflush(stdout);
         } else {
@@ -260,7 +263,7 @@ void TestFixture::complainMissingLib(const char* libname) const
 void TestFixture::run(const std::string &str)
 {
     testToRun = str;
-    if (quiet_tests) {
+    if (quiet_tests && !mute_tests) {
         std::cout << '\n' << classname << ':';
     }
     if (quiet_tests) {
@@ -272,7 +275,8 @@ void TestFixture::run(const std::string &str)
 
 void TestFixture::processOptions(const options& args)
 {
-    quiet_tests = args.quiet();
+    mute_tests  = args.mute();
+    quiet_tests = mute_tests || args.quiet();
 }
 
 std::size_t TestFixture::runTests(const options& args)

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -42,6 +42,7 @@ protected:
     std::string classname;
     std::string testToRun;
     bool quiet_tests;
+    bool mute_tests;
 
     virtual void run() = 0;
 


### PR DESCRIPTION
When searching travis-ci logs for failures, the tremendous output of testrunner on stdout makes it harder than necessary to find the error(s) in the log.
I propose a new option -Q, which silences testrunners stdout channel.
In that case only statistics and error reports are output, resulting in much more readable travis-ci logs.
