### PR TITLE
Fix false positive with inner conditions when using pointers

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -645,7 +645,7 @@ void CheckCondition::multiCondition2()
                     const Token *parent = tok;
                     while (Token::Match(parent->astParent(), ".|[") || (Token::simpleMatch(parent->astParent(), "*") && !parent->astParent()->astOperand2()))
                         parent = parent->astParent();
-                    if (Token::Match(parent->astParent(), "%assign%"))
+                    if (Token::Match(parent->astParent(), "%assign%|++|--"))
                         break;
                 }
                 if (_tokenizer->isCPP() && Token::Match(tok, "%name% <<") && (!tok->valueType() || !tok->valueType()->isIntegral()))

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -90,6 +90,7 @@ private:
         TEST_CASE(identicalInnerCondition);
 
         TEST_CASE(identicalConditionAfterEarlyExit);
+        TEST_CASE(innerConditionModified);
 
         TEST_CASE(clarifyCondition1);     // if (a = b() < 0)
         TEST_CASE(clarifyCondition2);     // if (a & b == c)
@@ -1986,6 +1987,32 @@ private:
               "  in >> ch;\n"
               "  if (ch != '|') {}\n"
               "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void innerConditionModified() {
+        check("void f(int x, int y) {\n"
+              "  if (x == 0) {\n"
+              "    x += y;\n"
+              "    if (x == 0) {}\n"
+              "  }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int x) {\n"
+              "  if (x == 0) {\n"
+              "    x += y;\n"
+              "    if (x == 1) {}\n"
+              "  }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int * x, int * y) {\n"
+              "  if (x[*y] == 0) {\n"
+              "    (*y)++;\n"
+              "    if (x[*y] == 0) {}\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
This checks if the pointer gets modified with `++` or `--`. Ideally, it might be better to reuse `isVariableModified` for this instead.