### PR TITLE
Fix for embedded PL/SQL blocks (Oracle Pro*C)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9892,6 +9892,8 @@ const Token *Tokenizer::findSQLBlockEnd(const Token *tokSQLStart) const
     for (const Token *tok = tokSQLStart->tokAt(2); tok != nullptr && tokSQLEnd == nullptr; tok = tok->next()) {
         if (tokLastEnd == nullptr && tok->str() == ";")
             tokLastEnd = tok;
+        else if (tok->str() == "}")
+            tokSQLEnd = tok; // Explicit syntax error, enforce stop here
         else if (tok->str() == "EXEC") {
             const Token *tokPrev = tok->previous();
             const Token *tokBeforePrev = tokPrev->previous();

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -718,6 +718,9 @@ private:
      */
     void printUnknownTypes() const;
 
+    /** Find end of SQL (or PL/SQL) block */
+    const Token *findSQLBlockEnd(const Token *tokSQLStart) const;
+
 public:
 
     /** Was there templates in the code? */

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5791,6 +5791,8 @@ private:
               tokenizeAndStringify("EXEC SQL UPDATE A SET B = C; EXEC SQL COMMIT;",false));
         ASSERT_EQUALS("asm ( \"\"EXEC SQL COMMIT\"\" ) ; asm ( \"\"EXEC SQL EXECUTE BEGIN Proc1 ( A ) ; END ; END - EXEC\"\" ) ;",
               tokenizeAndStringify("EXEC SQL COMMIT; EXEC SQL EXECUTE BEGIN Proc1(A); END; END-EXEC;",false));
+        // Syntax error, but need to enforce SQL block end at least at the end of nearest outer C block
+        ASSERT_EQUALS("int f ( ) { asm ( \"\"EXEC SQL\"\" ) ; } int a ;", tokenizeAndStringify("int f(){ EXEC SQL } int a;",false));
     }
 
     void simplifyCAlternativeTokens() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5785,6 +5785,12 @@ private:
         ASSERT_EQUALS("asm ( \"\"EXEC SQL SELECT A FROM B\"\" ) ;", tokenizeAndStringify("EXEC SQL SELECT A FROM B;",false));
         ASSERT_EQUALS("asm ( \"\"EXEC SQL\"\" ) ;", tokenizeAndStringify("EXEC SQL",false));
 
+        ASSERT_EQUALS("asm ( \"\"EXEC SQL EXECUTE BEGIN Proc1 ( A ) ; END ; END - EXEC\"\" ) ; asm ( \"\"EXEC SQL COMMIT\"\" ) ;",
+              tokenizeAndStringify("EXEC SQL EXECUTE BEGIN Proc1(A); END; END-EXEC; EXEC SQL COMMIT;",false));
+        ASSERT_EQUALS("asm ( \"\"EXEC SQL UPDATE A SET B = C\"\" ) ; asm ( \"\"EXEC SQL COMMIT\"\" ) ;",
+              tokenizeAndStringify("EXEC SQL UPDATE A SET B = C; EXEC SQL COMMIT;",false));
+        ASSERT_EQUALS("asm ( \"\"EXEC SQL COMMIT\"\" ) ; asm ( \"\"EXEC SQL EXECUTE BEGIN Proc1 ( A ) ; END ; END - EXEC\"\" ) ;",
+              tokenizeAndStringify("EXEC SQL COMMIT; EXEC SQL EXECUTE BEGIN Proc1(A); END; END-EXEC;",false));
     }
 
     void simplifyCAlternativeTokens() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5783,7 +5783,7 @@ private:
         // Oracle PRO*C extensions for inline SQL. Just replace the SQL with "asm()" to fix wrong error messages
         // ticket: #1959
         ASSERT_EQUALS("asm ( \"\"EXEC SQL SELECT A FROM B\"\" ) ;", tokenizeAndStringify("EXEC SQL SELECT A FROM B;",false));
-        ASSERT_EQUALS("asm ( \"\"EXEC SQL\"\" ) ;", tokenizeAndStringify("EXEC SQL",false));
+        ASSERT_THROW(tokenizeAndStringify("EXEC SQL",false), InternalError);
 
         ASSERT_EQUALS("asm ( \"\"EXEC SQL EXECUTE BEGIN Proc1 ( A ) ; END ; END - EXEC\"\" ) ; asm ( \"\"EXEC SQL COMMIT\"\" ) ;",
               tokenizeAndStringify("EXEC SQL EXECUTE BEGIN Proc1(A); END; END-EXEC; EXEC SQL COMMIT;",false));
@@ -5791,8 +5791,10 @@ private:
               tokenizeAndStringify("EXEC SQL UPDATE A SET B = C; EXEC SQL COMMIT;",false));
         ASSERT_EQUALS("asm ( \"\"EXEC SQL COMMIT\"\" ) ; asm ( \"\"EXEC SQL EXECUTE BEGIN Proc1 ( A ) ; END ; END - EXEC\"\" ) ;",
               tokenizeAndStringify("EXEC SQL COMMIT; EXEC SQL EXECUTE BEGIN Proc1(A); END; END-EXEC;",false));
-        // Syntax error, but need to enforce SQL block end at least at the end of nearest outer C block
-        ASSERT_EQUALS("int f ( ) { asm ( \"\"EXEC SQL\"\" ) ; } int a ;", tokenizeAndStringify("int f(){ EXEC SQL } int a;",false));
+
+        ASSERT_THROW(tokenizeAndStringify("int f(){ EXEC SQL } int a;",false), InternalError);
+        ASSERT_THROW(tokenizeAndStringify("EXEC SQL int f(){",false), InternalError);
+        ASSERT_THROW(tokenizeAndStringify("EXEC SQL END-EXEC int a;",false), InternalError);
     }
 
     void simplifyCAlternativeTokens() {


### PR DESCRIPTION
Cppcheck is able to isolate embedded SQL blocks written for Oracle Pro\*C precompiler with use of wrappers in the form of assembler inline sections. So any following constructions are skipped well:
`EXEC SQL ... ;`
However Pro\*C precompiler also allows to embed more complicated blocks containing unnamed procedures written in Oracle procedure language (PL/SQL) or even definitions of named Oracle objects, like procedures, functions and sequences. In both the cases embedded block syntax as follows [(docs.oracle.com)](https://docs.oracle.com/cd/B28359_01/appdev.111/b28427/pc_07pls.htm#i2332) :
```
EXEC SQL EXECUTE
DECLARE
   ... 
BEGIN 
   ... 
END; 
END-EXEC; 
```
Both DECLARE section (optional) and procedure body section can contain mutiple lines terminated with ';'.
Suggested patch allows to locate and isolate all of the embedded SQL or PL/SQL blocks.