### PR TITLE
std library: Add tests for wide character string functions, fix config

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -4994,6 +4994,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- long double strtold(const char *s, char **endp); -->
   <function name="strtold,std::strtold">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5006,6 +5007,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- long strtol(const char *s, char **endp, int base); -->
   <function name="strtol,std::strtol">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5021,6 +5023,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- unsigned long strtoul(const char *s, char **endp, int base); -->
   <function name="strtoul,std::strtoul">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="unsigned long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5036,6 +5039,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- long long strtoll(const char *s, char **endp, int base); -->
   <function name="strtoll,std::strtoll">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5051,6 +5055,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- unsigned long long strtoull(const char *s, char **endp, int base); -->
   <function name="strtoull,std::strtoull">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="unsigned long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5066,6 +5071,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- intmax_t strtoimax (const char* str, char** endptr, int base); -->
   <function name="strtoimax,std::strtoimax">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="intmax_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5081,6 +5087,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- uintmax_t strtoumax (const char* str, char** endptr, int base); -->
   <function name="strtoumax,std::strtoumax">
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="uintmax_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5466,7 +5473,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- long wcstol(const wchar_t *s, wchar ** endp, int base); -->
   <function name="wcstol,std::wcstol">
-    <use-retval/>
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5481,7 +5488,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- long long wcstoll(const wchar_t *s, wchar ** endp, int base); -->
   <function name="wcstoll,std::wcstoll">
-    <use-retval/>
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5496,7 +5503,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- unsigned long wcstoul(const wchar_t *s, wchar ** endp, int base); -->
   <function name="wcstoul,std::wcstoul">
-    <use-retval/>
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="unsigned long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5511,7 +5518,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- unsigned long long wcstoull(const wchar_t *s, wchar ** endp, int base); -->
   <function name="wcstoull,std::wcstoull">
-    <use-retval/>
+    <!-- TODO #8387: use-retval is only valid when arg2==NULL -->
     <returnValue type="unsigned long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -76,6 +76,7 @@ void nullpointer(int value)
 {
     int res = 0;
     FILE *fp;
+    wchar_t *pWcsUninit;
 
 #ifndef __CYGWIN__
     // cppcheck-suppress nullPointer
@@ -126,39 +127,77 @@ void nullpointer(int value)
     strchr(0,0);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
+    wcschr(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
     strlen(0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
+    wcslen(0);
     // cppcheck-suppress nullPointer
     strcpy(0,0);
+    // cppcheck-suppress nullPointer
+    wcscpy(0,0);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
     strspn(0,0);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
+    wcsspn(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
     strcspn(0,0);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
+    wcscspn(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
     strcoll(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
+    wcscoll(0,0);
     // cppcheck-suppress nullPointer
     strcat(0,0);
+    // cppcheck-suppress nullPointer
+    wcscat(0,0);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
     strcmp(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
+    wcscmp(0,0);
     // cppcheck-suppress nullPointer
     strncpy(0,0,1);
     // cppcheck-suppress nullPointer
+    wcsncpy(0,0,1);
+    // cppcheck-suppress nullPointer
     strncat(0,0,1);
+    // cppcheck-suppress nullPointer
+    wcsncat(0,0,1);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
     strncmp(0,0,1);
     // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress nullPointer
+    wcsncmp(0,0,1);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
     strstr(0,0);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress nullPointer
+    wcsstr(0,0);
     // cppcheck-suppress nullPointer
     strtoul(0,0,0);
     // cppcheck-suppress nullPointer
+    wcstoul(0,0,0);
+    // cppcheck-suppress nullPointer
     strtoull(0,0,0);
     // cppcheck-suppress nullPointer
+    wcstoull(0,0,0);
+    // cppcheck-suppress nullPointer
     strtol(0,0,0);
+    // cppcheck-suppress nullPointer
+    wcstol(0,0,0);
 
     // #6100 False positive nullPointer - calling mbstowcs(NULL,)
     res += mbstowcs(0,"",0);
@@ -166,10 +205,14 @@ void nullpointer(int value)
     res += wcstombs(0,L"",0);
 
     strtok(NULL,"xyz");
+    wcstok(NULL,L"xyz",&pWcsUninit);
 
     strxfrm(0,"foo",0);
     // TODO: error message (#6306 and http://trac.cppcheck.net/changeset/d11eb4931aea51cf2cb74faccdcd2a3289b818d6/)
     strxfrm(0,"foo",42);
+    wcsxfrm(0,L"foo",0);
+    // TODO: error message when arg1==NULL and arg3!=0 #6306: https://trac.cppcheck.net/ticket/6306#comment:2
+    wcsxfrm(0,L"foo",42);
 
     snprintf(NULL, 0, "someformatstring"); // legal
     // cppcheck-suppress nullPointer
@@ -178,6 +221,9 @@ void nullpointer(int value)
     scanf("%i", &res);
     // cppcheck-suppress nullPointer
     scanf("%i", NULL);
+    wscanf(L"%i", &res);
+    // cppcheck-suppress nullPointer
+    wscanf(L"%i", NULL);
 }
 
 void nullpointerMemchr1(char *p, char *s)


### PR DESCRIPTION
Add equivalent tests for the wide character string functions like they
are already done for the normal string functions.
Fixed some issues with the configuration of the wide character string
functions that arised through the tests and were already fixed for the
normal string functions.