### PR TITLE
Do not use bit operations on boolean types

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3159,8 +3159,8 @@ static void valueFlowUninit(TokenList *tokenlist, SymbolDatabase * /*symbolDatab
         bool stdtype = false;
         bool pointer = false;
         while (Token::Match(vardecl, "%name%|::|*") && vardecl->varId() == 0) {
-            stdtype |= vardecl->isStandardType();
-            pointer |= vardecl->str() == "*";
+            stdtype = stdtype || vardecl->isStandardType();
+            pointer = pointer || vardecl->str() == "*";
             vardecl = vardecl->next();
         }
         if (!stdtype && !pointer)


### PR DESCRIPTION
We should probably have a check for bit operations on booleans. GCC has some in the 7.x branch, but is always good to have a second opinion.