### PR TITLE
windows.cfg: Add macros SUCCEEDED() and FAILED().

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -5349,4 +5349,8 @@ HFONT CreateFont(
   <define name="LOBYTE(wValue)" value="((BYTE)(((DWORD_PTR)(wValue)) &amp; 0xff))"/>
   <!-- BYTE HIBYTE(WORD wValue); -->
   <define name="HIBYTE(wValue)" value="((BYTE)((((DWORD_PTR)(wValue)) &gt;&gt; 8) &amp; 0xff))"/>
+  <!-- BOOL SUCCEEDED(HRESULT hr); -->
+  <define name="SUCCEEDED(hr)" value="(((HRESULT)(hr)) &gt;= 0)"/>
+  <!-- BOOL FAILED(HRESULT hr); -->
+  <define name="FAILED(hr)" value="(((HRESULT)(hr)) &lt; 0)"/>
 </def>

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -706,3 +706,12 @@ void uninitvar_towupper(_locale_t l)
     // cppcheck-suppress uninitvar
     (void)_towupper_l(i, l);
 }
+
+void oppositeInnerCondition_SUCCEEDED_FAILED(HRESULT hr)
+{
+    if (SUCCEEDED(hr)) {
+        // TODO ticket #8596 cppcheck-suppress oppositeInnerCondition
+        if (FAILED(hr)) {
+        }
+    }
+}


### PR DESCRIPTION
Somehow the opposite inner condition is not detected when macros are used. I created this ticket: https://trac.cppcheck.net/ticket/8596