### PR TITLE
Ticket #8679: Add support for C++11 thread_local and GCC's (among others) __thread extension.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9024,6 +9024,7 @@ static const std::set<std::string> keywords = {
     , "register"
     , "__restrict"
     , "__restrict__"
+    , "__thread"
 };
 // Remove "inline", "register", "restrict", "override", "final", "static" and "constexpr"
 // "restrict" keyword
@@ -9092,6 +9093,11 @@ void Tokenizer::simplifyKeyword()
                 Token * braceStart = tokNoExcept->next();
                 tok = tok->tokAt(3);
                 Token::createMutualLinks(braceStart, braceEnd);
+            }
+
+            // 3) thread_local
+            else if (tok->str() == "thread_local") {
+                tok->deleteThis();
             }
         }
     }
@@ -10410,4 +10416,3 @@ bool Tokenizer::VariableMap::hasVariable(const std::string &varname) const
 {
     return mVariableId.find(varname) != mVariableId.end();
 }
-

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -224,6 +224,7 @@ private:
         TEST_CASE(crash1);  // Ticket #1587 - crash
         TEST_CASE(crash2);  // Ticket #3034 - crash
         TEST_CASE(crash3);  // Ticket #5426 - crash
+        TEST_CASE(crash4);  // Ticket #8679 - crash
 
         TEST_CASE(executionPaths1);
         TEST_CASE(executionPaths2);
@@ -3639,6 +3640,19 @@ private:
               "void d() { struct b *f; f = malloc(108); }");
     }
 
+    void crash4() { // #8679
+        check("__thread void *thread_local_var; "
+              "int main() { "
+              "  thread_local_var = malloc(1337); "
+              "  return 0; "
+              "}");
+
+        check("thread_local void *thread_local_var; "
+              "int main() { "
+              "  thread_local_var = malloc(1337); "
+              "  return 0; "
+              "}");
+    }
 
     void executionPaths1() {
         check("void f(int a)\n"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4081,6 +4081,13 @@ private:
 
             ASSERT_EQUALS(out5, tokenizeAndStringify(in5));
         }
+        {
+            // Ticket #8679
+            const char code[] = "thread_local void *thread_local_var; "
+                                "__thread void *thread_local_var_2;";
+            ASSERT_EQUALS("void * thread_local_var ; "
+                          "void * thread_local_var_2 ;", tokenizeAndStringify(code));
+        }
     }
 
     /**


### PR DESCRIPTION
This patch fixes a crash upon valid, when the __thread extension is used (https://en.wikipedia.org/wiki/Thread-local_storage#C_and_C++), or C++11's thread_local.

I don't handle both the same, because one is a compiler extension, while the other is linked to the C++ version being used.