### PR TITLE
 Travis: Parallelize naming.py calls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,8 +76,6 @@ script:
 # check naming conventions
   - ${CPPCHECK} -j 2 --dump -q gui lib
   - find . -name "*.dump" | grep -P "\.\/(lib|gui)\/[^\/]*\.cpp\.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m[A-Z].*'
-  # Travis must fail for the following command since the name regex does not match Cppcheck naming. Remove this once it is verified that it fails for incorrect names.
-  - find . -name "*.dump" | grep -P "\.\/(lib|gui)\/[^\/]*\.cpp\.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m_[A-Z].*'
 # run extra tests
   - tools/generate_and_run_more_tests.sh
 # Validate XML

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - ${CPPCHECK} --library=qt  --error-exitcode=1  -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml/ -Icli --enable=style,performance,portability,warning,internal  --exception-handling -j 2 gui --suppressions-list=.travis_suppressions -igui/test |& tee --append /tmp/cppcheck.cppcheck
   - sh -c "! grep '^\[' /tmp/cppcheck.cppcheck"
 # check naming conventions
-  - ${CPPCHECK} -j 2 --dump -q gui lib
+  - ${CPPCHECK} -i gui/test -j 2 --dump -q gui lib
   - find lib gui -maxdepth 1 -name "*.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m[A-Z].*'
 # run extra tests
   - tools/generate_and_run_more_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,9 @@ script:
   - sh -c "! grep '^\[' /tmp/cppcheck.cppcheck"
 # check naming conventions
   - ${CPPCHECK} -j 2 --dump -q gui lib
-  - python addons/naming.py --private-member-variable='m[A-Z].*' gui/*.cpp.dump lib/*.cpp.dump
+  - find . -name "*.dump" | grep -P "\.\/(lib|gui)\/[^\/]*\.cpp\.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m[A-Z].*'
+  # Travis must fail for the following command since the name regex does not match Cppcheck naming. Remove this once it is verified that it fails for incorrect names.
+  - find . -name "*.dump" | grep -P "\.\/(lib|gui)\/[^\/]*\.cpp\.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m_[A-Z].*'
 # run extra tests
   - tools/generate_and_run_more_tests.sh
 # Validate XML

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
   - sh -c "! grep '^\[' /tmp/cppcheck.cppcheck"
 # check naming conventions
   - ${CPPCHECK} -j 2 --dump -q gui lib
-  - find . -name "*.dump" | grep -P "\.\/(lib|gui)\/[^\/]*\.cpp\.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m[A-Z].*'
+  - find lib gui -maxdepth 1 -name "*.dump" | xargs -n 1 -P 4 python addons/naming.py --private-member-variable='m[A-Z].*'
 # run extra tests
   - tools/generate_and_run_more_tests.sh
 # Validate XML


### PR DESCRIPTION
naming.py is called parallel (4 times at a time) for all *.cpp.dump files directly in gui/ and lib/.
@matthiaskrgr had the idea for it: https://github.com/danmar/cppcheck/commit/e46c499f5a6c552672ce246e0be8f14c9febcc51#commitcomment-29717495