### PR TITLE
std.cfg: Fix redundant function names

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -1530,7 +1530,7 @@
   </function>
   <!-- wint_t fgetwc(FILE * stream); -->
   <!-- wint_t getwc(FILE* stream); -->
-  <function name="fgetwc,std::fgetwc,getc,getwc,std::getwc">
+  <function name="fgetwc,std::fgetwc,getwc,std::getwc">
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3007,7 +3007,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- ldiv_t ldiv(long int num, long int denom); -->
-  <function name="ldiv,lldiv,std::ldiv,std::lldiv">
+  <function name="ldiv,std::ldiv">
     <pure/>
     <returnValue type="ldiv_t"/>
     <noreturn>false</noreturn>
@@ -3021,7 +3021,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- lldiv_t lldiv(long long int num, long long int denom); -->
-  <function name="ldiv,lldiv,std::ldiv,std::lldiv">
+  <function name="lldiv,std::lldiv">
     <pure/>
     <returnValue type="lldiv_t"/>
     <noreturn>false</noreturn>


### PR DESCRIPTION
This fixes some more redundant function configurations. Seems like they
are the result of copy & paste errors.