### PR TITLE
Modified misra.py to fix issue parsing arguements

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1119,6 +1119,8 @@ for arg in sys.argv[1:]:
         loadRuleTexts(filename)
     elif arg.startswith('--misra-pdf='):
         loadRuleTextsFromPdf(arg[12:])
+    elif ".dump" in arg:
+        continue
     else:
         print('Fatal error: unhandled argument ' + arg)
         sys.exit(1)


### PR DESCRIPTION
Added additional elif confition to cause error checks to ignore .dump files.
Previous change meant that .dump always falls into else statement and script exits.