### PR TITLE
Ticket #8333: Properly report a syntax error for functions with invalid parameter types.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3082,6 +3082,10 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
         // skip over stuff to get to type
         while (Token::Match(typeTok, "const|enum|struct|::"))
             typeTok = typeTok->next();
+        if (Token::Match(typeTok, ",|)")) { // #8333
+            symbolDatabase->_tokenizer->syntaxError(typeTok);
+            return;
+        }
         // skip over qualification
         while (Token::Match(typeTok, "%type% ::"))
             typeTok = typeTok->tokAt(2);

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -221,6 +221,7 @@ private:
         TEST_CASE(garbageCode188);
         TEST_CASE(garbageCode189); // #8317
         TEST_CASE(garbageCode190); // #8307
+        TEST_CASE(garbageCode191); // #8333
         TEST_CASE(garbageValueFlow);
         TEST_CASE(garbageSymbolDatabase);
         TEST_CASE(garbageAST);
@@ -1203,7 +1204,7 @@ private:
                            "{\n"
                            "    (foo(s, , 2, , , 5, , 7)) abort()\n"
                            "}\n";
-        checkCode(code);
+        ASSERT_THROW(checkCode(code), InternalError);
 
         // #6106
         code = " f { int i ; b2 , [ ] ( for ( i = 0 ; ; ) ) }";
@@ -1449,6 +1450,15 @@ private:
                   "    i *= 0;\n"
                   "    !i <;\n"
                   "}");
+    }
+
+    void garbageCode191() { // #8333
+        ASSERT_THROW(checkCode("struct A { int f(const); };"), InternalError);
+        ASSERT_THROW(checkCode("struct A { int f(int, const, char); };"), InternalError);
+        ASSERT_THROW(checkCode("struct A { int f(struct); };"), InternalError);
+
+        // The following code is valid and should not trigger any error
+        checkCode("struct A { int f ( char ) ; } ;");
     }
 
     void syntaxErrorFirstToken() {


### PR DESCRIPTION
Properly bailout upon invalid function parameters in SymbolDatabase.