### PR TITLE
windows.cfg: Add *Event functions configuration

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -960,6 +960,7 @@
     <alloc init="true">OpenFileMapping</alloc>
     <alloc init="true">CreateNamedPipe</alloc>
     <alloc init="true">CreateEvent</alloc>
+    <alloc init="true">CreateEventEx</alloc>
     <alloc init="true">CreateMutex</alloc>
     <alloc init="true">CreateSemaphore</alloc>
     <alloc init="true">CreateTimerQueue</alloc>
@@ -3735,6 +3736,89 @@ HFONT CreateFont(
       <not-null/>
     </arg>
     <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI CreateEvent(
+  _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
+  _In_     BOOL                  bManualReset,
+  _In_     BOOL                  bInitialState,
+  _In_opt_ LPCTSTR               lpName);-->
+  <function name="CreateEvent">
+    <noreturn>false</noreturn>
+    <returnValue type="HANDLE"/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI CreateEventEx(
+  _In_opt_ LPSECURITY_ATTRIBUTES lpEventAttributes,
+  _In_opt_ LPCTSTR               lpName,
+  _In_     DWORD                 dwFlags,
+  _In_     DWORD                 dwDesiredAccess);-->
+  <function name="CreateEventEx">
+    <noreturn>false</noreturn>
+    <returnValue type="HANDLE"/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI OpenEvent(
+  _In_ DWORD   dwDesiredAccess,
+  _In_ BOOL    bInheritHandle,
+  _In_ LPCTSTR lpName);-->
+  <function name="OpenEvent">
+    <noreturn>false</noreturn>
+    <returnValue type="HANDLE"/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI PulseEvent(
+  _In_ HANDLE hEvent);-->
+  <!--BOOL WINAPI ResetEvent(
+  _In_ HANDLE hEvent);-->
+  <!--BOOL WINAPI SetEvent(
+  _In_ HANDLE hEvent);-->
+  <function name="PulseEvent,ResetEvent,SetEvent">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
       <not-uninit/>
     </arg>
   </function>


### PR DESCRIPTION
Tested with this code:
```
// Valid code
void test_ok1()
{
    HANDLE event;
    event = CreateEvent(NULL, FALSE, FALSE, NULL);
    if(NULL != event)
    {
        SetEvent(event);
        CloseHandle(event);
    }
}

void test_ok2()
{
    HANDLE event;
    event = OpenEvent(EVENT_ALL_ACCESS, FALSE, L"testevent");
    if(NULL != event)
    {
        PulseEvent(event);
        SetEvent(event);
        CloseHandle(event);
    }
}

void test_ok3()
{
    HANDLE event;
    event = CreateEventEx(NULL, L"testevent3", CREATE_EVENT_INITIAL_SET, EVENT_MODIFY_STATE);
    if(NULL != event)
    {
        ResetEvent(event);
        CloseHandle(event);
    }
}

// Invalid code: uninitialized handles used
void test_error1()
{
    HANDLE event1;
    // cppcheck-suppress uninitvar
    PulseEvent(event1);
    HANDLE event2;
    // cppcheck-suppress uninitvar
    ResetEvent(event2);
    HANDLE event3;
    // cppcheck-suppress uninitvar
    SetEvent(event3);
    HANDLE event4;
    // cppcheck-suppress uninitvar
    CloseHandle(event4);
}

// Invalid code: HANDLE not closed
void test_error2()
{
    HANDLE event;
    event = CreateEvent(NULL, FALSE, FALSE, NULL);
    SetEvent(event);
    // cppcheck-suppress resourceLeak
}

// Invalid code: NULL used for SetEvent, HANDLE not closed
void test_error3()
{
    HANDLE event;
    event = CreateEvent(NULL, FALSE, FALSE, NULL);
    if(NULL == event)
    {
        // cppcheck-suppress nullPointerRedundantCheck
        SetEvent(event);
        CloseHandle(event);
    }
    // cppcheck-suppress resourceLeak
}

// Invalid code: 3. parameter of OpenEvent must not be null
void test_error4()
{
    HANDLE event;
    // cppcheck-suppress unreadVariable
    // cppcheck-suppress nullPointer
    event = OpenEvent(EVENT_ALL_ACCESS, FALSE, NULL);
    // cppcheck-suppress resourceLeak
}

// Invalid code: Return values of allocation functions not used
void test_error5()
{
    // cppcheck-suppress leakReturnValNotUsed
    CreateEvent(NULL, FALSE, FALSE, NULL);
    // cppcheck-suppress leakReturnValNotUsed
    OpenEvent(EVENT_ALL_ACCESS, FALSE, L"testevent");
    // cppcheck-suppress leakReturnValNotUsed
    CreateEventEx(NULL, L"testevent3", CREATE_EVENT_INITIAL_SET, EVENT_MODIFY_STATE);
}
```
Called via:
`cppcheck --check-library --enable=information --enable=style -v --error-exitcode=1 --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}" --library=windows "windows_lib_events.cpp"`
