### PR TITLE
Greatly improve performance

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -152,6 +152,10 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
 			toolinfo += _settings.isEnabled(Settings::INFORMATION) ? 'i' : ' ';
 			toolinfo += _settings.userDefines;
 
+			// Reset filestream in case it was used already
+			fileStream.clear();
+			fileStream.seekg(0, std::ios::beg);
+
 			// Read complete file to generate checksum over it
 			const std::string filecontent(std::string((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>()));
 
@@ -167,7 +171,7 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
 				return exitcode;  // known results => no need to reanalyze file
 			}
 
-			// reset stream state and position for analysis
+			// Reset stream state and position to beginning for analysis
 			fileStream.clear();
 			fileStream.seekg(0, std::ios::beg);
 		}

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -153,7 +153,7 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
 			toolinfo += _settings.userDefines;
 
 			// Read complete file to generate checksum over it
-			const std::string filecontent(std::istreambuf_iterator<char>(fileStream), {});
+			const std::string filecontent(std::string((std::istreambuf_iterator<char>(fileStream)), std::istreambuf_iterator<char>()));
 
 			// Calculate checksum so it can be compared with old checksum / future checksums
 			const unsigned int checksum = preprocessor.calculateChecksum(toolinfo+'\n'+filecontent);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -139,6 +139,39 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
     bool internalErrorFound(false);
     try {
         Preprocessor preprocessor(_settings, this);
+
+		// Check with checksum for unmodified file early to avoid expensive tokenizing
+		if (!_settings.buildDir.empty()) {
+			// Get toolinfo
+			std::string toolinfo;
+			toolinfo += CPPCHECK_VERSION_STRING;
+			toolinfo += _settings.isEnabled(Settings::WARNING) ? 'w' : ' ';
+			toolinfo += _settings.isEnabled(Settings::STYLE) ? 's' : ' ';
+			toolinfo += _settings.isEnabled(Settings::PERFORMANCE) ? 'p' : ' ';
+			toolinfo += _settings.isEnabled(Settings::PORTABILITY) ? 'p' : ' ';
+			toolinfo += _settings.isEnabled(Settings::INFORMATION) ? 'i' : ' ';
+			toolinfo += _settings.userDefines;
+
+			// Read complete file to generate checksum over it
+			const std::string filecontent(std::istreambuf_iterator<char>(fileStream), {});
+
+			// Calculate checksum so it can be compared with old checksum / future checksums
+			const unsigned int checksum = preprocessor.calculateChecksum(toolinfo+'\n'+filecontent);
+
+			std::list<ErrorLogger::ErrorMessage> errors;
+			if (!analyzerInformation.analyzeFile(_settings.buildDir, filename, cfgname, checksum, &errors)) {
+				while (!errors.empty()) {
+					reportErr(errors.front());
+					errors.pop_front();
+				}
+				return exitcode;  // known results => no need to reanalyze file
+			}
+
+			// reset stream state and position for analysis
+			fileStream.clear();
+			fileStream.seekg(0, std::ios::beg);
+		}
+
         std::set<std::string> configurations;
 
         simplecpp::OutputList outputList;
@@ -226,29 +259,6 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
         preprocessor.inlineSuppressions(tokens1);
         tokens1.removeComments();
         preprocessor.removeComments();
-
-        if (!_settings.buildDir.empty()) {
-            // Get toolinfo
-            std::string toolinfo;
-            toolinfo += CPPCHECK_VERSION_STRING;
-            toolinfo += _settings.isEnabled(Settings::WARNING) ? 'w' : ' ';
-            toolinfo += _settings.isEnabled(Settings::STYLE) ? 's' : ' ';
-            toolinfo += _settings.isEnabled(Settings::PERFORMANCE) ? 'p' : ' ';
-            toolinfo += _settings.isEnabled(Settings::PORTABILITY) ? 'p' : ' ';
-            toolinfo += _settings.isEnabled(Settings::INFORMATION) ? 'i' : ' ';
-            toolinfo += _settings.userDefines;
-
-            // Calculate checksum so it can be compared with old checksum / future checksums
-            const unsigned int checksum = preprocessor.calculateChecksum(tokens1, toolinfo);
-            std::list<ErrorLogger::ErrorMessage> errors;
-            if (!analyzerInformation.analyzeFile(_settings.buildDir, filename, cfgname, checksum, &errors)) {
-                while (!errors.empty()) {
-                    reportErr(errors.front());
-                    errors.pop_front();
-                }
-                return exitcode;  // known results => no need to reanalyze file
-            }
-        }
 
         // Get directives
         preprocessor.setDirectives(tokens1);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -868,6 +868,11 @@ static std::uint32_t crc32(const std::string &data)
     return crc ^ ~0U;
 }
 
+unsigned int Preprocessor::calculateChecksum(const std::string &data)
+{
+	return crc32(data);
+}
+
 unsigned int Preprocessor::calculateChecksum(const simplecpp::TokenList &tokens1, const std::string &toolinfo) const
 {
     std::ostringstream ostr;

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -163,6 +163,14 @@ public:
     bool validateCfg(const std::string &cfg, const std::list<simplecpp::MacroUsage> &macroUsageList);
     void validateCfgError(const std::string &file, const unsigned int line, const std::string &cfg, const std::string &macro);
 
+	/**
+	* Calculate CRC32 checksum. Using string.
+	*
+	* @param data		string to generate checksum for
+	* @return CRC32 checksum
+	*/
+	static unsigned int calculateChecksum(const std::string &data);
+
     /**
      * Calculate CRC32 checksum. Using toolinfo, tokens1, filedata.
      *


### PR DESCRIPTION
by not checking file tokens but instead using the filecontent directly to compute the checksum.

Tokenizing is expensive so by checking if the file itself changed (alongside the toolinfo data) it can be quickly evaluated if the file needs rechecking.

This of course only works if `--cppcheck-build-dir` is used and a previous run generated an `analyzerinfo` file.

This basically implements incremental/differential file checking, so in codebases with few files changing, cppcheck will be incredibly fast.

Caveats i see are:

- reading the whole file possibly twice
- the checksum might produce collisions (maybe change to SHA1?)
- [more sophisticated](https://stackoverflow.com/a/32495156/7926064) algorithm could be implemented