### PR TITLE
misra.py: Typo in number of rules (comment)

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -11,7 +11,7 @@
 #
 # The MISRA standard documents may be obtained from https://www.misra.org.uk
 #
-# Total number of rules: 153
+# Total number of rules: 143
 
 import cppcheckdata
 import sys


### PR DESCRIPTION
I have no copy of the misra pdf but according to
https://sourceforge.net/p/cppcheck/discussion/general/thread/ccbe9e89/#a6ab
and the number of lines/rules printed by misra.py -generate-table i
guess 143 is really the correct number of rules.