### PR TITLE
Qt library: Add missing podtype information

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -625,12 +625,15 @@
   <podtype name="quint16" sign="u" size="2"/>
   <podtype name="quint32" sign="u" size="4"/>
   <podtype name="quint64" sign="u" size="8"/>
-  <podtype name="qlonglong" sign="s"/>
-  <podtype name="qulonglong" sign="u"/>
-  <podtype name="uchar" sign="u"/>
+  <!-- https://doc.qt.io/qt-5/qtglobal.html#qlonglong-typedef "This is the same as qint64." -->
+  <podtype name="qlonglong" sign="s" size="8"/>
+  <!-- https://doc.qt.io/qt-5/qtglobal.html#qulonglong-typedef "This is the same as quint64." -->
+  <podtype name="qulonglong" sign="u" size="8"/>
+  <podtype name="uchar" sign="u" size="1"/>
   <podtype name="uint" sign="u"/>
   <podtype name="ulong" sign="u"/>
   <podtype name="ushort" sign="u"/>
   <podtype name="qptrdiff" sign="s"/>
+  <podtype name="qintptr" sign="s"/>
   <podtype name="quinitptr" sign="u"/>
 </def>


### PR DESCRIPTION
The type qintptr was missing.
qlonglong, qulonglong and uchar have known sizes, so the sizes can be
specified.