### PR TITLE
Show summary of violations

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -23,9 +23,10 @@ import subprocess
 ruleTexts = {}
 
 VERIFY = False
+SHOW_SUMMARY = True
 VERIFY_EXPECTED = []
 VERIFY_ACTUAL = []
-
+VIOLATIONS = []
 
 def reportError(location, num1, num2):
     if VERIFY:
@@ -39,8 +40,10 @@ def reportError(location, num1, num2):
             errmsg = 'misra violation (use --rule-texts=<file> to get proper output) [' + id + ']'
         else:
             return
-        sys.stderr.write('[' + location.file + ':' + str(location.linenr) + '] (style): ' + errmsg + '\n')
+        errmsg = '[' + location.file + ':' + str(location.linenr) + '] (style): ' + errmsg + '\n'
+        sys.stderr.write(errmsg)
 
+        VIOLATIONS.append(errmsg)
 
 def simpleMatch(token, pattern):
     for p in pattern.split(' '):
@@ -1493,10 +1496,13 @@ for arg in sys.argv[1:]:
         continue
     elif arg == "-generate-table":
         generateTable()
+    elif arg == "--no-summary":
+        SHOW_SUMMARY = False
     else:
         print('Fatal error: unhandled argument ' + arg)
         sys.exit(1)
 
+exitCode = 0
 for arg in sys.argv[1:]:
     if not arg.endswith('.dump'):
         continue
@@ -1618,4 +1624,11 @@ for arg in sys.argv[1:]:
             if actual not in VERIFY_EXPECTED:
                 print('Not expected: ' + actual)
                 exitCode = 1
-        sys.exit(exitCode)
+
+if not VERIFY:
+    if len(VIOLATIONS) > 0:
+        if SHOW_SUMMARY:
+            print("\nRule violations found: %d\n"%(len(VIOLATIONS)))
+        exitCode = 1
+
+sys.exit(exitCode)


### PR DESCRIPTION
- Show a summary of the of the number of violations.  This can be
  disabled with the --no-summary option.

- Return an error code if -verify flag not used and violation exists.