### PR TITLE
GUI: Minor fix: Rename one of the two layout items with the same name

### DIFF
--- a/gui/projectfiledialog.ui
+++ b/gui/projectfiledialog.ui
@@ -532,7 +532,7 @@
          <property name="title">
           <string>External tools</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
+         <layout class="QVBoxLayout" name="verticalLayout_1">
           <item>
            <widget class="QCheckBox" name="mToolClangTidy">
             <property name="text">


### PR DESCRIPTION
Qt warns about two QVBoxLayout objects with the same name and
automatically renames one.
This fixes the warning.