### PR TITLE
Added ignore list to misra.py addon

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1617,18 +1617,18 @@ parser.add_argument("-generate-table", help="Generate rule table", action="store
 parser.add_argument("file", help="Path of dump file from cppcheck")
 args = parser.parse_args()
 
-if args.verify:
-    VERIFY = True
-elif args.generate_table:
+if args.generate_table:
     generateTable()
 else:
+    if args.verify:
+        VERIFY = True
     if args.rule_texts:
         filename = os.path.normpath(args.rule_texts)
         if not os.path.isfile(filename):
             print('Fatal error: file is not found: ' + filename)
             sys.exit(1)
         loadRuleTexts(filename)
-    if args.ignore_rules:
-        setIgnoreList(args.ignore_rules)
+    if args.suppress_rules:
+        setIgnoreList(args.suppress_rules)
     if args.file:
         parseDump(args.file)

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1611,7 +1611,7 @@ def parseDump(dumpfile):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--rule-texts", type=str, help="Path to text file of MISRA rules")
-parser.add_argument("--ignore-rules", type=str, help="MISRA rules to ignore (comma-separated string)")
+parser.add_argument("--suppress-rules", type=str, help="MISRA rules to suppress (comma-separated)")
 parser.add_argument("-verify", help="Verify check", action="store_true")
 parser.add_argument("-generate-table", help="Generate rule table", action="store_true")
 parser.add_argument("file", help="Path of dump file from cppcheck")


### PR DESCRIPTION
- Added ignore list
- Use argparse to parse arguments
- Python formatting

Provide a comma-separated list of rules to ignore. For example
```bash
cppcheck --max-configs=1 --dump test/misra-test.c
python misra.py --rule-texts misra-texts.txt --ignore-rules 12.1,8.14 test/misra-test.c.dump
```
