### PR TITLE
Workaround for syntax error on Microsoft specific __pragma keyword

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3620,4 +3620,5 @@ HFONT CreateFont(
   <define name="INVALID_HANDLE_VALUE" value="0"/>
   <define name="INVALID_SOCKET" value="0"/>
   <define name="WINAPI" value=""/>
+  <define name="__pragma(x)" value=""/>
 </def>


### PR DESCRIPTION
__pragma is Microsoft specific keyword equivalent to C99 _Pragma operator
https://msdn.microsoft.com/en-us/library/d9x1s805.aspx
https://gcc.gnu.org/onlinedocs/cpp/Pragmas.html
http://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas

It seems cppcheck does not support _Pragma at the moment.

This change will fix syntax error on code that looks like this:

 #define MY_DEPRECATED_ENUM(X) X __pragma(deprecated(X))
enum myEnum
{
    myEnum_1 = 1,
    MY_DEPRECATED_ENUM(myEnum_2) = 2,
    myEnum_3,
    myEnum_4,
};
int main()
{
    myEnum a = myEnum_3;
    printf("%d", a);
    return 0;
}

This change was fiscussed here: https://sourceforge.net/p/cppcheck/discussion/general/thread/1808a46b/