### PR TITLE
Add suppressions to the XML dump

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -437,13 +437,36 @@ class ValueFlow:
         self.values = []
         for value in element:
             self.values.append(ValueFlow.Value(value))
+            
+class Suppression
+    """
+    Suppression class
+    This class contains a suppression entry to suppress a warning.
+    
+    Attributes
+      errorId     The id string of the error to suppress, can be a wildcard
+      fileName    The name of the file to suppress warnings for, can include wildcards
+      lineNumber  The number of the line to suppress warnings from, can be 0 to represent any line
+      symbolName  The name of the symbol to match warnings for, can include wildcards
+    """
+    
+    errorId = None
+    fileName = None
+    lineNumber = None
+    symbolName = None
+    
+    def __init__(self, element):
+        self.errorId = element.get('errorId')
+        self.fileName = element.get('fileName')
+        self.lineNumber = element.get('lineNumber')
+        self.symbolName = element.get('symbolName')
 
 
 class Configuration:
     """
     Configuration class
     This class contains the directives, tokens, scopes, functions,
-    variables and value flows for one configuration.
+    variables, value flows, and suppressions for one configuration.
 
     Attributes:
         name          Name of the configuration, "" for default
@@ -453,6 +476,7 @@ class Configuration:
         functions     List of Function items
         variables     List of Variable items
         valueflow     List of ValueFlow values
+        suppressions  List of warning suppressions
     """
 
     name = ''
@@ -462,6 +486,7 @@ class Configuration:
     functions = []
     variables = []
     valueflow = []
+    suppressions = []
 
     def __init__(self, confignode):
         self.name = confignode.get('cfg')
@@ -471,6 +496,7 @@ class Configuration:
         self.functions = []
         self.variables = []
         self.valueflow = []
+        self.suppressions = []
         arguments = []
 
         for element in confignode:
@@ -506,6 +532,9 @@ class Configuration:
             if element.tag == 'valueflow':
                 for values in element:
                     self.valueflow.append(ValueFlow(values))
+            if element.tag == "suppressions":
+                for suppression in element:
+                    self.suppressions.append(Suppression(suppression))
 
         IdMap = {None: None, '0': None, '00000000': None, '0000000000000000': None}
         for token in self.tokenlist:

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -225,6 +225,9 @@ unsigned int CppCheck::processFile(const std::string& filename, const std::strin
 
         // Parse comments and then remove them
         preprocessor.inlineSuppressions(tokens1);
+		if (_settings.dump && fdump.is_open()) {
+			_settings.nomsg.dump(fdump);
+		}
         tokens1.removeComments();
         preprocessor.removeComments();
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -274,6 +274,23 @@ bool Suppressions::isSuppressed(const Suppressions::ErrorMessage &errmsg)
     return false;
 }
 
+void Suppressions::dump(std::ostream & out)
+{
+	out << "  <suppressions>" << std::endl;
+	for (std::list<Suppression>::const_iterator it = _suppressions.begin(); it != _suppressions.end(); ++it) {
+		const Suppression &suppression = *it;
+		out << "    <suppression";
+		out << " errorId=\"" << ErrorLogger::toxml(suppression.errorId) << '"';
+		if (!suppression.fileName.empty()) 
+			out << " fileName=\"" << ErrorLogger::toxml(suppression.fileName) << '"';
+		out << " lineNumber=\"" << suppression.lineNumber << '"';
+		if (!suppression.symbolName.empty())
+			out << " symbolName=\"" << ErrorLogger::toxml(suppression.symbolName) << '\"';
+		out << " />" << std::endl;
+	}
+	out << "  </suppressions>" << std::endl;
+}
+
 std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions(const std::string &file, const bool unusedFunctionChecking) const
 {
     std::list<Suppression> result;

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -135,6 +135,12 @@ public:
     bool isSuppressed(const ErrorMessage &errmsg);
 
     /**
+	 * @brief Create an xml dump of suppressions
+	 * @param out stream to write XML to
+	*/
+	void dump(std::ostream &out);
+
+    /**
      * @brief Returns list of unmatched local (per-file) suppressions.
      * @return list of unmatched suppressions
      */


### PR DESCRIPTION
This change is to allow addons to use the same suppression syntax as CppCheck.

Currently there are two issues that I know of that need consideration.  
    Firstly I have only added a call to dump() for the nomsg suppressions, which I did because I felt that the nofail suppressions were much more specific to CppCheck's behaviour.  I'm open to contrary opinions if people disagree, this is very easy to change.  
    The second issue is that adding suppressions for addon-specific warnings could trigger CppCheck's unmatchedSuppression warning.  I'm not sure of the best workaround for this.  Those warnings could be suppressed, addon-specific suppressions could be tagged as such so that CppCheck parses them but doesn't validate them, or we could find some other way of CppCheck knowing that a suppression is for an addon and can't be validated.  My biggest concern is that the user adding the suppression shouldn't need to know whether a warning comes from CppCheck or from an addon, because that would mean all users would need more knowledge about how CppCheck work which isn't always practical.