### PR TITLE
Check if member function modifies the variable

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -781,9 +781,13 @@ bool isVariableChanged(const Token *start, const Token *end, const unsigned int 
 
         // Member function call
         if(Token::Match(tok, "%name% . %name% (")) {
+            const Variable * var = tok->variable();
+            const ValueType * valueType = var->valueType();
+            bool isConst = var->isConst() || (valueType && valueType->pointer == 1 && valueType->constness == 1);
+            
             const Token *ftok = tok->tokAt(2);
             const Function * fun = ftok->function();
-            if(fun && !fun->isConst())
+            if(!isConst && (!fun || !fun->isConst()))
                 return true;
         }
 

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -779,6 +779,14 @@ bool isVariableChanged(const Token *start, const Token *end, const unsigned int 
         if (isLikelyStreamRead(cpp, tok->previous()))
             return true;
 
+        // Member function call
+        if(Token::Match(tok, "%name% . %name% (")) {
+            const Token *ftok = tok->tokAt(2);
+            const Function * fun = ftok->function();
+            if(fun && !fun->isConst())
+                return true;
+        }
+
         const Token *ftok = tok;
         while (ftok && !Token::Match(ftok, "[({[]"))
             ftok = ftok->astParent();

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -782,9 +782,12 @@ bool isVariableChanged(const Token *start, const Token *end, const unsigned int 
         // Member function call
         if(Token::Match(tok, "%name% . %name% (")) {
             const Variable * var = tok->variable();
-            const ValueType * valueType = var->valueType();
-            bool isConst = var->isConst() || (valueType && valueType->pointer == 1 && valueType->constness == 1);
-            
+            bool isConst = var && var->isConst();
+            if(!isConst && var) {
+                const ValueType * valueType = var->valueType();
+                isConst = (valueType && valueType->pointer == 1 && valueType->constness == 1);
+            }
+                        
             const Token *ftok = tok->tokAt(2);
             const Function * fun = ftok->function();
             if(!isConst && (!fun || !fun->isConst()))

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -1258,6 +1258,24 @@ private:
               "    return;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void foo(A a) {\n"
+              "  A x = a;\n"
+              "  A y = a;\n"
+              "  y.f();\n"
+              "  if (a > x && a < y)\n"
+              "    return;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo(A a) {\n"
+              "  const A x = a;\n"
+              "  const A y = a;\n"
+              "  y.f();\n"
+              "  if (a > x && a < y)\n"
+              "    return;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:5]: (warning) Logical conjunction always evaluates to false: a > x && a < y.\n", errout.str());
     }
 
     void secondAlwaysTrueFalseWhenFirstTrueError() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -71,6 +71,7 @@ private:
         TEST_CASE(incorrectLogicOperator9);
         TEST_CASE(incorrectLogicOperator10); // enum
         TEST_CASE(incorrectLogicOperator11);
+        TEST_CASE(incorrectLogicOperator12);
         TEST_CASE(secondAlwaysTrueFalseWhenFirstTrueError);
         TEST_CASE(incorrectLogicOp_condSwapping);
         TEST_CASE(testBug5895);
@@ -1231,6 +1232,32 @@ private:
 
         check("void foo(int i, const int n) { if ( i == n && i < n ) {} }");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Logical conjunction always evaluates to false: i == n && i < n.\n", errout.str());
+    }
+
+    void incorrectLogicOperator12() { // #8696
+        check("struct A {\n"
+              "    void f() const;\n"
+              "};\n"
+              "void foo(A a) {\n"
+              "  A x = a;\n"
+              "  A y = a;\n"
+              "  y.f();\n"
+              "  if (a > x && a < y)\n"
+              "    return;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:8]: (warning) Logical conjunction always evaluates to false: a > x && a < y.\n", errout.str());
+
+        check("struct A {\n"
+              "    void f();\n"
+              "};\n"
+              "void foo(A a) {\n"
+              "  A x = a;\n"
+              "  A y = a;\n"
+              "  y.f();\n"
+              "  if (a > x && a < y)\n"
+              "    return;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void secondAlwaysTrueFalseWhenFirstTrueError() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -3133,6 +3133,13 @@ private:
         ASSERT_EQUALS(true, values.size()==1U && values.front().isUninitValue());
 
         code = "void f() {\n"
+               "    C *c;\n"
+               "    if (c->x() == 4) {}\n"
+               "}";
+        values = tokenValues(code, "c .");
+        TODO_ASSERT_EQUALS(true, false, values.size()==1U && values.front().isUninitValue());
+
+        code = "void f() {\n"
                "    int **x;\n"
                "    y += 10;\n"
                "    x = dostuff(sizeof(*x)*y);\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -3126,7 +3126,7 @@ private:
         ASSERT_EQUALS(true, values.size()==1U && values.front().isUninitValue());
 
         code = "void f() {\n"
-               "    C *c;\n"
+               "    const C *c;\n"
                "    if (c->x() == 4) {}\n"
                "}";
         values = tokenValues(code, "c .");


### PR DESCRIPTION
This should help fix issue 8696, but it requires a definition of the class:

```cpp
struct Date {
    void advance();
};

void foo(Date date) {
  Date today = date;
  Date upcoming = date;
  upcoming.advance();
  if (date > today && date < upcoming)
    return;
}
```

It doesn't assume that unknown member functions modify the variable as this seems to break several tests in valueflow.