### PR TITLE
token: Fixed potential null pointer dereference.

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1469,7 +1469,7 @@ const ValueFlow::Value * Token::getValueGE(const MathLib::bigint val, const Sett
 
 const ValueFlow::Value * Token::getInvalidValue(const Token *ftok, unsigned int argnr, const Settings *settings) const
 {
-    if (!_values)
+    if (!_values || !settings)
         return nullptr;
     const ValueFlow::Value *ret = nullptr;
     std::list<ValueFlow::Value>::const_iterator it;
@@ -1481,7 +1481,7 @@ const ValueFlow::Value * Token::getInvalidValue(const Token *ftok, unsigned int 
                 break;
         }
     }
-    if (settings && ret) {
+    if (ret) {
         if (ret->isInconclusive() && !settings->inconclusive)
             return nullptr;
         if (ret->condition && !settings->isEnabled(Settings::WARNING))


### PR DESCRIPTION
A `nullPointerRedundantCheck`-warning should be shown by cppcheck.
This PR fixes this issue in our codebase.

This is a reduced testcase:
```
void f(bool a, int *s)
{
    for(int i = 0; i < 42; ++i)
        if(*s) {}
    if(s && a) {}
}
```
