### PR TITLE
Don't try to detect Qt if GUI is disabled

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -1,6 +1,9 @@
-set(GUI_QT_COMPONENTS Core Gui Widgets PrintSupport)
-find_package(Qt5 COMPONENTS ${GUI_QT_COMPONENTS})
-find_package(Qt5LinguistTools)
+if (BUILD_GUI)
+    set(GUI_QT_COMPONENTS Core Gui Widgets PrintSupport)
+    find_package(Qt5 COMPONENTS ${GUI_QT_COMPONENTS})
+    find_package(Qt5LinguistTools)
+endif()
+
 if (HAVE_RULES)
     find_library(PCRE pcre)
     if (NOT PCRE)


### PR DESCRIPTION
Otherwise the build may fail if Qt libraries are installed but qmake is not

Log from such failure:

```
-- The C compiler identification is Clang 4.0.0
-- The CXX compiler identification is Clang 4.0.0
-- Check for working C compiler: /usr/local/libexec/ccache/cc
-- Check for working C compiler: /usr/local/libexec/ccache/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/local/libexec/ccache/c++
-- Check for working CXX compiler: /usr/local/libexec/ccache/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /usr/local/lib/cmake/Qt5Core/Qt5CoreConfig.cmake:15 (message):
  The imported target "Qt5::Core" references the file
                                                                                                    
     "/usr/local/lib/qt5/bin/qmake"
                                                                                                                                                                                                                                                                        
  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.
 
  * An install or uninstall procedure did not complete successfully.
 
  * The installation package was faulty and contained
  
     "/usr/local/lib/cmake/Qt5Core/Qt5CoreConfigExtras.cmake"
  
  but not all the files it references.

Call Stack (most recent call first):
  /usr/local/lib/cmake/Qt5Core/Qt5CoreConfigExtras.cmake:6 (_qt5_Core_check_file_exists)
  /usr/local/lib/cmake/Qt5Core/Qt5CoreConfig.cmake:172 (include)
  /usr/local/lib/cmake/Qt5/Qt5Config.cmake:28 (find_package)
  cmake/findDependencies.cmake:2 (find_package)
  CMakeLists.txt:8 (include)

                                                                                                   
-- Configuring incomplete, errors occurred!
See also "/wrkdirs/usr/ports/devel/cppcheck/work/cppcheck-1.82/CMakeFiles/CMakeOutput.log".
```