### PR TITLE
std.cfg: Add some missing C++11 declarations and not-bool attributes

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -3127,25 +3127,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isfinite(double x); -->
-  <function name="isfinite">
-    <use-retval/>
-    <pure/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-  </function>
   <!-- bool isfinite(float x); // since C++11 -->
   <!-- bool isfinite(double x); // since C++11 -->
   <!-- bool isfinite(long double x); // since C++11 -->
   <!-- bool isfinite(Integral x); // since C++11 -->
-  <function name="std::isfinite">
+  <function name="isfinite,std::isfinite">
     <use-retval/>
     <pure/>
-    <returnValue type="bool"/>
+    <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3182,25 +3171,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isinf(double x); -->
-  <function name="isinf">
-    <use-retval/>
-    <pure/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-  </function>
   <!-- bool isinf(float x); // since C++11 -->
   <!-- bool isinf(double x); // since C++11 -->
   <!-- bool isinf(long double x); // since C++11 -->
   <!-- bool isinf(Integral x); // since C++11 -->
-  <function name="std::isinf">
+  <function name="isinf,std::isinf">
     <use-retval/>
     <pure/>
-    <returnValue type="bool"/>
+    <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3320,25 +3298,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isnan(double x); -->
-  <function name="isnan">
-    <use-retval/>
-    <pure/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-  </function>
   <!-- bool isnan(float x); // since C++11 -->
   <!-- bool isnan(double x); // since C++11 -->
   <!-- bool isnan(long double x); // since C++11 -->
   <!-- bool isnan(Integral x); // since C++11 -->
-  <function name="std::isnan">
+  <function name="isnan,std::isnan">
     <use-retval/>
     <pure/>
-    <returnValue type="bool"/>
+    <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3347,25 +3314,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isnormal(double x); -->
-  <function name="isnormal">
-    <use-retval/>
-    <pure/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-  </function>
   <!--bool isnormal(float x); // since C++11 -->
   <!--bool isnormal(double x); // since C++11 -->
   <!--bool isnormal(long double x); // since C++11 -->
   <!--bool isnormal(Integral x); // since C++11 -->
-  <function name="std::isnormal">
+  <function name="isnormal,std::isnormal">
     <use-retval/>
     <pure/>
-    <returnValue type="bool"/>
+    <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3374,29 +3330,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isunordered(double x, double y);-->
-  <function name="isunordered">
-    <use-retval/>
-    <pure/>
-    <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="1">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-    <arg nr="2">
-      <not-uninit/>
-      <not-bool/>
-    </arg>
-  </function>
   <!-- bool isunordered(float x, float y); // since C++11 -->
   <!-- bool isunordered(double x, double y); // since C++11 -->
   <!-- bool isunordered(long double x, long double y); // since C++11 -->
   <!-- bool isunordered(Arithmetic x, Arithmetic y); // since C++11 -->
-  <function name="std::isunordered">
+  <function name="isunordered,std::isunordered">
     <use-retval/>
     <pure/>
-    <returnValue type="bool"/>
+    <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -3127,7 +3127,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isfinite(double x); -->
-  <function name="isfinite,std::isfinite">
+  <function name="isfinite">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
@@ -3135,6 +3135,22 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- bool isfinite(float x); // since C++11 -->
+  <!-- bool isfinite(double x); // since C++11 -->
+  <!-- bool isfinite(long double x); // since C++11 -->
+  <!-- bool isfinite(Integral x); // since C++11 -->
+  <function name="std::isfinite">
+    <use-retval/>
+    <pure/>
+    <returnValue type="bool"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- int isgreater(double x, double y); -->
@@ -3166,7 +3182,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isinf(double x); -->
-  <function name="isinf,std::isinf">
+  <function name="isinf">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
@@ -3174,6 +3190,22 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- bool isinf(float x); // since C++11 -->
+  <!-- bool isinf(double x); // since C++11 -->
+  <!-- bool isinf(long double x); // since C++11 -->
+  <!-- bool isinf(Integral x); // since C++11 -->
+  <function name="std::isinf">
+    <use-retval/>
+    <pure/>
+    <returnValue type="bool"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- double logb(double x); -->
@@ -3288,7 +3320,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     </arg>
   </function>
   <!-- int isnan(double x); -->
-  <function name="isnan,std::isnan">
+  <function name="isnan">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
@@ -3296,10 +3328,26 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- bool isnan(float x); // since C++11 -->
+  <!-- bool isnan(double x); // since C++11 -->
+  <!-- bool isnan(long double x); // since C++11 -->
+  <!-- bool isnan(Integral x); // since C++11 -->
+  <function name="std::isnan">
+    <use-retval/>
+    <pure/>
+    <returnValue type="bool"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- int isnormal(double x); -->
-  <function name="isnormal,std::isnormal">
+  <function name="isnormal">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
@@ -3307,10 +3355,26 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!--bool isnormal(float x); // since C++11 -->
+  <!--bool isnormal(double x); // since C++11 -->
+  <!--bool isnormal(long double x); // since C++11 -->
+  <!--bool isnormal(Integral x); // since C++11 -->
+  <function name="std::isnormal">
+    <use-retval/>
+    <pure/>
+    <returnValue type="bool"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- int isunordered(double x, double y);-->
-  <function name="isunordered,std::isunordered">
+  <function name="isunordered">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
@@ -3318,9 +3382,30 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
+      <not-bool/>
     </arg>
     <arg nr="2">
       <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- bool isunordered(float x, float y); // since C++11 -->
+  <!-- bool isunordered(double x, double y); // since C++11 -->
+  <!-- bool isunordered(long double x, long double y); // since C++11 -->
+  <!-- bool isunordered(Arithmetic x, Arithmetic y); // since C++11 -->
+  <function name="std::isunordered">
+    <use-retval/>
+    <pure/>
+    <returnValue type="bool"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- int ilogb(double x); -->


### PR DESCRIPTION
Move std::... functions with bool instead of int return type to their
own function configurations.
Add not-bool for the arguments that must not be bool.