### PR TITLE
windows library: Add function configurations with tests

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -1176,6 +1176,10 @@
     <!-- Do not add _alloca here. It is automatically freed! -->
     <dealloc>_freea</dealloc>
   </memory>
+  <memory>
+    <alloc init="true" arg="11">AllocateAndInitializeSid</alloc>
+    <dealloc>FreeSid</dealloc>
+  </memory>
   <function name="RtlCompareMemory">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4187,6 +4191,161 @@ HFONT CreateFont(
       <strz/>
     </arg>
     <warn severity="style" reason="Obsolete" alternatives="_strupr,_strupr_s"/>
+  </function>
+  <!--void WINAPI GetLocalTime(_Out_ LPSYSTEMTIME lpSystemTime);-->
+  <!--void WINAPI GetSystemTime(_Out_ LPSYSTEMTIME lpSystemTime);-->
+  <function name="GetLocalTime,GetSystemTime">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!--DWORD WINAPI GetLastError(void);-->
+  <function name="GetLastError">
+    <noreturn>false</noreturn>
+    <returnValue type="DWORD"/>
+    <use-retval/>
+  </function>
+  <!--void WINAPI SetLastError(_In_ DWORD dwErrCode);-->
+  <function name="SetLastError">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI AllocateAndInitializeSid(
+  _In_  PSID_IDENTIFIER_AUTHORITY pIdentifierAuthority,
+  _In_  BYTE                      nSubAuthorityCount,
+  _In_  DWORD                     dwSubAuthority0,
+  _In_  DWORD                     dwSubAuthority1,
+  _In_  DWORD                     dwSubAuthority2,
+  _In_  DWORD                     dwSubAuthority3,
+  _In_  DWORD                     dwSubAuthority4,
+  _In_  DWORD                     dwSubAuthority5,
+  _In_  DWORD                     dwSubAuthority6,
+  _In_  DWORD                     dwSubAuthority7,
+  _Out_ PSID                      *pSid);-->
+  <function name="AllocateAndInitializeSid">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+    <arg nr="11">
+      <not-null/>
+    </arg>
+  </function>
+  <!--PVOID WINAPI FreeSid(_In_ PSID pSid);-->
+  <function name="FreeSid">
+    <noreturn>false</noreturn>
+    <returnValue type="PVOID"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--LPVOID WINAPI HeapAlloc(
+  _In_ HANDLE hHeap,
+  _In_ DWORD  dwFlags,
+  _In_ SIZE_T dwBytes);-->
+  <function name="HeapAlloc">
+    <noreturn>false</noreturn>
+    <returnValue type="LPVOID"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+  </function>
+  <!--LPVOID WINAPI HeapReAlloc(
+  _In_ HANDLE hHeap,
+  _In_ DWORD  dwFlags,
+  _In_ LPVOID lpMem,
+  _In_ SIZE_T dwBytes);-->
+  <function name="HeapReAlloc">
+    <noreturn>false</noreturn>
+    <returnValue type="LPVOID"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+  </function>
+  <!--BOOL WINAPI HeapFree(
+  _In_ HANDLE hHeap,
+  _In_ DWORD  dwFlags,
+  _In_ LPVOID lpMem);-->
+  <function name="HeapFree">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--SIZE_T WINAPI HeapSize(
+  _In_ HANDLE  hHeap,
+  _In_ DWORD   dwFlags,
+  _In_ LPCVOID lpMem);-->
+  <function name="HeapSize">
+    <noreturn>false</noreturn>
+    <returnValue type="SIZE_T"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--BOOL WINAPI HeapValidate(
+  _In_     HANDLE  hHeap,
+  _In_     DWORD   dwFlags,
+  _In_opt_ LPCVOID lpMem);-->
+  <function name="HeapValidate">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!--HANDLE WINAPI GetProcessHeap(void);-->
+  <function name="GetProcessHeap">
+    <noreturn>false</noreturn>
+    <returnValue type="HANDLE"/>
+    <use-retval/>
   </function>
   <podtype name="LARGE_INTEGER" sign="s" size="8"/>
   <podtype name="POINTER_SIGNED" sign="s"/>

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -40,6 +40,6 @@ ${CPPCHECK} ${CPPCHECK_OPT} ${DIR}std.cpp
 # windows.cpp
 # Syntax check via g++ does not work because it can not find a valid windows.h
 #${CXX} ${CXX_OPT} ${DIR}windows.cpp
-${CPPCHECK} ${CPPCHECK_OPT} --platform=win32A  ${DIR}windows.cpp
-${CPPCHECK} ${CPPCHECK_OPT} --platform=win32W  ${DIR}windows.cpp
-${CPPCHECK} ${CPPCHECK_OPT} --platform=win64  ${DIR}windows.cpp
+${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win32A  ${DIR}windows.cpp
+${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win32W  ${DIR}windows.cpp
+${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win64  ${DIR}windows.cpp


### PR DESCRIPTION
Add function configurations with tests for:
GetLocalTime, GetSystemTime, GetLastError, SetLastError,
AllocateAndInitializeSid, FreeSid, HeapAlloc, HeapReAlloc, HeapFree,
HeapSize, HeapValidate and GetProcessHeap.
test/cfg/runtests.sh: Enable --inconclusive for the windows tests to
avoid some issues in the future.