### PR TITLE
Add support for simple c++ 11 type ailases like: using INT = int;

### DIFF
--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -100,13 +100,24 @@ public:
     std::vector<BaseInfo> derivedFrom;
     std::list<FriendInfo> friendList;
 
+    const Token * typeStart;
+    const Token * typeEnd;
+
     Type(const Token* classDef_ = nullptr, const Scope* classScope_ = nullptr, const Scope* enclosingScope_ = nullptr) :
         classDef(classDef_),
         classScope(classScope_),
         enclosingScope(enclosingScope_),
-        needInitialization(Unknown) {
+        needInitialization(Unknown),
+        typeStart(nullptr),
+        typeEnd(nullptr) {
         if (classDef_ && classDef_->str() == "enum")
             needInitialization = True;
+        else if (classDef_ && classDef_->str() == "using") {
+            typeStart = classDef->tokAt(3);
+            typeEnd = typeStart;
+            while (typeEnd->next() && typeEnd->next()->str() != ";")
+                typeEnd = typeEnd->next();
+        }
     }
 
     const std::string& name() const;
@@ -121,6 +132,10 @@ public:
 
     bool isEnumType() const {
         return classDef && classDef->str() == "enum";
+    }
+
+    bool isTypeAlias() const {
+        return classDef && classDef->str() == "using";
     }
 
     bool isStructType() const {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5538,6 +5538,8 @@ void Tokenizer::simplifyVarDecl(const bool only_k_r_fpar)
 
 void Tokenizer::simplifyVarDecl(Token * tokBegin, const Token * const tokEnd, const bool only_k_r_fpar)
 {
+    const bool isCPP11  = _settings->standards.cpp >= Standards::CPP11;
+
     // Split up variable declarations..
     // "int a=4;" => "int a; a=4;"
     bool finishedwithkr = true;
@@ -5585,6 +5587,8 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, const Token * const tokEnd, co
         if (!Token::Match(type0, "::|extern| %type%"))
             continue;
         if (Token::Match(type0, "else|return|public:|protected:|private:"))
+            continue;
+        if (isCPP11 && type0->str() == "using")
             continue;
 
         bool isconst = false;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5832,6 +5832,8 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, const Token * const tokEnd, co
 
 void Tokenizer::simplifyPlatformTypes()
 {
+    const bool isCPP11  = _settings->standards.cpp >= Standards::CPP11;
+
     enum { isLongLong, isLong, isInt } type;
 
     /** @todo This assumes a flat address space. Not true for segmented address space (FAR *). */
@@ -5850,11 +5852,15 @@ void Tokenizer::simplifyPlatformTypes()
         if (!Token::Match(tok, "std| ::| %type%"))
             continue;
         bool isUnsigned;
-        if (Token::Match(tok, "std| ::| size_t|uintptr_t|uintmax_t"))
+        if (Token::Match(tok, "std| ::| size_t|uintptr_t|uintmax_t")) {
+            if (isCPP11 && tok->strAt(-1) == "using" && tok->strAt(1) == "=")
+                continue;
             isUnsigned = true;
-        else if (Token::Match(tok, "std| ::| ssize_t|ptrdiff_t|intptr_t|intmax_t"))
+        } else if (Token::Match(tok, "std| ::| ssize_t|ptrdiff_t|intptr_t|intmax_t")) {
+            if (isCPP11 && tok->strAt(-1) == "using" && tok->strAt(1) == "=")
+                continue;
             isUnsigned = false;
-        else
+        } else
             continue;
 
         bool inStd = false;


### PR DESCRIPTION
Only types supported by ValueType are supported. Complex types like
function pointers are not supported. Template type aliases are not
supported.