### PR TITLE
Avoid duplicates in the error path

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -218,7 +218,10 @@ static void followVariableExpressionError(const Token *tok1, const Token *tok2, 
         return;
     if (!tok2)
         return;
-    errors->push_back(std::make_pair(tok2, "'" + tok1->str() + "' is assigned value '" + tok2->expressionString() + "' here."));
+    ErrorPathItem item = std::make_pair(tok2, "'" + tok1->str() + "' is assigned value '" + tok2->expressionString() + "' here.");
+    if(std::find(errors->begin(), errors->end(), item) != errors->end())
+        return;
+    errors->push_back(item);
 }
 
 bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, ErrorPath* errors)


### PR DESCRIPTION
For:

```cpp
void f() {
    int x = 0;
    int y = 0;
    if(x == 0) {
        if (y == 0) {}
    }
}
```

It now shows:

```
issue-8670.cpp:5:15: warning: Identical inner 'if' condition is always true. [identicalInnerCondition]
        if (y == 0) {}
              ^
issue-8670.cpp:2:13: note: 'x' is assigned value '0' here.
    int x = 0;
            ^
issue-8670.cpp:3:13: note: 'y' is assigned value '0' here.
    int y = 0;
            ^
issue-8670.cpp:4:10: note: outer condition: x==0
    if(x == 0) {
         ^
issue-8670.cpp:5:15: note: identical inner condition: y==0
        if (y == 0) {}
              ^
```