### PR TITLE
std config: Remove misspelled function "strbprk"

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -4570,7 +4570,8 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:</valid>
     </arg>
   </function>
-  <!-- char * strpbrk(const char *cs, const char *ct); -->
+  <!-- const char *strpbrk(const char *str1, const char *str2); -->
+  <!--       char *strpbrk(      char *str1, const char *str2); -->
   <function name="strpbrk,std::strpbrk">
     <use-retval/>
     <returnValue type="char *"/>
@@ -4920,23 +4921,6 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="2">
       <not-uninit/>
       <valid>0:255</valid>
-    </arg>
-  </function>
-  <!-- const char * strpbrk(const char * str1, const char * str2);-->
-  <!-- char * strpbrk(char * str1, const char * str2); -->
-  <function name="strbprk">
-    <use-retval/>
-    <pure/>
-    <returnValue type="char *"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
     </arg>
   </function>
   <!-- const wchar_t* wcsrchr(const wchar_t* ws, wchar_t wc);-->

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -3180,14 +3180,6 @@ void uninivar_strrchr(void)
     (void)strrchr(str,c);
 }
 
-void uninivar_strbprk(void)
-{
-    char *cs;
-    char *ct;
-    // cppcheck-suppress uninitvar
-    (void)strbprk(cs,ct);
-}
-
 void uninivar_wcsrchr(void)
 {
     wchar_t* ws;


### PR DESCRIPTION
Remove misspelled function configuration "strbprk" (also from the
tests). The correct function "strpbrk" is already configured and tested.