### PR TITLE
posix.cfg: Remove redundant entries

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -68,26 +68,6 @@
     </arg>
     <arg nr="2"/>
   </function>
-  <!-- struct group *getgrnam(const char *name); -->
-  <function name="getgrnam">
-    <use-retval/>
-    <returnValue type="struct group *"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-    </arg>
-  </function>
-  <!-- struct group *getgrgid(gid_t gid);-->
-  <function name="getgrgid">
-    <use-retval/>
-    <returnValue type="struct group *"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-    </arg>
-  </function>
   <!-- int gettimeofday(struct timeval *tv, struct timezone *tz); -->
   <function name="gettimeofday">
     <noreturn>false</noreturn>
@@ -1043,16 +1023,6 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
          very special case. -->
     <arg nr="1"/>
   </function>
-  <!-- struct dirent *readdir(DIR *dir); -->
-  <function name="readdir">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <returnValue type="struct dirent *"/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-  </function>
   <!-- void rewinddir(DIR *dir); -->
   <function name="rewinddir">
     <noreturn>false</noreturn>
@@ -1824,11 +1794,6 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- void endhostent(void); -->
   <function name="endhostent">
-    <noreturn>false</noreturn>
-  </function>
-  <!-- struct hostent *gethostent(void); -->
-  <function name="gethostent">
-    <use-retval/>
     <noreturn>false</noreturn>
   </function>
   <!-- void sethostent(int stayopen); -->
@@ -3268,25 +3233,6 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <arg nr="4">
       <not-uninit/>
       <valid>0:</valid>
-    </arg>
-  </function>
-  <!-- http://man7.org/linux/man-pages/man3/fnmatch.3.html -->
-  <!-- int fnmatch(const char *pattern, const char *string, int flags); -->
-  <function name="fnmatch">
-    <use-retval/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-uninit/>
-      <not-null/>
-    </arg>
-    <arg nr="3">
-      <not-uninit/>
     </arg>
   </function>
   <!-- http://man7.org/linux/man-pages/man3/opterr.3.html-->


### PR DESCRIPTION
I carefully removed the duplicate/redundant entries with less/missing
configuration, so no information is lost.