### PR TITLE
Check for double frees when using smart pointers

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -550,7 +550,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
         }
 
         // Check smart pointer
-        else if (Token::Match(ftok, "%type% < %type%") && (ftok->str() == "auto_ptr" || ftok->str() == "unique_ptr" || ftok->str() == "shared_ptr")) {
+        else if (Token::Match(ftok, "auto_ptr|unique_ptr|shared_ptr < %type%")) {
 
             const Token * endToken = ftok->linkAt(1);
             // TODO: Check deallocator

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -559,12 +559,12 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
 
 
             const Token * endToken = ftok->linkAt(1);
+            if(!Token::Match(endToken, "> %var% {|( %var%"))
+                continue;
 
             bool arrayDelete = false;
             if(Token::findsimplematch(ftok->tokAt(1), "[ ]", endToken))
                 arrayDelete = true;
-            if(!Token::Match(endToken, "> %var% {|( %var%"))
-                continue;
             
             // Check deleter
             const Token * deleterToken = nullptr;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -548,6 +548,21 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
         else if (Token::Match(tok, "continue|break ;")) {
             varInfo->clear();
         }
+
+        // Check smart pointer
+        else if (Token::Match(ftok, "%type% < %type%") && (ftok->str() == "auto_ptr" || ftok->str() == "unique_ptr" || ftok->str() == "shared_ptr")) {
+
+            const Token * endToken = ftok->linkAt(1);
+            // TODO: Check deallocator
+            bool arrayDelete = false;
+            if(Token::findsimplematch(ftok->tokAt(1), "[ ]", endToken))
+                arrayDelete = true;
+            if(!Token::Match(endToken, "> %var% {|( %var%"))
+                continue;
+            const Token * vtok = endToken->tokAt(3);
+            const VarInfo::AllocInfo allocation(arrayDelete ? -2 : -1, VarInfo::DEALLOC);
+            changeAllocStatus(varInfo, allocation, vtok, vtok);
+        }
     }
 }
 

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -563,9 +563,9 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                 continue;
 
             bool arrayDelete = false;
-            if(Token::findsimplematch(ftok->tokAt(1), "[ ]", endToken))
+            if(Token::findsimplematch(ftok->next(), "[ ]", endToken))
                 arrayDelete = true;
-            
+
             // Check deleter
             const Token * deleterToken = nullptr;
             const Token * endDeleterToken = nullptr;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -565,7 +565,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             if(!Token::Match(endToken, "> %var% {|( %var%"))
                 continue;
             const Token * vtok = endToken->tokAt(3);
-            const VarInfo::AllocInfo allocation(arrayDelete ? -2 : -1, VarInfo::DEALLOC);
+            const VarInfo::AllocInfo allocation(arrayDelete ? NEW_ARRAY : NEW, VarInfo::DEALLOC);
             changeAllocStatus(varInfo, allocation, vtok, vtok);
         }
     }

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -47,6 +47,11 @@ public:
          */
         int type;
         AllocInfo(int type_ = 0, AllocStatus status_ = NOALLOC) : status(status_), type(type_) {}
