### PR TITLE
ErrorLogger: add {cwe}

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1050,6 +1050,7 @@ void CmdLineParser::printHelp()
               "                           {severity}          severity\n"
               "                           {message}           warning message\n"
               "                           {id}                warning id\n"
+              "                           {cwe}               CWE id (Common Weakness Enumeration)\n"
               "                           {code}              show the real code\n"
               "                           \\t                 insert tab\n"
               "                           \\n                 insert newline\n"

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -487,6 +487,7 @@ std::string ErrorLogger::ErrorMessage::toString(bool verbose, const std::string 
         findAndReplace(result, replaceFrom, replaceWith);
     }
     findAndReplace(result, "{severity}", Severity::toString(_severity));
+    findAndReplace(result, "{cwe}", MathLib::toString(_cwe.id));
     findAndReplace(result, "{message}", verbose ? mVerboseMessage : mShortMessage);
     findAndReplace(result, "{callstack}", _callStack.empty() ? emptyString : callStackToString(_callStack));
     if (!_callStack.empty()) {


### PR DESCRIPTION
The CWE info is currently only available in the XML output.  This one-line patch makes it available via the `--template` interface, too.