### PR TITLE
Added TODO test for #8262

### DIFF
--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -141,6 +141,8 @@ private:
         TEST_CASE(testKeywords); // #6767
 
         TEST_CASE(inlineFunction); // #3989
+
+		TEST_CASE(smartPtrInContainer); // #8262
     }
 
     void check(const char code[], bool cpp = false) {
@@ -1520,6 +1522,19 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
     }
+
+	// #8262
+	void smartPtrInContainer() {
+		check(  "std::list< std::shared_ptr<int> > mList;\n"
+				"void test(){\n"
+				"  int *pt = new int(1);\n"
+				"  mList.push_back(std::shared_ptr<int>(pt));\n"
+				"}\n",
+				true
+			);
+		TODO_ASSERT_EQUALS("", "[test.cpp:5]: (error) Memory leak: pt\n", errout.str());
+	}
+
 };
 
 REGISTER_TEST(TestLeakAutoVar)


### PR DESCRIPTION
Added TODO test case for
```cpp
std::list< std::shared_ptr<int> > mList;

void test(){
  int *pt = new int(1);
  mList.push_back(std::shared_ptr<int>(pt));  
}

```