### PR TITLE
windows.cfg: Add CRITICAL_SECTION handling functions.

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3738,6 +3738,89 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
+  <!--void WINAPI InitializeCriticalSection(
+  _Out_ LPCRITICAL_SECTION lpCriticalSection);-->
+  <function name="InitializeCriticalSection">
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI InitializeCriticalSectionAndSpinCount(
+  _Out_ LPCRITICAL_SECTION lpCriticalSection,
+  _In_  DWORD              dwSpinCount);-->
+  <function name="InitializeCriticalSectionAndSpinCount">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--DWORD WINAPI SetCriticalSectionSpinCount(
+  _Inout_ LPCRITICAL_SECTION lpCriticalSection,
+  _In_    DWORD              dwSpinCount);-->
+  <function name="SetCriticalSectionSpinCount">
+    <noreturn>false</noreturn>
+    <returnValue type="DWORD"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--void WINAPI DeleteCriticalSection(
+  _Inout_ LPCRITICAL_SECTION lpCriticalSection);-->
+  <function name="DeleteCriticalSection">
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--void WINAPI EnterCriticalSection(
+  _Inout_ LPCRITICAL_SECTION lpCriticalSection);-->
+  <function name="EnterCriticalSection">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI TryEnterCriticalSection(
+  _Inout_ LPCRITICAL_SECTION lpCriticalSection);-->
+  <function name="TryEnterCriticalSection">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--void WINAPI LeaveCriticalSection(
+  _Inout_ LPCRITICAL_SECTION lpCriticalSection);-->
+  <function name="LeaveCriticalSection">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <podtype name="LARGE_INTEGER" sign="s" size="8"/>
   <podtype name="POINTER_SIGNED" sign="s"/>
   <podtype name="POINTER_UNSIGNED" sign="u"/>

--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3804,6 +3804,7 @@ HFONT CreateFont(
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-null/>
+      <not-uninit/>
       <not-bool/>
     </arg>
   </function>

--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3762,6 +3762,26 @@ HFONT CreateFont(
       <not-bool/>
     </arg>
   </function>
+  <!--BOOL WINAPI InitializeCriticalSectionEx(
+  _Out_ LPCRITICAL_SECTION lpCriticalSection,
+  _In_  DWORD              dwSpinCount,
+  _In_  DWORD              Flags);-->
+  <function name="InitializeCriticalSectionEx">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!--DWORD WINAPI SetCriticalSectionSpinCount(
   _Inout_ LPCRITICAL_SECTION lpCriticalSection,
   _In_    DWORD              dwSpinCount);-->


### PR DESCRIPTION
I have some problems configuring the CRITICAL_SECTION functions:

How should i define CRITICAL_SECTION for cppcheck?
It is a struct and only used internally by Windows and looks like this:
```
typedef struct _RTL_CRITICAL_SECTION {
    PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
    LONG LockCount;
    LONG RecursionCount;
    HANDLE OwningThread;        // from the thread's ClientId->UniqueThread
    HANDLE LockSemaphore;
    ULONG_PTR SpinCount;        // force size on 64-bit systems when packed
} RTL_CRITICAL_SECTION, *PRTL_CRITICAL_SECTION;
typedef RTL_CRITICAL_SECTION CRITICAL_SECTION;
```
I guess the checks will not detect as much as they could if this is not known to cppcheck.

Since a CRITICAL_SECTION is some sort of resource i wanted to add a resource description:
```
  <resource>
    <alloc init="true" arg="1">InitializeCriticalSection</alloc>
    <alloc init="true" arg="1">InitializeCriticalSectionAndSpinCount</alloc>
    <alloc init="true" arg="1">InitializeCriticalSectionEx</alloc>
    <dealloc>DeleteCriticalSection</dealloc>
  </resource>
```
But for code like this:
```
    CRITICAL_SECTION CriticalSection;
    // Initialize the critical section one time only.
    if (!InitializeCriticalSectionAndSpinCount(&CriticalSection, 0x00000400) )
        return;

    // Release resources used by the critical section object.
    DeleteCriticalSection(&CriticalSection);
```
cppcheck complains:
error:autovarInvalidDeallocation:The deallocation of an auto-variable results in undefined behaviour. You should only free memory that has been allocated dynamically.
Is there a way to tell cppcheck that there is no "real" allocation/deallocation but init/deinit here?
  
  