### PR TITLE
Fix false positive for opposite conditions when using different containers

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -273,11 +273,15 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
             if (isSameExpression(cpp, true, cond1->astOperand2(), cond2->astOperand2(), library, pure))
                 return isDifferentKnownValues(cond1->astOperand1(), cond2->astOperand1());
         }
-        if (Library::isContainerYield(cond1, Library::Container::EMPTY, "empty") && Library::isContainerYield(cond2->astOperand1(), Library::Container::SIZE, "size")) {
+        if (Library::isContainerYield(cond1, Library::Container::EMPTY, "empty") && 
+            Library::isContainerYield(cond2->astOperand1(), Library::Container::SIZE, "size") && 
+            cond1->astOperand1()->astOperand1()->varId() == cond2->astOperand1()->astOperand1()->astOperand1()->varId()) {
             return !(cond2->str() == "==" && cond2->astOperand2()->getValue(0));
         }
 
-        if (Library::isContainerYield(cond2, Library::Container::EMPTY, "empty") && Library::isContainerYield(cond1->astOperand1(), Library::Container::SIZE, "size")) {
+        if (Library::isContainerYield(cond2, Library::Container::EMPTY, "empty") && 
+            Library::isContainerYield(cond1->astOperand1(), Library::Container::SIZE, "size") &&
+            cond2->astOperand1()->astOperand1()->varId() == cond1->astOperand1()->astOperand1()->astOperand1()->varId()) {
             return !(cond1->str() == "==" && cond1->astOperand2()->getValue(0));
         }
     }

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -1866,6 +1866,12 @@ private:
 
         check("void f1(const std::string &s, bool b) { if(s.empty() || ((s.size() == 1) && b)) {}} ");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f1(const std::string &x, const std::string &y) { if(x.size() > 42) if(y.empty()) {}} ");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f1(const std::string &x, const std::string &y) { if(y.empty()) if(x.size() > 42) {}} ");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void identicalConditionAfterEarlyExit() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -1872,6 +1872,9 @@ private:
 
         check("void f1(const std::string &x, const std::string &y) { if(y.empty()) if(x.size() > 42) {}} ");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f1(const std::string v[10]) { if(v[0].size() > 42) if(v[1].empty()) {}} ");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void identicalConditionAfterEarlyExit() {


### PR DESCRIPTION
This fixes the false positive for things like:

```cpp
void f1(const std::string &x, const std::string &y) { if(y.empty()) if(x.size() > 42) {}}
```