### PR TITLE
Report opposite expressions

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1970,10 +1970,11 @@ void CheckOther::checkDuplicateExpression()
                             duplicateExpressionError(tok, tok, tok->str());
                         }
                     } 
-                } else if (styleEnabled && isOppositeCond(true, _tokenizer->isCPP(), tok->astOperand1(), tok->astOperand2(), _settings->library, false)) {
-                    if (isWithoutSideEffects(_tokenizer->isCPP(), tok->astOperand1())) {
-                        oppositeExpressionError(tok, tok, tok->str());
-                    }
+                } else if (styleEnabled && 
+                    isOppositeCond(true, _tokenizer->isCPP(), tok->astOperand1(), tok->astOperand2(), _settings->library, false) && 
+                    !Token::simpleMatch(tok, "=") &&
+                    isWithoutSideEffects(_tokenizer->isCPP(), tok->astOperand1())) {
+                    oppositeExpressionError(tok, tok, tok->str());
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
                     if (styleEnabled && tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), tok->astOperand1()->astOperand2(), _settings->library, true) && isWithoutSideEffects(_tokenizer->isCPP(), tok->astOperand2()))
                         duplicateExpressionError(tok->astOperand2(), tok->astOperand2(), tok->str());

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1969,6 +1969,10 @@ void CheckOther::checkDuplicateExpression()
                             }
                             duplicateExpressionError(tok, tok, tok->str());
                         }
+                    } 
+                } else if (styleEnabled && isOppositeCond(true, _tokenizer->isCPP(), tok->astOperand1(), tok->astOperand2(), _settings->library, false)) {
+                    if (isWithoutSideEffects(_tokenizer->isCPP(), tok->astOperand1())) {
+                        oppositeExpressionError(tok, tok, tok->str());
                     }
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
                     if (styleEnabled && tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), tok->astOperand1()->astOperand2(), _settings->library, true) && isWithoutSideEffects(_tokenizer->isCPP(), tok->astOperand2()))
@@ -1996,6 +2000,16 @@ void CheckOther::checkDuplicateExpression()
             }
         }
     }
+}
+
+void CheckOther::oppositeExpressionError(const Token *tok1, const Token *tok2, const std::string &op)
+{
+    const std::list<const Token *> toks = { tok2, tok1 };
+
+    reportError(toks, Severity::style, "oppositeExpression", "Opposite expression on both sides of \'" + op + "\'.\n"
+                "Finding the opposite expression on both sides of an operator is suspicious and might "
+                "indicate a cut and paste or logic error. Please examine this code carefully to "
+                "determine if it is correct.", CWE398, false);
 }
 
 void CheckOther::duplicateExpressionError(const Token *tok1, const Token *tok2, const std::string &op)

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -239,6 +239,7 @@ private:
     void misusedScopeObjectError(const Token *tok, const std::string &varname);
     void duplicateBranchError(const Token *tok1, const Token *tok2);
     void duplicateAssignExpressionError(const Token *tok1, const Token *tok2);
+    void oppositeExpressionError(const Token *tok1, const Token *tok2, const std::string &op);
     void duplicateExpressionError(const Token *tok1, const Token *tok2, const std::string &op);
     void duplicateValueTernaryError(const Token *tok);
     void duplicateExpressionTernaryError(const Token *tok);
@@ -298,6 +299,7 @@ private:
         c.clarifyCalculationError(nullptr,  "+");
         c.clarifyStatementError(nullptr);
         c.duplicateBranchError(nullptr, nullptr);
+        c.oppositeExpressionError(nullptr, nullptr, "&&");
         c.duplicateExpressionError(nullptr, nullptr, "&&");
         c.duplicateValueTernaryError(nullptr);
         c.duplicateExpressionTernaryError(nullptr);

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -131,6 +131,7 @@ private:
         TEST_CASE(duplicateValueTernary);
         TEST_CASE(duplicateExpressionTernary); // #6391
         TEST_CASE(duplicateExpressionTemplate); // #6930
+        TEST_CASE(oppositeExpression);
         TEST_CASE(duplicateVarExpression);
 
         TEST_CASE(checkSignOfUnsignedVariable);
@@ -3916,6 +3917,33 @@ private:
               "\n"
               "static auto a = f<0>();");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void oppositeExpression() {
+        check("void f(bool a) { if(a && !a) {} }");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '&&'.\n", errout.str());
+
+        check("void f(bool a) { if(a != !a) {} }");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
+        
+        check("void f(bool a) { if( a == !(a) ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '=='.\n", errout.str());
+        
+        
+        check("void f(bool a) { if( a != !(a) ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
+        
+        check("void f(bool a) { if( !(a) == a ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '=='.\n", errout.str());
+        
+        check("void f(bool a) { if( !(a) != a ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
+        
+        check("void f(bool a) { if( !(!a) == !(a) ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '=='.\n", errout.str());
+        
+        check("void f(bool a) { if( !(!a) != !(a) ) {}}");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
     }
 
     void duplicateVarExpression() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3929,7 +3929,6 @@ private:
         check("void f(bool a) { if( a == !(a) ) {}}");
         ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '=='.\n", errout.str());
         
-        
         check("void f(bool a) { if( a != !(a) ) {}}");
         ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
         
@@ -3944,6 +3943,9 @@ private:
         
         check("void f(bool a) { if( !(!a) != !(a) ) {}}");
         ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1]: (style) Opposite expression on both sides of '!='.\n", errout.str());
+        
+        check("void f(bool a) { a = !a; }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateVarExpression() {


### PR DESCRIPTION
This will report when opposite expressions are used in operators, such as:

```cpp
void f(bool a) { if(a != !a) {} }
```