### PR TITLE
Allow syntax "typedef 'typename' unsigned 'typename' (functon_name)()"

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -674,11 +674,11 @@ void Tokenizer::simplifyTypedef()
             typeEnd = tokOffset;
             tokOffset = tokOffset->next();
 
-			while(tokOffset && Token::Match(tokOffset, "%type%") &&
-				(tokOffset->isStandardType() || Token::Match(tokOffset, "unsigned|signed")) ) {
-				typeEnd = tokOffset;
-				tokOffset = tokOffset->next();
-			}
+            while(Token::Match(tokOffset, "%type%") &&
+	            (tokOffset->isStandardType() || Token::Match(tokOffset, "unsigned|signed")) ) {
+	            typeEnd = tokOffset;
+	            tokOffset = tokOffset->next();
+            }
 			
             bool atEnd = false;
             while (!atEnd) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -674,6 +674,12 @@ void Tokenizer::simplifyTypedef()
             typeEnd = tokOffset;
             tokOffset = tokOffset->next();
 
+			while(tokOffset && Token::Match(tokOffset, "%type%") &&
+				(tokOffset->isStandardType() || Token::Match(tokOffset, "unsigned|signed")) ) {
+				typeEnd = tokOffset;
+				tokOffset = tokOffset->next();
+			}
+			
             bool atEnd = false;
             while (!atEnd) {
                 if (tokOffset && tokOffset->str() == "::") {

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -161,6 +161,7 @@ private:
         TEST_CASE(simplifyTypedef121); // ticket #5766
         TEST_CASE(simplifyTypedef122); // segmentation fault
         TEST_CASE(simplifyTypedef123); // ticket #7406
+        TEST_CASE(simplifyTypedef124); // ticket #7792
 
         TEST_CASE(simplifyTypedefFunction1);
         TEST_CASE(simplifyTypedefFunction2); // ticket #1685
@@ -2508,6 +2509,22 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
+    void simplifyTypedef124() { // ticket #7792
+        const char code[] = "typedef long unsigned int size_t;\n"
+                            "typedef size_t (my_func)(char *, size_t, size_t, void *);";
+
+        // Check for output..
+        checkSimplifyTypedef(code);
+        ASSERT_EQUALS_WITHOUT_LINENUMBERS("[test.cpp:1]: (debug) Failed to parse 'typedef long unsigned int size_t ;'. The checking continues anyway.\n", errout.str());
+
+        const char code1[] = "typedef long unsigned int uint32_t;\n"
+                             "typedef uint32_t (my_func)(char *, uint32_t, uint32_t, void *);";
+
+        // Check for output..
+        checkSimplifyTypedef(code1);
+        ASSERT_EQUALS("", errout.str());
+
+    }
 
     void simplifyTypedefFunction1() {
         {


### PR DESCRIPTION
Some old systems/libraries are still use syntax "typedef 'typename' unsigned 'typename' (functon_name)()", and it can't change as our self. And it wrong when use cppcheck.
ex: typedef long unsigned int (callback_fn)(void*)

In fact, the compile as gcc is good in compile and runtime with this syntax, and passing all testcase are avaiable, so i think it can should share. Plz help review it
