### PR TITLE
Allow per project misra.py addon

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1455,7 +1455,7 @@ def generateTable():
     # what rules are handled by this addon?
     addon = []
     compiled = re.compile(r'[ ]+misra_([0-9]+)_([0-9]+)[(].*')
-    for line in open('misra.py'):
+    for line in open('__file__'):
         res = compiled.match(line)
         if res is None:
             continue


### PR DESCRIPTION
Use python's __file__ variable to figure out where the checker script is
located.

This allows a customized per project scripts to be used instead of the
one provided in the cppcheck release.