### PR TITLE
Modified rule 8.12

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -594,24 +594,22 @@ def misra_8_11(data):
 
 
 def misra_8_12(data):
-    for token in data.tokenlist:
-        if token.str != '{':
+    for scope in data.scopes:
+        enum = []
+        implicit_enum = []
+        if scope.type != 'Enum':
             continue
-        if not token.scope or token.scope.type != 'Enum':
-            continue
-        etok = token
-        values = []
-        while etok:
-            if etok.str == '}':
-                break
-            if etok.str == '=':
-                rhsValues = etok.astOperand2.values
-                if rhsValues and len(rhsValues) == 1:
-                    if rhsValues[0].intvalue in values:
-                        reportError(etok, 8, 12)
-                        break
-                    values.append(rhsValues[0].intvalue)
-            etok = etok.next
+        e_token = scope.bodyStart.next
+        while e_token != scope.bodyEnd:
+            if e_token.values:
+                enum.append(e_token.str)
+            if (e_token.values and e_token.isName and e_token.next.str != "="):
+                for v in e_token.values:
+                    implicit_enum.append(v.intvalue)
+            e_token = e_token.next
+        for implicit_enum_value in implicit_enum:
+            if str(implicit_enum_value) in enum:
+                reportError(scope.bodyStart, 8, 12)
 
 
 def misra_8_14(rawTokens):

--- a/addons/test/misra-test.c
+++ b/addons/test/misra-test.c
@@ -55,7 +55,7 @@ const char *s41_2 = "\x41\x42";
 
 void misra_5_1() {
   int a123456789012345678901234567890; // no-warning
-  int a1234567890123456789012345678901; // 5.1 ,5.2
+  int a1234567890123456789012345678901; // 5.1 5.2
 }
 
 extern int misra_5_3_var_hides_var______31x;
@@ -127,15 +127,13 @@ void misra_7_1() {
 
 void misra_7_3() {
   int x = 12l; // 7.3
-  int x = 12lu; // 7.3, 5.2
+  int x = 12lu; // 7.3 5.2
 }
 
 extern int a811[]; // 8.11
 
-enum e812 {
-  A=3,
-  B=3 // 8.12
-};
+enum misra_8_12_a { misra_a1 = 1, misra_a2 = 2, misra_a3, misra_a4 = 3 }; //8.12
+enum misra_8_12_b { misra_b1, misra_b2, misra_b3 = 3, misra_b4 = 3 }; // no-warning
 
 void misra_8_14(char * restrict str) {} // 8.14
 


### PR DESCRIPTION
According to rule 8.12, the value of an implicitly-specified enumeration constant shall be unique.
If an enumeration constant is explicitly specified, it need not be unique.