### PR TITLE
windows.cfg: Add _countof macro configuration

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -4060,4 +4060,5 @@ HFONT CreateFont(
   <define name="WINAPI" value=""/>
   <define name="__pragma(x)" value=""/>
   <define name="TEXT(str)" value="str"/>
+  <define name="_countof(_Array)" value="(sizeof(_Array) / sizeof(_Array[0]))"/>
 </def>


### PR DESCRIPTION
By telling cppcheck about the Microsoft Windows _countof() macro it is
now able to detect out of bounds array accesses like this:
```cpp
wchar_t buf[10];
for(size_t i = 0; i <= _countof(buf); ++i) {
buf[i] = L'\0'; /* (error) Array 'buf[10]' accessed at index 10, which is out of bounds.*/
}
```