### PR TITLE
cfg/runtests.sh: Check syntax of defines in configuration files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 before_install:
 # install needed deps
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common
+ - sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet
 
 script:
 # fail the entire job as soon as one of the subcommands exits non-zero to save time and resources

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -100,3 +100,25 @@ else
     fi
 fi
 ${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --library=gtk -f ${DIR}gtk.c
+
+# Check the syntax of the defines in the configuration files
+set +e
+xmlstarlet --version
+XMLSTARLET_RETURNCODE=$?
+set -e
+if [ $XMLSTARLET_RETURNCODE -ne 0 ]; then
+    echo "xmlstarlet needed to extract defines, skipping defines check."
+else
+    for configfile in cfg/*.cfg; do
+        echo "Checking defines in $configfile"
+        # Disable debugging output temorarily since there could be many defines
+        set +x
+        # XMLStarlet returns 1 if no elements were found which is no problem here
+        set +e
+        EXTRACTED_DEFINES=$(xmlstarlet sel -t -m '//define' -c . -n <$configfile)
+        set -e
+        EXTRACTED_DEFINES=$(echo "$EXTRACTED_DEFINES" | sed 's/<define name="/#define /g' | sed 's/" value="/ /g' | sed 's/"\/>//g')
+        echo "$EXTRACTED_DEFINES" | gcc -fsyntax-only -xc -
+        set -x
+    done
+fi

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -111,7 +111,7 @@ if [ $XMLSTARLET_RETURNCODE -ne 0 ]; then
 else
     for configfile in cfg/*.cfg; do
         echo "Checking defines in $configfile"
-        # Disable debugging output temorarily since there could be many defines
+        # Disable debugging output temporarily since there could be many defines
         set +x
         # XMLStarlet returns 1 if no elements were found which is no problem here
         set +e

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -118,7 +118,7 @@ else
         EXTRACTED_DEFINES=$(xmlstarlet sel -t -m '//define' -c . -n <$configfile)
         set -e
         EXTRACTED_DEFINES=$(echo "$EXTRACTED_DEFINES" | sed 's/<define name="/#define /g' | sed 's/" value="/ /g' | sed 's/"\/>//g')
-        echo "$EXTRACTED_DEFINES" | gcc -fsyntax-only -xc -
+        echo "$EXTRACTED_DEFINES" | gcc -fsyntax-only -xc -Werror -
         set -x
     done
 fi


### PR DESCRIPTION
.travis.yml is enhanced so xmlstarlet is installed which is used to extract the defines in the configuration files.