### PR TITLE
Remove redundant parts of conditional expressions

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -404,7 +404,7 @@ bool isVariableChangedByFunctionCall(const Token *tok, const Settings *settings,
         return false;
 
     // address of variable
-    const bool addressOf = tok && Token::simpleMatch(tok->previous(), "&");
+    const bool addressOf = Token::simpleMatch(tok->previous(), "&");
 
     // passing variable to subfunction?
     if (Token::Match(tok->tokAt(-2), ") & %name% [,)]") && Token::Match(tok->linkAt(-2)->previous(), "[,(] ("))

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -706,7 +706,7 @@ void CheckBufferOverrun::checkScope(const Token *tok, const std::vector<const st
         }
 
         // memset, memcmp, memcpy, strncpy, fgets..
-        if (declarationId == 0 && size > 0 && Token::Match(tok, "%name% ( !!)")) {
+        if (declarationId == 0 && Token::Match(tok, "%name% ( !!)")) {
             std::list<const Token *> callstack;
             callstack.push_back(tok);
             const Token* tok2 = tok->tokAt(2);

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1010,14 +1010,14 @@ void CheckCondition::checkIncorrectLogicOperator()
                 incorrectLogicOperatorError(tok, text, alwaysTrue, inconclusive);
             } else if (printStyle && secondTrue) {
                 const std::string text = "If '" + cond1str + "', the comparison '" + cond2str +
-                                         "' is always " + (secondTrue ? "true" : "false") + ".";
+                                         "' is always true.";
                 redundantConditionError(tok, text, inconclusive);
             } else if (printStyle && firstTrue) {
                 //const std::string text = "The comparison " + cond1str + " is always " +
                 //                         (firstTrue ? "true" : "false") + " when " +
                 //                         cond2str + ".";
                 const std::string text = "If '" + cond2str + "', the comparison '" + cond1str +
-                                         "' is always " + (firstTrue ? "true" : "false") + ".";
+                                         "' is always true.";
                 redundantConditionError(tok, text, inconclusive);
             }
         }

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1033,7 +1033,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                                 break;
                             }
                         }
-                    } else if (!scan && printWarning) {
+                    } else if (printWarning) {
                         std::string specifier;
                         bool done = false;
                         while (!done) {

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -392,7 +392,7 @@ void CheckNullPointer::nullConstantDereference()
 
         const Token *tok = scope->classStart;
 
-        if (scope->function && scope->function->isConstructor())
+        if (scope->function->isConstructor())
             tok = scope->function->token; // Check initialization list
 
         for (; tok != scope->classEnd; tok = tok->next()) {

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -265,7 +265,7 @@ void CheckStl::iterators()
 
             // bailout handling. Assume that the iterator becomes valid if we see else.
             // TODO: better handling
-            else if (tok2 && tok2->str() == "else") {
+            else if (tok2->str() == "else") {
                 validIterator = true;
             }
         }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3973,7 +3973,6 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
 
     // check each function against the arguments in the function call for a match
     for (std::size_t i = 0; i < matches.size();) {
-        bool erased = false;
         bool constFallback = false;
         const Function * func = matches[i];
         size_t same = 0;
@@ -3987,8 +3986,7 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
                 // check if isConst mismatches
                 if (scope->function->isConst() != func->isConst()) {
                     if (scope->function->isConst()) {
-                        if (!erased)
-                            ++i;
+                        ++i;
                         continue;
                     }
                     constFallback = true;
@@ -3998,6 +3996,7 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
 
         size_t fallback1 = 0;
         size_t fallback2 = 0;
+        bool erased = false;
         for (std::size_t j = 0; j < args; ++j) {
 
             // don't check variadic arguments

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9437,7 +9437,7 @@ void Tokenizer::simplifyOperatorName()
             bool done = false;
             while (!done && par) {
                 done = true;
-                if (par && par->isName()) {
+                if (par->isName()) {
                     op += par->str();
                     par = par->next();
                     // merge namespaces eg. 'operator std :: string () const {'


### PR DESCRIPTION
I'm a member of the [Pinguem.ru](https://pinguem.ru) competition on finding errors in open source projects. All issues were found with [PVS-Studio](https://www.viva64.com/en/pvs-studio/):

- V560 A part of conditional expression is always true: tok. astutils.cpp 407
- V560 A part of conditional expression is always true: size > 0. checkbufferoverrun.cpp 709
- V547 Expression 'secondTrue' is always true. checkcondition.cpp 1013
- V547 Expression 'firstTrue' is always true. checkcondition.cpp 1020
- V560 A part of conditional expression is always true: !scan. checkio.cpp 1036
- V560 A part of conditional expression is always true: scope->function. checknullpointer.cpp 395
- V560 A part of conditional expression is always true: tok2. checkstl.cpp 268
- V560 A part of conditional expression is always true: par. tokenize.cpp 9440
- V547 Expression '!erased' is always true. symboldatabase.cpp 3990