### PR TITLE
Fixed #8350 (False positive: enum class static_cast to int is treated…

### DIFF
--- a/lib/checkpostfixoperator.h
+++ b/lib/checkpostfixoperator.h
@@ -50,12 +50,14 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {
     }
 
-    void runSimplifiedChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) {
         if (tokenizer->isC())
             return;
 
         CheckPostfixOperator checkPostfixOperator(tokenizer, settings, errorLogger);
         checkPostfixOperator.postfixOperator();
+    }
+    void runSimplifiedChecks(const Tokenizer * /*tokenizer*/, const Settings * /*settings*/, ErrorLogger * /*errorLogger*/) {
     }
 
     /** Check postfix operators */

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -40,7 +40,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
-        tokenizer.simplifyTokenList2();
 
         // Check for postfix operators..
         CheckPostfixOperator checkPostfixOperator(&tokenizer, &settings, this);
@@ -59,6 +58,7 @@ private:
         TEST_CASE(testtemplate); // #4686
         TEST_CASE(testmember);
         TEST_CASE(testcomma);
+        TEST_CASE(testauto); // #8350
     }
 
     void testsimple() {
@@ -349,6 +349,18 @@ private:
               "    A a;\n"
               "    foo(i, a++);\n"
               "    foo(a++, i);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void testauto() { // #8350
+        check("enum class Color { Red = 0, Green = 1, };\n"
+              "int fun(const Color color) {\n"
+              "    auto a = 0;\n"
+              "    for (auto i = static_cast<int>(color); i < 10; i++) {\n"
+              "        a += i;\n"
+              "    }\n"
+              "    return a;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
… as non-primitive when type inference is used)