### PR TITLE
wxwidgets library: Fix/Enhance cfg, add test file

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -634,7 +634,6 @@
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="wxWindow *"/>
-    <use-retval/>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_button.html -->
   <!-- void 	SetLabel (const wxString &label) -->

--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -84,8 +84,15 @@
     <returnValue type="bool"/>
     <use-retval/>
   </function>
+  <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#gaec3640fa3b46c970ff0c86fe354e59ff -->
+  <!-- unsigned long wxSysErrorCode() -->
+  <function name="wxSysErrorCode">
+    <noreturn>false</noreturn>
+    <returnValue type="unsigned long"/>
+    <use-retval/>
+  </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga249358701f3c2d410088ddf7a61d8564 -->
-  <!-- void wxLogMessage(const wxString & format, ...) -->
+  <!-- void wxLogMessage(const char * formatString, ...) -->
   <function name="wxLogMessage">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -98,7 +105,7 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#gaf57b7e28ab76bacf10b3be044e8bd634 -->
-  <!-- void wxLogVerbose(const wxString & format, ...) -->
+  <!-- void wxLogVerbose(const char * formatString, ...) -->
   <function name="wxLogVerbose">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -111,7 +118,7 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga0c2b19580ef6721508e6d69534b10e90 -->
-  <!-- void wxLogWarning(const wxString & format, ...) -->
+  <!-- void wxLogWarning(const char * formatString, ...) -->
   <function name="wxLogWarning">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -124,9 +131,10 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga4ae39c06cbeaa5461cd1b5c293a31403 -->
-  <!-- void wxLogFatalError(const wxString & format, ...) -->
+  <!-- void wxLogFatalError(const char * formatString, ...) -->
   <function name="wxLogFatalError">
-    <noreturn>false</noreturn>
+    <!-- From the docs: Like wxLogError(), but also terminates the program with the exit code 3. -->
+    <noreturn>true</noreturn>
     <leak-ignore/>
     <formatstr/>
     <arg nr="1">
@@ -137,7 +145,7 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga0dd3c633f990f794e76065c9a7af4c87 -->
-  <!-- void wxLogError(const wxString & format, ...) -->
+  <!-- void wxLogError(const char * formatString, ...) -->
   <function name="wxLogError">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -149,8 +157,23 @@
       <not-bool/>
     </arg>
   </function>
+  <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga947e317db477914c12b13c4534867ec9 -->
+  <!-- void wxLogTrace(const char *mask, const char *formatString, ...) -->
+  <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#gae28a46b220921cd87a6f75f0842294c5 -->
+  <!-- void wxLogTrace(wxTraceMask mask, const char *formatString, ...) // Deprecated! -->
+  <function name="wxLogTrace">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <formatstr/>
+    <arg nr="2">
+      <formatstr/>
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga9c530ae20eb423744f90874d2c97d02b -->
-  <!-- void wxLogDebug(const wxString & format, ...) -->
+  <!-- void wxLogDebug(const char *formatString, ...) -->
   <function name="wxLogDebug">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -163,7 +186,7 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#ga28f01715af5aaf37caffdc5bc00fde3f -->
-  <!-- void wxLogSysError(const wxString & format, ...) -->
+  <!-- void wxLogSysError(const char *formatString, ...) -->
   <function name="wxLogSysError">
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -176,12 +199,28 @@
     </arg>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#gac47036f8bd8f711bf4646418c71828a5 -->
-  <!-- void wxLogGeneric(wxLogLevel level, const wxString & format, ...) -->
+  <!-- void wxLogGeneric(wxLogLevel level, const char * formatString, ...) -->
   <function name="wxLogGeneric">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <formatstr/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
     <arg nr="2">
+      <formatstr/>
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__log.html#gadf3ee751bc5ecbbc6d73fa0ecf3217f0 -->
+  <!-- void wxLogInfo(const char * formatString, ...) -->
+  <function name="wxLogInfo">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <formatstr/>
+    <arg nr="1">
       <formatstr/>
       <not-null/>
       <not-uninit/>
