### PR TITLE
Performance improvement: Token::chrInFirstWord() & Token::simpleMatch()

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -588,9 +588,12 @@ void CheckBufferOverrun::checkScope(const Token *tok, const std::vector<const st
     const int varcount = varname.empty() ? 0 : static_cast<int>((varname.size() - 1) * 2U);
 
     // ValueFlow array index..
-    if ((declarationId > 0 && Token::Match(tok, "%varid% [", declarationId)) ||
-        (declarationId == 0 && Token::simpleMatch(tok, (varnames + " [").c_str()))) {
-
+    bool doCheckFlowArrayIndex = declarationId > 0 && Token::Match(tok, "%varid% [", declarationId);
+    if (!doCheckFlowArrayIndex && declarationId == 0) {
+        std::string pattern = varnames + " [";
+        doCheckFlowArrayIndex = Token::simpleMatch(tok, pattern);
+    }
+    if (doCheckFlowArrayIndex) {
         const Token *tok2 = tok->next();
         while (tok2->str() != "[")
             tok2 = tok2->next();

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1315,7 +1315,7 @@ void CheckClass::checkReturnPtrThis(const Scope *scope, const Function *func, co
 
         foundReturn = true;
         std::string cast("( " + scope->className + " & )");
-        if (Token::simpleMatch(tok->next(), cast.c_str()))
+        if (Token::simpleMatch(tok->next(), cast))
             tok = tok->tokAt(4);
 
         // check if a function is called
@@ -1361,7 +1361,8 @@ void CheckClass::checkReturnPtrThis(const Scope *scope, const Function *func, co
         return;
     }
     if (startTok->next() == last) {
-        if (Token::simpleMatch(func->argDef, std::string("( const " + scope->className + " &").c_str())) {
+        std::string pattern("( const " + scope->className + " &");
+        if (Token::simpleMatch(func->argDef, pattern)) {
             // Typical wrong way to suppress default assignment operator by declaring it and leaving empty
             operatorEqMissingReturnStatementError(func->token, func->access == Public);
         } else {
@@ -1613,7 +1614,8 @@ void CheckClass::virtualDestructor()
                         if (Token::Match(tok, "[;{}] %var% =") &&
                             baseClassPointers.find(tok->next()->varId()) != baseClassPointers.end()) {
                             // new derived class..
-                            if (Token::simpleMatch(tok->tokAt(3), ("new " + derivedClass->str()).c_str())) {
+                            std::string pattern("new " + derivedClass->str());
+                            if (Token::simpleMatch(tok->tokAt(3), pattern)) {
                                 dontDelete.insert(tok->next()->varId());
                             }
                         }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1982,7 +1982,7 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
         else if (depth && Token::Match(first->next(), "%name%")) {
             std::string param = path + first->next()->str();
 
-            if (Token::simpleMatch(second->next(), param.c_str())) {
+            if (Token::simpleMatch(second->next(), param)) {
                 second = second->tokAt(int(depth) * 2);
             } else if (depth > 1) {
                 std::string short_path = path;
@@ -1996,7 +1996,7 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
                     short_path.resize(lastSpace+1);
 
                 param = short_path + first->next()->str();
-                if (Token::simpleMatch(second->next(), param.c_str())) {
+                if (Token::simpleMatch(second->next(), param)) {
                     second = second->tokAt((int(depth) - 1) * 2);
                 }
             }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -661,8 +661,8 @@ void TemplateSimplifier::useDefaultArgumentValues(const std::list<TokenAndName> 
         // iterate through all template instantiations
         for (std::list<TokenAndName>::const_iterator iter2 = templateInstantiations->begin(); iter2 != templateInstantiations->end(); ++iter2) {
             Token *tok = iter2->token;
-
-            if (!Token::simpleMatch(tok, (classname + " <").c_str()))
+            std::string pattern(classname + " <");
+            if (!Token::simpleMatch(tok, pattern))
                 continue;
 
             // count the parameters..

--- a/lib/token.h
+++ b/lib/token.h
@@ -146,7 +146,19 @@ public:
      * @return true if given token matches with given pattern
      *         false if given token does not match with given pattern
      */
-    static bool simpleMatch(const Token *tok, const char pattern[]);
+    template <size_t N>
+    static inline bool simpleMatch(const Token *tok, const char (&pattern)[N])
+    {
+        return simpleMatch(tok, pattern, N - 1);
+    }
+
+    // non-const ref in order to forbid implicit conversion from const char*
+    static inline bool simpleMatch(const Token *tok, std::string& pattern)
+    {
+        return simpleMatch(tok, pattern.c_str(), pattern.length());
+    }
+
+    static bool simpleMatch(const Token *tok, const char pattern[], size_t patternLength);
 
     /**
      * Match given token (or list of tokens) to a pattern list.
@@ -863,13 +875,6 @@ private:
      * as if it were &apos;\\0&apos;
      */
     static bool firstWordEquals(const char *str, const char *word);
-
-    /**
-     * Works almost like strchr() except
-     * if str has empty space &apos; &apos; character, that character is handled
-     * as if it were &apos;\\0&apos;
-     */
-    static const char *chrInFirstWord(const char *str, char c);
 
     std::string _str;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1120,7 +1120,7 @@ void Tokenizer::simplifyTypedef()
                 }
 
                 // check for typedef that can be substituted
-                else if (Token::simpleMatch(tok2, pattern.c_str()) ||
+                else if (Token::simpleMatch(tok2, pattern) ||
                          (inMemberFunc && tok2->str() == typeName->str())) {
                     // member function class variables don't need qualification
                     if (!(inMemberFunc && tok2->str() == typeName->str()) && pattern.find("::") != std::string::npos) { // has a "something ::"


### PR DESCRIPTION
After profiling cppcheck on large project I've found relevant candidates for
performance improvement. The basic idea is:

* Token::chrInFirstWord(): inline the single possible searched character
* Token::simpleMatch(): avoid recalculation of pattern's length
  a. either it is known at compile time -> use template
  b. or pattern is a std::string and the length is already calculated