### PR TITLE
posix.cfg: access(): Removed redundant configuration, added tests

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -303,20 +303,6 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     </arg>
   </function>
   <!-- http://man7.org/linux/man-pages/man2/access.2.html -->
-  <!-- int access(const char *pathname, int mode); -->
-  <function name="access">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <returnValue type="int"/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="2">
-      <not-uninit/>
-    </arg>
-  </function>
-  <!-- http://man7.org/linux/man-pages/man2/access.2.html -->
   <!-- int faccessat(int dirfd, const char *pathname, int mode, int flags); -->
   <function name="faccessat">
     <noreturn>false</noreturn>

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -68,6 +68,9 @@ void nullPointer(char *p, int fd)
     // cppcheck-suppress leakReturnValNotUsed
     // cppcheck-suppress nullPointer
     open(NULL, 0, 0);
+    // cppcheck-suppress unreadVariable
+    // cppcheck-suppress nullPointer
+    int ret = access(NULL, 0);
 }
 
 void memleak_getaddrinfo()
@@ -159,6 +162,8 @@ void ignoredReturnValue(void *addr, int fd)
     setuid(42);
     // cppcheck-suppress ignoredReturnValue
     getuid();
+    // cppcheck-suppress ignoredReturnValue
+    access("filename", 1);
 }
 
 
@@ -221,6 +226,10 @@ void uninitvar(int fd)
     // cppcheck-suppress uninitvar
     // cppcheck-suppress utimeCalled
     utime(filename, times1);
+    
+    // cppcheck-suppress unreadVariable
+    // cppcheck-suppress uninitvar
+    int access_ret = access("file", x);
 }
 
 void uninitvar_getcwd(void)


### PR DESCRIPTION
I intentionally removed the second access() configuration because it was
missing the use-retval attribute. But calling access() without using the
return value is absolutely senseless.
I added tests to posix.c to verify the correct configuration of
access().