### PR TITLE
windows.cfg: Add 32/64 bit time related functions and types.

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -3789,8 +3789,8 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <!-- errno_t _localtime32_s( struct tm* _tm, const time32_t *time);
-       errno_t _localtime64_s( struct tm* _tm, const _time64_t *time); -->
+  <!-- errno_t _localtime32_s( struct tm* _tm, const __time32_t *time);
+       errno_t _localtime64_s( struct tm* _tm, const __time64_t *time); -->
   <function name="_localtime32_s,_localtime64_s">
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
@@ -3800,6 +3800,26 @@ HFONT CreateFont(
     </arg>
     <arg nr="2">
       <not-null/>
+    </arg>
+  </function>
+  <!-- __time32_t _time32( __time32_t *destTime ); -->
+  <function name="_time32">
+    <returnValue type="__time32_t"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- __time64_t _time64( __time64_t *destTime ); -->
+  <function name="_time64">
+    <returnValue type="__time64_t"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <!-- BOOL WINAPI CreateDirectory(_In_ LPCTSTR lpPathName,
@@ -5263,6 +5283,8 @@ HFONT CreateFont(
   <podtype name="POINTER_SIGNED" sign="s"/>
   <podtype name="POINTER_UNSIGNED" sign="u"/>
   <podtype name="ULARGE_INTEGER" sign="u" size="8"/>
+  <podtype name="__time32_t" sign="s" size="4"/>
+  <podtype name="__time64_t" sign="s" size="8"/>
   <define name="afx_msg" value=""/>
   <define name="DEBUG_NEW" value="new"/>
   <define name="DECLARE_MESSAGE_MAP()" value=""/>


### PR DESCRIPTION
Fix declaration comments for _localtime32_s() and _localtime64_s().
Add functions _time32 and _time64, and types __time32_t and __time64_t.
References: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-s-localtime32-s-localtime64-s
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/time-time32-time64