### PR TITLE
Select int when int and long have identical sizes

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5685,14 +5685,28 @@ void Tokenizer::simplifyPlatformTypes()
 
     /** @todo This assumes a flat address space. Not true for segmented address space (FAR *). */
 
-    if (_settings->sizeof_size_t == _settings->sizeof_long)
-        type = isLong;
-    else if (_settings->sizeof_size_t == _settings->sizeof_long_long)
-        type = isLongLong;
-    else if (_settings->sizeof_size_t == _settings->sizeof_int)
-        type = isInt;
+    if (_settings->platformType == Settings::Win32A || _settings->platformType == Settings::Win32W)
+    {
+        if (_settings->sizeof_size_t == _settings->sizeof_int)
+            type = isInt;
+        else if (_settings->sizeof_size_t == _settings->sizeof_long)
+            type = isLong;
+        else if (_settings->sizeof_size_t == _settings->sizeof_long_long)
+            type = isLongLong;
+        else
+            return;
+    }
     else
-        return;
+    {
+        if (_settings->sizeof_size_t == _settings->sizeof_long)
+            type = isLong;
+        else if (_settings->sizeof_size_t == _settings->sizeof_long_long)
+            type = isLongLong;
+        else if (_settings->sizeof_size_t == _settings->sizeof_int)
+            type = isInt;
+        else
+           return;
+    }
 
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         // pre-check to reduce unneeded match calls

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -775,61 +775,61 @@ private:
 
     void testScanfNoWarn(const char *filename, unsigned int linenr, const char* code) {
         check(code, true, false, Settings::Unix32);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Unix32");
         check(code, true, false, Settings::Unix64);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Unix64");
         check(code, true, false, Settings::Win32A);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Win32A");
         check(code, true, false, Settings::Win64);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Win64");
     }
 
     void testScanfWarn(const char *filename, unsigned int linenr,
                        const char* code, const char* testScanfErrString) {
         check(code, true, false, Settings::Unix32);
-        assertEquals(filename, linenr, testScanfErrString, errout.str());
+        assertEquals(filename, linenr, testScanfErrString, errout.str(), "Platform: Unix32");
         check(code, true, false, Settings::Unix64);
-        assertEquals(filename, linenr, testScanfErrString, errout.str());
+        assertEquals(filename, linenr, testScanfErrString, errout.str(), "Platform: Unix64");
         check(code, true, false, Settings::Win32A);
-        assertEquals(filename, linenr, testScanfErrString, errout.str());
+        assertEquals(filename, linenr, testScanfErrString, errout.str(), "Platform: Win32A");
         check(code, true, false, Settings::Win64);
-        assertEquals(filename, linenr, testScanfErrString, errout.str());
+        assertEquals(filename, linenr, testScanfErrString, errout.str(), "Platform: Win64");
     }
 
     void testScanfWarnAka(const char *filename, unsigned int linenr,
                           const char* code, const char* testScanfErrAkaString, const char* testScanfErrAkaWin64String) {
         check(code, true, true, Settings::Unix32);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Unix32");
         check(code, true, true, Settings::Unix64);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Unix64");
         check(code, true, true, Settings::Win32A);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Win32A");
         check(code, true, true, Settings::Win64);
-        assertEquals(filename, linenr, testScanfErrAkaWin64String, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaWin64String, errout.str(), "Platform: Win64");
     }
 
     void testScanfWarnAkaWin64(const char *filename, unsigned int linenr,
                                const char* code, const char* testScanfErrAkaWin64String) {
         check(code, true, true, Settings::Unix32);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Unix32");
         check(code, true, true, Settings::Unix64);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Unix64");
         check(code, true, true, Settings::Win32A);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Win32A");
         check(code, true, true, Settings::Win64);
-        assertEquals(filename, linenr, testScanfErrAkaWin64String, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaWin64String, errout.str(), "Platform: Win64");
     }
 
     void testScanfWarnAkaWin32(const char *filename, unsigned int linenr,
                                const char* code, const char* testScanfErrAkaString) {
         check(code, true, true, Settings::Unix32);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Unix32");
         check(code, true, true, Settings::Unix64);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Unix64");
         check(code, true, true, Settings::Win32A);
-        assertEquals(filename, linenr, testScanfErrAkaString, errout.str());
+        assertEquals(filename, linenr, testScanfErrAkaString, errout.str(), "Platform: Win32A");
         check(code, true, true, Settings::Win64);
-        assertEquals(filename, linenr, "", errout.str());
+        assertEquals(filename, linenr, "", errout.str(), "Platform: Win64");
     }
 
 #define TEST_SCANF_NOWARN(FORMAT, FORMATSTR, TYPE) \


### PR DESCRIPTION
@danmar This is a draft of a proposed change. Currently `intptr_t` is treated as `long` in Win32 but it's actually `int` in library headers. This is well, simply wrong, and also this causes a lot of `printf()` format check code to be non-callable ever. Looks like this change only requires rather neutral changes of tests for Win32.