### PR TITLE
Manual: Fix sizeof reference to strncpy config

### DIFF
--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -1281,7 +1281,7 @@ Checking minsize.c...
 
               <listitem>
                 <para>buffer size must be larger than other argument buffer
-                size. Example: see strncpy configuration in std.cfg</para>
+                size. Example: see memccpy configuration in posix.cfg</para>
               </listitem>
             </varlistentry>
 


### PR DESCRIPTION
Because the configuration for strncpy contained sizeof by error, the example was no longer correct.
Replaced with a reference to memccpy which uses sizeof.