### PR TITLE
Fix Fix FP when using non-const members and also check return type of function for uniqueness

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -433,8 +433,13 @@ bool isUniqueExpression(const Token* tok)
         const Scope * scope = fun->nestedIn;
         if (!scope)
             return true;
+        std::string returnType = fun->retType ? fun->retType->name() : fun->retDef->stringifyList(fun->tokenDef);
         for (const Function& f:scope->functionList) {
-            if (f.argumentList.size() == fun->argumentList.size() && f.name() != fun->name()) {
+            std::string freturnType = f.retType ? f.retType->name() : f.retDef->stringifyList(f.tokenDef);
+            if (f.argumentList.size() == fun->argumentList.size() &&
+                f.type == Function::eFunction &&
+                returnType == freturnType &&
+                f.name() != fun->name()) {
                 return false;
             }
         }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1947,7 +1947,7 @@ void CheckOther::checkDuplicateExpression()
                         tok->next()->tokType() != Token::eType &&
                         tok->next()->tokType() != Token::eName &&
                         isSameExpression(_tokenizer->isCPP(), true, tok->next(), nextAssign->next(), _settings->library, true) &&
-                        isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), nextAssign->astOperand2(), _settings->library, false) &&
+                        isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), nextAssign->astOperand2(), _settings->library, true) &&
                         !isUniqueExpression(tok->astOperand2())) {
                         duplicateAssignExpressionError(var1, var2);
                     }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3969,11 +3969,12 @@ private:
 
     void duplicateVarExpression() {
         check("int f() __attribute__((pure));\n"
+              "int g() __attribute__((pure));\n"
               "void test() {\n"
               "    int i = f();\n"
               "    int j = f();\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("struct Foo { int f() const; int g() const; };\n"
               "void test() {\n"
@@ -3993,18 +3994,20 @@ private:
         ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:5]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("int f() __attribute__((pure));\n"
+              "int g() __attribute__((pure));\n"
               "void test() {\n"
               "    int i = 1 + f();\n"
               "    int j = 1 + f();\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("int f() __attribute__((pure));\n"
+              "int g() __attribute__((pure));\n"
               "void test() {\n"
               "    int i = f() + f();\n"
               "    int j = f() + f();\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("int f(int) __attribute__((pure));\n"
               "int g(int) __attribute__((pure));\n"
@@ -4047,6 +4050,7 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("int f();\n"
+              "int g();\n"
               "void test() {\n"
               "    int i = f() || f();\n"
               "    int j = f() && f();\n"
@@ -4064,6 +4068,22 @@ private:
               "void test() {\n"
               "    Foo i = Foo{};\n"
               "    Foo j = Foo{};\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct Foo { int f() const; float g() const; };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct Foo { int f(); int g(); };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
               "}");
         ASSERT_EQUALS("", errout.str());
 


### PR DESCRIPTION
This should fix issue 8613:

```cpp
class PortWindow
{
public:
  ~PortWindow();
  uint16_t newPort();
};

class CommandHandler
{
public:
  void f();
  PortWindow& port_window_;
};

void CommandHandler::f()
{
      uint16_t port1 = port_window_.newPort();
      uint16_t port2 = port_window_.newPort();
      if(!port1 || !port2) {
      }
}
```