### PR TITLE
Move three assignments behind a sanity check in Token::insertToken()

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -909,11 +909,12 @@ void Token::insertToken(const std::string &tokenStr, const std::string &original
     newToken->str(tokenStr);
     if (!originalNameStr.empty())
         newToken->originalName(originalNameStr);
-    newToken->_linenr = _linenr;
-    newToken->_fileIndex = _fileIndex;
-    newToken->_progressValue = _progressValue;
 
     if (newToken != this) {
+        newToken->_linenr = _linenr;
+        newToken->_fileIndex = _fileIndex;
+        newToken->_progressValue = _progressValue;
+
         if (prepend) {
             /*if (this->previous())*/ {
                 newToken->previous(this->previous());


### PR DESCRIPTION
Three attributes were reset in this member function even if their values are stored in the same token object.
[I suggest](https://trac.cppcheck.net/ticket/8532 "Adjust implementation of Token::insertToken()") to move a corresponding sanity check so that less assignments could be performed eventually.