### PR TITLE
windows.cfg: Add Mutex function configurations

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -962,6 +962,11 @@
     <alloc init="true">CreateEvent</alloc>
     <alloc init="true">CreateEventEx</alloc>
     <alloc init="true">CreateMutex</alloc>
+    <alloc init="true">CreateMutexA</alloc>
+    <alloc init="true">CreateMutexW</alloc>
+    <alloc init="true">CreateMutexEx</alloc>
+    <alloc init="true">CreateMutexExA</alloc>
+    <alloc init="true">CreateMutexExW</alloc>
     <alloc init="true">CreateSemaphore</alloc>
     <alloc init="true">CreateSemaphoreA</alloc>
     <alloc init="true">CreateSemaphoreW</alloc>
@@ -972,6 +977,8 @@
     <alloc init="true">CreateWaitableTimer</alloc>
     <alloc init="true">OpenEvent</alloc>
     <alloc init="true">OpenMutex</alloc>
+    <alloc init="true">OpenMutexA</alloc>
+    <alloc init="true">OpenMutexW</alloc>
     <alloc init="true">OpenSemaphore</alloc>
     <alloc init="true">OpenSemaphoreA</alloc>
     <alloc init="true">OpenSemaphoreW</alloc>
@@ -4041,6 +4048,80 @@ HFONT CreateFont(
       <valid>1:</valid>
     </arg>
     <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI CreateMutex(
+  _In_opt_ LPSECURITY_ATTRIBUTES lpMutexAttributes,
+  _In_     BOOL                  bInitialOwner,
+  _In_opt_ LPCTSTR               lpName);-->
+  <function name="CreateMutex,CreateMutexA,CreateMutexW">
+    <returnValue type="HANDLE"/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI CreateMutexEx(
+  _In_opt_ LPSECURITY_ATTRIBUTES lpMutexAttributes,
+  _In_opt_ LPCTSTR               lpName,
+  _In_     DWORD                 dwFlags,
+  _In_     DWORD                 dwDesiredAccess);-->
+  <function name="CreateMutexEx,CreateMutexExA,CreateMutexExW">
+    <returnValue type="HANDLE"/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <valid>0,1</valid>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI OpenMutex(
+  _In_ DWORD   dwDesiredAccess,
+  _In_ BOOL    bInheritHandle,
+  _In_ LPCTSTR lpName);-->
+  <function name="OpenMutex,OpenMutexA,OpenMutexW">
+    <returnValue type="HANDLE"/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-null/>
+      <not-bool/>
+      <strz/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI ReleaseMutex(
+  _In_ HANDLE hMutex);-->
+  <function name="ReleaseMutex">
+    <returnValue type="BOOL"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
       <not-uninit/>
       <not-bool/>
     </arg>


### PR DESCRIPTION
Code used for testing:
```cpp
// Valid code
void test_mutex1ok()
{
    HANDLE hMutex;

    hMutex = CreateMutex(NULL, TRUE, NULL);

    if(hMutex)
    {
        ReleaseMutex(hMutex);
    }

    CloseHandle(hMutex);
}

void test_mutex2ok()
{
    HANDLE hMutex;

    hMutex = CreateMutexEx(NULL, NULL, 0, MUTEX_ALL_ACCESS);

    CloseHandle(hMutex);
}

void test_mutex3ok()
{
    HANDLE hMutex;

    hMutex = OpenMutex(MUTEX_ALL_ACCESS, FALSE, "sem");

    CloseHandle(hMutex);
}

// Invalid code: Wrong arguments
void test_mutex1error()
{
    HANDLE hMutex;

    // cppcheck-suppress uninitvar
    ReleaseMutex(hMutex);

    // cppcheck-suppress uninitvar
    CloseHandle(hMutex);
    
    // cppcheck-suppress invalidFunctionArgBool
    hMutex = CreateMutex(NULL, TRUE, false);
    CloseHandle(hMutex);

    // cppcheck-suppress invalidFunctionArgBool
    hMutex = CreateMutex(NULL, FALSE, true);
    CloseHandle(hMutex);

    // cppcheck-suppress invalidFunctionArg
    hMutex = CreateMutexEx(NULL, NULL, 3, MUTEX_ALL_ACCESS);
    CloseHandle(hMutex);

    // cppcheck-suppress nullPointer
    hMutex = OpenMutex(MUTEX_ALL_ACCESS, FALSE, NULL);
    CloseHandle(hMutex);
}

// Invalid code: Missing CloseHandle call
void test_mutex2error()
{
    HANDLE hMutex;

    // cppcheck-suppress unreadVariable
    hMutex = CreateMutexA(NULL, TRUE, "sem1");
    // cppcheck-suppress resourceLeak
}

// Invalid code: Missing CloseHandle call
void test_mutex3error()
{
    HANDLE hMutex;

    // cppcheck-suppress unreadVariable
    hMutex = CreateMutexEx(NULL, "sem", 0, MUTEX_ALL_ACCESS);
    // cppcheck-suppress resourceLeak
}

// Invalid code: Missing CloseHandle call
void test_mutex4error()
{
    HANDLE hMutex;

    // cppcheck-suppress unreadVariable
    hMutex = OpenMutex(MUTEX_ALL_ACCESS, TRUE, "sem");
    // cppcheck-suppress resourceLeak
}

void test_mutex5error()
{
    // cppcheck-suppress leakReturnValNotUsed
    CreateMutexW(NULL, FALSE, NULL);
    // cppcheck-suppress leakReturnValNotUsed
    CreateMutexExA(NULL, NULL, 1, MUTEX_ALL_ACCESS);
    // cppcheck-suppress leakReturnValNotUsed
    OpenMutexA(MUTEX_ALL_ACCESS, TRUE, "sem");
}

```