### PR TITLE
Fix double free regression with smart pointers

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -562,7 +562,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
 
 
             const Token * typeEndTok = ftok->linkAt(1);
-            if (!Token::Match(typeEndTok, "> %var% {|( %var%"))
+            if (!Token::Match(typeEndTok, "> %var% {|( %var% ,|)|}"))
                 continue;
 
             bool arrayDelete = false;

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -73,6 +73,8 @@ private:
         TEST_CASE(doublefree6); // #7685
         TEST_CASE(doublefree7);
         TEST_CASE(doublefree8);
+        TEST_CASE(doublefree9);
+
 
         // exit
         TEST_CASE(exit1);
@@ -942,6 +944,17 @@ private:
               "    delete i;\n"
               "}\n", true);
         ASSERT_EQUALS("[test.cpp:4]: (error) Memory pointed to by 'i' is freed twice.\n", errout.str());
+    }
+
+    void doublefree9() {
+      check("struct foo {\n"
+            "    int* get(int) { return new int(); }\n"
+            "};\n"
+            "void f(foo* b) {\n"
+            "    std::unique_ptr<int> x(b->get(0));\n"
+            "    std::unique_ptr<int> y(b->get(1));\n"
+            "}\n", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void exit1() {


### PR DESCRIPTION
This fixes false positive for:

```cpp
#include <memory>

struct Foo {};

struct Bar
{
    Foo* get(int) { return new Foo(); }
};

void foo(Bar* b)
{
    std::unique_ptr<Foo> x(b->get(0));
    std::unique_ptr<Foo> y(b->get(1));
}
```