### PR TITLE
MISRA 15.7 only checks if...else if constructs

### DIFF
--- a/addons/misra-test.c
+++ b/addons/misra-test.c
@@ -193,7 +193,9 @@ void misra_15_6() {
 }
 
 void misra_15_7() {
-  if (x!=0){} // 15.7
+  if (x!=0){} // no-warning
+  if (x!=0){} else if(x==1){} // 15.7
+  if (x!=0){} else if(x==1){}else{;} // no-warning
 }
 
 void misra_16_2() {

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -773,11 +773,13 @@ def misra_15_6(rawTokens):
 
 def misra_15_7(data):
     for token in data.tokenlist:
-        if not simpleMatch(token, 'if ('):
+        if not simpleMatch(token, '}'):
             continue
-        if not simpleMatch(token.next.link, ') {'):
+        if not token.scope.type == 'If':
             continue
-        if not simpleMatch(token.next.link.next.link, '} else'):
+        if not token.scope.nestedIn.type == 'Else':
+            continue
+        if not token.next.str == 'else':
             reportError(token, 15, 7)
 
 # TODO add 16.1 rule


### PR DESCRIPTION
Hello! I found one misbehavior of current MISRA addon, and made small change :)

MISRA 15.7 is limited to if-else statements. Rule 15.7 says `if-else` constructs shall end with `else` block.

In current `addons/misra.py`, every if statements is checked whether they has else statements including simple if statements, which is explicitly mentioned in MISRA C Guide Document as an exception.

My change works as follow (also added following change to `addons/misra-test.c`)
```
  if (x!=0){} // compliant, (is reported in current misra.py)
  if (x!=0){} else if(x==1){} // non-compliant, 15.7
  if (x!=0){} else if(x==1){}else{;} // compliant
```