### PR TITLE
windows.cfg: Fix redundant function configurations

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -1684,8 +1684,8 @@
       <not-uninit/>
     </arg>
   </function>
-  <!-- unsigned char *_mbstok(unsigned char *strToken, const unsigned char *strDelimit, _locale_t locale );  -->
-  <function name="_mbstok">
+  <!-- unsigned char *_mbstok_l(unsigned char *strToken, const unsigned char *strDelimit, _locale_t locale );  -->
+  <function name="_mbstok_l">
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1703,7 +1703,7 @@
   <!-- char *_strtok_s_l(char *strToken, const char *strDelimit, char **context,_locale_t locale ); -->
   <!-- wchar_t *_wcstok_s_l(wchar_t *strToken, const wchar_t *strDelimit, wchar_t**context,_locale_t locale); -->
   <!-- unsigned char *_mbstok_s_l(unsigned char*strToken, const unsigned char *strDelimit, char **context,_locale_t locale); -->
-  <function name="_strtok_s_l,_wcstok_s_l,_mbstok_s,_tcstok_s_l">
+  <function name="_strtok_s_l,_wcstok_s_l,_mbstok_s_l,_tcstok_s_l">
     <!-- strtok may modify the first argument, so using the return value is not mandatory -->
     <noreturn>false</noreturn>
     <pure/>
@@ -2769,14 +2769,6 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <function name="GetModuleHandle,GetModuleHandleA,GetModuleHandleW">
-    <noreturn>false</noreturn>
-    <use-retval/>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-    </arg>
-  </function>
   <function name="RegisterClass,RegisterClassEx">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3677,6 +3669,8 @@ HFONT CreateFont(
   <function name="GetModuleHandle,GetModuleHandleA,GetModuleHandleW">
     <noreturn>false</noreturn>
     <returnValue type="HMODULE"/>
+    <use-retval/>
+    <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
       <strz/>


### PR DESCRIPTION
Detected some errors when checking for redundant function
configurations:
The functions that receive an additional argument "locale" have the
suffix "_l".
Sadly the MSDN shows wrong declarations that are missing the "_l", i
guess this caused the wrong names (I have reported it to Microsoft, but
do not expect that this is fixed soon).

The function configuration for GetModuleHandle* existed twice, i have
merged them, and it looks sane for me now.