### PR TITLE
wxwidgets: Fix syntax checking errors and warning

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -3,6 +3,9 @@
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga437ea6ba615b75dac8603e96ec864160 -->
   <!-- #define wxT(string) -->
   <define name="wxT" value=""/>
+  <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga2e7c1f911a731a4b98a85fa44f1d9fbc -->
+  <!-- #define wxT_2(string) -->
+  <define name="wxT_2(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga0a06701ea0e6bb00c5171ace1b1f5691 -->
   <!-- #define wxS(string) -->
   <define name="wxS" value=""/>

--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -2,22 +2,22 @@
 <def format="2">
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga437ea6ba615b75dac8603e96ec864160 -->
   <!-- #define wxT(string) -->
-  <define name="wxT" value=""/>
+  <define name="wxT(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga2e7c1f911a731a4b98a85fa44f1d9fbc -->
   <!-- #define wxT_2(string) -->
   <define name="wxT_2(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga0a06701ea0e6bb00c5171ace1b1f5691 -->
   <!-- #define wxS(string) -->
-  <define name="wxS" value=""/>
+  <define name="wxS(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga7dfc2888539861afe6c4337ef315472b -->
   <!-- #define _T(string) -->
-  <define name="_T" value=""/>
+  <define name="_T(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#gab8862de0f74049708bfea75ae9e14c45 -->
   <!-- #define wxTRANSLATE(string) -->
-  <define name="wxTRANSLATE" value=""/>
+  <define name="wxTRANSLATE(str)" value="str"/>
   <!-- http://docs.wxwidgets.org/trunk/group__group__funcmacro__string.html#ga8a02b8875a521df57263a9e6f090f2d0 -->
-  <!-- #define _(string) -->
-  <define name="_" value=""/>
+  <!-- const wxString& _(const wxString & string) // Macro that expands to wxGetTranslation -->
+  <define name="_(str)" value="wxGetTranslation(str)"/>
   <!-- http://docs.wxwidgets.org/trunk/classwx_string.html#addd9ccfa3ae2b7ab2d66bcbf034d0be0 -->
   <!-- static wxString wxString::Format(const wxString & format, ...) -->
   <function name="wxString::Format">
@@ -1359,9 +1359,6 @@
   <define name="wxUINT64_MAX" value="0xffffffffffffffffULL"/>
   <define name="wxINT64_MAX" value="0x7fffffffffffffffLL"/>
   <define name="wxINT64_MIN" value="0x8000000000000000LL"/>
-  <!-- http://docs.wxwidgets.org/3.0/group__group__funcmacro__string.html#ga8a02b8875a521df57263a9e6f090f2d0 -->
-  <!-- const wxString& _(const wxString & string) // Macro that expands to wxGetTranslation -->
-  <define name="_(str)" value="wxGetTranslation(str)"/>
   <podtype name="wxInt8" sign="s" size="1"/>
   <podtype name="wxUint8" sign="u" size="1"/>
   <podtype name="wxByte" sign="u" size="1"/>

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -123,18 +123,20 @@ void deprecatedFunctions(wxApp &a,
     // cppcheck-suppress SetTextIndentCalled
     comboCtrl.SetTextIndent(0);
 
+#if wxUSE_DEBUG_CONTEXT==1
     // cppcheck-suppress GetLevelCalled
     // cppcheck-suppress ignoredReturnValue
     wxDebugContext::GetLevel();
     // cppcheck-suppress SetLevelCalled
     wxDebugContext::SetLevel(42);
+#endif
 
     // cppcheck-suppress wxDos2UnixFilenameCalled
     wxDos2UnixFilename(path);
 
     // cppcheck-suppress wxFileNameFromPathCalled
     // cppcheck-suppress ignoredReturnValue
-    wxFileNameFromPath(wxT("../test.c"));
+    wxFileNameFromPath(wxT_2("../test.c"));
 #endif
 
 #if defined(__WXMSW__) || defined(__WXGTK__)


### PR DESCRIPTION
wxDebugContext is only defined if wxUSE_DEBUG_CONTEXT is 1, so otherwise
just skip it for syntax checking because it will fail.
Change wxT to wxT_2 and add wxT_2 to the config to remove a warning
during syntax check and be more compatible with newer/older wxwidgets
versions.