### PR TITLE
Fixes issue with case inside switch that is not a compound statement

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8296,12 +8296,16 @@ const Token * Tokenizer::findGarbageCode() const
 
     // case keyword must be inside switch
     for (const Token *tok = tokens(); tok; tok = tok->next()) {
-        if (Token::simpleMatch(tok, "switch (") && Token::simpleMatch(tok->linkAt(1), ")")) {
-            if (tok->linkAt(1)->linkAt(1) && tok->linkAt(1)->linkAt(1)->str() == "}") {
+        if (Token::simpleMatch(tok, "switch (")) {
+            if (Token::simpleMatch(tok->linkAt(1), ") {")) {
                 tok = tok->linkAt(1)->linkAt(1);
             } else {
-                while (tok && tok->str() != ";" && tok->str() != "{")
+                while (tok->str() != ";" && tok->str() != "{") {
+                    if (tok->next() == nullptr) {
+                        return tok;
+                    }
                     tok = tok->next();
+                }
             }
         } else if (tok->str() == "(") {
             tok = tok->link();

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8296,12 +8296,18 @@ const Token * Tokenizer::findGarbageCode() const
 
     // case keyword must be inside switch
     for (const Token *tok = tokens(); tok; tok = tok->next()) {
-        if (Token::simpleMatch(tok, "switch (") && Token::simpleMatch(tok->linkAt(1), ") {"))
-            tok = tok->linkAt(1)->linkAt(1);
-        else if (tok->str() == "(")
+        if (Token::simpleMatch(tok, "switch (") && Token::simpleMatch(tok->linkAt(1), ")")) {
+            if (tok->linkAt(1)->linkAt(1) && tok->linkAt(1)->linkAt(1)->str() == "}") {
+                tok = tok->linkAt(1)->linkAt(1);
+            } else {
+                while (tok && tok->str() != ";" && tok->str() != "{")
+                    tok = tok->next();
+            }
+        } else if (tok->str() == "(") {
             tok = tok->link();
-        else if (tok->str() == "case")
+        } else if (tok->str() == "case") {
             return tok;
+        }
     }
 
     for (const Token *tok = tokens(); tok ; tok = tok->next()) {

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -375,6 +375,9 @@ private:
 
         //ticket #4267
         ASSERT_THROW(checkCode("f ( ) { switch break; { switch ( x ) { case } case break; -6: ( ) ; } }"), InternalError);
+
+        // Missing semicolon
+        ASSERT_THROW(checkCode("void foo () { switch(0) case 0 : default : }"), InternalError);
     }
 
     void garbageCode1() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4738,6 +4738,7 @@ private:
         //ticket #3227
         ASSERT_EQUALS("void foo ( ) { switch ( n ) { label : ; case 1 : ; label1 : ; label2 : ; break ; } }",
                       tokenizeAndStringify("void foo(){ switch (n){ label: case 1: label1: label2: break; }}"));
+        //ticket #8345
         ASSERT_EQUALS("void foo ( ) { switch ( 0 ) { case 0 : ; default : ; } }",
                       tokenizeAndStringify("void foo () { switch(0) case 0 : default : ; }"));
     }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4738,6 +4738,8 @@ private:
         //ticket #3227
         ASSERT_EQUALS("void foo ( ) { switch ( n ) { label : ; case 1 : ; label1 : ; label2 : ; break ; } }",
                       tokenizeAndStringify("void foo(){ switch (n){ label: case 1: label1: label2: break; }}"));
+        ASSERT_EQUALS("void foo ( ) { switch ( 0 ) { case 0 : ; default : ; } }",
+                      tokenizeAndStringify("void foo () { switch(0) case 0 : default : ; }"));
     }
 
     void simplifyPointerToStandardType() {


### PR DESCRIPTION
This fixes an issue with the check for case keywords outside of switch
detection that would treat a case statement inside a switch that is not
a compound statement as garbage, but this is perfectly valid C++. This
construct is used in several libraries, i.e. Google Test.