### PR TITLE
Fix define parsing from compile_command.json

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -93,7 +93,9 @@ unsigned int CppCheck::check(const ImportProject::FileSettings &fs)
 {
     CppCheck temp(_errorLogger, _useGlobalSuppressions);
     temp._settings = _settings;
-    temp._settings.userDefines = fs.cppcheckDefines();
+    if (!temp._settings.userDefines.empty())
+        temp._settings.userDefines += ";";
+    temp._settings.userDefines += fs.cppcheckDefines();
     temp._settings.includePaths = fs.includePaths;
     // TODO: temp._settings.userUndefs = fs.undefs;
     if (fs.platformType != Settings::Unspecified) {

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -94,7 +94,7 @@ unsigned int CppCheck::check(const ImportProject::FileSettings &fs)
     CppCheck temp(_errorLogger, _useGlobalSuppressions);
     temp._settings = _settings;
     if (!temp._settings.userDefines.empty())
-        temp._settings.userDefines += ";";
+        temp._settings.userDefines += ';';
     temp._settings.userDefines += fs.cppcheckDefines();
     temp._settings.includePaths = fs.includePaths;
     // TODO: temp._settings.userUndefs = fs.undefs;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -222,8 +222,18 @@ void ImportProject::importCompileCommands(std::istream &istr)
                             fval += command[pos];
                         pos++;
                     }
-                    if (F=='D')
-                        fs.defines += fval + ";";
+                    if (F=='D') {
+                        std::string defval;
+                        while (pos < command.size() && command[pos] != ' ') {
+                            if (command[pos] != '\\')
+                                defval += command[pos];
+                            pos++;
+                        }
+                        fs.defines += fval;
+                        if (!defval.empty())
+                            fs.defines += defval;
+                        fs.defines += ";";
+                    }
                     else if (F=='U')
                         fs.undefs.insert(fval);
                     else if (F=='I')

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -232,7 +232,7 @@ void ImportProject::importCompileCommands(std::istream &istr)
                             }
                             else {
                                 if (escape) {
-                                    defval += "\\";
+                                    defval += '\\';
                                     escape = false;
                                 }
                                 else {
@@ -244,7 +244,7 @@ void ImportProject::importCompileCommands(std::istream &istr)
                         fs.defines += fval;
                         if (!defval.empty())
                             fs.defines += defval;
-                        fs.defines += ";";
+                        fs.defines += ';';
                     }
                     else if (F=='U')
                         fs.undefs.insert(fval);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -224,9 +224,21 @@ void ImportProject::importCompileCommands(std::istream &istr)
                     }
                     if (F=='D') {
                         std::string defval;
+                        bool escape = false;
                         while (pos < command.size() && command[pos] != ' ') {
-                            if (command[pos] != '\\')
+                            if (command[pos] != '\\') {
                                 defval += command[pos];
+                                escape = false;
+                            }
+                            else {
+                                if (escape) {
+                                    defval += "\\";
+                                    escape = false;
+                                }
+                                else {
+                                    escape = true;
+                                }
+                            }
                             pos++;
                         }
                         fs.defines += fval;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -74,8 +74,9 @@ public:
     void ignoreOtherPlatforms(cppcheck::Platform::PlatformType platformType);
 
     void import(const std::string &filename);
-private:
+protected:
     void importCompileCommands(std::istream &istr);
+private:
     void importSln(std::istream &istr, const std::string &path);
     void importVcxproj(const std::string &filename, std::map<std::string, std::string, cppcheck::stricmp> &variables, const std::string &additionalIncludeDirectories);
 };

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -22,6 +22,15 @@
 #include <list>
 #include <map>
 #include <string>
+#include <iostream>
+
+class TestImporter : public ImportProject {
+public:
+    void importCompileCommands(std::istream &istr) {
+        ImportProject::importCompileCommands(istr);
+    }
+};
+
 
 class TestImportProject : public TestFixture {
 public:
@@ -35,6 +44,7 @@ private:
         TEST_CASE(setIncludePaths1);
         TEST_CASE(setIncludePaths2);
         TEST_CASE(setIncludePaths3); // macro names are case insensitive
+        TEST_CASE(importCompileCommands);
     }
 
     void setDefines() const {
@@ -83,6 +93,18 @@ private:
         fs.setIncludePaths("/home/fred", in, variables);
         ASSERT_EQUALS(1U, fs.includePaths.size());
         ASSERT_EQUALS("c:/abc/other/", fs.includePaths.front());
+    }
+
+    void importCompileCommands() const {
+
+        const char json[] = "[ { \"directory\": \"/tmp\","
+                            "\"command\": \"gcc -I/tmp -DTEST1 -DTEST2=2  -DTEST3=\\\"\\\\\\\"3\\\\\\\"\\\" -o /tmp/src.o -c /tmp/src.c\","
+                            "\"file\": \"/tmp/src.c\" } ]";
+        std::istringstream istr(json);
+        TestImporter importer;
+        importer.importCompileCommands(istr);
+        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS("TEST1=1;TEST2=2;TEST3=\"\\\"3\\\"\"", importer.fileSettings.begin()->defines);
     }
 };
 

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -22,7 +22,6 @@
 #include <list>
 #include <map>
 #include <string>
-#include <iostream>
 
 class TestImporter : public ImportProject {
 public:


### PR DESCRIPTION
Define values are now parsed when using compile_commands.json.