### PR TITLE
Extend nullPointerArithmetic to check for addition as well

### DIFF
--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -516,7 +516,7 @@ void CheckNullPointer::arithmetic()
                 const Token *operand = *operand_it;
                 if(!(operand && operand->valueType() && operand->valueType()->pointer)) 
                     continue;
-                long checkValue = 0;
+                MathLib::bigint checkValue = 0;
                 // When using an assign op, the value read from
                 // valueflow has already been updated, so instead of
                 // checking for zero we check that the value is equal

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -511,28 +511,30 @@ void CheckNullPointer::arithmetic()
         for (const Token* tok = scope->classStart->next(); tok != scope->classEnd; tok = tok->next()) {
             if (!Token::Match(tok, "-|+|+=|-="))
                 continue;
-            const Token *arguments[] = {tok->astOperand1(), tok->astOperand2()};
-            for(const Token **argument_it = begin(arguments); argument_it != end(arguments);argument_it++) {
-                const Token *argument = *argument_it;
-                if(argument && argument->valueType() && argument->valueType()->pointer) {
-                    long checkValue = 0;
-                    // When using an assign op, the value read from
-                    // valueflow has already been updated, so instead of
-                    // checking for zero we check that the value is equal
-                    // to RHS
-                    if (tok->astOperand2()->hasKnownIntValue()) {
-                        if (tok->str() == "-=") checkValue -= tok->astOperand2()->values().front().intvalue;
-                        else if (tok->str() == "+=") checkValue = tok->astOperand2()->values().front().intvalue;
-                    }
-                    const ValueFlow::Value *value = argument->getValue(checkValue);
-                    if (!value)
-                        continue;
-                    if (!_settings->inconclusive && value->isInconclusive())
-                        continue;
-                    if (value->condition && !_settings->isEnabled(Settings::WARNING))
-                        continue;
-                    arithmeticError(tok,value);
+            const Token *operands[] = {tok->astOperand1(), tok->astOperand2()};
+            for(const Token **operand_it = begin(operands); operand_it != end(operands);operand_it++) {
+                const Token *operand = *operand_it;
+                if(!(operand && operand->valueType() && operand->valueType()->pointer)) 
+                    continue;
+                long checkValue = 0;
+                // When using an assign op, the value read from
+                // valueflow has already been updated, so instead of
+                // checking for zero we check that the value is equal
+                // to RHS
+                if (tok->astOperand2()->hasKnownIntValue()) {
+                    if (tok->str() == "-=") 
+                        checkValue -= tok->astOperand2()->values().front().intvalue;
+                    else if (tok->str() == "+=") 
+                        checkValue = tok->astOperand2()->values().front().intvalue;
                 }
+                const ValueFlow::Value *value = operand->getValue(checkValue);
+                if (!value)
+                    continue;
+                if (!_settings->inconclusive && value->isInconclusive())
+                    continue;
+                if (value->condition && !_settings->isEnabled(Settings::WARNING))
+                    continue;
+                arithmeticError(tok,value);
             }
         }
     }

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -515,7 +515,8 @@ void CheckNullPointer::arithmetic()
                 tok->valueType()->pointer
             )
             {
-                for(const ValueFlow::Value *value:{tok->astOperand1()->getValue(0), tok->astOperand2()->getValue(0)}) {
+                const ValueFlow::Value *values[] = {tok->astOperand1()->getValue(0), tok->astOperand2()->getValue(0)};
+                for(const ValueFlow::Value *value:values) {
                     if (!value)
                         continue;
                     if (!_settings->inconclusive && value->isInconclusive())

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -509,7 +509,7 @@ void CheckNullPointer::arithmetic()
     for (std::size_t i = 0; i < functions; ++i) {
         const Scope * scope = symbolDatabase->functionScopes[i];
         for (const Token* tok = scope->classStart->next(); tok != scope->classEnd; tok = tok->next()) {
-            if (!Token::Match(tok, "-|+|+=|-="))
+            if (!Token::Match(tok, "-|+|+=|-=|++|--"))
                 continue;
             const Token *operands[] = {tok->astOperand1(), tok->astOperand2()};
             for(const Token **operand_it = begin(operands); operand_it != end(operands);operand_it++) {
@@ -521,7 +521,7 @@ void CheckNullPointer::arithmetic()
                 // valueflow has already been updated, so instead of
                 // checking for zero we check that the value is equal
                 // to RHS
-                if (tok->astOperand2()->hasKnownIntValue()) {
+                if (tok->astOperand2() && tok->astOperand2()->hasKnownIntValue()) {
                     if (tok->str() == "-=") 
                         checkValue -= tok->astOperand2()->values().front().intvalue;
                     else if (tok->str() == "+=") 

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -92,6 +92,18 @@ inline static int caseInsensitiveStringCompare(const std::string &lhs, const std
     return 0;
 }
 
+template< class T, std::size_t N >
+T* begin( T (&array)[N] )
+{
+    return array;
+}
+
+template< class T, std::size_t N >
+T* end( T (&array)[N] )
+{
+    return array+N;
+}
+
 #define UNUSED(x) (void)(x)
 
 #endif

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2584,6 +2584,12 @@ private:
               "  s -= 20;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is overflow in pointer subtraction.\n", errout.str());
+
+        check("int* f8() { int *x = NULL; return --x; }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Overflow in pointer arithmetic, NULL pointer is subtracted.\n", errout.str());
+        
+        check("int* f9() { int *x = NULL; return x--; }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Overflow in pointer arithmetic, NULL pointer is subtracted.\n", errout.str());
     }
 
     void addNull() {
@@ -2622,6 +2628,12 @@ private:
               "  s += 20;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("int* f7() { int *x = NULL; return ++x; }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Pointer arithmetic with NULL pointer.\n", errout.str());
+        
+        check("int* f10() { int *x = NULL; return x++; } ");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Pointer arithmetic with NULL pointer.\n", errout.str());
     }
 };
 

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2572,6 +2572,18 @@ private:
               "  p = s - 20;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is overflow in pointer subtraction.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  s -= 20;\n"
+              "}\n"
+              "void bar() { foo(0); }\n");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Overflow in pointer arithmetic, NULL pointer is subtracted.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  if (!s) {}\n"
+              "  s -= 20;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is overflow in pointer subtraction.\n", errout.str());
     }
 
     void addNull() {
@@ -2596,6 +2608,18 @@ private:
         check("void foo(char *s) {\n"
               "  if (!s) {}\n"
               "  char * p = 20 + s;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  s += 20;\n"
+              "}\n"
+              "void bar() { foo(0); }\n");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  if (!s) {}\n"
+              "  s += 20;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is pointer arithmetic with NULL pointer.\n", errout.str());
     }

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -105,6 +105,7 @@ private:
         TEST_CASE(nullpointer_internal_error); // #5080
         TEST_CASE(ticket6505);
         TEST_CASE(subtract);
+        TEST_CASE(addNull);
     }
 
     void check(const char code[], bool inconclusive = false, const char filename[] = "test.cpp") {
@@ -2571,6 +2572,32 @@ private:
               "  p = s - 20;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is overflow in pointer subtraction.\n", errout.str());
+    }
+
+    void addNull() {
+        check("void foo(char *s) {\n"
+              "  char * p = s + 20;\n"
+              "}\n"
+              "void bar() { foo(0); }\n");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  if (!s) {}\n"
+              "  char * p = s + 20;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  char * p = 20 + s;\n"
+              "}\n"
+              "void bar() { foo(0); }\n");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Pointer arithmetic with NULL pointer.\n", errout.str());
+
+        check("void foo(char *s) {\n"
+              "  if (!s) {}\n"
+              "  char * p = 20 + s;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Either the condition '!s' is redundant or there is pointer arithmetic with NULL pointer.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
Check for addition with null pointer as it is most likely an error:

```cpp
#include <stdlib.h>
int* f() {
    int *x = NULL;
    return x + 5;
}
```