### PR TITLE
Fix link error when building with MinGW about __imp_PathFileExistsA

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(cppcheck ${hdrs} ${mainfile} $<TARGET_OBJECTS:cli_objs> $<TARGET_
 if (HAVE_RULES)
     target_link_libraries(cppcheck pcre)
 endif()
-if (MSVC)
+if (WIN32 AND NOT BORLAND)
     target_link_libraries(cppcheck Shlwapi.lib)
 endif()
 


### PR DESCRIPTION
Following error occurs when building with MinGW 7.2.0 and Ninja on Windows:

  cli/CMakeFiles/cli_objs.dir/filelister.cpp.obj: In function `MyIsDirectory':
  cppcheck-1.84\build/../cli/filelister.cpp:49: undefined reference to `__imp_PathIsDirectoryA'
  cli/CMakeFiles/cli_objs.dir/filelister.cpp.obj: In function `MyFileExists':
  cppcheck-1.84\build/../cli/filelister.cpp:67: undefined reference to `__imp_PathFileExistsA'
  collect2.exe: error: ld returned 1 exit status

This is the corresponding code in filelister.cpp:

  #ifdef _WIN32

  // snip

  static BOOL MyIsDirectory(const std::string& path)
  {
  #ifdef __BORLANDC__
      return (GetFileAttributes(path.c_str()) & FILE_ATTRIBUTE_DIRECTORY);
  #else
  // See http://msdn.microsoft.com/en-us/library/bb773621(VS.85).aspx
      return PathIsDirectoryA(path.c_str());
  #endif
  }

  static BOOL MyFileExists(const std::string& path)
  {
  #ifdef __BORLANDC__
      DWORD fa = GetFileAttributes(path.c_str());
      BOOL result = FALSE;
      if (fa != INVALID_FILE_ATTRIBUTES && !(fa & FILE_ATTRIBUTE_DIRECTORY))
	  result = TRUE;
  #else
      const BOOL result = PathFileExistsA(path.c_str());
  #endif
      return result;
  }

The else blocks assume that Shlwapi.lib is available on Windows except with Borland,
so the patch set ensures that the library is linked on the same condition.