### PR TITLE
Fix 7439: GUI: Remove value "constant" from minsize attribute items list

### DIFF
--- a/gui/libraryeditargdialog.cpp
+++ b/gui/libraryeditargdialog.cpp
@@ -22,7 +22,7 @@ LibraryEditArgDialog::LibraryEditArgDialog(QWidget *parent, const CppcheckLibrar
     ui->minsize2arg2->setEnabled(arg.minsizes.count() >= 2 && arg.minsizes[1].type == "mul");
 
     QStringList items;
-    items << "None" << "argvalue" << "constant" << "mul" << "sizeof" << "strlen";
+    items << "None" << "argvalue" << "mul" << "sizeof" << "strlen";
 
     ui->minsize1type->clear();
     ui->minsize1type->addItems(items);

--- a/gui/libraryeditargdialog.ui
+++ b/gui/libraryeditargdialog.ui
@@ -116,11 +116,6 @@
          </item>
          <item>
           <property name="text">
-           <string>constant</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
            <string>mul</string>
           </property>
          </item>
@@ -222,11 +217,6 @@
          <item>
           <property name="text">
            <string>argvalue</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>constant</string>
           </property>
          </item>
          <item>


### PR DESCRIPTION
The list of items for the minsize attributes in the LibraryEditor
contains the illegal value "constant" which is removed by this PR.