### PR TITLE
Fixed #7331: Detect copy and move constructors with default parameters

### DIFF
--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1163,6 +1163,7 @@ private:
     void createSymbolDatabaseFindAllScopes();
     void createSymbolDatabaseClassInfo();
     void createSymbolDatabaseVariableInfo();
+    void createSymbolDatabaseCopyAndMoveConstructors();
     void createSymbolDatabaseFunctionScopes();
     void createSymbolDatabaseClassAndStructScopes();
     void createSymbolDatabaseFunctionReturnTypes();

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1271,6 +1271,12 @@ private:
 
     void testConstructors() {
         {
+            GET_SYMBOL_DB("class Foo { Foo(); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
             GET_SYMBOL_DB("class Foo { Foo(Foo f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor && !ctor->isExplicit());
@@ -1283,13 +1289,49 @@ private:
             ASSERT(ctor && ctor->retDef == 0);
         }
         {
+            GET_SYMBOL_DB("class Foo { Foo(Bar& f); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
             GET_SYMBOL_DB("class Foo { Foo(Foo& f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
             ASSERT(ctor && ctor->retDef == 0);
         }
         {
+            GET_SYMBOL_DB("class Foo { Foo(const Foo &f); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
+            GET_SYMBOL_DB("template <T> class Foo { Foo(Foo<T>& f); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(7)->function();
+            ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
+            GET_SYMBOL_DB("class Foo { Foo(Foo& f, int default = 0); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
+            GET_SYMBOL_DB("class Foo { Foo(Foo& f, char noDefault); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
             GET_SYMBOL_DB("class Foo { Foo(Foo&& f); };");
+            const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
+            ASSERT(db && ctor && ctor->type == Function::eMoveConstructor);
+            ASSERT(ctor && ctor->retDef == 0);
+        }
+        {
+            GET_SYMBOL_DB("class Foo { Foo(Foo & & f, int default = 1, bool defaultToo = true); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eMoveConstructor);
             ASSERT(ctor && ctor->retDef == 0);


### PR DESCRIPTION
This is an attempt to fix issue #7331.
Copy and move constructors can have additional trailing parameters provided that they all have default values. See [copy ctors](http://en.cppreference.com/w/cpp/language/copy_constructor) and [move ctors](http://en.cppreference.com/w/cpp/language/move_constructor).

My approach has been to move the copy/move constructor detection to a later stage in the symbol database construction. They're initially parsed as regular constructors and checked if copy/move after default values have been parsed. Suggestions welcome, of course :innocent: 