### PR TITLE
Check for functions calls in sizeof calculations

### DIFF
--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -337,7 +337,7 @@ void CheckSizeof::sizeofFunction()
                 }
             }
 
-            for (const Token *argument = tok->next()->astOperand2(); argument; argument = argument->astOperand2()) {
+            if (const Token *argument = tok->next()->astOperand2()) {
                 const Token *checkToken = argument->previous();
                 if (checkToken->tokType() == Token::eName)
                     break;

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -338,7 +338,9 @@ void CheckSizeof::sizeofFunction()
             }
 
             const Token *errorTok = nullptr;
-            for (const Token *argument = tok->next(); argument && argument->str() != ")"; argument = argument->next()) {
+            const Token *start = tok->next();
+            const Token *end = start->link();
+            for (const Token *argument = start; argument != end; argument = argument->next()) {
                 // Dont report an error if there is a nested sizeof
                 if (argument->str() == "sizeof") {
                     errorTok = nullptr;

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -358,6 +358,8 @@ void CheckSizeof::sizeofFunction()
                     } else {
                         errorTok = tok;
                     }
+                } else if (argument->tokType() == Token::eName) {
+                    break;
                 }
             }
             if (errorTok) sizeofFunctionError(errorTok, false);

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -343,7 +343,11 @@ void CheckSizeof::sizeofFunction()
             for (const Token *argument = tok->next(); argument; argument = argument->next()) {
                 if (argument->str() == "sizeof") {
                     break;
-                } else if (const Function * fun = argument->function()) {
+                } else if (argument->str() == "decltype") {
+                    errorTok = nullptr;
+                    break;
+                }
+                else if (const Function * fun = argument->function()) {
                     if (fun->nestedIn->functionMap.count(argument->str()) > 1) {
                         // If the function is overloaded then dont error
                         errorTok = nullptr;

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -305,7 +305,9 @@ void CheckSizeof::sizeofCalculation()
             }
 
             const Token *argument = tok->next()->astOperand2();
-            if (argument && argument->isCalculation() && (!argument->isExpandedMacro() || printInconclusive))
+            if (argument && 
+               (argument->isCalculation() || (argument->previous()->str() != "sizeof" && argument->str() == "(")) && 
+               (!argument->isExpandedMacro() || printInconclusive))
                 sizeofCalculationError(argument, argument->isExpandedMacro());
         }
     }

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -324,8 +324,6 @@ void CheckSizeof::sizeofFunction()
     if (!_settings->isEnabled(Settings::WARNING))
         return;
 
-    const bool printInconclusive = _settings->inconclusive;
-
     for (const Token *tok = _tokenizer->tokens(); tok; tok = tok->next()) {
         if (Token::simpleMatch(tok, "sizeof (")) {
 

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -339,11 +339,21 @@ void CheckSizeof::sizeofFunction()
                 }
             }
 
-            const Token *argument = tok->next()->astOperand2();
-            if (argument && 
-               (argument->previous()->str() != "sizeof" && argument->str() == "(") && 
-               (!argument->isExpandedMacro() || printInconclusive))
-                sizeofFunctionError(argument, argument->isExpandedMacro());
+            const Token *errorTok = nullptr;
+            for (const Token *argument = tok->next(); argument; argument = argument->next()) {
+                if (argument->str() == "sizeof") {
+                    break;
+                } else if (const Function * fun = argument->function()) {
+                    if (fun->nestedIn->functionMap.count(argument->str()) > 1) {
+                        // If the function is overloaded then dont error
+                        errorTok = nullptr;
+                        break;
+                    } else {
+                        errorTok = tok;
+                    }
+                }
+            }
+            if (errorTok) sizeofFunctionError(errorTok, false);
         }
     }
 }

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -344,17 +344,17 @@ void CheckSizeof::sizeofFunction()
                 const Function * fun = checkToken->function();
                 // Dont report error if the function is overloaded
                 if (fun && fun->nestedIn->functionMap.count(checkToken->str()) == 1) {
-                    sizeofFunctionError(tok, false);
+                    sizeofFunctionError(tok);
                 }
             }
         }
     }
 }
 
