### PR TITLE
Use compiled regular expressions for DACA2 functions

### DIFF
--- a/tools/daca2-report.py
+++ b/tools/daca2-report.py
@@ -94,6 +94,7 @@ for severity in ['error', 'warning', 'style', 'portability', 'performance']:
     categories[severity] = []
 
 daca2 = daca2folder
+pattern = re.compile(r'.*: (error|warning|style|performance|portability):.* \[([a-zA-Z0-9_\\-]+)\]')
 for lib in (False, True):
     for a in "0123456789abcdefghijklmnopqrstuvwxyz":
         if lib:
@@ -120,7 +121,7 @@ for lib in (False, True):
             datestr = ''
 
         for line in data.split('\n'):
-            res = re.match(r'.*: (error|warning|style|performance|style|portability):.* \[([a-zA-Z0-9_\\-]+)\]', line)
+            res = pattern.match(line)
             if res is None:
                 continue
             severity = res.group(1)

--- a/tools/daca2-search.cgi
+++ b/tools/daca2-search.cgi
@@ -53,10 +53,10 @@ def doSearch(path,arguments):
 
 def summary(path, arguments):
   count = {}
+  pattern = re.compile(r'.*: (error|warning|style|performance|portability):.*\[([a-zA-Z0-9]+)\]$')
   for g in getfiles(path, arguments):
     for line in readlines(g):
-      line = trimline(line)
-      res = re.match(r'.*: (error|warning|style|performance|portability):.*\[([a-zA-Z0-9]+)\]$', line)
+      res = pattern.match(trimline(line))
       if res is None:
         continue
       id = res.group(2)


### PR DESCRIPTION
​​[The method “match”](https://docs.python.org/3/library/re.html#re.match "Matching a regular expression pattern") was used as a module-level function in ​for loops of implementations for DACA2 functions [so far](https://trac.cppcheck.net/ticket/8553 "Using compiled regular expressions for DACA2 function implementations").
* Use ​[compiled regular expression objects](https://docs.python.org/3/library/re.html#re-objects "Efficient matching of regular expression patterns") instead.
* Delete a duplicate element from an alternation.