### PR TITLE
Ticket #8337: Fix false positive in copy constructor detection.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -924,7 +924,7 @@ void SymbolDatabase::createSymbolDatabaseCopyAndMoveConstructors()
             if (firstArg->type() == scope->definedType) {
                 if (firstArg->isRValueReference())
                     func->type = Function::eMoveConstructor;
-                else if (firstArg->isReference())
+                else if (firstArg->isReference() && !firstArg->isPointer())
                     func->type = Function::eCopyConstructor;
             }
 

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -287,6 +287,13 @@ private:
                                    "  }\n"
                                    "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        // #8337 - False positive in copy constructor detection
+        checkCopyCtorAndEqOperator("struct StaticListNode {\n"
+                                   "  StaticListNode(StaticListNode*& prev) : m_next(0) {}\n"
+                                   "  StaticListNode* m_next;\n"
+                                   "};");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkExplicitConstructors(const char code[]) {


### PR DESCRIPTION
A::A(A*&) is not a copy constructor for A.