### PR TITLE
Static analyser issues

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -404,7 +404,7 @@ bool isVariableChangedByFunctionCall(const Token *tok, const Settings *settings,
         return false;
 
     // address of variable
-    const bool addressOf = tok && Token::simpleMatch(tok->previous(), "&");
+    const bool addressOf = Token::simpleMatch(tok->previous(), "&");
 
     // passing variable to subfunction?
     if (Token::Match(tok->tokAt(-2), ") & %name% [,)]") && Token::Match(tok->linkAt(-2)->previous(), "[,(] ("))

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -706,7 +706,7 @@ void CheckBufferOverrun::checkScope(const Token *tok, const std::vector<const st
         }
 
         // memset, memcmp, memcpy, strncpy, fgets..
-        if (declarationId == 0 && size > 0 && Token::Match(tok, "%name% ( !!)")) {
+        if (declarationId == 0 && Token::Match(tok, "%name% ( !!)")) {
             std::list<const Token *> callstack;
             callstack.push_back(tok);
             const Token* tok2 = tok->tokAt(2);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
cppcheck/lib/astutils.cpp   407     warn    V560 A part of conditional expression is always true: tok.
cppcheck/lib/checkbufferoverrun.cpp 709     warn    V560 A part of conditional expression is always true: size > 0.