### PR TITLE
small change

### DIFF
--- a/tools/git-pre-commit-cppcheck
+++ b/tools/git-pre-commit-cppcheck
@@ -38,7 +38,7 @@ fi
 
 # We should pass only added or modified C/C++ source files to cppcheck.
 changed_files=$(git diff-index --cached $against | \
-	grep -E '[MA]	.*\.(c|cpp|cc|cxx)$' | cut -d'	' -f 2)
+	grep -E '[MA]	.*\.(c|cpp|cc|cxx)$' | cut -f 2)
 
 if [ -n "$changed_files" ]; then
 	cppcheck --error-exitcode=1 $changed_files


### PR DESCRIPTION
do not need -d'^i'(TAB) argument for cut command, it's easy to input wrong invisible char when user copping the script.
cut' default delimiter  is TAB, so this argument is needless 