### PR TITLE
remove outputList 

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -566,9 +566,7 @@ void Preprocessor::loadFiles(const simplecpp::TokenList &rawtokens, std::vector<
 {
     const simplecpp::DUI dui = createDUI(_settings, emptyString, files[0]);
 
-    simplecpp::OutputList outputList;
-
-    tokenlists = simplecpp::load(rawtokens, files, dui, &outputList);
+    tokenlists = simplecpp::load(rawtokens, files, dui, nullptr);
 }
 
 void Preprocessor::removeComments()


### PR DESCRIPTION
since its not used subsequently and all subfunction check for nullptr.

Since `Preprocessor::loadFiles()` is often called, this might have a performance impact.

Testrunner finishes without error and the output/results of `cppcheck` seem to be the same.

There might be a very good reason for the existance of `outputList` but then id expect at least a comment.