### PR TITLE
std library: Resolve two TODOs

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -177,7 +177,6 @@
   </function>
   <!-- void assert(int expression) -->
   <function name="assert">
-    <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -177,6 +177,7 @@
   </function>
   <!-- void assert(int expression) -->
   <function name="assert">
+    <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -162,7 +162,6 @@ void nullpointer(int value)
 
     // #6100 False positive nullPointer - calling mbstowcs(NULL,)
     res += mbstowcs(0,"",0);
-    // TODO cppcheck-suppress unreadVariable
     res += wcstombs(0,L"",0);
 
     strtok(NULL,"xyz");
@@ -437,14 +436,12 @@ void uninitvar_asctime(void)
     (void)asctime(tm);
 }
 
-#if 0
 void uninitvar_assert(void)
 {
     int i;
-    // TODO cppcheck-suppress uninitvar
+    // cppcheck-suppress uninitvar
     assert(i);
 }
-#endif
 
 void uninitvar_sqrt(void)
 {

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -439,6 +439,7 @@ void uninitvar_asctime(void)
 void uninitvar_assert(void)
 {
     int i;
+    // cppcheck-suppress checkLibraryNoReturn
     // cppcheck-suppress uninitvar
     assert(i);
 }


### PR DESCRIPTION
First resolved TODO in std.c is obsolete since the "res" variable is used later
and there is therefore no warning issued.
Second resolved TODO in std.c: A warning for uninit variables is issued by
cppcheck, so this check can be enabled. But to let "make checkcfg"
succeed also the noreturn in std.cfg had to be specified for assert.
Since assert normally does return (depending on the implementation it
always returns and only prints something) it only makes sense to
configure it as noreturn=false.