### PR TITLE
Adjust summary for the rule “modernizeUseNullPtr”

### DIFF
--- a/rules/suggest_nullptr.xml
+++ b/rules/suggest_nullptr.xml
@@ -5,6 +5,6 @@
     <message>
         <id>modernizeUseNullPtr</id>
         <severity>style</severity>
-        <summary>Prefer to use a 'nullptr' instead of initialize a pointer with 0.</summary>
+        <summary>Prefer to use a 'nullptr' instead of initializing a pointer with 0.</summary>
     </message>
 </rule>


### PR DESCRIPTION
Correct a wording in the summary for this rule.