-void CheckSizeof::sizeofFunctionError(const Token *tok, bool inconclusive)
+void CheckSizeof::sizeofFunctionError(const Token *tok)
 {
     reportError(tok, Severity::warning,
-                "sizeofFunction", "Found function call inside sizeof().", CWE682, inconclusive);
+                "sizeofFunctionCall", "Found function call inside sizeof().", CWE682, false);
 }
 
 //-----------------------------------------------------------------------------

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -338,16 +338,19 @@ void CheckSizeof::sizeofFunction()
             }
 
             const Token *errorTok = nullptr;
-            for (const Token *argument = tok->next(); argument; argument = argument->next()) {
+            for (const Token *argument = tok->next(); argument && argument->str() != ")"; argument = argument->next()) {
+                // Dont report an error if there is a nested sizeof
                 if (argument->str() == "sizeof") {
+                    errorTok = nullptr;
                     break;
+                // Dont report error if using decltype
                 } else if (argument->str() == "decltype") {
                     errorTok = nullptr;
                     break;
                 }
                 else if (const Function * fun = argument->function()) {
+                    // Dont report error if the function is overloaded
                     if (fun->nestedIn->functionMap.count(argument->str()) > 1) {
-                        // If the function is overloaded then dont error
                         errorTok = nullptr;
                         break;
                     } else {

--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -96,7 +96,7 @@ private:
     // Error messages..
     void sizeofsizeofError(const Token* tok);
     void sizeofCalculationError(const Token* tok, bool inconclusive);
-    void sizeofFunctionError(const Token* tok, bool inconclusive);
+    void sizeofFunctionError(const Token* tok);
     void multiplySizeofError(const Token* tok);
     void divideSizeofError(const Token* tok);
     void sizeofForArrayParameterError(const Token* tok);
@@ -116,7 +116,7 @@ private:
         c.sizeofForNumericParameterError(nullptr);
         c.sizeofsizeofError(nullptr);
         c.sizeofCalculationError(nullptr, false);
-        c.sizeofFunctionError(nullptr, false);
+        c.sizeofFunctionError(nullptr);
         c.multiplySizeofError(nullptr);
         c.divideSizeofError(nullptr);
         c.sizeofVoidError(nullptr);

--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -56,6 +56,7 @@ public:
         // Checks
         checkSizeof.sizeofsizeof();
         checkSizeof.sizeofCalculation();
+        checkSizeof.sizeofFunction();
         checkSizeof.suspiciousSizeofCalculation();
         checkSizeof.checkSizeofForArrayParameter();
         checkSizeof.checkSizeofForPointerSize();
@@ -72,6 +73,9 @@ public:
 
     /** @brief %Check for calculations inside sizeof */
     void sizeofCalculation();
+
+    /** @brief %Check for function call inside sizeof */
+    void sizeofFunction();
 
     /** @brief %Check for suspicious calculations with sizeof results */
     void suspiciousSizeofCalculation();
@@ -92,6 +96,7 @@ private:
     // Error messages..
     void sizeofsizeofError(const Token* tok);
     void sizeofCalculationError(const Token* tok, bool inconclusive);
+    void sizeofFunctionError(const Token* tok, bool inconclusive);
     void multiplySizeofError(const Token* tok);
     void divideSizeofError(const Token* tok);
     void sizeofForArrayParameterError(const Token* tok);
@@ -111,6 +116,7 @@ private:
         c.sizeofForNumericParameterError(nullptr);
         c.sizeofsizeofError(nullptr);
         c.sizeofCalculationError(nullptr, false);
+        c.sizeofFunctionError(nullptr, false);
         c.multiplySizeofError(nullptr);
         c.divideSizeofError(nullptr);
         c.sizeofVoidError(nullptr);
@@ -129,6 +135,7 @@ private:
                "- using sizeof(pointer) instead of the size of pointed data\n"
                "- look for 'sizeof sizeof ..'\n"
                "- look for calculations inside sizeof()\n"
+               "- look for function calls inside sizeof()\n"
                "- look for suspicious calculations with sizeof()\n"
                "- using 'sizeof(void)' which is undefined\n";
     }

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -193,6 +193,14 @@ private:
         check("int foo() { return 1; }; int a,sizeof(foo())");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
 
+        check("#define M(x) sizeof(x)\n"
+              "int foo() { return 1; }; int a,M(foo())");
+        ASSERT_EQUALS("", errout.str());
+
+        check("#define M sizeof(foo())\n"
+              "int foo() { return 1; }; int a,M");
+        ASSERT_EQUALS("", errout.str());
+
         check("int foo() { return 1; }; sizeof(decltype(foo()))");
         ASSERT_EQUALS("", errout.str());
 
@@ -206,6 +214,22 @@ private:
         ASSERT_EQUALS("", errout.str());
         
         check("int foo(int) { return 1; }; char buf[1024]; int a,sizeof(buf), foo(0)");
+        ASSERT_EQUALS("", errout.str());
+
+        check("template<class T>\n"
+              "struct A\n"
+              "{\n"
+              "    static B f(const B &);\n"
+              "    static A f(const A &);\n"
+              "    static A &g();\n"
+              "    static T &h();\n"
+              "\n"
+              "    enum {\n"
+              "        X = sizeof(f(g() >> h())) == sizeof(A),\n"
+              "        Y = sizeof(f(g() << h())) == sizeof(A),\n"
+              "        Z = X & Y\n"
+              "    };\n"
+              "};\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -168,7 +168,7 @@ private:
               "{\n"
               "    int bar() { return 1; };\n"
               "}\n"
-              "Foo f;int a,sizeof(f.bar())");
+              "Foo f;int a=sizeof(f.bar());");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
 
         check("class Foo\n"
@@ -176,44 +176,35 @@ private:
               "    int bar() { return 1; };\n"
               "    int bar() const { return 1; };\n"
               "}\n"
-              "Foo f;int a,sizeof(f.bar())");
+              "Foo f;int a=sizeof(f.bar());");
         ASSERT_EQUALS("", errout.str());
 
         check("class Foo\n"
               "{\n"
               "    int bar() { return 1; };\n"
               "}\n"
-              "Foo * fp;int a,sizeof(fp->bar())");
+              "Foo * fp;int a=sizeof(fp->bar());");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
 
