### PR TITLE
runtest.sh: Bugfix cfg dir when run in test/cfg

### DIFF
--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -5,9 +5,11 @@ set -x # be verbose
 if [[ $(pwd) == */test/cfg ]] ; then # we are in test/cfg
 	CPPCHECK="../../cppcheck"
 	DIR=""
+	CFG="../../cfg/"
 else # assume we are in repo root
 	CPPCHECK="./cppcheck"
 	DIR=test/cfg/
+	CFG="cfg/"
 fi
 
 # Cppcheck options
@@ -109,7 +111,7 @@ set -e
 if [ $XMLSTARLET_RETURNCODE -ne 0 ]; then
     echo "xmlstarlet needed to extract defines, skipping defines check."
 else
-    for configfile in cfg/*.cfg; do
+    for configfile in ${CFG}*.cfg; do
         echo "Checking defines in $configfile"
         # Disable debugging output temporarily since there could be many defines
         set +x


### PR DESCRIPTION
Commit 5cc8da2db473 introduced syntax checking of xml-files. This broke
running the file directly in the test/cfg folder since it assumed the
config files to check were located in cfg in the current working
directory. Fix this by adding a variable that holds the correct path.