### PR TITLE
windows string macros: Handle _T, _TEXT and TEXT internally, add tests

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -5201,7 +5201,6 @@ HFONT CreateFont(
   <define name="INVALID_SOCKET" value="0"/>
   <define name="WINAPI" value=""/>
   <define name="__pragma(x)" value=""/>
-  <define name="TEXT(str)" value="str"/>
   <define name="_countof(_Array)" value="(sizeof(_Array) / sizeof(_Array[0]))"/>
   <define name="__wchar_t" value="wchar_t"/>
   <define name="RtlEqualMemory(Destination,Source,Length)" value="(!memcmp((Destination),(Source),(Length)))"/>

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9541,13 +9541,13 @@ void Tokenizer::simplifyMicrosoftStringFunctions()
         if (match!=apis.end()) {
             tok->str(ansi ? match->second.mbcs : match->second.unicode);
             tok->originalName(match->first);
-        } else if (Token::Match(tok, "_T ( %char%|%str% )")) {
+        } else if (Token::Match(tok, "_T|_TEXT|TEXT ( %char%|%str% )")) {
             tok->deleteNext();
             tok->deleteThis();
             tok->deleteNext();
             if (!ansi)
                 tok->isLong(true);
-            while (Token::Match(tok->next(), "_T ( %char%|%str% )")) {
+            while (Token::Match(tok->next(), "_T|_TEXT|TEXT ( %char%|%str% )")) {
                 tok->next()->deleteNext();
                 tok->next()->deleteThis();
                 tok->next()->deleteNext();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -364,6 +364,7 @@ private:
         TEST_CASE(simplifyNamespaceStd);
 
         TEST_CASE(microsoftMemory);
+        TEST_CASE(microsoftString);
 
         TEST_CASE(borland);
 
@@ -5716,6 +5717,25 @@ private:
 
         const char code7[] = "void foo() { FillMemory(f(1, g(a, b)), h(i, j(0, 1)), 255); }";
         ASSERT_EQUALS("void foo ( ) { memset ( f ( 1 , g ( a , b ) ) , 255 , h ( i , j ( 0 , 1 ) ) ) ; }", tokenizeAndStringify(code7,false,true,Settings::Win32A));
+    }
+
+    void microsoftString() {
+        const char code1a[] = "void foo() { _tprintf (_T(\"test\") _T(\"1\")); }";
+        ASSERT_EQUALS("void foo ( ) { printf ( \"test1\" ) ; }", tokenizeAndStringify(code1a, false, true, Settings::Win32A));
+        const char code1b[] = "void foo() { _tprintf (_TEXT(\"test\") _TEXT(\"2\")); }";
+        ASSERT_EQUALS("void foo ( ) { printf ( \"test2\" ) ; }", tokenizeAndStringify(code1b, false, true, Settings::Win32A));
+        const char code1c[] = "void foo() { _tprintf (TEXT(\"test\") TEXT(\"3\")); }";
+        ASSERT_EQUALS("void foo ( ) { printf ( \"test3\" ) ; }", tokenizeAndStringify(code1c, false, true, Settings::Win32A));
+
+        const char code2a[] = "void foo() { _tprintf (_T(\"test\") _T(\"1\")); }";
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test1\" ) ; }", tokenizeAndStringify(code2a, false, true, Settings::Win32W));
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test1\" ) ; }", tokenizeAndStringify(code2a, false, true, Settings::Win64));
+        const char code2b[] = "void foo() { _tprintf (_TEXT(\"test\") _TEXT(\"2\")); }";
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test2\" ) ; }", tokenizeAndStringify(code2b, false, true, Settings::Win32W));
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test2\" ) ; }", tokenizeAndStringify(code2b, false, true, Settings::Win64));
+        const char code2c[] = "void foo() { _tprintf (TEXT(\"test\") TEXT(\"3\")); }";
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test3\" ) ; }", tokenizeAndStringify(code2c, false, true, Settings::Win32W));
+        ASSERT_EQUALS("void foo ( ) { wprintf ( L\"test3\" ) ; }", tokenizeAndStringify(code2c, false, true, Settings::Win64));
     }
 
     void borland() {


### PR DESCRIPTION
Remove TEXT() macro from windows.cfg and handle it internally where it
can be correctly simplified (Ansi vs. Unicode).
Also add handling of _TEXT() macro which is just a synonym for _T().
Add tests to verify correct function and macro simplification.