### PR TITLE
One more Qt5 CMake fix

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -24,7 +24,7 @@ if (BUILD_GUI)
     if (HAVE_RULES)
         target_link_libraries(cppcheck-gui pcre)
     endif()
-    target_link_libraries(cppcheck-gui Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport Qt5::LinguistTools)
+    target_link_libraries(cppcheck-gui Qt5::Core Qt5::Gui Qt5::Widgets Qt5::PrintSupport)
 
     install(TARGETS cppcheck-gui RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)
     install(FILES ${qms} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT applications)


### PR DESCRIPTION
#1273 erroneously tried to link to Qt5LinguistTools, which isn't a library. This is fixed in the current PR; sorry for not realizing this before #1273 was merged. I guess Travis isn't checking CMake builds, since the earlier job went through? :stuck_out_tongue: 