### PR TITLE
windows.cfg: Add lstrcat configuration

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3926,6 +3926,27 @@ HFONT CreateFont(
       <not-bool/>
     </arg>
   </function>
+  <!--LPTSTR WINAPI lstrcat(
+  _Inout_ LPTSTR lpString1,
+  _In_    LPTSTR lpString2);-->
+  <!-- TODO: When implemented use minsize for argument 1 to verify that the
+  buffer is at least "(strlen(arg1)+strlen(arg2)+1)*sizeof(TCHAR)" bytes in size.-->
+  <function name="lstrcat">
+    <returnValue type="LPTSTR"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <warn severity="style" alternatives="StringCchCat">Due to security concerns it is not recommended to use this function, see MSDN for details.</warn>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+    </arg>
+  </function>
   <podtype name="LARGE_INTEGER" sign="s" size="8"/>
   <podtype name="POINTER_SIGNED" sign="s"/>
   <podtype name="POINTER_UNSIGNED" sign="u"/>


### PR DESCRIPTION
On the MSDN there is a prominent warning to not use this function, so i
decided to add a warn entry. See
https://msdn.microsoft.com/de-de/library/windows/desktop/ms647487(v=vs.85).aspx
for details.