### PR TITLE
wxwidgets library tests: Add syntax checking, fix test file.

### DIFF
--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -7,7 +7,15 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+#include <wx/app.h>
+#include <wx/log.h>
 #include <wx/filefn.h>
+#include <wx/spinctrl.h>
+#include <wx/artprov.h>
+#include <wx/calctrl.h>
+#include <wx/combo.h>
+#include <wx/icon.h>
+#include <wx/bitmap.h>
 
 void validCode()
 {
@@ -16,20 +24,28 @@ void validCode()
     wxLogGeneric(wxLOG_Message, "test %d", 0);
     wxLogMessage("test %s", "str");
 
-    wxSpinCtrl::SetBase(10);
-    wxSpinCtrl::SetBase(16);
-
     wxString translation1 = _("text");
     wxString translation2 = wxGetTranslation("text");
     wxString translation3 = wxGetTranslation("string", "domain");
 }
 
+#if wxUSE_GUI==1
+void validGuiCode()
+{
+#if wxUSE_SPINCTRL==1
+    extern wxSpinCtrl spinCtrlInstance;
+    spinCtrlInstance.SetBase(10);
+    spinCtrlInstance.SetBase(16);
+#endif
+}
+#endif
+
 void nullPointer()
 {
     // cppcheck-suppress nullPointer
-    wxLogGeneric(wxLOG_Message, NULL);
+    wxLogGeneric(wxLOG_Message, (char*)NULL);
     // cppcheck-suppress nullPointer
-    wxLogMessage(NULL);
+    wxLogMessage((char*)NULL);
 }
 
 void ignoredReturnValue()
@@ -40,10 +56,13 @@ void ignoredReturnValue()
 
 void invalidFunctionArg()
 {
+#if wxUSE_SPINCTRL==1
+    extern wxSpinCtrl spinCtrlInstance;
     // cppcheck-suppress invalidFunctionArg
-    wxSpinCtrl::SetBase(0);
+    spinCtrlInstance.SetBase(0);
     // cppcheck-suppress invalidFunctionArg
-    wxSpinCtrl::SetBase(5);
+    spinCtrlInstance.SetBase(5);
+#endif
 }
 
 void uninitvar()
@@ -61,14 +80,20 @@ void uninitvar()
 
 void deprecatedFunctions(wxApp &a, const wxString &s, wxArtProvider *artProvider, wxCalendarCtrl &calenderCtrl, wxComboCtrl &comboCtrl)
 {
+#ifdef __WXOSX__
     // cppcheck-suppress MacOpenFileCalled
     a.MacOpenFile(s);
+#endif
     // cppcheck-suppress InsertCalled
     wxArtProvider::Insert(artProvider);
+#if defined(__WXMSW__) || defined(__WXGTK__)
+    // EnableYearChange() is not available on these GUI systems
+#else
     // cppcheck-suppress EnableYearChangeCalled
     calenderCtrl.EnableYearChange(false);
     // cppcheck-suppress EnableYearChangeCalled
     calenderCtrl.EnableYearChange(/*default=yes*/);
+#endif
     // cppcheck-suppress GetTextIndentCalled
     // cppcheck-suppress ignoredReturnValue
     comboCtrl.GetTextIndent();


### PR DESCRIPTION
For the syntax check g++ needs to know the wxWidgets include paths which
are retrieved via wx-config. If includes are missing or not working the
syntax check is skipped.
wxwidgets.cpp: Fixed syntax, includes and added code so the syntax check
does not fail if some special features are not present.