### PR TITLE
Fix crash in isUniqueExpression when there is no return type parsed

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -433,9 +433,9 @@ bool isUniqueExpression(const Token* tok)
         const Scope * scope = fun->nestedIn;
         if (!scope)
             return true;
-        std::string returnType = fun->retType ? fun->retType->name() : fun->retDef->stringifyList(fun->tokenDef);
+        std::string returnType = fun->getReturnTypeName();
         for (const Function& f:scope->functionList) {
-            std::string freturnType = f.retType ? f.retType->name() : f.retDef->stringifyList(f.tokenDef);
+            std::string freturnType = f.getReturnTypeName();
             if (f.argumentList.size() == fun->argumentList.size() &&
                 f.type == Function::eFunction &&
                 returnType == freturnType &&

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -819,6 +819,10 @@ public:
         setFlag(fHasBody, state);
     }
 
+    std::string getReturnTypeName() const {
+        return retType ? retType->name() : retDef ? retDef->stringifyList(tokenDef) : "";
+    }
+
     const Token *tokenDef;            ///< function name token in class definition
     const Token *argDef;              ///< function argument start '(' in class definition
     const Token *token;               ///< function name token in implementation

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -135,6 +135,7 @@ private:
         TEST_CASE(duplicateVarExpression);
         TEST_CASE(duplicateVarExpressionUnique);
         TEST_CASE(duplicateVarExpressionAssign);
+        TEST_CASE(duplicateVarExpressionCrash);
 
         TEST_CASE(checkSignOfUnsignedVariable);
         TEST_CASE(checkSignOfPointer);
@@ -4221,6 +4222,22 @@ private:
               "        }\n"
               "        previous = current;\n"
               "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void duplicateVarExpressionCrash() {
+      // Issue #8624
+        check("struct  X {\n"
+              "    X();\n"
+              "    int f() const;\n"
+              "};\n"
+              "void run() {\n"
+              "        X x;\n"
+              "        int a = x.f();\n"
+              "        int b = x.f();\n"
+              "        (void)a;\n"
+              "        (void)b;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
This fixes the crash in issue 8624: 

```cpp
class TRH {
public:
    TRH();
    int getET() const;
};

void calc() {
        TRH trh;
        int zv = trh.getET();
        int zz = trh.getET();
}
```

But there is a deeper issue that cppcheck doesn't parse the return type of the function.