### PR TITLE
enable high dpi scaling when qt version >= 5.6.0

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -41,6 +41,11 @@ static bool CheckArgs(const QStringList &args);
 
 int main(int argc, char *argv[])
 {
+    
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+    
     QApplication app(argc, argv);
 
 #if QT_VERSION < 0x050000


### PR DESCRIPTION
Currently cpp check doesn't use its full user interface potential because of the lack of high dpi scaling. Without proper high dpi scaling, the user interface symbols become very tiny.
This patch enables high dpi scaling per default in case the target qt version is >= 5.6.0