### PR TITLE
Fix false positive of allocation function not being stored when constructing with curly brace

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -2698,8 +2698,15 @@ void CheckMemoryLeakNoVar::checkForUnusedReturnValue(const Scope *scope)
         while (parent && parent->str() == "(" && !parent->astOperand2())
             parent = parent->astParent();
 
-        if (!parent || Token::Match(parent, "%comp%|!"))
+        if (!parent) {
+            // Check if we are in a C++11 constructor
+            const Token * closingBrace = Token::findmatch(tok, "}|;");
+            if(closingBrace->str() == "}" && Token::Match(closingBrace->link()->tokAt(-1), "%name%"))
+                continue; 
             returnValueNotUsedError(tok, tok->str());
+        } else if (Token::Match(parent, "%comp%|!")) {
+            returnValueNotUsedError(tok, tok->str());
+        }
     }
 }
 


### PR DESCRIPTION
This will get rid of the false positives when doing `Handle{fopen(...)}`. 