### PR TITLE
Fix false positive with negative array index in issue 8536

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1663,7 +1663,7 @@ static bool valueFlowForward(Token * const               startToken,
                 // '{'
                 Token * const startToken1 = tok2->linkAt(1)->next();
 
-                valueFlowForward(startToken1->next(),
+                if (!valueFlowForward(startToken1->next(),
                                  startToken1->link(),
                                  var,
                                  varid,
@@ -1672,7 +1672,8 @@ static bool valueFlowForward(Token * const               startToken,
                                  subFunction,
                                  tokenlist,
                                  errorLogger,
-                                 settings);
+                                 settings))
+                    return false;
 
                 if (!condAlwaysFalse && isVariableChanged(startToken1, startToken1->link(), varid, var->isGlobal(), settings, tokenlist->isCPP())) {
                     removeValues(values, truevalues);
@@ -1691,7 +1692,7 @@ static bool valueFlowForward(Token * const               startToken,
                 if (Token::simpleMatch(tok2, "} else {")) {
                     Token * const startTokenElse = tok2->tokAt(2);
 
-                    valueFlowForward(startTokenElse->next(),
+                    if (!valueFlowForward(startTokenElse->next(),
                                      startTokenElse->link(),
                                      var,
                                      varid,
@@ -1700,7 +1701,8 @@ static bool valueFlowForward(Token * const               startToken,
                                      subFunction,
                                      tokenlist,
                                      errorLogger,
-                                     settings);
+                                     settings))
+                        return false;
 
                     if (!condAlwaysTrue && isVariableChanged(startTokenElse, startTokenElse->link(), varid, var->isGlobal(), settings, tokenlist->isCPP())) {
                         removeValues(values, falsevalues);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1663,7 +1663,7 @@ static bool valueFlowForward(Token * const               startToken,
                 // '{'
                 Token * const startToken1 = tok2->linkAt(1)->next();
 
-                if (!valueFlowForward(startToken1->next(),
+                bool vfresult = valueFlowForward(startToken1->next(),
                                  startToken1->link(),
                                  var,
                                  varid,
@@ -1672,8 +1672,7 @@ static bool valueFlowForward(Token * const               startToken,
                                  subFunction,
                                  tokenlist,
                                  errorLogger,
-                                 settings))
-                    return false;
+                                 settings);
 
                 if (!condAlwaysFalse && isVariableChanged(startToken1, startToken1->link(), varid, var->isGlobal(), settings, tokenlist->isCPP())) {
                     removeValues(values, truevalues);
@@ -1683,7 +1682,7 @@ static bool valueFlowForward(Token * const               startToken,
                 // goto '}'
                 tok2 = startToken1->link();
 
-                if (isReturnScope(tok2)) {
+                if (isReturnScope(tok2) || !vfresult) {
                     if (condAlwaysTrue)
                         return false;
                     removeValues(values, truevalues);
@@ -1692,7 +1691,7 @@ static bool valueFlowForward(Token * const               startToken,
                 if (Token::simpleMatch(tok2, "} else {")) {
                     Token * const startTokenElse = tok2->tokAt(2);
 
-                    if (!valueFlowForward(startTokenElse->next(),
+                    vfresult = valueFlowForward(startTokenElse->next(),
                                      startTokenElse->link(),
                                      var,
                                      varid,
@@ -1701,8 +1700,7 @@ static bool valueFlowForward(Token * const               startToken,
                                      subFunction,
                                      tokenlist,
                                      errorLogger,
-                                     settings))
-                        return false;
+                                     settings);
 
                     if (!condAlwaysTrue && isVariableChanged(startTokenElse, startTokenElse->link(), varid, var->isGlobal(), settings, tokenlist->isCPP())) {
                         removeValues(values, falsevalues);
@@ -1712,7 +1710,7 @@ static bool valueFlowForward(Token * const               startToken,
                     // goto '}'
                     tok2 = startTokenElse->link();
 
-                    if (isReturnScope(tok2)) {
+                    if (isReturnScope(tok2) || !vfresult) {
                         if (condAlwaysFalse)
                             return false;
                         removeValues(values, falsevalues);

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -134,6 +134,7 @@ private:
         TEST_CASE(array_index_calculation);
         TEST_CASE(array_index_negative1);
         TEST_CASE(array_index_negative2);    // ticket #3063
+        TEST_CASE(array_index_negative3);
         TEST_CASE(array_index_for_decr);
         TEST_CASE(array_index_varnames);     // FP: struct member. #1576
         TEST_CASE(array_index_for_continue); // for,continue
@@ -1776,6 +1777,22 @@ private:
               "    test.a[-1] = 3;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Array 'test.a[10]' accessed at index -1, which is out of bounds.\n", errout.str());
+    }
+
+    void array_index_negative3() {
+      check("int f(int i) {\n"
+            "    int p[2] = {0, 0};\n"
+            "    if(i >= 2)\n"
+            "        return 0;\n"
+            "    else if(i == 0)\n"
+            "        return 0;\n"
+            "    return p[i - 1];\n"
+            "}\n"
+            "void g(int i) {\n"
+            "    if( i == 0 )\n"
+            "        return f(i);\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void array_index_for_decr() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -2455,6 +2455,18 @@ private:
         ASSERT_EQUALS(false, testValueOfX(code, 3U, 0));
         ASSERT_EQUALS(true, testValueOfX(code, 3U, 4));
 
+        code = "int f(int i) {\n"
+               "  if(i >= 2)\n"
+               "    return 0;\n"
+               "  else if(i == 0)\n"
+               "    return 0;\n"
+               "  int a = i;\n"
+               "}\n"
+               "void g(int i) {\n"
+               "  return f(0);\n"
+               "}";
+        ASSERT_EQUALS(false, testValueOfX(code, 6U, 0));
+
         code = "void f1(int x) { a=x; }\n"
                "void f2(int y) { f1(y<123); }\n";
         ASSERT_EQUALS(true, testValueOfX(code, 1U, 0));


### PR DESCRIPTION
This fixes the false positive for cases like this:

```cpp
int f(int i) {
    int p[2] = {0, 0};
    if(i >= 2)
        return 0;
    else if(i == 0)
        return 0;
    return p[i - 1];
}
void g(int i) {
    if( i == 0 )
        return f(i);
}
```