### PR TITLE
Fix false positive when using null arithmetic with class type

### DIFF
--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -528,11 +528,18 @@ void CheckNullPointer::arithmetic()
             if (!Token::Match(tok, "-|+|+=|-=|++|--"))
                 continue;
             const Token *pointerOperand;
-            if (tok->astOperand1() && tok->astOperand1()->valueType() && tok->astOperand1()->valueType()->pointer != 0)
+            const Token *numericOperand;
+            if (tok->astOperand1() && tok->astOperand1()->valueType() && tok->astOperand1()->valueType()->pointer != 0) {
                 pointerOperand = tok->astOperand1();
-            else if (tok->astOperand2() && tok->astOperand2()->valueType() && tok->astOperand2()->valueType()->pointer != 0)
+                numericOperand = tok->astOperand2();
+            }
+            else if (tok->astOperand2() && tok->astOperand2()->valueType() && tok->astOperand2()->valueType()->pointer != 0) {
                 pointerOperand = tok->astOperand2();
+                numericOperand = tok->astOperand1();
+            }
             else
+                continue;
+            if (numericOperand && numericOperand->valueType() && !numericOperand->valueType()->isIntegral())
                 continue;
             MathLib::bigint checkValue = 0;
             // When using an assign op, the value read from

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2649,6 +2649,11 @@ private:
 
         check("int* f10() { int *x = NULL; return x++; } ");
         ASSERT_EQUALS("[test.cpp:1]: (error) Pointer addition with NULL pointer.\n", errout.str());
+
+        check("class foo {};\n"
+              "const char* get() const { return 0; }\n"
+              "void f(foo x) { if (get()) x += get(); }\n");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
This should fix issue 8559:

```cpp
class foo
{
};

const char* get() const { return 0; }

void CreateOverlay()
{
        foo xFoo;

        if (get())
        {
                xFoo += get();
        }
}
```