### PR TITLE
cppcheck-cfg.rng: Allow return value by reference

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -80,7 +80,7 @@
               <optional>
                 <attribute name="type">
                   <data type="string">
-                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*([ ]?[*])*</param>
+                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*([ ]?[*|&amp;])*</param>
                   </data>
                 </attribute>
               </optional>

--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -80,7 +80,7 @@
               <optional>
                 <attribute name="type">
                   <data type="string">
-                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*([ ]?[*|&amp;])*</param>
+                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*([ ]?[*&amp;])*</param>
                   </data>
                 </attribute>
               </optional>


### PR DESCRIPTION
I need a solution to configure functions that return a value by
reference.
This PR might not be the best solution, since it also allows reference
to reference to...
I'm not sure if this is valid C++, but generally a reference to a
reference is possible.
I'm also no regex expert, so any help here is greatly apreciated.