### PR TITLE
windows.cfg: fix GetPrivateProfileString nullPointer FP

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -2546,12 +2546,10 @@ HFONT CreateFont(
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
-      <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
     <arg nr="2">
-      <not-null/>
       <not-uninit/>
       <strz/>
     </arg>


### PR DESCRIPTION
The first three arguments can be NULL.
Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724353.aspx