### PR TITLE
Windows library: Enhance functions, add tests

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -1204,62 +1204,45 @@
     <alloc init="true" arg="11">AllocateAndInitializeSid</alloc>
     <dealloc>FreeSid</dealloc>
   </memory>
+  <!--SIZE_T RtlCompareMemory(
+  _In_ const VOID   *Source1,
+  _In_ const VOID   *Source2,
+  _In_       SIZE_T Length);-->
   <function name="RtlCompareMemory">
     <noreturn>false</noreturn>
+    <returnValue type="SIZE_T"/>
     <leak-ignore/>
+    <use-retval/>
     <arg nr="1">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="2">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="3">
       <not-bool/>
       <valid>0:</valid>
     </arg>
   </function>
+  <!--VOID RtlCopyBytes(
+  _Out_       PVOID  Destination,
+  _In_  const VOID   *Source,
+  _In_        SIZE_T Length);-->
   <function name="RtlCopyBytes">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
+      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="2">
       <not-null/>
       <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <function name="RtlCopyMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <function name="RtlEqualMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="3">
       <not-bool/>
@@ -1279,41 +1262,18 @@
     <arg nr="3">
       <not-uninit/>
     </arg>
+    <warn severity="style" reason="Obsolete" alternatives="RtlFillMemory"/>
   </function>
-  <function name="RtlFillMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-    <arg nr="3">
-      <not-uninit/>
-    </arg>
-  </function>
-  <function name="RtlMoveMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
+  <!--PVOID RtlSecureZeroMemory(
+  _Out_ PVOID  ptr,
+  _In_  SIZE_T cnt);-->
   <function name="RtlSecureZeroMemory">
     <noreturn>false</noreturn>
+    <returnValue type="PVOID"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
+      <minsize type="argvalue" arg="2"/>
     </arg>
     <arg nr="2">
       <not-bool/>
@@ -1330,87 +1290,7 @@
       <not-bool/>
       <valid>0:</valid>
     </arg>
-  </function>
-  <function name="RtlZeroMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <!-- void CopyMemory(
-  _In_       PVOID  Destination,
-  _In_ const VOID   *Source,
-  _In_       SIZE_T Length); -->
-  <function name="CopyMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <function name="FillMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-    <arg nr="3">
-      <not-uninit/>
-    </arg>
-  </function>
-  <function name="MoveMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="3">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <function name="SecureZeroMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
-  <function name="ZeroMemory">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-null/>
-    </arg>
-    <arg nr="2">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="RtlZeroMemory"/>
   </function>
   <function name="KeBugCheck">
     <noreturn>true</noreturn>
@@ -4964,4 +4844,14 @@ HFONT CreateFont(
   <define name="TEXT(str)" value="str"/>
   <define name="_countof(_Array)" value="(sizeof(_Array) / sizeof(_Array[0]))"/>
   <define name="__wchar_t" value="wchar_t"/>
+  <define name="RtlEqualMemory(Destination,Source,Length)" value="(!memcmp((Destination),(Source),(Length)))"/>
+  <define name="RtlMoveMemory(Destination,Source,Length)" value="memmove((Destination),(Source),(Length))"/>
+  <define name="RtlCopyMemory(Destination,Source,Length)" value="memcpy((Destination),(Source),(Length))"/>
+  <define name="RtlFillMemory(Destination,Length,Fill)" value="memset((Destination),(Fill),(Length))"/>
+  <define name="RtlZeroMemory(Destination,Length)" value="memset((Destination),0,(Length))"/>
+  <define name="MoveMemory" value="RtlMoveMemory"/>
+  <define name="CopyMemory" value="RtlCopyMemory"/>
+  <define name="FillMemory" value="RtlFillMemory"/>
+  <define name="ZeroMemory" value="RtlZeroMemory"/>
+  <define name="SecureZeroMemory" value="RtlSecureZeroMemory"/>
 </def>

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -131,6 +131,21 @@ void validCode()
     }
     WSACleanup();
 
+    bool boolVar;
+    uint8_t byteBuf[5] = {0};
+    uint8_t byteBuf2[10] = {0};
+    boolVar = RtlEqualMemory(byteBuf, byteBuf2, sizeof(byteBuf));
+    if (boolVar) {}
+    boolVar = RtlCompareMemory(byteBuf, byteBuf2, sizeof(byteBuf));
+    if (boolVar) {}
+    RtlMoveMemory(byteBuf, byteBuf2, sizeof(byteBuf));
+    RtlCopyMemory(byteBuf, byteBuf2, sizeof(byteBuf));
+    RtlZeroMemory(byteBuf, sizeof(byteBuf));
+    ZeroMemory(byteBuf, sizeof(byteBuf));
+    RtlSecureZeroMemory(byteBuf, sizeof(byteBuf));
+    SecureZeroMemory(byteBuf, sizeof(byteBuf));
+    RtlFillMemory(byteBuf, sizeof(byteBuf), 0xff);
+
     // Valid Library usage, no leaks, valid arguments
     HINSTANCE hInstLib = LoadLibrary(L"My.dll");
     FreeLibrary(hInstLib);
@@ -157,6 +172,38 @@ void bufferAccessOutOfBounds()
         // cppcheck-suppress arrayIndexOutOfBounds
         buf[i] = L'\0';
     }
+
+    uint8_t byteBuf[5] = {0};
+    uint8_t byteBuf2[10] = {0};
+    // TODO ticket #8412 cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlEqualMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlCompareMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlMoveMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress redundantCopy
+    // cppcheck-suppress bufferAccessOutOfBounds
+    MoveMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress redundantCopy
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlCopyMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress redundantCopy
+    // cppcheck-suppress bufferAccessOutOfBounds
+    CopyMemory(byteBuf, byteBuf2, 20);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlZeroMemory(byteBuf, sizeof(byteBuf)+1);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    ZeroMemory(byteBuf, sizeof(byteBuf)+1);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlSecureZeroMemory(byteBuf, sizeof(byteBuf)+1);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    SecureZeroMemory(byteBuf, sizeof(byteBuf)+1);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    RtlFillMemory(byteBuf, sizeof(byteBuf)+1, 0x01);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    FillMemory(byteBuf, sizeof(byteBuf)+1, 0x01);
 }
 
 void nullPointer()


### PR DESCRIPTION
Enhance *Equal/*Compare/*Copy/*Move/*Zero/*Fill memory functions to
catch buffer access out of bounds errors and ignored return values.
Replaced some function configuration by according defines as it is done
in windows to avoid redundant (and error prone) configurations.