### PR TITLE
windows.cfg: Add _TCHAR platform type.

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -831,6 +831,13 @@
     <platform type="win32W"/>
     <platform type="win64"/>
   </platformtype>
+  <platformtype name="_TCHAR" value="char">
+    <platform type="win32A"/>
+  </platformtype>
+  <platformtype name="_TCHAR" value="wchar_t">
+    <platform type="win32W"/>
+    <platform type="win64"/>
+  </platformtype>
   <platformtype name="UCHAR" value="char">
     <unsigned/>
     <platform type="win32A"/>


### PR DESCRIPTION
_TCHAR is simply the same as TCHAR. Defined in tchar.h.
More information about it:
https://social.msdn.microsoft.com/Forums/vstudio/en-US/0073fa7b-5cf5-469c-978f-2961f9d4ecb2/tchar-vs-tchar?forum=vcgeneral