### PR TITLE
Platforms: Add arm32 and arm64 platform files

### DIFF
--- a/platforms/arm32-wchar_t2.xml
+++ b/platforms/arm32-wchar_t2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <short>2</short>
+    <int>4</int>
+    <long>4</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>8</long-double>
+    <pointer>4</pointer>
+    <size_t>4</size_t>
+    <wchar_t>2</wchar_t>
+  </sizeof>
+</platform>

--- a/platforms/arm32-wchar_t4.xml
+++ b/platforms/arm32-wchar_t4.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <short>2</short>
+    <int>4</int>
+    <long>4</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>8</long-double>
+    <pointer>4</pointer>
+    <size_t>4</size_t>
+    <wchar_t>4</wchar_t>
+  </sizeof>
+</platform>

--- a/platforms/arm64-wchar_t2.xml
+++ b/platforms/arm64-wchar_t2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <short>2</short>
+    <int>4</int>
+    <long>4</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>8</long-double>
+    <pointer>8</pointer>
+    <size_t>4</size_t>
+    <wchar_t>2</wchar_t>
+  </sizeof>
+</platform>

--- a/platforms/arm64-wchar_t4.xml
+++ b/platforms/arm64-wchar_t4.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <short>2</short>
+    <int>4</int>
+    <long>4</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>8</long-double>
+    <pointer>8</pointer>
+    <size_t>4</size_t>
+    <wchar_t>4</wchar_t>
+  </sizeof>
+</platform>


### PR DESCRIPTION
The default is "unsigned" so i have choosen it for the platformfiles.
This can be changed via a compiler option, but i am not sure if it makes
sense to add all the platform files with "signed" also.
Since the size of wchar_t depends on the compiler i added both possible
variants respectively.
Sizes of data types can be checked here for example:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.den0024a/ch08s02.html