### PR TITLE
Implemented suppressing warnings using error message text

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -221,6 +221,7 @@ Suppressions::ErrorMessage ErrorLogger::ErrorMessage::toSuppressionsErrorMessage
     }
     ret.inconclusive = _inconclusive;
     ret.symbolNames = mSymbolNames;
+    ret.message = _shortMessage;
     return ret;
 }
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -99,6 +99,8 @@ std::string Suppressions::parseXmlFile(const char *filename)
                 s.lineNumber = std::atoi(text);
             else if (std::strcmp(e2->Name(), "symbolName") == 0)
                 s.symbolName = text;
+            else if (std::strcmp(e2->Name(), "messageText") == 0)
+                s.messageGlob = text;
             else
                 return "Unknown suppression element <" + std::string(e2->Name()) + ">, expected <id>/<fileName>/<lineNumber>/<symbolName>";
         }
@@ -238,6 +240,12 @@ bool Suppressions::Suppression::isSuppressed(const Suppressions::ErrorMessage &e
                 return true;
         }
         return false;
+    }
+    if (!messageGlob.empty()) {
+        if (!matchglob(messageGlob, errmsg.message))
+        {
+            return false;
+        }
     }
     return true;
 }

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -43,6 +43,7 @@ public:
         int lineNumber;
         bool inconclusive;
         std::string symbolNames;
+        std::string message;
     private:
         std::string mFileName;
     };
@@ -60,6 +61,7 @@ public:
             lineNumber = other.lineNumber;
             symbolName = other.symbolName;
             matched = other.matched;
+            messageGlob = other.messageGlob;
             return *this;
         }
 
@@ -72,6 +74,8 @@ public:
                 return fileName < other.fileName;
             if (symbolName != other.symbolName)
                 return symbolName < other.symbolName;
+            if (messageGlob != other.messageGlob)
+                return messageGlob < other.messageGlob;
             return false;
         }
 
@@ -96,6 +100,7 @@ public:
         std::string fileName;
         int lineNumber;
         std::string symbolName;
+        std::string messageGlob;
         bool matched;
 
         static const int NO_LINE = 0;

--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -1075,6 +1075,7 @@ uninitvar</programlisting>
     &lt;fileName&gt;src/file1.c&lt;/fileName&gt;
     &lt;lineNumber&gt;10&lt;/lineNumber&gt;
     &lt;symbolName&gt;var&lt;/symbolName&gt;
+    &lt;messageText&gt;*auto&lt;/messageText&gt;
   &lt;/suppression&gt;
 &lt;/suppressions&gt;</programlisting>
 


### PR DESCRIPTION
I encountered a situation where I wanted to suppress a warning that was being emitted by an assert macro:
"knownConditionTrueFalse: Condition '!true' is always false"

Because this warning has no symbol and comes from many locations, there was no other way to suppress it than by introducing this functionality.