### PR TITLE
Gtk library: Add configuration to avoid syntax error, add test file

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -5,6 +5,8 @@
   <define name="g_return_val_if_fail(expr, val)" value="do{if(!(expr)){return val;}}while(0)"/>
   <define name="g_return_if_reached()" value="do{return;}while(0)"/>
   <define name="g_return_val_if_reached(val)" value="do{return val;}while(0)"/>
+  <define name="G_LIKELY(expr)" value="(expr)"/>
+  <define name="G_UNLIKELY(expr)" value="(expr)"/>
   <memory>
     <alloc init="true">g_thread_new</alloc>
     <alloc init="true">g_thread_try_new</alloc>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -1,0 +1,22 @@
+
+// Test library configuration for gtk.cfg
+//
+// Usage:
+// $ cppcheck --check-library --enable=information --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=gtk test/cfg/gtk.cpp
+// =>
+// No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
+//
+
+#include <gtk/gtk.h>
+
+void validCode(int argInt)
+{
+    // if G_UNLIKELY is not defined this results in a syntax error
+    if G_UNLIKELY(argInt == 1) {
+    } else if (G_UNLIKELY(argInt == 2)) {
+    }
+
+    if G_LIKELY(argInt == 0) {
+    } else if (G_LIKELY(argInt == -1)) {
+    }
+}


### PR DESCRIPTION
Add configuration for G_UNLIKELY and G_LIKELY to avoid syntax errors
when these macros are used as condition without enclosing brackets.
Add test file to verify Gtk library configuration. Syntax check for the
test file is only done when Gtk+2.0 or Gtk+3.0 is found and working.
Tested on Cygwin and on Ubuntu 16.04.