### PR TITLE
posix library: Add strtok tests

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -1834,17 +1834,8 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- char *strtok(char *s, const char *ct); -->
   <function name="strtok,std::strtok">
-    <returnValue type="char *"/>
-    <pure/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
-    </arg>
+    <!-- Already configured in std.cfg. Add only a warning for POSIX that a
+    threadsafe function exists that should be used. -->
     <warn severity="portability">Non reentrant function 'strtok' called. For threadsafe applications it is recommended to use the reentrant replacement function 'strtok_r'.</warn>
   </function>
   <!-- char *strtok_r(char *str, const char *delim, char **saveptr); -->

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -75,6 +75,9 @@ void nullPointer(char *p, int fd)
     // cppcheck-suppress leakReturnValNotUsed
     // cppcheck-suppress nullPointer
     fdopen(fd, NULL);
+    // cppcheck-suppress strtokCalled
+    // cppcheck-suppress nullPointer
+    strtok(p, NULL);
 }
 
 void memleak_getaddrinfo()
@@ -239,6 +242,11 @@ void uninitvar(int fd)
     // cppcheck-suppress leakReturnValNotUsed
     // cppcheck-suppress uninitvar
     fdopen(x, "rw");
+
+    char *strtok_arg1;
+    // cppcheck-suppress strtokCalled
+    // cppcheck-suppress uninitvar
+    strtok(strtok_arg1, ";");
 }
 
 void uninitvar_getcwd(void)


### PR DESCRIPTION
In the posix library there is the same configuration for strtok but a
warning is added. This commit adds tests for the posix strtok.