### PR TITLE
Fix FP when using `-` as a binary operator

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -365,9 +365,9 @@ bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * cons
         return false;
     if (isOppositeCond(true, cpp, tok1, tok2, library, pure))
         return true;
-    if (tok1->str() == "-")
+    if (tok1->str() == "-" && !tok1->astOperand2()) 
         return isSameExpression(cpp, true, tok1->astOperand1(), tok2, library, pure);
-    if (tok2->str() == "-")
+    if (tok2->str() == "-" && !tok1->astOperand2())
         return isSameExpression(cpp, true, tok2->astOperand1(), tok1, library, pure);
     return false;
 }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3955,6 +3955,9 @@ private:
 
         check("void f(int a) { a = a / (-a); }");
         ASSERT_EQUALS("", errout.str());
+
+        check("bool f(int i){ return !((i - 1) & i); }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateVarExpression() {


### PR DESCRIPTION
This fixes issue 8537:

```cpp
bool f(int i){ return !((i - 1) & i); }
```