### PR TITLE
GUI: Avoid path concatenation when path is absolute

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1462,7 +1462,14 @@ void MainWindow::analyzeProject(const ProjectFile *projectFile)
 
     if (!projectFile->getImportProject().isEmpty()) {
         ImportProject p;
-        QString prjfile = inf.canonicalPath() + '/' + projectFile->getImportProject();
+        QString prjfile;
+
+        if(QFileInfo(projectFile->getImportProject()).isAbsolute()) {
+            prjfile = projectFile->getImportProject();
+        }
+        else {
+            prjfile = inf.canonicalPath() + '/' + projectFile->getImportProject();
+        }
         try {
             p.import(prjfile.toStdString());
         } catch (InternalError &e) {


### PR DESCRIPTION
When using an absolute path for import project, prepending the current
directory results in an invalid path and the analysis (silently, no
error shown in the GUI) fails.