### PR TITLE
MS SAL config: add more defines for annotations

### DIFF
--- a/cfg/microsoft_sal.cfg
+++ b/cfg/microsoft_sal.cfg
@@ -177,6 +177,39 @@
   <define name="_At_buffer_(expr, iter, elem-count, anno-list)" value=""/>
   <define name="_Group_(anno-list)" value=""/>
   <define name="_When_(expr, anno-list)" value=""/>
+  <!-- Annotations not or poorly documented by MSDN (see sal.h) -->
+  <!-- Format string parameters -->
+  <define name="_Printf_format_string_" value=""/>
+  <define name="_Scanf_format_string_" value=""/>
+  <define name="_Scanf_s_format_string_" value=""/>
+  <!-- Annotations for strict type checking -->
+  <define name="_Points_to_data_" value=""/>
+  <define name="_Literal_" value=""/>
+  <define name="_Notliteral_" value=""/>
+  <!-- Annotations for defensive programming -->
+  <define name="_Pre_defensive_" value=""/>
+  <define name="_Post_defensive_" value=""/>
+  <define name="_In_defensive_(annotes)" value=""/>
+  <define name="_Out_defensive_(annotes)" value=""/>
+  <define name="_Inout_defensive_(annotes)" value=""/>
+  <!-- _In_\_Out_ Layer -->
+  <define name="_Reserved_" value=""/>
+  <define name="_Const_" value=""/>
+  <define name="_Unchanged_(e)" value=""/>
+  <!-- Output Parameters -->
+  <define name="_Outref_result_nullonfailure_" value=""/>
+  <define name="_Result_nullonfailure_" value=""/>
+  <define name="_Result_zeroonfailure_" value=""/>
+  <!-- _Pre_\_Post_ Layer -->
+  <define name="_Pre_" value=""/>
+  <define name="_Post_" value=""/>
+  <define name="_Valid_" value=""/>
+  <define name="_Notvalid_" value=""/>
+  <define name="_Maybevalid_" value=""/>
+  <!-- Pointer null-ness properties -->
+  <define name="_Null_" value=""/>
+  <define name="_Notnull_" value=""/>
+  <define name="_Maybenull_" value=""/>
   <!-- (old) Windows Header Annotations (see http://msdn.microsoft.com/en-us/library/windows/desktop/aa383701%28v=vs.85%29.aspx) -->
   <define name="__bcount(size)" value=""/>
   <define name="__bcount_opt(size)" value=""/>
@@ -292,4 +325,5 @@
   <define name="__out_ecount_part(size,length)" value=""/>
   <define name="__out_ecount_part_opt(size,length)" value=""/>
   <define name="__out_opt" value=""/>
+  <define name="__format_string" value=""/>
 </def>


### PR DESCRIPTION
Add annotations which are not so well documented, but could be/are used
in custom code.