### PR TITLE
std.cfg: Add offsetof configuration

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6345,6 +6345,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <iterator container="2" type="first"/>
     </arg>
   </function>
+  <!--#define offsetof(type, member) /*implementation-defined*/-->
+  <function name="offsetof">
+    <noreturn>false</noreturn>
+    <returnValue type="std::size_t"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1"/>
+    <arg nr="2"/>
+  </function>
   <memory>
     <alloc init="false">malloc</alloc>
     <alloc init="true">calloc</alloc>


### PR DESCRIPTION
Currently Cppcheck seems to be not really aware of the offsetof function like macro.
This PR adds a configuration so Cppcheck knows a bit more about it.