### PR TITLE
Missing override specifier warning on a pure virtual function makes n…

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2584,7 +2584,7 @@ void CheckClass::checkOverride()
             if (func.hasOverrideSpecifier() || func.hasFinalSpecifier())
                 continue;
             const Function *baseFunc = func.getOverridenFunction();
-            if (baseFunc)
+            if (baseFunc && !baseFunc->isPure())
                 overrideError(baseFunc, &func);
         }
     }

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -212,6 +212,7 @@ private:
         TEST_CASE(unsafeClassDivZero);
 
         TEST_CASE(override1);
+        TEST_CASE(override2);
     }
 
     void checkCopyCtorAndEqOperator(const char code[]) {
@@ -6782,6 +6783,19 @@ private:
                       "class Derived : Base { virtual void f() final; };");
         ASSERT_EQUALS("", errout.str());
     }
+
+    void override2() {
+        checkOverride("class TimerResultsIntf {\n"
+                      "public:\n"
+                      "    virtual void AddResults(const std::string& str, std::clock_t clocks) = 0;\n"
+                      "};\n"
+                      "class TimerResults : public TimerResultsIntf {\n"
+                      "public:\n"
+                      "    virtual void AddResults(const std::string& str, std::clock_t clocks);\n"
+                      "};");
+        ASSERT_EQUALS("", errout.str());
+    };
+
 };
 
 REGISTER_TEST(TestClass)


### PR DESCRIPTION
…o sense.

This fixes a large number of false positives for cppcheck source code.