### PR TITLE
posix.cfg: Fix getprotobynumber configuration

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -420,7 +420,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <warn severity="portability">Non reentrant function 'getprotobyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getprotobyname_r'.</warn>
   </function>
   <!-- struct protoent *getprotobynumber(int proto); -->
-  <function name="getservbyport">
+  <function name="getprotobynumber">
     <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>


### PR DESCRIPTION
It seems to be a copy & paste error.
The comment, the return value, the warn entry and the rest of the
configuration suggest that this must be the getprotobynumber function
configuration and not the getservbyport configuration which would be
redundant as it is configured a bit later.