### PR TITLE
std.cfg: Smaller enhancements and fixes

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -177,6 +177,7 @@
   </function>
   <!-- void assert(int expression) -->
   <function name="assert">
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -891,6 +892,7 @@
   <function name="calloc">
     <use-retval/>
     <noreturn>false</noreturn>
+    <returnValue type="void *"/>
     <arg nr="1">
       <not-uninit/>
       <valid>1:</valid>
@@ -978,6 +980,7 @@
   <!-- void clearerr(FILE * stream); -->
   <function name="clearerr,std::clearerr">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -1396,7 +1399,8 @@
     </arg>
   </function>
   <!-- void _Exit(int status); -->
-  <function name="_Exit,quick_exit">
+  <!-- void quick_exit(int exit_code); -->
+  <function name="_Exit,std::_Exit,quick_exit,std::quick_exit">
     <noreturn>true</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -1922,6 +1926,7 @@
   <!-- void free(void *block); -->
   <function name="free,std::free">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <arg nr="1">
       <not-uninit/>
     </arg>
@@ -2267,7 +2272,7 @@
     </arg>
   </function>
   <!-- wint_t getwchar(void); -->
-  <function name="getwchar">
+  <function name="getwchar,std::getwchar">
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2341,7 +2346,7 @@
     </arg>
   </function>
   <!-- int getchar(void); -->
-  <function name="getchar">
+  <function name="getchar,std::getchar">
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2416,6 +2421,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <pure/>
     <noreturn>false</noreturn>
+    <returnValue type="struct tm *"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -3000,6 +3006,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void srand(unsigned int seed); -->
   <function name="srand,std::srand">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -3555,7 +3562,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="nexttowardl,std::nexttowardl">
     <use-retval/>
     <pure/>
-    <returnValue type="float"/>
+    <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3568,6 +3575,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void longjmp(jmp_buf env, int val); -->
   <function name="longjmp,std::longjmp">
     <noreturn>true</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -3860,6 +3868,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void perror(const char *string); -->
   <function name="perror,std::perror">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -4077,6 +4086,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void qsort(void *base, size_t n, size_t size, int (*cmp)(const void *, const void *)); -->
   <function name="qsort,std::qsort">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -4197,6 +4207,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void rewind(FILE *stream); -->
   <function name="rewind,std::rewind">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -4347,7 +4358,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- void setbuf(FILE *stream, char *buf); -->
   <function name="setbuf,std::setbuf">
-    <returnValue type="int"/>
+    <returnValue type="void"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -4610,6 +4621,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- wchar_t *wcsncat(wchar_t *ct, const wchar_t *cs, size_t n); -->
   <function name="wcsncat,std::wcsncat">
     <noreturn>false</noreturn>
+    <returnValue type="wchar_t *"/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -5160,6 +5172,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:255</valid>
     </arg>
   </function>
+  <!-- typeid operator -->
   <function name="typeid">
     <use-retval/>
     <noreturn>false</noreturn>
@@ -5174,18 +5187,21 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void va_copy(va_list dest, va_list src); -->
   <function name="va_copy">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="2"/>
   </function>
   <!-- void va_end(va_list ap); -->
   <function name="va_end">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1"/>
   </function>
   <!-- void va_start(va_list ap, paramN); -->
   <function name="va_start">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="2"/>
   </function>
@@ -5381,6 +5397,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void std::wstring::resize (size_t n, wchar_t c);-->
   <function name="std::string::resize,std::wstring::resize">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -5850,6 +5867,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- template< class T > void swap( T& a, T& b );-->
   <function name="std::swap">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <arg nr="1">
       <not-uninit/>
     </arg>
@@ -5894,24 +5912,66 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="bool"/>
     <noreturn>false</noreturn>
   </function>
-  <function name="std::array::clear,std::deque::clear,std::list::clear,std::forward_list::clear,std::map::clear,std::unordered_map::clear,std::queue::clear,std::set::clear,std::unordered_set::clear,std::stack::clear,std::string::clear,std::wstring::clear,std::basic_string::clear,std::vector::clear">
+  <!-- void clear(); // until C++11 -->
+  <!-- void clear() noexcept; // since C++11 -->
+  <function name="std::deque::clear,std::list::clear,std::forward_list::clear,std::map::clear,std::unordered_map::clear,std::queue::clear,std::set::clear,std::unordered_set::clear,std::stack::clear,std::string::clear,std::wstring::clear,std::basic_string::clear,std::vector::clear">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
   </function>
+  <!-- bool empty() const; // until C++11 -->
+  <!-- constexpr bool empty() const noexcept; // since C++11 until C++20 -->
+  <!-- [[nodiscard]] constexpr bool empty() const noexcept; // since C++20 -->
   <function name="std::array::empty,std::deque::empty,std::list::empty,std::forward_list::empty,std::map::empty,std::unordered_map::empty,std::queue::empty,std::set::empty,std::unordered_set::empty,std::stack::empty,std::string::empty,std::wstring::empty,std::basic_string::empty,std::vector::empty">
     <use-retval/>
     <const/>
     <returnValue type="bool"/>
     <noreturn>false</noreturn>
   </function>
