### PR TITLE
Remove duplicate namespace aliases so they don't produce syntax errors.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10227,10 +10227,10 @@ static bool sameTokens(const Token *first, const Token *last, const Token *other
 
 static Token * deleteAlias(Token * tok)
 {
-    // delete all tokens up to ';'
-    do {
-        tok->deleteThis();
-    } while (tok->str() != ";");
+    Token::eraseTokens(tok, Token::findsimplematch(tok, ";"));
+
+    // delete first token
+    tok->deleteThis();
 
     // delete ';' if not last token
     tok->deleteThis();

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -3547,6 +3547,11 @@ private:
         ASSERT_EQUALS("namespace NS { boost :: iostreams :: istream foo ( \"foo\" ) ; }",
                       tok("namespace NS { using namespace std; namespace ios = boost::iostreams; ios::istream foo(\"foo\"); }"));
 
+        // duplicate namespace aliases
+        ASSERT_EQUALS(";",
+                      tok("namespace ios = boost::iostreams;\nnamespace ios = boost::iostreams;"));
+        ASSERT_EQUALS(";",
+                      tok("namespace ios = boost::iostreams;\nnamespace ios = boost::iostreams;\nnamespace ios = boost::iostreams;"));
         ASSERT_EQUALS("namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; } } }",
                       tok("namespace A::B {"
                           "namespace AB = A::B;"
@@ -3556,6 +3561,8 @@ private:
                           "}"
                           "namespace AB = A::B;" //duplicate declaration
                           "}"));
+
+        // redeclared nested namespace aliases
         TODO_ASSERT_EQUALS("namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; { baz ( A :: a ( ) ) ; } bar ( A :: B :: ab ( ) ) ; } } }",
                            "namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; { baz ( A :: B :: a ( ) ) ; } bar ( A :: B :: ab ( ) ) ; } } }",
                            tok("namespace A::B {"

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -3546,6 +3546,31 @@ private:
                       tok("using namespace std; namespace ios = boost::iostreams;"));
         ASSERT_EQUALS("namespace NS { boost :: iostreams :: istream foo ( \"foo\" ) ; }",
                       tok("namespace NS { using namespace std; namespace ios = boost::iostreams; ios::istream foo(\"foo\"); }"));
+
+        ASSERT_EQUALS("namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; } } }",
+                      tok("namespace A::B {"
+                          "namespace AB = A::B;"
+                          "void foo() {"
+                          "    namespace AB = A::B;" // duplicate declaration
+                          "    bar(AB::ab());"
+                          "}"
+                          "namespace AB = A::B;" //duplicate declaration
+                          "}"));
+        TODO_ASSERT_EQUALS("namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; { baz ( A :: a ( ) ) ; } bar ( A :: B :: ab ( ) ) ; } } }",
+                           "namespace A { namespace B { void foo ( ) { bar ( A :: B :: ab ( ) ) ; { baz ( A :: B :: a ( ) ) ; } bar ( A :: B :: ab ( ) ) ; } } }",
+                           tok("namespace A::B {"
+                               "namespace AB = A::B;"
+                               "void foo() {"
+                               "    namespace AB = A::B;" // duplicate declaration
+                               "    bar(AB::ab());"
+                               "    {"
+                               "         namespace AB = A;"
+                               "         baz(AB::a());" // redeclaration OK
+                               "    }"
+                               "    bar(AB::ab());"
+                               "}"
+                               "namespace AB = A::B;" //duplicate declaration
+                               "}"));
     }
 };
 


### PR DESCRIPTION
DACA2 results showed new SymbolDatabase syntax errors when duplicate
namespace aliases were simplified improperly. The solution is to remove
them in the tokenizer when found.