### PR TITLE
Bug fix: Macro in namespace after class definition gave a syntax error.

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1658,7 +1658,7 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
     }
 
     // UNKNOWN_MACRO(a,b) { ... }
-    else if (outerScope->type == Scope::eGlobal &&
+    else if ((outerScope->type == Scope::eGlobal || outerScope->type == Scope::eNamespace) &&
              Token::Match(tok, "%name% (") &&
              tok->isUpperCaseName() &&
              Token::simpleMatch(tok->linkAt(1), ") {") &&


### PR DESCRIPTION
A Google test macro inside a namespace after a test fixture class definition gave a syntax error.

Test code in test.cpp (stripped version of my unit test code):
```
namespace mmachine
{
  class clsOccurrence_UnitTest : public ::testing::Test
  {
  };

  TEST_F(clsOccurrence_UnitTest, FromJSON)
  {
  }
}
```

This gave the following error:
[test.cpp:7]: (error) syntax error

Solved this by adding the namespace scope to the UNKNOWN_MACRO check in SymbolDatabase::isFunction().