### PR TITLE
std.cfg: Fix remaining functions found to be redundant

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -4985,34 +4985,6 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
     </arg>
   </function>
-  <!-- intmax_t strtoimax(const char *s, char **endp, int base); -->
-  <function name="strtoimax,std::strtoimax">
-    <returnValue type="intmax_t"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-uninit/>
-      <valid>0,2:36</valid>
-    </arg>
-  </function>
-  <!-- uintmax_t strtoumax(const char *s, char **endp, int base); -->
-  <function name="strtoumax,std::strtoumax">
-    <returnValue type="uintmax_t"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-uninit/>
-      <valid>0,2:36</valid>
-    </arg>
-  </function>
   <!-- float strtof(const char *s, char **endp); -->
   <function name="strtof,std::strtof">
     <returnValue type="float"/>
@@ -5923,10 +5895,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="bool"/>
     <noreturn>false</noreturn>
   </function>
-  <function name="std::array::clear,std::deque::clear,std::list::clear,std::forward_list::clear,std::map::clear,std::unordered_map::clear,std::queue::clear,std::set::clear,std::unordered_set::clear,std::stack::clear,std::string::clear,std::wstring::clear,std::basic_string::empty,std::vector::clear">
+  <function name="std::array::clear,std::deque::clear,std::list::clear,std::forward_list::clear,std::map::clear,std::unordered_map::clear,std::queue::clear,std::set::clear,std::unordered_set::clear,std::stack::clear,std::string::clear,std::wstring::clear,std::basic_string::clear,std::vector::clear">
     <noreturn>false</noreturn>
   </function>
-  <function name="std::array::empty,std::deque::empty,std::list::empty,std::forward_list::empty,std::map::empty,std::unordered_map::empty,std::queue::empty,std::set::empty,std::unordered_set::empty,std::stack::empty,std::string::empty,std::wstring::empty,std::basic_string::empty,std::vector::empty,std::queue::empty,std::array::empty">
+  <function name="std::array::empty,std::deque::empty,std::list::empty,std::forward_list::empty,std::map::empty,std::unordered_map::empty,std::queue::empty,std::set::empty,std::unordered_set::empty,std::stack::empty,std::string::empty,std::wstring::empty,std::basic_string::empty,std::vector::empty">
     <use-retval/>
     <returnValue type="bool"/>
     <noreturn>false</noreturn>
@@ -6046,7 +6018,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:</valid>
     </arg>
   </function>
-  <function name="std::string::length,std::wstring::length,std::string::size,std::wstring::size,std::basic_string::size,std::basic_string::size">
+  <function name="std::string::length,std::wstring::length,std::basic_string::size,std::basic_string::length">
     <use-retval/>
     <returnValue type="std::size_t"/>
     <noreturn>false</noreturn>


### PR DESCRIPTION
[std::]strtoimax and [std::]strtoumax:
They were nearly completely duplicates, i removed the ones with
less/missing configuration.
std::basic_string::empty:
It was found to be redundant because very likely someone forgot to
change "empty" to "clear" when copy&pasting the function names. The
empty function in all these clear functions makes no sense, and the
clear function also was missing.
std::queue::empty and std::array:empty:
They were both twice in the same function name list.
std::string::size, std::wstring::size:
They were already configured with many other size functions above.
std::basic_string::size:
This entry was twice in the same function name list directly one after
another. Very likely one of them should be the length function, which
does simply the same but was missing in the std.cfg.