@@ -665,18 +704,13 @@
   </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_text_file.html -->
   <!-- bool 	Create () -->
-  <function name="wxTextFile::Create">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <returnValue type="bool"/>
-  </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_text_file.html -->
   <!-- bool 	Create (const wxString &strFile) -->
   <function name="wxTextFile::Create">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="bool"/>
-    <arg nr="1">
+    <arg nr="1" default="">
       <not-uninit/>
     </arg>
   </function>
@@ -823,11 +857,11 @@
   </function>
   <!-- http://docs.wxwidgets.org/3.1/classwx_box_sizer.html -->
   <!-- virtual wxSizerItem* wxBoxSizer::AddSpacer( int size )-->
-  <function name="wxBoxSizer::AddSpacer">
+  <!-- virtual wxSizerItem* wxSizer::AddSpacer( int size)-->
+  <function name="wxSizer::AddSpacer,wxBoxSizer::AddSpacer">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="wxSizerItem*"/>
-    <use-retval/>
     <arg nr="1">
       <not-uninit/>
     </arg>
@@ -894,6 +928,110 @@
     <arg nr="2" default="wxEmptyString"/>
     <arg nr="3" default="wxEmptyString"/>
     <arg nr="4" default="wxITEM_NORMAL">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.0/group__group__funcmacro__misc.html#ga3ff36fe489da2a779248b56f283615ca -->
+  <!-- bool wxLaunchDefaultBrowser(const wxString &url, int flags=0) -->
+  <function name="wxLaunchDefaultBrowser">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" default="0">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga3e960a6805631320fede18bf1176f278 -->
+  <!-- bool wxDirExists(const wxString &dirname) -->
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga72d2e4ef03d51c0d59c2cb788462d600 -->
+  <!-- bool wxFileExists(const wxString &filename) -->
+  <function name="wxDirExists,wxFileExists">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga139aabab52fdd09c37716662d6a47110 -->
+  <!-- wxString wxGetWorkingDirectory(char *buf=NULL, int sz=1000) -->
+  <function name="wxGetWorkingDirectory">
+    <noreturn>false</noreturn>
+    <returnValue type="wxString"/>
+    <arg nr="1">
+      <minsize type="argvalue" arg="2"/>
+    </arg>
+    <arg nr="2" default="1000">
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="wxGetCwd"/>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#gab0cc6ceca11d23f61cba353c01eeac06 -->
+  <!-- wxString wxGetCwd() -->
+  <function name="wxGetCwd">
+    <noreturn>false</noreturn>
+    <returnValue type="wxString"/>
+    <use-retval/>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga315b861f905ae6b3915faa79526a198e -->
+  <!-- bool wxSetWorkingDirectory(const wxString &dir) -->
+  <function name="wxSetWorkingDirectory">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga3510d5cf8163eded5bae385ce758df57 -->
+  <!-- bool wxMkdir(const wxString &dir, int perm=wxS_DIR_DEFAULT) -->
+  <function name="wxMkdir">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" default="wxS_DIR_DEFAULT">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.1/group__group__funcmacro__file.html#ga9ae2276737ad4fe72ea96c5f2d9bbfd3 -->
+  <!-- bool wxRmdir(const wxString &dir, int flags=0) -->
+  <function name="wxRmdir">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" default="0">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://docs.wxwidgets.org/3.0/group__group__funcmacro__string.html#ga223e9aea5b1a2252c7e632613c7b9a74 -->
+  <!-- const wxString& wxGetTranslation(const wxString & string, const wxString & domain = wxEmptyString) -->
+  <!-- http://docs.wxwidgets.org/3.0/group__group__funcmacro__string.html#ga6810b710e8860fa7088fc454feb9ecb1 -->
+  <!-- const wxString& wxGetTranslation(const wxString & string, const wxString & plural, unsigned n, const wxString & domain = wxEmptyString) -->
+  <function name="wxGetTranslation">
+    <noreturn>false</noreturn>
+    <returnValue type="wxString&amp;"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" default="0">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" default="0">
+      <not-uninit/>
+    </arg>
+    <arg nr="4" default="0">
       <not-uninit/>
     </arg>
   </function>
