### PR TITLE
std.cfg: Fix copy&paste error or typo

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -272,7 +272,7 @@
     </arg>
   </function>
   <!-- float sinf(float f); -->
-  <function name="sinf,std::sinl">
+  <function name="sinf,std::sinf">
     <use-retval/>
     <pure/>
     <returnValue type="float"/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -441,7 +441,7 @@
     </arg>
   </function>
   <!-- float tanf(float x); -->
-  <function name="tanf,std::tanl">
+  <function name="tanf,std::tanf">
     <use-retval/>
     <pure/>
     <returnValue type="float"/>


### PR DESCRIPTION
It should be std::sinf here. std::sinl is described directly in the next function description and does not make sense here because of the return type.