### PR TITLE
GUI: Remove connect call with nonexistent slot function

### DIFF
--- a/gui/codeeditor.cpp
+++ b/gui/codeeditor.cpp
@@ -138,7 +138,6 @@ CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent)
 
     connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
     connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
 
     updateLineNumberAreaWidth(0);
 }


### PR DESCRIPTION
When starting the application Qt prints this message:
QObject::connect: No such slot CodeEditor::highlightCurrentLine() in
..\gui\codeeditor.cpp:141
And this function really does not exist, i guess it is some relict. If
it is planned to implement it this PR can just be closed.