### PR TITLE
Ticket #8281 and #8417: Properly detect the end of "switch" statements to accept all legitimate uses of "case".

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4770,6 +4770,24 @@ private:
         //ticket #8477
         ASSERT_EQUALS("void foo ( ) { enum Anonymous0 : int { Six = 6 } ; return Six ; }",
                       tokenizeAndStringify("void foo () { enum : int { Six = 6 } ; return Six ; }"));
+        // ticket #8281
+        tokenizeAndStringify("void lzma_decode(int i) { "
+                             "  bool state; "
+                             "  switch (i) "
+                             "  while (true) { "
+                             "     state=false; "
+                             "   case 1: "
+                             "      ; "
+                             "  }"
+                             "}");
+        // ticket #8417
+        tokenizeAndStringify("void printOwnedAttributes(int mode) { "
+                             "  switch(mode) case 0: { break; } "
+                             "}");
+        ASSERT_THROW(tokenizeAndStringify("void printOwnedAttributes(int mode) { "
+                                          "  switch(mode) case 0: { break; } case 1: ; "
+                                          "}"),
+                     InternalError);
     }
 
     void simplifyPointerToStandardType() {


### PR DESCRIPTION
This patch fixes a false positive in Tokenizer::findGarbageCode, that did not properly detect the end of switch statements (see examples in http://en.cppreference.com/w/cpp/language/switch for legitimate cases, including the one in the test case)