### PR TITLE
Fix FP with duplicate assign

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1965,6 +1965,7 @@ void CheckOther::checkDuplicateExpression()
                         tok->next()->tokType() != Token::eName &&
                         isSameExpression(mTokenizer->isCPP(), true, tok->next(), nextAssign->next(), mSettings->library, true) &&
                         isSameExpression(mTokenizer->isCPP(), true, tok->astOperand2(), nextAssign->astOperand2(), mSettings->library, true) &&
+                        tok->astOperand2()->expressionString() == nextAssign->astOperand2()->expressionString() &&
                         !isUniqueExpression(tok->astOperand2())) {
                         bool assigned = false;
                         const Scope * varScope = var1->scope() ? var1->scope() : &scope;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4252,6 +4252,23 @@ private:
         check("int f() __attribute__((pure));\n"
               "int g() __attribute__((pure));\n"
               "void test() {\n"
+              "    int i = f() + 1;\n"
+              "    int j = 1 + f();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() __attribute__((pure));\n"
+              "int g() __attribute__((pure));\n"
+              "void test() {\n"
+              "    int x = f();\n"
+              "    int i = x + 1;\n"
+              "    int j = f() + 1;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() __attribute__((pure));\n"
+              "int g() __attribute__((pure));\n"
+              "void test() {\n"
               "    int i = f() + f();\n"
               "    int j = f() + f();\n"
               "}");
@@ -4264,6 +4281,15 @@ private:
               "    int j = f(0);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+
+        check("int f(int) __attribute__((pure));\n"
+              "int g(int) __attribute__((pure));\n"
+              "void test() {\n"
+              "    const int x = 0;\n"
+              "    int i = f(0);\n"
+              "    int j = f(x);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
 
         check("void test(int * p, int * q) {\n"
               "    int i = *p;\n"
@@ -4362,6 +4388,12 @@ private:
         check("void test(int x) {\n"
               "    int i = x--;\n"
               "    int j = x--;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void test(int x) {\n"
+              "    int i = x + 1;\n"
+              "    int j = 1 + x;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
This fixes FPs from variable substitution:

```cpp
int f(int) __attribute__((pure));
int g(int) __attribute__((pure));
void test() {
    const int x = 0;
    int i = f(0);
    int j = f(x);
}
```