### PR TITLE
qt.cfg: Add obsolete functions with warning and one alternative one.

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -660,6 +660,36 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- QtMessageHandler qInstallMessageHandler(QtMessageHandler handler) -->
+  <function name="qInstallMessageHandler">
+    <noreturn>false</noreturn>
+    <returnValue type="QtMessageHandler"/>
+    <arg nr="1">
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- QtMsgHandler qInstallMsgHandler(QtMsgHandler handler) -->
+  <function name="qInstallMsgHandler">
+    <noreturn>false</noreturn>
+    <returnValue type="QtMsgHandler"/>
+    <arg nr="1">
+      <not-bool/>
+    </arg>
+    <warn severity="style" alternatives="qInstallMessageHandler" reason="Obsolete"/>
+  </function>
+  <!-- int qrand() -->
+  <function name="qrand">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="int"/>
+    <warn severity="style" alternatives="QRandomGenerator" reason="Obsolete"/>
+  </function>
+  <!-- void qsrand(uint seed) -->
+  <function name="qsrand">
+    <noreturn>false</noreturn>
+    <arg nr="1"/>
+    <warn severity="style" alternatives="QRandomGenerator" reason="Obsolete"/>
+  </function>
   <!-- QString & QString::remove(int position, int n) -->
   <!-- QString & QString::remove(QChar ch, Qt::CaseSensitivity cs = Qt::CaseSensitive) -->
   <!-- QString & QString::remove(const QString & str, Qt::CaseSensitivity cs = Qt::CaseSensitive) -->


### PR DESCRIPTION
For qInstallMsgHandler there is an alternative function qInstallMessageHandler. Both are added.
For qsrand and qrand there is only a hint that the class QRandomGenerator should be used instead.
Reference: https://doc.qt.io/qt-5/qtglobal-obsolete.html