### PR TITLE
Fix issue 7904: Handle double nots in isSameExpression

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -145,11 +145,11 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         if (tok2->str() == "." && tok2->astOperand1() && tok2->astOperand1()->str() == "this")
             tok2 = tok2->astOperand2();
     }
-    if(Token::simpleMatch(tok1, "! !") && !Token::simpleMatch(tok1->astParent(), "=")) {
-        return isSameExpression(cpp, macro, tok1->tokAt(2), tok2, library, pure);
+    if(Token::simpleMatch(tok1, "!") && Token::simpleMatch(tok1->astOperand1(), "!") && !Token::simpleMatch(tok1->astParent(), "=")) {
+        return isSameExpression(cpp, macro, tok1->astOperand1()->astOperand1(), tok2, library, pure);
     }
-    if(Token::simpleMatch(tok2, "! !") && !Token::simpleMatch(tok2->astParent(), "=")) {
-        return isSameExpression(cpp, macro, tok1, tok2->tokAt(2), library, pure);
+    if(Token::simpleMatch(tok2, "!") && Token::simpleMatch(tok2->astOperand1(), "!") && !Token::simpleMatch(tok2->astParent(), "=")) {
+        return isSameExpression(cpp, macro, tok1, tok2->astOperand1()->astOperand1(), library, pure);
     }
     if (tok1->varId() != tok2->varId() || tok1->str() != tok2->str() || tok1->originalName() != tok2->originalName()) {
         if ((Token::Match(tok1,"<|>")   && Token::Match(tok2,"<|>")) ||

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -145,10 +145,10 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         if (tok2->str() == "." && tok2->astOperand1() && tok2->astOperand1()->str() == "this")
             tok2 = tok2->astOperand2();
     }
-    if(Token::simpleMatch(tok1, "! !")) {
+    if(Token::simpleMatch(tok1, "! !") && !Token::simpleMatch(tok1->astParent(), "=")) {
         return isSameExpression(cpp, macro, tok1->tokAt(2), tok2, library, pure);
     }
-    if(Token::simpleMatch(tok2, "! !")) {
+    if(Token::simpleMatch(tok2, "! !") && !Token::simpleMatch(tok2->astParent(), "=")) {
         return isSameExpression(cpp, macro, tok1, tok2->tokAt(2), library, pure);
     }
     if (tok1->varId() != tok2->varId() || tok1->str() != tok2->str() || tok1->originalName() != tok2->originalName()) {

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -145,6 +145,12 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         if (tok2->str() == "." && tok2->astOperand1() && tok2->astOperand1()->str() == "this")
             tok2 = tok2->astOperand2();
     }
+    if(Token::simpleMatch(tok1, "! !")) {
+        return isSameExpression(cpp, macro, tok1->tokAt(2), tok2, library, pure);
+    }
+    if(Token::simpleMatch(tok2, "! !")) {
+        return isSameExpression(cpp, macro, tok1, tok2->tokAt(2), library, pure);
+    }
     if (tok1->varId() != tok2->varId() || tok1->str() != tok2->str() || tok1->originalName() != tok2->originalName()) {
         if ((Token::Match(tok1,"<|>")   && Token::Match(tok2,"<|>")) ||
             (Token::Match(tok1,"<=|>=") && Token::Match(tok2,"<=|>="))) {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -630,6 +630,24 @@ private:
               "  else if (x & 0x08) {}\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( !!b && !!a){}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( !!b && a){}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( b && !!a){}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
     }
 
     void checkBadBitmaskCheck() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -648,6 +648,24 @@ private:
               "   else if( b && !!a){}\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( b && !(!a)){}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( !!b && !(!a)){}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Expression is always false because 'else if' condition matches previous condition at line 2.\n", errout.str());
+
+        check("void f(bool a, bool b) {\n"
+              "   if(a && b){}\n"
+              "   else if( !!(b) && !!(a+b)){}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkBadBitmaskCheck() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3009,6 +3009,9 @@ private:
                       "[test.cpp:10]: (warning) Redundant assignment of 'y' to itself.\n"
                       "[test.cpp:10]: (warning) Redundant assignment of 'z' to itself.\n", errout.str());
 
+        check("void f(int i) { i = !!i; }");
+        ASSERT_EQUALS("", errout.str());
+
     }
 
     void trac1132() {


### PR DESCRIPTION
This fixes false negative in:

```cpp
void f(bool a, bool b)
{
   if(a && b){}
   else if( !!b && !!a){}
}
```