+
+        bool managed() const
+        {
+            return status < 0;
+        }
     };
     std::map<unsigned int, AllocInfo> alloctype;
     std::map<unsigned int, std::string> possibleUsage;

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -38,7 +38,7 @@ class Tokenizer;
 
 class CPPCHECKLIB VarInfo {
 public:
-    enum AllocStatus { DEALLOC = -1, NOALLOC = 0, ALLOC = 1 };
+    enum AllocStatus { OWNED = -2, DEALLOC = -1, NOALLOC = 0, ALLOC = 1 };
     struct AllocInfo {
         AllocStatus status;
         /** Allocation type. If it is a positive value then it corresponds to

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -770,7 +770,7 @@ std::string Library::getFunctionName(const Token *ftok, bool *error) const
 
 std::string Library::getFunctionName(const Token *ftok) const
 {
-    if (!Token::Match(ftok, "%name% (") && ftok->strAt(-1) != "&")
+    if (!Token::Match(ftok, "%name% (") && (ftok->strAt(-1) != "&" || ftok->previous()->astOperand2()))
         return "";
 
     // Lookup function name using AST..

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -770,7 +770,7 @@ std::string Library::getFunctionName(const Token *ftok, bool *error) const
 
 std::string Library::getFunctionName(const Token *ftok) const
 {
-    if (!Token::Match(ftok, "%name% ("))
+    if (!Token::Match(ftok, "%name% (") && ftok->strAt(-1) != "&")
         return "";
 
     // Lookup function name using AST..

--- a/lib/token.h
+++ b/lib/token.h
@@ -197,7 +197,7 @@ public:
      * @return length of C-string.
      *
      * Should be called for %%str%% tokens only.
-     *
+     *@
      * @param tok token with C-string
      **/
     static std::size_t getStrLength(const Token *tok);

--- a/lib/token.h
+++ b/lib/token.h
@@ -197,7 +197,7 @@ public:
      * @return length of C-string.
      *
      * Should be called for %%str%% tokens only.
-     *@
+     *
      * @param tok token with C-string
      **/
     static std::size_t getStrLength(const Token *tok);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -918,6 +918,21 @@ private:
               "    delete i;\n"
               "}\n", true);
         ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+
+        // Check for use-after-free FP
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::shared_ptr<int> x{i};\n"
+              "    *x = 123;\n"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int[1];\n"
+              "    std::unique_ptr<int[]> x(i);\n"
+              "    delete i;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
     }
 
     void exit1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1201,6 +1201,12 @@ private:
     void smartPointerDeleter() {
         check("void f() {\n"
               "    FILE*f=fopen(fname,a);\n"
+              "    std::unique_ptr<FILE> fp{f};\n"
+              "}", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: f\n", errout.str());
+
+        check("void f() {\n"
+              "    FILE*f=fopen(fname,a);\n"
               "    std::unique_ptr<FILE, decltype(&fclose)> fp{f, &fclose};\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1223,6 +1223,22 @@ private:
               "    std::unique_ptr<FILE, deleter> fp{f};\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+
+        check("int * create();\n"
+              "void destroy(int * x);\n"
+              "void f() {\n"
+              "    int x * = create()\n"
+              "    std::unique_ptr<int, decltype(&destroy)> xp{x, &destroy()};\n"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("int * create();\n"
+              "void destroy(int * x);\n"
+              "void f() {\n"
+              "    int x * = create()\n"
+              "    std::unique_ptr<int, decltype(&destroy)> xp(x, &destroy());\n"
+              "}\n", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void return1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -902,6 +902,13 @@ private:
 
         check("void f() {\n"
               "    int * i = new int;\n"
+              "    delete i;\n"
+              "    std::unique_ptr<int> x(i);\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int;\n"
               "    std::unique_ptr<int> x{i};\n"
               "    delete i;\n"
               "}\n", true);
@@ -925,7 +932,7 @@ private:
         check("void f() {\n"
               "    int * i = new int;\n"
               "    std::shared_ptr<int> x{i};\n"
-              "    *x = 123;\n"
+              "    *i = 123;\n"
               "}\n", true);
         ASSERT_EQUALS("", errout.str());
 

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1175,6 +1175,18 @@ private:
               "    char *cPtr = new (buf) char[100];\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int[1];\n"
+              "    std::unique_ptr<int> x(i);\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: i\n", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::unique_ptr<int[]> x(i);\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: i\n", errout.str());
     }
 
     void return1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -72,6 +72,7 @@ private:
         TEST_CASE(doublefree5); // #5522
         TEST_CASE(doublefree6); // #7685
         TEST_CASE(doublefree7);
+        TEST_CASE(doublefree8);
 
         // exit
         TEST_CASE(exit1);
@@ -887,6 +888,36 @@ private:
               "        delete[] p;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void doublefree8() {
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::unique_ptr<int> x(i);\n"
+              "    delete i;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::unique_ptr<int> x{i};\n"
+              "    delete i;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::shared_ptr<int> x(i);\n"
+              "    delete i;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+
+        check("void f() {\n"
+              "    int * i = new int;\n"
+              "    std::shared_ptr<int> x{i};\n"
+              "    delete i;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
     }
 
     void exit1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -105,6 +105,8 @@ private:
 
         // mismatching allocation/deallocation
         TEST_CASE(mismatchAllocDealloc);
+        
+        TEST_CASE(smartPointerDeleter);
 
         // Execution reaches a 'return'
         TEST_CASE(return1);
@@ -1187,6 +1189,27 @@ private:
               "    std::unique_ptr<int[]> x(i);\n"
               "}\n", true);
         ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: i\n", errout.str());
+    }
+
+    void smartPointerDeleter() {
+        check("void f() {\n"
+              "    FILE*f=fopen(fname,a);\n"
+              "    std::unique_ptr<FILE, decltype(&fclose)> fp{f, &fclose};\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    FILE*f=fopen(fname,a);\n"
+              "    std::shared_ptr<FILE> fp{f, &fclose};\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct deleter { void operator()(FILE* f) { fclose(f); }};\n"
+              "void f() {\n"
+              "    FILE*f=fopen(fname,a);\n"
+              "    std::unique_ptr<FILE, deleter> fp{f};\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void return1() {


### PR DESCRIPTION
This catches double frees with smart pointers:

```cpp
#include <iostream>
#include <memory>
 
int main()
{
    int *i = new int;
    // smart pointer gets ownership
    std::unique_ptr<int> x(i);
    // this delete leads to a double free!!
    delete i;
}
```