### PR TITLE
Use modern CMake syntax.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(CppCheck)
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 2.8.11)
 
 include(GNUInstallDirs)
 

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -1,6 +1,8 @@
 if (BUILD_GUI)
-    set(GUI_QT_COMPONENTS Core Gui Widgets PrintSupport)
-    find_package(Qt5 COMPONENTS ${GUI_QT_COMPONENTS})
+    find_package(Qt5Core)
+    find_package(Qt5Gui)
+    find_package(Qt5Widgets)
+    find_package(Qt5PrintSupport)
     find_package(Qt5LinguistTools)
 endif()
 
@@ -21,4 +23,3 @@ if (NOT ${USE_MATCHCOMPILER_OPT} STREQUAL "Off")
         set(USE_MATCHCOMPILER_OPT "Off")
     endif()
 endif()
-

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -24,7 +24,7 @@ if (BUILD_GUI)
     if (HAVE_RULES)
         target_link_libraries(cppcheck-gui pcre)
     endif()
-    qt5_use_modules(cppcheck-gui ${GUI_QT_COMPONENTS})
+    target_link_libraries(cppcheck-gui Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport Qt5::LinguistTools)
 
     install(TARGETS cppcheck-gui RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)
     install(FILES ${qms} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)


### PR DESCRIPTION
The qt5_use_modules syntax has been obsoleted and no longer works in up-to-date CMake (Fedora rawhide). This PR makes the program build again using standard CMake syntax.