### PR TITLE
Add test for platform configurations

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,3 +1,4 @@
 exclude_paths:
   - test/cfg/*.c
   - test/cfg/*.cpp
+  - test/platforms/*.c

--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -13,6 +13,7 @@ nullPointer:build/checkother.cpp
 *:gui/test*
 *:test/test.cxx
 *:test/cfg*
+*:test/platforms*
 
 *:externals*
 *:htmlreport*

--- a/test/platforms/avr8.c
+++ b/test/platforms/avr8.c
@@ -1,0 +1,66 @@
+
+// Test platform configuration for avr8
+//
+// Usage:
+// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/platforms/avr8.c
+// =>
+// No warnings about unmatched suppressions, etc. exitcode=0
+//
+
+#include <stdint.h>
+
+void test()
+{
+    signed char charVar = INT8_MAX;
+    // cppcheck-suppress redundantAssignment
+    charVar = 0;
+    // cppcheck-suppress shiftTooManyBitsSigned
+    charVar << 7;
+    // cppcheck-suppress shiftTooManyBits
+    charVar << 8;
+
+    char ucharVar = UINT8_MAX;
+    ucharVar << 7;
+    // cppcheck-suppress shiftTooManyBits
+    ucharVar << 8;
+
+    short shortVar = INT16_MAX;
+    shortVar << 14;
+    // cppcheck-suppress shiftTooManyBitsSigned
+    shortVar << 15;
+    // cppcheck-suppress shiftTooManyBits
+    shortVar << 16;
+
+    unsigned short ushortVar = UINT16_MAX;
+    ushortVar << 15;
+    // cppcheck-suppress shiftTooManyBits
+    ushortVar << 16;
+
+    int intVar = INT16_MAX;
+    // cppcheck-suppress redundantAssignment
+    intVar = 0;
+    intVar << 14;
+    // cppcheck-suppress shiftTooManyBitsSigned
+    intVar << 15;
+    // cppcheck-suppress shiftTooManyBits
+    intVar << 16;
+
+    unsigned int uintVar = UINT16_MAX;
+    uintVar << 15;
+    // cppcheck-suppress shiftTooManyBits
+    uintVar << 16;
+
+    long longVar = INT32_MAX;
+    // cppcheck-suppress redundantAssignment
+    longVar = 0;
+    longVar << 30;
+    // cppcheck-suppress shiftTooManyBitsSigned
+    longVar << 31;
+    // cppcheck-suppress shiftTooManyBits
+    longVar << 32;
+
+    unsigned long ulongVar = UINT32_MAX;
+    ulongVar << 31;
+    // cppcheck-suppress shiftTooManyBits
+    ulongVar << 32;
+}

--- a/test/platforms/runtests.sh
+++ b/test/platforms/runtests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e # abort on error
+set -x # be verbose
+
+if [[ $(pwd) == */test/platforms ]] ; then # we are in test/platforms
+    CPPCHECK="../../cppcheck"
+    DIR=""
+else # assume we are in repo root
+    CPPCHECK="./cppcheck"
+    DIR=test/platforms/
+fi
+
+# Cppcheck options
+CPPCHECK_OPT='--check-library --enable=information --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}"'
+
+# Compiler settings
+CXX=g++
+CXX_OPT='-fsyntax-only -std=c++0x -Wno-format -Wno-format-security'
+CC=gcc
+CC_OPT='-Wno-format -Wno-nonnull -Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-format-security -Wno-nonnull -fsyntax-only'
+
+# avr8.c
+${CC} ${CC_OPT} ${DIR}avr8.c
+${CPPCHECK} ${CPPCHECK_OPT} --platform=avr8 ${DIR}avr8.c

--- a/test/platforms/runtests.sh
+++ b/test/platforms/runtests.sh
@@ -14,8 +14,8 @@ fi
 CPPCHECK_OPT='--check-library --enable=information --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}"'
 
 # Compiler settings
-CXX=g++
-CXX_OPT='-fsyntax-only -std=c++0x -Wno-format -Wno-format-security'
+#CXX=g++
+#CXX_OPT='-fsyntax-only -std=c++0x -Wno-format -Wno-format-security'
 CC=gcc
 CC_OPT='-Wno-format -Wno-nonnull -Wno-implicit-function-declaration -Wno-deprecated-declarations -Wno-format-security -Wno-nonnull -fsyntax-only'
 


### PR DESCRIPTION
Starting with the avr8.xml platform configuration file this test
verifies the correct loading and usage of the platform configuration by
Cppcheck.
There are currently some unmatched suppressions, see ticket
https://trac.cppcheck.net/ticket/8398