### PR TITLE
windows library: Add config for some Local* functions

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -5098,6 +5098,70 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
+  <!-- HLOCAL WINAPI LocalAlloc(
+  _In_ UINT   uFlags,
+  _In_ SIZE_T uBytes); -->
+  <function name="LocalAlloc">
+    <noreturn>false</noreturn>
+    <returnValue type="HLOCAL"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="HeapAlloc"/>
+  </function>
+  <!-- HLOCAL WINAPI LocalReAlloc(
+  _In_ HLOCAL hMem,
+  _In_ SIZE_T uBytes,
+  _In_ UINT   uFlags); -->
+  <function name="LocalReAlloc">
+    <noreturn>false</noreturn>
+    <returnValue type="HLOCAL"/>
+    <arg nr="1"/>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- HLOCAL WINAPI LocalFree(_In_ HLOCAL hMem); -->
+  <function name="LocalFree">
+    <noreturn>false</noreturn>
+    <returnValue type="HLOCAL"/>
+    <arg nr="1"/>
+  </function>
+  <!-- UINT WINAPI LocalSize(_In_ HLOCAL hMem); -->
+  <!-- UINT WINAPI LocalFlags(_In_ HLOCAL hMem); -->
+  <function name="LocalSize,LocalFlags">
+    <noreturn>false</noreturn>
+    <returnValue type="UINT"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- LPVOID WINAPI LocalLock(_In_ HLOCAL hMem); -->
+  <function name="LocalLock">
+    <noreturn>false</noreturn>
+    <returnValue type="LPVOID"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- BOOL WINAPI LocalUnlock(_In_ HLOCAL hMem); -->
+  <function name="LocalUnlock">
+    <noreturn>false</noreturn>
+    <returnValue type="BOOL"/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+  </function>
   <!-- Intrinsic __noop https://docs.microsoft.com/en-us/cpp/intrinsics/noop -->
   <function name="__noop">
     <noreturn>false</noreturn>

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -159,6 +159,10 @@ void validCode()
     SecureZeroMemory(byteBuf, sizeof(byteBuf));
     RtlFillMemory(byteBuf, sizeof(byteBuf), 0xff);
 
+    // cppcheck-suppress LocalAllocCalled
+    HLOCAL pLocalAlloc = LocalAlloc(1, 2);
+    LocalFree(pLocalAlloc);
+
     // Intrinsics
     __noop();
     __noop(1, "test", NULL);
@@ -323,6 +327,18 @@ void memleak_HeapAlloc()
     HeapValidate(GetProcessHeap(), 0, pMem);
     // cppcheck-suppress unreadVariable
     SIZE_T memSize = HeapSize(GetProcessHeap(), 0, pMem);
+    // cppcheck-suppress memleak
+}
+
+void memleak_LocalAlloc()
+{
+    LPTSTR pszBuf;
+    // cppcheck-suppress LocalAllocCalled
+    pszBuf = (LPTSTR)LocalAlloc(LPTR, MAX_PATH*sizeof(TCHAR));
+    (void)LocalSize(pszBuf);
+    (void)LocalFlags(pszBuf);
+    LocalLock(pszBuf);
+    LocalUnlock(pszBuf);
     // cppcheck-suppress memleak
 }
 


### PR DESCRIPTION
Add configuration and tests for LocalAlloc, LocalFree and some other
Local* functions.
LocalReAlloc is currently not configured as an alloc/dealloc function
(like realloc is not configured in std.cfg), i am not sure how to
correctly configure it.