### PR TITLE
Ticket #8436: Handle C++11 initializations within ternary operator.

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -599,7 +599,7 @@ static void compileTerm(Token *&tok, AST_state& state)
                 compileUnaryOp(tok, state, compileExpression);
             else
                 compileBinOp(tok, state, compileExpression);
-            if (Token::simpleMatch(tok, "} ,")) {
+            if (Token::Match(tok, "} ,|:")) {
                 tok = tok->next();
             }
         } else if (!state.inArrayAssignment && !Token::simpleMatch(prev, "=")) {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -74,6 +74,7 @@ private:
         TEST_CASE(tokenize33);  // #5780 Various crashes on valid template code
         TEST_CASE(tokenize34);  // #8031
         TEST_CASE(tokenize35);  // #8361
+        TEST_CASE(tokenize36);  // #8436
 
         TEST_CASE(validate);
 
@@ -848,6 +849,11 @@ private:
     void tokenize35() { // #8361
         tokenizeAndStringify("typedef int CRCWord; "
                              "template<typename T> ::CRCWord const Compute(T const t) { return 0; }");
+    }
+
+    void tokenize36() { // #8436
+        const char code[] = "int foo ( int i ) { return i ? * new int { 5 } : int { i ? 0 : 1 } ; }";
+        ASSERT_EQUALS(code, tokenizeAndStringify(code));
     }
 
     void validate() {


### PR DESCRIPTION
This patch fixes AST construction for expressions involving the ternary operator and C++11 initializations.