### PR TITLE
Fix warning emitted by clang.

### DIFF
--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -72,6 +72,7 @@ public:
                 return fileName < other.fileName;
             if (symbolName != other.symbolName)
                 return symbolName < other.symbolName;
+            return false;
         };
 
         /**


### PR DESCRIPTION
Get rid of those

```
In file included from lib/analyzerinfo.cpp:19:
In file included from lib/analyzerinfo.h:25:
In file included from lib/errorlogger.h:25:
lib/suppressions.h:75:9: warning: control may reach end of non-void function [-Wreturn-type]
        };
        ^
1 warning generated.
```