### PR TITLE
Fix issue 8687: false positive with same expression

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -178,7 +178,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
     if (var->isArgument())
         return tok;
     // If this is in a loop then check if variables are modified in the entire scope
-    const Token * endToken = (isInLoopCondition(tok) || var->scope() != tok->scope()) ? var->scope()->bodyEnd : tok;
+    const Token * endToken = (isInLoopCondition(tok) || isInLoopCondition(varTok) || var->scope() != tok->scope()) ? var->scope()->bodyEnd : tok;
     if (!var->isConst() && isVariableChanged(varTok, endToken, tok->varId(), false, nullptr, cpp))
         return tok;
     // Start at begining of initialization

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4093,6 +4093,45 @@ private:
         check("void f(int b) { int a = 1; while (b) { if ( a != 1){} b++; } a++; } \n");
         ASSERT_EQUALS("", errout.str());
 
+        check("void f() {\n"
+              "    for(int i = 0; i < 10;) {\n"
+              "        if( i != 0 ) {}\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Same expression on both sides of '!=' because the value of 'i' and '0' are the same.\n", errout.str());
+
+        check("void f() {\n"
+              "    for(int i = 0; i < 10;) {\n"
+              "        if( i != 0 ) {}\n"
+              "        i++;\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    for(int i = 0; i < 10;) {\n"
+              "        if( i != 0 ) { i++; }\n"
+              "        i++;\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    for(int i = 0; i < 10;) {\n"
+              "        if( i != 0 ) { i++; }\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    int i = 0;\n"
+              "    while(i < 10) {\n"
+              "        if( i != 0 ) {}\n"
+              "        i++;\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f(int b) {\n"
               "    while (b) {\n"
               "        int a = 1;\n"


### PR DESCRIPTION
Fix false positive with issue [8687](https://trac.cppcheck.net/ticket/8687):

```cpp
int main()
{
    for(int i = 0; i < 10;)
    {
        if( i != 0 )
            i++;
        i++;
    }
    return 0;
}
```