### PR TITLE
windows.cfg: Add Sleep and SleepEx

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3605,6 +3605,31 @@ HFONT CreateFont(
     <noreturn>false</noreturn>
     <leak-ignore/>
   </function>
+  <!--VOID WINAPI Sleep(
+      _In_ DWORD dwMilliseconds);-->
+  <function name="Sleep">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--DWORD WINAPI SleepEx(
+  _In_ DWORD dwMilliseconds,
+  _In_ BOOL  bAlertable);-->
+  <function name="SleepEx">
+    <noreturn>false</noreturn>
+    <returnValue type="DWORD"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
   <podtype name="LARGE_INTEGER" sign="s" size="8"/>
   <podtype name="POINTER_SIGNED" sign="s"/>
   <podtype name="POINTER_UNSIGNED" sign="u"/>


### PR DESCRIPTION
Add configuration for Sleep and SleepEx on Windows.
Not sure how to implement that the functions do not return when the first parameter is INFINITE.