### PR TITLE
symboldatabase: Fix potential null pointer dereference

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -130,9 +130,8 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                     // goto initial '{'
                     if (!new_scope->definedType) {
                         _tokenizer->syntaxError(nullptr); // #6808
-                    }
-                    tok2 = new_scope->definedType->initBaseInfo(tok, tok2);
-
+						tok2 = new_scope->definedType->initBaseInfo(tok, tok2);
+					}
                     // make sure we have valid code
                     if (!tok2) {
                         break;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -130,8 +130,8 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                     // goto initial '{'
                     if (!new_scope->definedType) {
                         _tokenizer->syntaxError(nullptr); // #6808
-						tok2 = new_scope->definedType->initBaseInfo(tok, tok2);
-					}
+                        tok2 = new_scope->definedType->initBaseInfo(tok, tok2);
+                    }
                     // make sure we have valid code
                     if (!tok2) {
                         break;


### PR DESCRIPTION
There is a  potential `nullPointer` dereference in symboldatabase. This PR attempts to fix this. Additionally, this could be detected by Cppcheck as well. 

Here is a reduced and compilable testcase, where Cppcheck fails to detect a potential `nullPointer` dereference:

```
class Scope
{
public:
    bool bar();
    int *definedType;
};

int f(Scope *new_scope)
{
    int ret = 1;
    if (new_scope)
    {
        if (new_scope->bar())
        {
            if (!new_scope->definedType) {} // check for null
            ret = *new_scope->definedType; // dereference
        }
    }
    return ret;
}
```
The corresponding ticket on track, addressing the false negative: https://trac.cppcheck.net/ticket/8375