### PR TITLE
Ticket #8175: Fix bug in TemplateSimplifier::instantiateMatch with template parameters involving sizeof or namespace.

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -695,7 +695,7 @@ bool TemplateSimplifier::instantiateMatch(const Token *instance, const std::stri
         const Token *tok = instance;
         unsigned int indentlevel = 0;
         for (tok = instance; tok && (tok->str() != ">" || indentlevel > 0); tok = tok->next()) {
-            if (Token::Match(tok, "[<,] %name% <") && templateParameters(tok->tokAt(2)) > 0)
+            if (Token::Match(tok, "<|,|(|:: %name% <") && templateParameters(tok->tokAt(2)) > 0)
                 ++indentlevel;
             if (indentlevel > 0 && tok->str() == ">")
                 --indentlevel;


### PR DESCRIPTION
The ticket is due to instantiateMatch not working properly when template parameters involve sizeof or qualified namespaces. This patch fixes this.