### PR TITLE
checkunusedfunctions.cpp: Fix files.txt parsing

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -392,11 +392,11 @@ void CheckUnusedFunctions::analyseWholeProgram(ErrorLogger * const errorLogger, 
         const std::string::size_type firstColon = filesTxtLine.find(':');
         if (firstColon == std::string::npos)
             continue;
-        const std::string::size_type lastColon = filesTxtLine.rfind(':');
-        if (firstColon == lastColon)
+        const std::string::size_type secondColon = filesTxtLine.find(':', firstColon+1);
+        if (secondColon == std::string::npos)
             continue;
         const std::string xmlfile = buildDir + '/' + filesTxtLine.substr(0,firstColon);
-        const std::string sourcefile = filesTxtLine.substr(lastColon+1);
+        const std::string sourcefile = filesTxtLine.substr(secondColon+1);
 
         tinyxml2::XMLDocument doc;
         const tinyxml2::XMLError error = doc.LoadFile(xmlfile.c_str());


### PR DESCRIPTION
On Windows searching for the last colon finds the colon which is part of
the path of the source file (e.g. "C:/projects/a.cpp"). Thus the path is
saved incompletely. This fix searches for the second instead of the last
colon and uses the data after the second colon as the path of the source
file.