### PR TITLE
cppcheck crashes on certain brace initialization cases

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2175,7 +2175,7 @@ static void valueFlowAfterMove(TokenList *tokenlist, SymbolDatabase* symboldatab
                 (parent->str() == "return" || // MOVED in return statement
                  parent->str() == "(")) // MOVED in self assignment, isOpenParenthesisMemberFunctionCallOfVarId == true
                 continue;
-            if (parent && parent->astOperand1()->varId() == varId)
+            if (parent && parent->astOperand1() && parent->astOperand1()->varId() == varId)
                 continue;
             const Variable *var = varTok->variable();
             if (!var)


### PR DESCRIPTION
The exact use-case reproducing the crash:
```
struct ServerEntry {
    std::wstring address;
    unsigned short httpPort;
    unsigned short httpsPort;
};
…
std::wstring address;
DWORD httpPort = INTERNET_DEFAULT_HTTP_PORT;
DWORD httpsPort = INTERNET_DEFAULT_HTTPS_PORT;
…
ServerEntry m_entry;
…
m_entry = { std::move(address), static_cast<unsigned short>(httpPort), static_cast<unsigned short>(httpsPort) };
```

There are other cases all involving initialization from braces that cause false-positives