### PR TITLE
Fix false positive with oppositeExpression when using binary op

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -365,9 +365,9 @@ bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * cons
         return false;
     if (isOppositeCond(true, cpp, tok1, tok2, library, pure))
         return true;
-    if (tok1->str() == "-" && !(tok1->astOperand2() && tok1->astOperand1()))
+    if (tok1->str() == "-" && !tok1->astOperand2())
         return isSameExpression(cpp, true, tok1->astOperand1(), tok2, library, pure);
-    if (tok2->str() == "-" && !(tok2->astOperand2() && tok2->astOperand1()))
+    if (tok2->str() == "-" && !tok2->astOperand2())
         return isSameExpression(cpp, true, tok2->astOperand1(), tok1, library, pure);
     return false;
 }

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -365,9 +365,9 @@ bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * cons
         return false;
     if (isOppositeCond(true, cpp, tok1, tok2, library, pure))
         return true;
-    if (tok1->str() == "-" && !tok1->astOperand2())
+    if (tok1->str() == "-" && !(tok1->astOperand2() && tok1->astOperand1()))
         return isSameExpression(cpp, true, tok1->astOperand1(), tok2, library, pure);
-    if (tok2->str() == "-" && !tok1->astOperand2())
+    if (tok2->str() == "-" && !(tok2->astOperand2() && tok2->astOperand1()))
         return isSameExpression(cpp, true, tok2->astOperand1(), tok1, library, pure);
     return false;
 }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3958,6 +3958,9 @@ private:
 
         check("bool f(int i){ return !((i - 1) & i); }");
         ASSERT_EQUALS("", errout.str());
+
+        check("bool f(unsigned i){ return (x > 0) && (x & (x-1)) == 0; }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateVarExpression() {


### PR DESCRIPTION
This fixes issue 8549:

```cpp
bool test_one_bit_set(unsigned x)
{
    return (x > 0) && (x & (x-1)) == 0;
}
```