### PR TITLE
GUI: Add "Check library" and "Check configuration" menu entries

### DIFF
--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -77,6 +77,12 @@ public slots:
     /** @brief Slot to reanalyze all files */
     void reAnalyzeAll();
 
+    /** @brief Slot to reanalyze with checking library configuration */
+    void checkLibrary();
+
+    /** @brief Slot to check configuration */
+    void checkConfiguration();
+
     /**
      * @brief Slot to reanalyze selected files
      * @param selectedFilesList list of selected files
@@ -234,8 +240,10 @@ private:
     /**
       * @brief Analyze the project.
       * @param projectFile Pointer to the project to analyze.
+      * @param checkLibrary Flag to indicate if the library should be checked.
+      * @param checkConfiguration Flag to indicate if the configuration should be checked.
       */
-    void analyzeProject(const ProjectFile *projectFile);
+    void analyzeProject(const ProjectFile *projectFile, const bool checkLibrary = false, const bool checkConfiguration = false);
 
     /**
      * @brief Set current language
@@ -271,15 +279,19 @@ private:
     /**
      * @brief Analyze project
      * @param p imported project
+     * @param checkLibrary Flag to indicate if library should be checked
+     * @param checkConfiguration Flag to indicate if the configuration should be checked.
      */
-    void doAnalyzeProject(ImportProject p);
+    void doAnalyzeProject(ImportProject p, const bool checkLibrary = false, const bool checkConfiguration = false);
 
     /**
      * @brief Analyze all files specified in parameter files
      *
      * @param files List of files and/or directories to analyze
+     * @param checkLibrary Flag to indicate if library should be checked
+     * @param checkConfiguration Flag to indicate if the configuration should be checked.
      */
-    void doAnalyzeFiles(const QStringList &files);
+    void doAnalyzeFiles(const QStringList &files, const bool checkLibrary = false, const bool checkConfiguration = false);
 
     /**
      * @brief Get our default cppcheck settings and read project file.

--- a/gui/mainwindow.ui
+++ b/gui/mainwindow.ui
@@ -150,6 +150,8 @@
     <addaction name="mActionAnalyzeDirectory"/>
     <addaction name="mActionReanalyzeModified"/>
     <addaction name="mActionReanalyzeAll"/>
+    <addaction name="mActionCheckLibrary"/>
+    <addaction name="mActionCheckConfiguration"/>
     <addaction name="mActionStop"/>
     <addaction name="separator"/>
     <addaction name="menuC_standard"/>
@@ -791,6 +793,22 @@
    </property>
    <property name="text">
     <string>C++14</string>
+   </property>
+  </action>
+  <action name="mActionCheckLibrary">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Reanalyze and check library</string>
+   </property>
+  </action>
+  <action name="mActionCheckConfiguration">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Check configuration (defines, includes)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
They both are only enabled when a project is loaded and when started
they reanalyze the project one time with the according settings.