-  <function name="std::deque::push_back,std::deque::push_front,std::list::push_back,std::list::push_front,std::forward_list::push_front,std::queue::push,std::stack::push,std::vector::push_back,std::vector::push_front">
+  <!-- void std::deque::push_back( const T& value ); -->
+  <!-- void std::deque::push_back( T&& value ); // since C++11 -->
+  <!-- void std::deque::push_front( const T& value ); -->
+  <!-- void std::deque::push_front( T&& value ); // since C++11 -->
+  <!-- void std::list::push_back( const T& value ); -->
+  <!-- void std::list::push_back( T&& value ); // since C++11 -->
+  <!-- void std::list::push_front( const T& value ); -->
+  <!-- void std::list::push_front( T&& value ); // since C++11 -->
+  <!-- void std::forward_list::push_front( const T& value ); // since C++11 -->
+  <!-- void std::forward_list::push_front( T&& value ); // since C++11 -->
+  <!-- void std::queue::push( const value_type& value ); -->
+  <!-- void std::queue::push( value_type&& value ); // since C++11 -->
+  <!-- void std::stack::push( const value_type& value ); -->
+  <!-- void std::stack::push( value_type&& value ); // since C++11 -->
+  <!-- void std::vector::push_back( const T& value ); -->
+  <!-- void std::vector::push_back( T&& value ); // since C++11 -->
+  <function name="std::deque::push_back,std::deque::push_front,std::list::push_back,std::list::push_front,std::forward_list::push_front,std::queue::push,std::stack::push,std::vector::push_back">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <arg nr="1">
       <not-uninit/>
     </arg>
   </function>
+  <!-- iterator std::list::insert( iterator pos, const T& value ); // until C++11 -->
+  <!-- iterator std::list::insert( const_iterator pos, const T& value ); // since C++11 -->
+  <!-- iterator std::list::insert( const_iterator pos, T&& value ); // since C++11 -->
+  <!-- void std::list::insert( iterator pos, size_type count, const T& value ); // until C++11 -->
+  <!-- iterator std::list::insert( const_iterator pos, size_type count, const T& value ); // since C++11 -->
+  <!-- template<class InputIt> void std::list::insert( iterator pos, InputIt first, InputIt last); until C++11 -->
+  <!-- template<class InputIt> iterator std::list::insert( const_iterator pos, InputIt first, InputIt last ); since C++11 -->
+  <!-- iterator std::list::insert( const_iterator pos, std::initializer_list<T> ilist ); since C++11 -->
+  <!-- For std::multimap::insert see http://en.cppreference.com/w/cpp/container/multimap/insert -->
+  <!-- For std::set::insert see http://en.cppreference.com/w/cpp/container/set/insert -->
+  <!-- For std::string::insert see http://en.cppreference.com/w/cpp/string/basic_string/insert -->
+  <!-- For std::vector::insert see http://en.cppreference.com/w/cpp/container/vector/insert -->
+  <!-- Return value type is "iterator" or "void" depending on the overloaded function. -->
   <function name="std::list::insert,std::multimap::insert,std::set::insert,std::string::insert,std::vector::insert">
     <noreturn>false</noreturn>
     <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" default="0">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" default="0">
       <not-uninit/>
     </arg>
   </function>
@@ -5958,9 +6018,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <noreturn>false</noreturn>
   </function>
+  <!-- char& at(size_t pos); -->
+  <!-- const char& at(size_t pos) const; -->
   <function name="std::string::at">
     <use-retval/>
-    <returnValue type="char"/>
+    <returnValue type="char &amp;"/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -5970,29 +6032,39 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void push_back (char c); -->
   <function name="std::string::push_back">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <arg nr="1">
       <not-uninit/>
     </arg>
   </function>
+  <!-- char& std::string::back(); -->
+  <!-- const char& std::string::back() const; -->
   <function name="std::string::back">
     <use-retval/>
-    <returnValue type="char"/>
+    <returnValue type="char &amp;"/>
     <noreturn>false</noreturn>
   </function>
   <!-- void swap (string& str); -->
   <function name="std::string::swap">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <arg nr="1"/>
   </function>
+  <!-- const char* c_str() const; // until C++11 -->
+  <!-- const char* c_str() const noexcept; // since C++11 -->
+  <!-- const char* data() const; // until C++11 -->
+  <!-- const char* data() const noexcept; // since C++11 -->
   <function name="std::string::c_str,std::string::data">
     <use-retval/>
     <const/>
     <returnValue type="const char *"/>
     <noreturn>false</noreturn>
   </function>
+  <!-- char& front(); -->
+  <!-- const char& front() const; -->
   <function name="std::string::front">
     <use-retval/>
-    <returnValue type="char"/>
+    <returnValue type="char &amp;"/>
     <noreturn>false</noreturn>
   </function>
   <!-- size_t find (const string& str, size_t pos = 0) const; -->
@@ -6139,6 +6211,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void reserve (size_t n = 0); -->
   <function name="std::string::reserve,std::wstring::reserve,std::basic_string::reserve">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1" default="0">
       <not-uninit/>
@@ -6299,6 +6372,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-bool/>
     </arg>
   </function>
+  <!-- template<class BidirIt> void inplace_merge( BidirIt first, BidirIt middle, BidirIt last ); -->
+  <!-- template<class ExecutionPolicy, class BidirIt> void inplace_merge( ExecutionPolicy&& policy, BidirIt first, BidirIt middle, BidirIt last ); // since C++17 -->
+  <!-- template<class BidirIt, class Compare> void inplace_merge( BidirIt first, BidirIt middle, BidirIt last, Compare comp ); -->
+  <!-- template<class ExecutionPolicy, class BidirIt, class Compare> void inplace_merge( ExecutionPolicy&& policy, BidirIt first, BidirIt middle, BidirIt last, Compare comp ); // since C++17 -->
+  <!-- TODO: Function argument configuration is not valid for C++17 function overloads -->
   <function name="std::inplace_merge">
     <noreturn>false</noreturn>
     <arg nr="1">


### PR DESCRIPTION
Add missing returnValue types where appropriate and fixed a few wrong
ones.
Add some missing function names (mostly where the "std::" version of the
function is missing).
Add documentation for some functions where it is missing.
Remove functions that do not exist in the standard: std::array::clear,
std::vector::push_front.