### PR TITLE
Suppressed unused functions should not lead to non-zero exit code

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -2108,7 +2108,7 @@ bool CheckBufferOverrun::analyseWholeProgram(const std::list<Check::FileInfo*> &
             errors = true;
         }
     }
-    return errors;
+    return errors && errorLogger.hasErrors();
 }
 
 unsigned int CheckBufferOverrun::sizeOfType(const Token *type) const

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1606,6 +1606,5 @@ bool CheckUninitVar::analyseWholeProgram(const std::list<Check::FileInfo*> &file
         }
     }
 
-    return foundErrors;
+    return foundErrors && errorLogger.hasErrors();
 }
-

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -264,7 +264,7 @@ bool CheckUnusedFunctions::check(ErrorLogger * const errorLogger, const Settings
             */
         }
     }
-    return errors;
+    return errors && errorLogger->hasErrors();
 }
 
 void CheckUnusedFunctions::unusedFunctionError(ErrorLogger * const errorLogger,

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -191,6 +191,8 @@ private:
      */
     virtual void reportErr(const ErrorLogger::ErrorMessage &msg);
 
+    virtual bool hasErrors() const { return exitcode > 0; }
+
     /**
      * @brief Information about progress is directed here.
      *

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -332,6 +332,12 @@ public:
     virtual void reportErr(const ErrorLogger::ErrorMessage &msg) = 0;
 
     /**
+     * Returns true if an error has been reported which should
+     * cause a non-zero cppcheck exit code.
+     */
+    virtual bool hasErrors() const { return false; }
+
+    /**
      * Report progress to client
      * @param filename main file that is checked
      * @param stage for example preprocess / tokenize / simplify / check

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -77,11 +77,7 @@ private:
         // Check for unused functions..
         CheckUnusedFunctions checkUnusedFunctions(&tokenizer, &settings, this);
         checkUnusedFunctions.parseTokens(tokenizer,  "someFile.c", &settings);
-        // check() returns error if and only if errout is not empty.
-        if (checkUnusedFunctions.check(this, settings))
-            ASSERT(errout.str() != "");
-        else
-            ASSERT_EQUALS("", errout.str());
+        ASSERT(!checkUnusedFunctions.check(this, settings));
     }
 
     void incondition() {


### PR DESCRIPTION
This is a fix of commit 97ffec8 (of pull request #1026)

Tobias Burnus <tobias.burnus@physik.fu-berlin.de> reported me this issue:

To my problem: We use cppcheck with
  --error-exitcode=1
  --suppress=unusedFunction:xptiles.cc:805

Since the following patch that fails because cppcheck returns
the exit code 1 (as an unused function is found) but the patch
does not honor that it can be suppressed.
Namely, the test in lib/checkunusedfunctions.cpp's CheckUnusedFunctions::check
finds an unused function - and, hence, uses:
             unusedFunctionError(errorLogger, filename, func.lineNumber, it->first);
             errors = true;


This commit fixes the issue.
