### PR TITLE
GUI: Fix wrong receivers in connect calls

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -536,9 +536,9 @@ void MainWindow::analyzeCode(const QString& code, const QString& filename)
     connect(&result, SIGNAL(error(const ErrorItem &)),
             mUI.mResults, SLOT(error(const ErrorItem &)));
     connect(&result, SIGNAL(log(const QString &)),
-            this, SLOT(log(const QString &)));
+            mUI.mResults, SLOT(log(const QString &)));
     connect(&result, SIGNAL(debugError(const ErrorItem &)),
-            this, SLOT(debugError(const ErrorItem &)));
+            mUI.mResults, SLOT(debugError(const ErrorItem &)));
 
     // Create CppCheck instance
     CppCheck cppcheck(result, true);


### PR DESCRIPTION
Since the slots (functions) are not existent in the class MainWindow and
Qt complains that it can not connect the slots i guess it has been
forgotten to change the receiver.
The ResultsView class (from which mUI.mResults is an instance) contains
these slots, so i guess they should be connected here.