### PR TITLE
Member access operators inside the embedded SQL block

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10069,7 +10069,7 @@ const Token *Tokenizer::findSQLBlockEnd(const Token *tokSQLStart)
             if (Token::simpleMatch(tok->tokAt(-2), "END - __CPPCHECK_EMBEDDED_SQL_EXEC__ ;"))
                 return tok->next();
             return tokLastEnd;
-        } else if (Token::Match(tok, "{|}|==|&&|!|&|^|<<|>>|++|+=|-=|/=|*=|>>=|<<=|->|::|~"))
+        } else if (Token::Match(tok, "{|}|==|&&|!|^|<<|>>|++|+=|-=|/=|*=|>>=|<<=|~"))
             break; // We are obviously outside the SQL block
     }
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5829,6 +5829,7 @@ private:
         ASSERT_THROW(tokenizeAndStringify("int f(){ __CPPCHECK_EMBEDDED_SQL_EXEC__ SQL } int a;",false), InternalError);
         ASSERT_THROW(tokenizeAndStringify("__CPPCHECK_EMBEDDED_SQL_EXEC__ SQL int f(){",false), InternalError);
         ASSERT_THROW(tokenizeAndStringify("__CPPCHECK_EMBEDDED_SQL_EXEC__ SQL END-__CPPCHECK_EMBEDDED_SQL_EXEC__ int a;",false), InternalError);
+        ASSERT_NO_THROW(tokenizeAndStringify("__CPPCHECK_EMBEDDED_SQL_EXEC__ SQL UPDATE A SET B = :&b->b1, C = :c::c1;",false));
     }
 
     void simplifyCAlternativeTokens() {


### PR DESCRIPTION
There was improper check has been added in the pull request [#985](https://github.com/danmar/cppcheck/pull/985).
Member access operators (& | . | ->) in fact are allowed inside the arguments passed for embedded SQL query, for example:
`EXEC SQL SELECT 1
   INTO :dummy
   FROM SOME_TABLE
   WHERE SOME_COLUMN = :&some_ptr->some_struct.some_fld;`
I am not sure whether access to static members of a class in C++ (::) is permissible inside the incoming argument of queries, but I think it would be better to exclude it as well.