### PR TITLE
Fix #8382 (Syntax error when scanning code with template and attribute)

### DIFF
--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -671,9 +671,9 @@ private:
     void simplifyOperatorName();
 
     /**
-    * Remove [[attribute]] (C++14) from TokenList
+    * Remove [[attribute]] (C++11 and later) from TokenList
     */
-    void simplifyCPP14Attribute();
+    void simplifyCPPAttribute();
 
     /**
      * Replace strlen(str)

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -671,9 +671,9 @@ private:
     void simplifyOperatorName();
 
     /**
-    * Remove [[deprecated]] (C++14) from TokenList
+    * Remove [[attribute]] (C++14) from TokenList
     */
-    void simplifyDeprecated();
+    void simplifyCPP14Attribute();
 
     /**
      * Replace strlen(str)

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -4118,12 +4118,28 @@ private:
     }
 
     void noreturnAttributeFunction() {
-        GET_SYMBOL_DB("template <class T> [[noreturn]] void func() { }");
+        GET_SYMBOL_DB("[[noreturn]] void func1();\n"
+                      "void func1() { }\n"
+                      "[[noreturn]] void func2();\n"
+                      "[[noreturn]] void func3() { }\n"
+                      "template <class T> [[noreturn]] void func4() { }");
         ASSERT_EQUALS("", errout.str());
         ASSERT_EQUALS(true,  db != nullptr); // not null
 
         if (db) {
-            const Function *func = findFunctionByName("func", &db->scopeList.front());
+            const Function *func = findFunctionByName("func1", &db->scopeList.front());
+            ASSERT_EQUALS(true, func != nullptr);
+            if (func)
+                ASSERT_EQUALS(true, func->isAttributeNoreturn());
+            func = findFunctionByName("func2", &db->scopeList.front());
+            ASSERT_EQUALS(true, func != nullptr);
+            if (func)
+                ASSERT_EQUALS(true, func->isAttributeNoreturn());
+            func = findFunctionByName("func3", &db->scopeList.front());
+            ASSERT_EQUALS(true, func != nullptr);
+            if (func)
+                ASSERT_EQUALS(true, func->isAttributeNoreturn());
+            func = findFunctionByName("func4", &db->scopeList.front());
             ASSERT_EQUALS(true, func != nullptr);
             if (func)
                 ASSERT_EQUALS(true, func->isAttributeNoreturn());

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -316,6 +316,8 @@ private:
         TEST_CASE(nothrowAttributeFunction);
         TEST_CASE(nothrowDeclspecFunction);
 
+        TEST_CASE(noreturnAttributeFunction);
+
         TEST_CASE(varTypesIntegral); // known integral
         TEST_CASE(varTypesFloating); // known floating
         TEST_CASE(varTypesOther);    // (un)known
@@ -4112,6 +4114,19 @@ private:
             ASSERT_EQUALS(true, func != nullptr);
             if (func)
                 ASSERT_EQUALS(true, func->isAttributeNothrow());
+        }
+    }
+
+    void noreturnAttributeFunction() {
+        GET_SYMBOL_DB("template <class T> [[noreturn]] void func() { }");
+        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS(true,  db != nullptr); // not null
+
+        if (db) {
+            const Function *func = findFunctionByName("func", &db->scopeList.front());
+            ASSERT_EQUALS(true, func != nullptr);
+            if (func)
+                ASSERT_EQUALS(true, func->isAttributeNoreturn());
         }
     }
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -440,7 +440,7 @@ private:
         TEST_CASE(simplifyMathExpressions); //ticket #1620
         TEST_CASE(simplifyStaticConst);
 
-        TEST_CASE(simplifyCPP14Attribute);
+        TEST_CASE(simplifyCPPAttribute);
 
         TEST_CASE(simplifyCaseRange);
 
@@ -7972,7 +7972,7 @@ private:
         ASSERT_EQUALS(expected3, tokenizeAndStringify(code3, true));
     }
 
-    void simplifyCPP14Attribute() {
+    void simplifyCPPAttribute() {
         ASSERT_EQUALS("int f ( ) ;",
                       tokenizeAndStringify("[[deprecated]] int f();", false, true, Settings::Native, "test.cpp", true));
 
@@ -7987,6 +7987,12 @@ private:
 
         ASSERT_EQUALS("template < class T > [ [ noreturn ] ] int f ( ) { }",
                       tokenizeAndStringify("template <class T> [[noreturn]] int f(){}", false, true, Settings::Native, "test.cpp", false));
+        ASSERT_EQUALS("int f ( int i ) ;",
+                      tokenizeAndStringify("[[maybe_unused]] int f([[maybe_unused]] int i);", false, true, Settings::Native, "test.cpp", true));
+
+        ASSERT_EQUALS("[ [ maybe_unused ] ] int f ( [ [ maybe_unused ] ] int i ) ;",
+                      tokenizeAndStringify("[[maybe_unused]] int f([[maybe_unused]] int i);", false, true, Settings::Native, "test.cpp", false));
+
     }
 
     void simplifyCaseRange() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -440,7 +440,7 @@ private:
         TEST_CASE(simplifyMathExpressions); //ticket #1620
         TEST_CASE(simplifyStaticConst);
 
-        TEST_CASE(simplifyDeprecated);
+        TEST_CASE(simplifyCPP14Attribute);
 
         TEST_CASE(simplifyCaseRange);
 
@@ -7972,7 +7972,7 @@ private:
         ASSERT_EQUALS(expected3, tokenizeAndStringify(code3, true));
     }
 
-    void simplifyDeprecated() {
+    void simplifyCPP14Attribute() {
         ASSERT_EQUALS("int f ( ) ;",
                       tokenizeAndStringify("[[deprecated]] int f();", false, true, Settings::Native, "test.cpp", true));
 
@@ -7981,6 +7981,12 @@ private:
 
         ASSERT_EQUALS("[ [ deprecated ] ] int f ( ) ;",
                       tokenizeAndStringify("[[deprecated]] int f();", false, true, Settings::Native, "test.c", true));
+
+        ASSERT_EQUALS("template < class T > int f ( ) { }",
+                      tokenizeAndStringify("template <class T> [[noreturn]] int f(){}", false, true, Settings::Native, "test.cpp", true));
+
+        ASSERT_EQUALS("template < class T > [ [ noreturn ] ] int f ( ) { }",
+                      tokenizeAndStringify("template <class T> [[noreturn]] int f(){}", false, true, Settings::Native, "test.cpp", false));
     }
 
     void simplifyCaseRange() {


### PR DESCRIPTION
This commit only addresses #8382. There are issues concerning which
versions of C++ should be supported and also generic C++ 14 attribute
support which can be revisited later.