-        check("#define foo() int\n"
-              "int a,sizeof(foo())");
+        check("int a=sizeof(foo());");
         ASSERT_EQUALS("", errout.str());
 
-        check("int foo() { return 1; }; int a,sizeof(foo())");
+        check("int foo() { return 1; }; int a=sizeof(foo());");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
 
-        check("#define M(x) sizeof(x)\n"
-              "int foo() { return 1; }; int a,M(foo())");
+        check("int foo() { return 1; }; sizeof(decltype(foo()));");
         ASSERT_EQUALS("", errout.str());
 
-        check("#define M sizeof(foo())\n"
-              "int foo() { return 1; }; int a,M");
-        ASSERT_EQUALS("", errout.str());
-
-        check("int foo() { return 1; }; sizeof(decltype(foo()))");
-        ASSERT_EQUALS("", errout.str());
-
-        check("int foo(int) { return 1; }; int a,sizeof(foo(0))");
+        check("int foo(int) { return 1; }; int a=sizeof(foo(0))");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
 
-        check("char * buf; int a,sizeof(*buf)");
+        check("char * buf; int a=sizeof(*buf);");
         ASSERT_EQUALS("", errout.str());
 
-        check("int a,sizeof(foo())");
+        check("int a=sizeof(foo())");
         ASSERT_EQUALS("", errout.str());
         
-        check("int foo(int) { return 1; }; char buf[1024]; int a,sizeof(buf), foo(0)");
+        check("int foo(int) { return 1; }; char buf[1024]; int a=sizeof(buf), foo(0)");
         ASSERT_EQUALS("", errout.str());
 
         check("template<class T>\n"

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -164,13 +164,6 @@ private:
     }
 
     void sizeofFunction() {
-        // check("class Foo\n"
-        //       "{\n"
-        //       "    int bar() { return 1; };\n"
-        //       "}\n"
-        //       "int a,sizeof(Foo().bar())");
-        // ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
-
         check("class Foo\n"
               "{\n"
               "    int bar() { return 1; };\n"
@@ -193,8 +186,15 @@ private:
               "Foo * fp;int a,sizeof(fp->bar())");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
 
+        check("#define foo() int\n"
+              "int a,sizeof(foo())");
+        ASSERT_EQUALS("", errout.str());
+
         check("int foo() { return 1; }; int a,sizeof(foo())");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
+
+        check("int foo() { return 1; }; sizeof(decltype(foo()))");
+        ASSERT_EQUALS("", errout.str());
 
         check("int foo(int) { return 1; }; int a,sizeof(foo(0))");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -108,6 +108,9 @@ private:
               "    int i = sizeof (sizeof (p));\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (warning) Calling 'sizeof' on 'sizeof'.\n", errout.str());