@@ -1067,6 +1205,9 @@
   <define name="wxUINT64_MAX" value="0xffffffffffffffffULL"/>
   <define name="wxINT64_MAX" value="0x7fffffffffffffffLL"/>
   <define name="wxINT64_MIN" value="0x8000000000000000LL"/>
+  <!-- http://docs.wxwidgets.org/3.0/group__group__funcmacro__string.html#ga8a02b8875a521df57263a9e6f090f2d0 -->
+  <!-- const wxString& _(const wxString & string) // Macro that expands to wxGetTranslation -->
+  <define name="_(str)" value="wxGetTranslation(str)"/>
   <podtype name="wxInt8" sign="s" size="1"/>
   <podtype name="wxUint8" sign="u" size="1"/>
   <podtype name="wxByte" sign="u" size="1"/>
@@ -1084,4 +1225,5 @@
   <podtype name="wxUIntPtr" sign="u"/>
   <!-- typedef unsigned short wxDateTime_t; -->
   <podtype name="wxDateTime_t" sign="u"/>
+  <podtype name="wxLogLevel"/>
 </def>

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -43,3 +43,8 @@ ${CPPCHECK} ${CPPCHECK_OPT} ${DIR}std.cpp
 ${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win32A  ${DIR}windows.cpp
 ${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win32W  ${DIR}windows.cpp
 ${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --platform=win64  ${DIR}windows.cpp
+
+# wxwidgets.cpp
+# Syntax check via g++ is disabled because wx headers are not always present.
+#${CXX} ${CXX_OPT} ${DIR}wxwidgets.cpp
+${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --library=wxwidgets ${DIR}wxwidgets.cpp

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -1,0 +1,60 @@
+
+// Test library configuration for windows.cfg
+//
+// Usage:
+// $ cppcheck --check-library --library=windows --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/windows.cpp
+// =>
+// No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
+//
+
+#include <wx/filefn.h>
+
+void validCode()
+{
+    wxString str = wxGetCwd();
+
+    wxLogGeneric(wxLOG_Message, "test %d", 0);
+    wxLogMessage("test %s", "str");
+
+    wxSpinCtrl::SetBase(10);
+    wxSpinCtrl::SetBase(16);
+
+    wxString translation1 = _("text");
+    wxString translation2 = wxGetTranslation("text");
+    wxString translation3 = wxGetTranslation("string", "domain");
+}
+
+void nullPointer()
+{
+    // cppcheck-suppress nullPointer
+    wxLogGeneric(wxLOG_Message, NULL);
+    // cppcheck-suppress nullPointer
+    wxLogMessage(NULL);
+}
+
+void ignoredReturnValue()
+{
+    // cppcheck-suppress ignoredReturnValue
+    wxGetCwd();
+}
+
+void invalidFunctionArg()
+{
+    // cppcheck-suppress invalidFunctionArg
+    wxSpinCtrl::SetBase(0);
+    // cppcheck-suppress invalidFunctionArg
+    wxSpinCtrl::SetBase(5);
+}
+
+void uninitvar()
+{
+    wxLogLevel logLevelUninit;
+    char cBufUninit[10];
+    char *pcUninit;
+    // cppcheck-suppress uninitvar
+    wxLogGeneric(logLevelUninit, "test");
+    // cppcheck-suppress uninitvar
+    wxLogMessage(cBufUninit);
+    // cppcheck-suppress uninitvar
+    wxLogMessage(pcUninit);
+}


### PR DESCRIPTION
Add test file for wxwidgets configuration, fix found issues and enhance
the cfg a bit:
Fix declarations in comments for wxLog* functions.
Merge the two wxTextFile::Create overloaded function configurations into
one that works for both now.
Removed use-retval attribute from wxBoxSizer::AddSpacer configuration
since the function has side effects and there is no need to use the
return value.
Add some function configurations, the macro _(str) and POD wxLogLevel.