### PR TITLE
GUI: Fix loading of platform files in project file dialog

### DIFF
--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -123,7 +123,7 @@ ProjectFileDialog::ProjectFileDialog(ProjectFile *projectFile, QWidget *parent)
             const QString platformFile = item.fileName();
 
             cppcheck::Platform p;
-            if (!p.loadPlatformFile(appPath.toStdString().c_str(), platformFile.toStdString()))
+            if (!p.loadPlatformFile(applicationFilePath.toStdString().c_str(), platformFile.toStdString()))
                 continue;
 
             if (platformFiles.indexOf(platformFile) == -1)


### PR DESCRIPTION
Platform::loadPlatformFile needs the path to the binary not only the
path to the directory where the binary is in. Otherwise the last
directory could get stripped away and the platform files maybe will not
be found.