### PR TITLE
Accept nested templates in tokenizer-simplify

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8420,7 +8420,7 @@ const Token * Tokenizer::findGarbageCode() const
         for (const Token *tok = tokens(); tok; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "template <"))
                 continue;
-            if (tok->previous() && !Token::Match(tok->previous(), "[:;{})]"))
+            if (tok->previous() && !Token::Match(tok->previous(), "[:;{})>]"))
                 return tok;
             const Token * const tok1 = tok;
             tok = tok->next()->findClosingBracket();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -220,6 +220,7 @@ private:
         TEST_CASE(simplifyFunctionParameters1); // #3721
         TEST_CASE(simplifyFunctionParameters2); // #4430
         TEST_CASE(simplifyFunctionParameters3); // #4436
+        TEST_CASE(simplifyFunctionParametersMultiTemplate);
         TEST_CASE(simplifyFunctionParametersErrors);
 
         TEST_CASE(removeParentheses1);       // Ticket #61
@@ -3113,6 +3114,12 @@ private:
                             "Item ( int i , int j ) ; "
                             "} ; "
                             "Item :: Item ( int i , int j ) : i ( i ) , j ( j ) { }";
+        ASSERT_EQUALS(code, tokenizeAndStringify(code));
+    }
+
+    void simplifyFunctionParametersMultiTemplate() {
+        const char code[] = "template < typename T1 > template < typename T2 > "
+                            "void A < T1 > :: foo ( T2 ) { }";
         ASSERT_EQUALS(code, tokenizeAndStringify(code));
     }
 


### PR DESCRIPTION
The following snippet triggerd the error:

```
template<typename DerivedT>
template<typename T>
auto ComposableParserImpl<DerivedT>::operator|( T const &other ) const -> Parser {
    return Parser() | static_cast<DerivedT const &>( *this ) | other;
}
```

Whenever simplifyFunctionParameters was called on a templated class'
templated member function (and probably any nested template), the
tokenizer would recognise it as a syntax error, assuming that return
type *must* come after a template<> token.