### PR TITLE
Fix windows.cfg: GetProcAddress needs use-retval

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3727,6 +3727,7 @@ HFONT CreateFont(
   _In_ LPCSTR  lpProcName);-->
   <function name="GetProcAddress">
     <noreturn>false</noreturn>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>


### PR DESCRIPTION
While it was good to remove use-retval from the LoadLibrary* functions,
it is still needed for GetProcAddress. A call of GetProcAddress without
using the return value does not make sense.