### PR TITLE
Link to Shlwapi.lib on MSVC to get rid of missing symbol issues.

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(cppcheck ${hdrs} ${mainfile} $<TARGET_OBJECTS:cli_objs> $<TARGET_
 if (HAVE_RULES)
     target_link_libraries(cppcheck pcre)
 endif()
+if (MSVC)
+    target_link_libraries(cppcheck Shlwapi.lib)
+endif()
 
 install(TARGETS cppcheck
     RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR}


### PR DESCRIPTION
Fixes linking problems of the cmake project (at least for Visual Studio 2017). This is also vital for conan.io support, hence a new release after the pull would be nice.