### PR TITLE
std.cfg: Fix minsize configuration for vsprintf

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -5646,7 +5646,6 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
-      <minsize type="argvalue" arg="2"/>
     </arg>
     <arg nr="2">
       <not-null/>

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -3493,6 +3493,24 @@ void uninitvar_vsprintf(void)
     (void)vsprintf(s,format,arg);
 }
 
+void valid_vsprintf_helper(const char * format, ...)
+{
+    char buffer[2];
+    va_list args;
+    va_start(args, format);
+    vsprintf(buffer, format, args);
+    printf(buffer);
+    va_end(args);
+}
+
+void valid_vsprintf()
+{
+    // buffer will contain "2\0" => no bufferAccessOutOfBounds
+    // cppcheck-suppress checkLibraryFunction
+    // cppcheck-suppress checkLibraryNoReturn
+    valid_vsprintf_helper("%1.0f", 2.0f);
+}
+
 void uninitvar_vswprintf(void)
 {
     wchar_t *s;


### PR DESCRIPTION
minsize with argvalue for arg 2 which is a char pointer makes no sense.
Changing it to minsize with strlen for arg 2 results in false positives
(and i think false negatives too).
In std.c a test with a valid vsprintf usage is added that would result
in a FP when minsize with strlen for arg 2 would be used.