### PR TITLE
GUI: Remove redundant code

### DIFF
--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -165,9 +165,6 @@ void ProjectFileDialog::loadFromProjectFile(const ProjectFile *projectFile)
     updateAddonCheckBox(mUI.mAddonCert, projectFile, dataDir, "cert");
     updateAddonCheckBox(mUI.mAddonMisra, projectFile, dataDir, "misra");
 
-    mUI.mAddonY2038->setChecked(projectFile->getAddons().contains("y2038"));
-    mUI.mAddonCert->setChecked(projectFile->getAddons().contains("cert"));
-    mUI.mAddonMisra->setChecked(projectFile->getAddons().contains("misra"));
     mUI.mToolClangAnalyzer->setChecked(projectFile->getClangAnalyzer());
     mUI.mToolClangTidy->setChecked(projectFile->getClangTidy());
     if (CheckThread::clangTidyCmd().isEmpty()) {


### PR DESCRIPTION
The checked state of the addon checkboxes is already set in the
updateAddonCheckBox function directly above the removed code. I do not
see any reason to set it again and only for three of the four
checkboxes.