### PR TITLE
Skip literals for always true/false

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1194,7 +1194,9 @@ void CheckCondition::alwaysTrueFalse()
                 continue;
             if (!tok->hasKnownIntValue())
                 continue;
-            if (Token::Match(tok, "[01]"))
+            if (Token::Match(tok, "%num%|%bool%"))
+                continue;
+            if (Token::Match(tok, "! %num%|%bool%"))
                 continue;
 
             const bool constIfWhileExpression =

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2395,6 +2395,25 @@ private:
                       "[test.cpp:4]: (style) Condition '1&&'c'' is always true\n"
                       "[test.cpp:4]: (style) Condition ''c'' is always true\n"
                       "[test.cpp:5]: (style) Condition ''d'' is always true\n", errout.str());
+
+        // Skip literals
+        check("void f() { if(true) {} }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() { if(false) {} }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() { if(!true) {} }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() { if(!false) {} }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() { if(0) {} }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() { if(1) {} }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkInvalidTestForOverflow() {


### PR DESCRIPTION
This fixes false positives when the user is doing `if(true) {}` or `if(!true) {}`.