### PR TITLE
Support relative paths in Visual Studio projects properties

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -413,8 +413,16 @@ static void importPropertyGroup(const tinyxml2::XMLElement *node, std::map<std::
 static void loadVisualStudioProperties(const std::string &props, std::map<std::string,std::string,cppcheck::stricmp> *variables, std::string *includePath, const std::string &additionalIncludeDirectories, std::list<ItemDefinitionGroup> &itemDefinitionGroupList)
 {
     std::string filename(props);
+	// variables cant be resolved
     if (!simplifyPathWithVariables(filename, *variables))
         return;
+
+	// prepend project dir (if it exists) to transform relative paths into absolute ones
+	if (!Path::isAbsolute(filename) && variables->count("ProjectDir") > 0)
+	{
+		filename = Path::getAbsoluteFilePath(variables->at("ProjectDir") + filename);
+	}
+
     tinyxml2::XMLDocument doc;
     if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_SUCCESS)
         return;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -419,9 +419,7 @@ static void loadVisualStudioProperties(const std::string &props, std::map<std::s
 
 	// prepend project dir (if it exists) to transform relative paths into absolute ones
 	if (!Path::isAbsolute(filename) && variables->count("ProjectDir") > 0)
-	{
 		filename = Path::getAbsoluteFilePath(variables->at("ProjectDir") + filename);
-	}
 
     tinyxml2::XMLDocument doc;
     if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_SUCCESS)

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -48,7 +48,7 @@ namespace cppcheck {
 class CPPCHECKLIB ImportProject {
 public:
     /** File settings. Multiple configurations for a file is allowed. */
-    struct FileSettings {
+    struct CPPCHECKLIB FileSettings {
         FileSettings() : platformType(cppcheck::Platform::Unspecified), msc(false), useMfc(false) {}
         std::string cfg;
         std::string filename;

--- a/test/testrunner.vcxproj
+++ b/test/testrunner.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="testexceptionsafety.cpp" />
     <ClCompile Include="testfilelister.cpp" />
     <ClCompile Include="testgarbage.cpp" />
+    <ClCompile Include="testimportproject.cpp" />
     <ClCompile Include="testincompletestatement.cpp" />
     <ClCompile Include="testinternal.cpp" />
     <ClCompile Include="testio.cpp" />

--- a/test/testrunner.vcxproj.filters
+++ b/test/testrunner.vcxproj.filters
@@ -199,6 +199,9 @@
     <ClCompile Include="testfunctions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="testimportproject.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">


### PR DESCRIPTION
transform relative paths (to property sheets) with the help of the project dir to absolutepaths so the actual checker can resolve include paths defined in property sheets.

This helps with Visual Studio adding paths rather as relative than absolute, so it is the quasi default.

Before, relative property sheets were not loaded and so the defined include paths from the property sheets were unknown resulting in false errors. This completes PR #917.