### PR TITLE
qt.cfg: Fix false positives for function disconnect

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -101,7 +101,6 @@
       <not-uninit/>
     </arg>
     <arg nr="3">
-      <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="4">


### PR DESCRIPTION
There is no problem with a null pointer as third argument. 0 is used as
wildcard and stands for all receivers for example.