### PR TITLE
Improve test coverage for ptrdiff_t used as scanf read target with %Id

### DIFF
--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -1371,6 +1371,7 @@ private:
         TEST_SCANF_WARN("%Id", "ptrdiff_t", "long double");
         TEST_SCANF_WARN_AKA("%Id", "ptrdiff_t", "size_t", "unsigned long", "unsigned long long");
         TEST_SCANF_WARN_AKA("%Id", "ptrdiff_t", "ssize_t", "signed long", "signed long long");
+        TEST_SCANF_NOWARN("%Id", "ptrdiff_t", "ptrdiff_t");
         TEST_SCANF_WARN_AKA("%Id", "ptrdiff_t", "intmax_t", "signed long", "signed long long");
         TEST_SCANF_WARN_AKA("%Id", "ptrdiff_t", "uintmax_t", "unsigned long", "unsigned long long");
         TEST_SCANF_WARN_AKA("%Id", "ptrdiff_t", "std::size_t", "unsigned long", "unsigned long long");


### PR DESCRIPTION
Will push it myself if tests pass.