+
+        check("int foo() { return 1; }; int a,sizeof(sizeof(foo()))");
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Calling 'sizeof' on 'sizeof'.\n", errout.str());
     }
 
     void sizeofCalculation() {
@@ -199,7 +202,13 @@ private:
         check("int foo(int) { return 1; }; int a,sizeof(foo(0))");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
 
-        check("int foo(int) { return 1; }; int foo(...) { return 1; }; int a,sizeof(foo(0))");
+        check("char * buf; int a,sizeof(*buf)");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int a,sizeof(foo())");
+        ASSERT_EQUALS("", errout.str());
+        
+        check("int foo(int) { return 1; }; char buf[1024]; int a,sizeof(buf), foo(0)");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -108,9 +108,6 @@ private:
               "    int i = sizeof (sizeof (p));\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (warning) Calling 'sizeof' on 'sizeof'.\n", errout.str());
-
-        check("int foo() { return 1; }; int a,sizeof(sizeof(foo()))");
-        ASSERT_EQUALS("[test.cpp:1]: (warning) Calling 'sizeof' on 'sizeof'.\n", errout.str());
     }
 
     void sizeofCalculation() {

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -137,6 +137,16 @@ private:
         check("sizeof(--foo)");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Found calculation inside sizeof().\n", errout.str());
 
+        check("class Foo\n"
+              "{\n"
+              "    int bar() { return 1; };\n"
+              "}\n"
+              "int a,sizeof(Foo().bar())");
+        ASSERT_EQUALS("[test.cpp:5]: (warning) Found calculation inside sizeof().\n", errout.str());
+
+        check("int foo() { return 1; }; int a,sizeof(foo())");
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Found calculation inside sizeof().\n", errout.str());
+
         // #6888
         checkP("#define SIZEOF1   sizeof(i != 2)\n"
                "#define SIZEOF2   ((sizeof(i != 2)))\n"

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -40,6 +40,7 @@ private:
 
         TEST_CASE(sizeofsizeof);
         TEST_CASE(sizeofCalculation);
+        TEST_CASE(sizeofFunction);
         TEST_CASE(checkPointerSizeof);
         TEST_CASE(checkPointerSizeofStruct);
         TEST_CASE(sizeofDivisionMemset);
@@ -142,10 +143,10 @@ private:
               "    int bar() { return 1; };\n"
               "}\n"
               "int a,sizeof(Foo().bar())");
-        ASSERT_EQUALS("[test.cpp:5]: (warning) Found calculation inside sizeof().\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
 
         check("int foo() { return 1; }; int a,sizeof(foo())");
-        ASSERT_EQUALS("[test.cpp:1]: (warning) Found calculation inside sizeof().\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
 
         // #6888
         checkP("#define SIZEOF1   sizeof(i != 2)\n"
@@ -170,6 +171,18 @@ private:
                "}");
         ASSERT_EQUALS("[test.cpp:4]: (warning, inconclusive) Found calculation inside sizeof().\n"
                       "[test.cpp:5]: (warning, inconclusive) Found calculation inside sizeof().\n", errout.str());
+    }
+
+    void sizeofFunction() {
+        check("class Foo\n"
+              "{\n"
+              "    int bar() { return 1; };\n"
+              "}\n"
+              "int a,sizeof(Foo().bar())");
+        ASSERT_EQUALS("[test.cpp:5]: (warning) Found function call inside sizeof().\n", errout.str());
+
+        check("int foo() { return 1; }; int a,sizeof(foo())");
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Found function call inside sizeof().\n", errout.str());
     }
 
     void sizeofForArrayParameter() {


### PR DESCRIPTION
A common mistake that I have found in our codebase is calling a function to get an integer or enum that represents the type such as:

```cpp
int numBytes = numElements * sizeof(x.GetType());
```

This extends cppcheck for sizeof calculation to check for function calls as well.