### PR TITLE
Fix issue 8369: False negative: Condition 'condition' is always true

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1831,7 +1831,7 @@ static bool valueFlowForward(Token * const               startToken,
                 }
 
                 // Forward known values in the else branch
-                if(Token::Match(end, "} else {")) {
+                if(Token::simpleMatch(end, "} else {")) {
                     std::list<ValueFlow::Value> knownValues;
                     std::copy_if(values.begin(), values.end(), std::back_inserter(knownValues), std::mem_fn(&ValueFlow::Value::isKnown));
                     valueFlowForward(end->tokAt(2),

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -92,6 +92,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -1827,6 +1828,22 @@ static bool valueFlowForward(Token * const               startToken,
                     if (settings->debugwarnings)
                         bailout(tokenlist, errorLogger, tok2, "variable " + var->name() + " bailout when conditional code that contains var is seen");
                     return false;
+                }
+
+                // Forward known values in the else branch
+                if(Token::Match(end, "} else {")) {
+                    std::list<ValueFlow::Value> knownValues;
+                    std::copy_if(values.begin(), values.end(), std::back_inserter(knownValues), std::mem_fn(&ValueFlow::Value::isKnown));
+                    valueFlowForward(end->tokAt(2),
+                                     end->linkAt(2),
+                                     var,
+                                     varid,
+                                     knownValues,
+                                     constValue,
+                                     subFunction,
+                                     tokenlist,
+                                     errorLogger,
+                                     settings);
                 }
 
                 // Remove conditional values

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -93,6 +93,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <set>

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2447,6 +2447,15 @@ private:
 
         check("void f() { if(1) {} }");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(int i) {\n"
+              "    bool b = false;\n"
+              "    if (i == 0) b = true;\n"
+              "    else if (!b && i == 1) {}\n"
+              "    if (b)\n"
+              "    {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!b' is always true\n", errout.str());
     }
 
     void checkInvalidTestForOverflow() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -80,6 +80,7 @@ private:
         TEST_CASE(valueFlowAfterCondition);
         TEST_CASE(valueFlowForwardCompoundAssign);
         TEST_CASE(valueFlowForwardCorrelatedVariables);
+        TEST_CASE(valueFlowForwardModifiedVariables);
         TEST_CASE(valueFlowForwardFunction);
         TEST_CASE(valueFlowForwardTernary);
         TEST_CASE(valueFlowForwardLambda);
@@ -103,6 +104,25 @@ private:
         TEST_CASE(valueFlowInlineAssembly);
 
         TEST_CASE(valueFlowUninit);
+    }
+
+    bool testValueOfXKnown(const char code[], unsigned int linenr) {
+        // Tokenize..
+        Tokenizer tokenizer(&settings, this);
+        std::istringstream istr(code);
+        tokenizer.tokenize(istr, "test.cpp");
+
+        for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
+            if (tok->str() == "x" && tok->linenr() == linenr) {
+                std::list<ValueFlow::Value>::const_iterator it;
+                for (it = tok->values().begin(); it != tok->values().end(); ++it) {
+                    if (it->isKnown())
+                        return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     bool testValueOfX(const char code[], unsigned int linenr, int value) {
@@ -2131,6 +2151,28 @@ private:
                "}";
         ASSERT_EQUALS(true, testValueOfX(code, 3U, 0));
         ASSERT_EQUALS(false, testValueOfX(code, 4U, 0));
+    }
+
+    void valueFlowForwardModifiedVariables() {
+        const char *code;
+
+        code = "void f(bool b) {\n"
+               "  int x = 0;\n"
+               "  if (b) x = 1;\n"
+               "  else b = x;\n"
+               "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 0));
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 4U));
+
+        code = "void f(int i) {\n"
+               "    int x = 0;\n"
+               "    if (i == 0) \n"
+               "        x = 1;\n"
+               "    else if (!x && i == 1) \n"
+               "        int b = x;\n"
+               "}\n";
+        ASSERT_EQUALS(true, testValueOfX(code, 6U, 0));
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 6U));
     }
 
     void valueFlowForwardFunction() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -114,7 +114,6 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                std::list<ValueFlow::Value>::const_iterator it;
                 for(const ValueFlow::Value& val:tok->values()) {
                     if(val.isKnown() && val.intvalue == value)
                         return true;

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -106,7 +106,7 @@ private:
         TEST_CASE(valueFlowUninit);
     }
 
-    bool testValueOfXKnown(const char code[], unsigned int linenr) {
+    bool testValueOfXKnown(const char code[], unsigned int linenr, int value) {
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -115,8 +115,8 @@ private:
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
                 std::list<ValueFlow::Value>::const_iterator it;
-                for (it = tok->values().begin(); it != tok->values().end(); ++it) {
-                    if (it->isKnown())
+                for(const ValueFlow::Value& val:tok->values()) {
+                    if(val.isKnown() && val.intvalue == value)
                         return true;
                 }
             }
@@ -2161,8 +2161,7 @@ private:
                "  if (b) x = 1;\n"
                "  else b = x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 4U, 0));
-        ASSERT_EQUALS(true, testValueOfXKnown(code, 4U));
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 4U, 0));
 
         code = "void f(int i) {\n"
                "    int x = 0;\n"
@@ -2171,8 +2170,8 @@ private:
                "    else if (!x && i == 1) \n"
                "        int b = x;\n"
                "}\n";
-        ASSERT_EQUALS(true, testValueOfX(code, 6U, 0));
-        ASSERT_EQUALS(true, testValueOfXKnown(code, 6U));
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 5U, 0));
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 6U, 0));
     }
 
     void valueFlowForwardFunction() {


### PR DESCRIPTION
This fixes issue with:

```cpp
void f(int i)
{
    bool warn = false;
    if (i == 0)
    {
        warn = true;
    }
    else if (!warn && i == 1) // << the value of'warn' is always true
    {
        // warn = true;
    }
    if (warn)
    {}
}
```