### PR TITLE
Initial check for recommending algorithms

### DIFF
--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -5,6 +5,7 @@ nullPointer:lib/checkother.cpp
 nullPointer:build/checkother.cpp
 missingOverride
 noValidConfiguration
+useStlAlgorithm
 
 *:gui/test/*
 *:test/test.cxx

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2061,9 +2061,9 @@ void CheckOther::duplicateExpressionError(const Token *tok1, const Token *tok2, 
     std::string msg = "Same expression on both sides of \'" + op + "\'";
     if (expr1 != expr2) {
         std::string exprMsg = "The expression \'" + expr1 + " " + op +  " " + expr2 + "\' is always ";
-        if(Token::Match(opTok, "==|>=|<="))
+        if (Token::Match(opTok, "==|>=|<="))
             msg = exprMsg + "true";
-        else if(Token::Match(opTok, "!=|>|<"))
+        else if (Token::Match(opTok, "!=|>|<"))
             msg = exprMsg + "false";
         msg += " because '" + expr1 + "' and '" + expr2 + "' represent the same value";
     }

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1747,190 +1747,190 @@ void CheckStl::readingEmptyStlContainerError(const Token *tok, const ValueFlow::
     reportError(errorPath, value ? (value->errorSeverity() ? Severity::error : Severity::warning) : Severity::style, "reademptycontainer", "$symbol:" + varname +"\n" + errmsg, CWE398, !value);
 }
 
-void CheckStl::useStlAlgorithmError(const Token* tok, const std::string &algoName)
+void CheckStl::useStlAlgorithmError(const Token *tok, const std::string &algoName)
 {
     reportError(tok, Severity::style, "useStlAlgorithm",
                 "Consider using " + algoName + " algorithm instead of a raw loop.", CWE398, false);
 }
 
-static bool isEarlyExit(const Token* start)
+static bool isEarlyExit(const Token *start)
 {
-    if(start->str() != "{")
+    if (start->str() != "{")
         return false;
-    const Token * endToken = start->link();
-    const Token * tok = Token::findmatch(start, "return|throw|break", endToken);
-    if(!tok)
+    const Token *endToken = start->link();
+    const Token *tok = Token::findmatch(start, "return|throw|break", endToken);
+    if (!tok)
         return false;
-    const Token * endStatement = Token::findsimplematch(tok, "; }", endToken);
-    if(!endStatement)
+    const Token *endStatement = Token::findsimplematch(tok, "; }", endToken);
+    if (!endStatement)
         return false;
-    if(endStatement->next() != endToken)
+    if (endStatement->next() != endToken)
         return false;
     return true;
 }
 
-static const Token* singleStatement(const Token* start)
+static const Token *singleStatement(const Token *start)
 {
-    if(start->str() != "{")
+    if (start->str() != "{")
         return nullptr;
-    const Token * endToken = start->link();
-    const Token * endStatement = Token::findsimplematch(start->next(), ";");
-    if(!Token::simpleMatch(endStatement, "; }"))
+    const Token *endToken = start->link();
+    const Token *endStatement = Token::findsimplematch(start->next(), ";");
+    if (!Token::simpleMatch(endStatement, "; }"))
         return nullptr;
-    if(endStatement->next() != endToken)
+    if (endStatement->next() != endToken)
         return nullptr;
-    return endStatement;        
+    return endStatement;
 }
 
-static const Token* singleAssignInScope(const Token* start, unsigned int varid, bool& input)
+static const Token *singleAssignInScope(const Token *start, unsigned int varid, bool &input)
 {
-    const Token * endStatement = singleStatement(start);
-    if(!endStatement)
+    const Token *endStatement = singleStatement(start);
+    if (!endStatement)
         return nullptr;
-    if(!Token::Match(start->next(), "%var% %assign%"))
+    if (!Token::Match(start->next(), "%var% %assign%"))
         return nullptr;
-    const Token * assignTok = start->tokAt(2);
-    if(isVariableChanged(assignTok->next(), endStatement, assignTok->astOperand1()->varId(), false, nullptr, true))
+    const Token *assignTok = start->tokAt(2);
+    if (isVariableChanged(assignTok->next(), endStatement, assignTok->astOperand1()->varId(), false, nullptr, true))
         return nullptr;
-    if(isVariableChanged(assignTok->next(), endStatement, varid, false, nullptr, true))
+    if (isVariableChanged(assignTok->next(), endStatement, varid, false, nullptr, true))
         return nullptr;
     input = Token::findmatch(assignTok->next(), "%varid%", endStatement, varid);
-    return assignTok;        
+    return assignTok;
 }
 
-static const Token* singleMemberCallInScope(const Token* start, unsigned int varid, bool& input)
+static const Token *singleMemberCallInScope(const Token *start, unsigned int varid, bool &input)
 {
-    if(start->str() != "{")
+    if (start->str() != "{")
         return nullptr;
-    const Token * endToken = start->link();
-    if(!Token::Match(start->next(), "%var% . %name% ("))
+    const Token *endToken = start->link();
+    if (!Token::Match(start->next(), "%var% . %name% ("))
         return nullptr;
-    if(!Token::simpleMatch(start->linkAt(4), ") ; }"))
+    if (!Token::simpleMatch(start->linkAt(4), ") ; }"))
         return nullptr;
-    const Token * endStatement = start->linkAt(4)->next();
-    if(endStatement->next() != endToken)
+    const Token *endStatement = start->linkAt(4)->next();
+    if (endStatement->next() != endToken)
         return nullptr;
 
-    const Token * dotTok = start->tokAt(2);
-    if(!Token::findmatch(dotTok->tokAt(2), "%varid%", endStatement, varid))
+    const Token *dotTok = start->tokAt(2);
+    if (!Token::findmatch(dotTok->tokAt(2), "%varid%", endStatement, varid))
         return nullptr;
     input = Token::Match(start->next(), "%var% . %name% ( %varid% )", varid);
-    if(isVariableChanged(dotTok->next(), endStatement, dotTok->astOperand1()->varId(), false, nullptr, true))
+    if (isVariableChanged(dotTok->next(), endStatement, dotTok->astOperand1()->varId(), false, nullptr, true))
         return nullptr;
-    return dotTok;      
+    return dotTok;
 }
 
-static const Token* singleIncrementInScope(const Token* start, unsigned int varid, bool& input)
+static const Token *singleIncrementInScope(const Token *start, unsigned int varid, bool &input)
 {
-    if(start->str() != "{")
+    if (start->str() != "{")
         return nullptr;
-    const Token * varTok = nullptr;
-    if(Token::Match(start->next(), "++ %var% ; }"))
+    const Token *varTok = nullptr;
+    if (Token::Match(start->next(), "++ %var% ; }"))
         varTok = start->tokAt(2);
-    else if(Token::Match(start->next(), "%var% ++ ; }"))
-        varTok = start->tokAt(1);    
-    if(!varTok)
+    else if (Token::Match(start->next(), "%var% ++ ; }"))
+        varTok = start->tokAt(1);
+    if (!varTok)
         return nullptr;
     input = varTok->varId() == varid;
-    return varTok;      
+    return varTok;
 }
 
-static const Token* singleConditionalInScope(const Token* start, unsigned int varid)
+static const Token *singleConditionalInScope(const Token *start, unsigned int varid)
 {
-    if(start->str() != "{")
+    if (start->str() != "{")
         return nullptr;
-    const Token * endToken = start->link();
-    if(!Token::simpleMatch(start->next(), "if ("))
+    const Token *endToken = start->link();
+    if (!Token::simpleMatch(start->next(), "if ("))
         return nullptr;
-    if(!Token::simpleMatch(start->linkAt(2), ") {"))
+    if (!Token::simpleMatch(start->linkAt(2), ") {"))
         return nullptr;
-    const Token * bodyTok = start->linkAt(2)->next();
-    const Token * endBodyTok = bodyTok->link();
-    if(!Token::simpleMatch(endBodyTok, "} }"))
+    const Token *bodyTok = start->linkAt(2)->next();
+    const Token *endBodyTok = bodyTok->link();
+    if (!Token::simpleMatch(endBodyTok, "} }"))
         return nullptr;
-    if(endBodyTok->next() != endToken)
+    if (endBodyTok->next() != endToken)
         return nullptr;
-    if(!Token::findmatch(start, "%varid%", bodyTok, varid))
+    if (!Token::findmatch(start, "%varid%", bodyTok, varid))
         return nullptr;
-    if(isVariableChanged(start, bodyTok, varid, false, nullptr, true))
+    if (isVariableChanged(start, bodyTok, varid, false, nullptr, true))
         return nullptr;
     return bodyTok;
 }
 
-static bool addByOne(const Token * tok, unsigned int varid)
+static bool addByOne(const Token *tok, unsigned int varid)
 {
-    if(Token::Match(tok, "+= %any% ;") && 
-        tok->tokAt(1)->hasKnownIntValue() && 
+    if (Token::Match(tok, "+= %any% ;") &&
+        tok->tokAt(1)->hasKnownIntValue() &&
         tok->tokAt(1)->getValue(1)) {
         return true;
     }
-    if(Token::Match(tok, "= %varid% + %any% ;", varid) && 
-        tok->tokAt(3)->hasKnownIntValue() && 
+    if (Token::Match(tok, "= %varid% + %any% ;", varid) &&
+        tok->tokAt(3)->hasKnownIntValue() &&
         tok->tokAt(3)->getValue(1)) {
         return true;
     }
     return false;
 }
 
-static bool accumulateBoolLiteral(const Token * tok, unsigned int varid)
+static bool accumulateBoolLiteral(const Token *tok, unsigned int varid)
 {
     // TODO: Missing %oreq%
-    if(Token::Match(tok, "=|&= %bool% ;") && 
+    if (Token::Match(tok, "=|&= %bool% ;") &&
         tok->tokAt(1)->hasKnownIntValue()) {
         return true;
     }
-    if(Token::Match(tok, "= %varid% %oror%|%or%|&&|& %bool% ;", varid) && 
+    if (Token::Match(tok, "= %varid% %oror%|%or%|&&|& %bool% ;", varid) &&
         tok->tokAt(3)->hasKnownIntValue()) {
         return true;
     }
     return false;
 }
 
-static bool accumulateBool(const Token * tok, unsigned int varid)
+static bool accumulateBool(const Token *tok, unsigned int varid)
 {
     // TODO: Missing %oreq%
-    if(Token::simpleMatch(tok, "&=")) {
+    if (Token::simpleMatch(tok, "&=")) {
         return true;
     }
-    if(Token::Match(tok, "= %varid% %oror%|%or%|&&|&", varid)) {
+    if (Token::Match(tok, "= %varid% %oror%|%or%|&&|&", varid)) {
         return true;
     }
     return false;
 }
 
-static bool hasVarIds(const Token * tok, unsigned int var1, unsigned int var2)
+static bool hasVarIds(const Token *tok, unsigned int var1, unsigned int var2)
 {
-    if(tok->astOperand1()->varId() == tok->astOperand2()->varId())
+    if (tok->astOperand1()->varId() == tok->astOperand2()->varId())
         return false;
-    if(tok->astOperand1()->varId() == var1 || tok->astOperand1()->varId() == var2) {
-        if(tok->astOperand2()->varId() == var1 || tok->astOperand2()->varId() == var2) {
+    if (tok->astOperand1()->varId() == var1 || tok->astOperand1()->varId() == var2) {
+        if (tok->astOperand2()->varId() == var1 || tok->astOperand2()->varId() == var2) {
             return true;
         }
     }
     return false;
 }
 
-static std::string flipMinMax(const std::string& algo)
+static std::string flipMinMax(const std::string &algo)
 {
-    if(algo == "std::max_element")
+    if (algo == "std::max_element")
         return "std::min_element";
-    if(algo == "std::min_element")
+    if (algo == "std::min_element")
         return "std::max_element";
     return algo;
 }
 
-static std::string minmaxCompare(const Token * condTok, unsigned int loopVar, unsigned int assignVar, bool invert=false)
+static std::string minmaxCompare(const Token *condTok, unsigned int loopVar, unsigned int assignVar, bool invert = false)
 {
-    if(!Token::Match(condTok, "<|<=|>=|>"))
+    if (!Token::Match(condTok, "<|<=|>=|>"))
         return "std::accumulate";
-    if(!hasVarIds(condTok, loopVar, assignVar))
+    if (!hasVarIds(condTok, loopVar, assignVar))
         return "std::accumulate";
     std::string algo = "std::max_element";
-    if(Token::Match(condTok, "<|<="))
+    if (Token::Match(condTok, "<|<="))
         algo = "std::min_element";
-    if(condTok->astOperand1()->varId() == assignVar)
+    if (condTok->astOperand1()->varId() == assignVar)
         algo = flipMinMax(algo);
-    if(invert)
+    if (invert)
         algo = flipMinMax(algo);
     return algo;
 }
@@ -1942,39 +1942,39 @@ void CheckStl::useStlAlgorithm()
     for (const Scope *function : mTokenizer->getSymbolDatabase()->functionScopes) {
         for (const Token *tok = function->bodyStart; tok != function->bodyEnd; tok = tok->next()) {
             // Parse range-based for loop
-            if(!Token::simpleMatch(tok, "for ("))
+            if (!Token::simpleMatch(tok, "for ("))
                 continue;
-            if(!Token::simpleMatch(tok->next()->link(), ") {"))
+            if (!Token::simpleMatch(tok->next()->link(), ") {"))
                 continue;
-            const Token * bodyTok = tok->next()->link()->next();
+            const Token *bodyTok = tok->next()->link()->next();
             const Token *splitTok = tok->next()->astOperand2();
             if (!Token::simpleMatch(splitTok, ":"))
                 continue;
-            const Token * loopVar = splitTok->previous();
-            if(!Token::Match(loopVar, "%var%"))
+            const Token *loopVar = splitTok->previous();
+            if (!Token::Match(loopVar, "%var%"))
                 continue;
 
             // Check for single assignment
             bool useLoopVarInAssign;
-            const Token * assignTok = singleAssignInScope(bodyTok, loopVar->varId(), useLoopVarInAssign);
-            if(assignTok) {
+            const Token *assignTok = singleAssignInScope(bodyTok, loopVar->varId(), useLoopVarInAssign);
+            if (assignTok) {
                 unsigned int assignVarId = assignTok->astOperand1()->varId();
                 std::string algo;
-                if(assignVarId == loopVar->varId()) {
-                    if(useLoopVarInAssign)
+                if (assignVarId == loopVar->varId()) {
+                    if (useLoopVarInAssign)
                         algo = "std::transform";
-                    else if(Token::Match(assignTok->next(), "%var%|%bool%|%num%|%char% ;"))
+                    else if (Token::Match(assignTok->next(), "%var%|%bool%|%num%|%char% ;"))
                         algo = "std::fill";
-                    else if(Token::Match(assignTok->next(), "%name% ( )"))
+                    else if (Token::Match(assignTok->next(), "%name% ( )"))
                         algo = "std::generate";
                     else
                         algo = "std::fill or std::generate";
                 } else {
-                    if(addByOne(assignTok, assignVarId))
+                    if (addByOne(assignTok, assignVarId))
                         algo = "std::distance";
-                    else if(accumulateBool(assignTok, assignVarId))
+                    else if (accumulateBool(assignTok, assignVarId))
                         algo = "std::any_of, std::all_of, std::none_of, or std::accumulate";
-                    else if(Token::Match(assignTok, "= %var% <|<=|>=|> %var% ? %var% : %var%") && hasVarIds(assignTok->tokAt(6), loopVar->varId(), assignVarId))
+                    else if (Token::Match(assignTok, "= %var% <|<=|>=|> %var% ? %var% : %var%") && hasVarIds(assignTok->tokAt(6), loopVar->varId(), assignVarId))
                         algo = minmaxCompare(assignTok->tokAt(2), loopVar->varId(), assignVarId, assignTok->tokAt(5)->varId() == assignVarId);
                     else
                         algo = "std::accumulate";
@@ -1984,17 +1984,17 @@ void CheckStl::useStlAlgorithm()
             }
             // Check for container calls
             bool useLoopVarInMemCall;
-            const Token * memberAccessTok = singleMemberCallInScope(bodyTok, loopVar->varId(), useLoopVarInMemCall);
-            if(memberAccessTok) {
-                const Token * memberCallTok = memberAccessTok->astOperand2();
+            const Token *memberAccessTok = singleMemberCallInScope(bodyTok, loopVar->varId(), useLoopVarInMemCall);
+            if (memberAccessTok) {
+                const Token *memberCallTok = memberAccessTok->astOperand2();
                 unsigned int contVarId = memberAccessTok->astOperand1()->varId();
-                if(contVarId == loopVar->varId())
+                if (contVarId == loopVar->varId())
                     continue;
-                if(memberCallTok->str() == "push_back" || 
+                if (memberCallTok->str() == "push_back" ||
                     memberCallTok->str() == "push_front" ||
                     memberCallTok->str() == "emplace_back") {
                     std::string algo;
-                    if(useLoopVarInMemCall)
+                    if (useLoopVarInMemCall)
                         algo = "std::copy";
                     else
                         algo = "std::transform";
@@ -2005,10 +2005,10 @@ void CheckStl::useStlAlgorithm()
 
             // Check for increment in loop
             bool useLoopVarInIncrement;
-            const Token * incrementTok = singleIncrementInScope(bodyTok, loopVar->varId(), useLoopVarInIncrement);
-            if(incrementTok) {
+            const Token *incrementTok = singleIncrementInScope(bodyTok, loopVar->varId(), useLoopVarInIncrement);
+            if (incrementTok) {
                 std::string algo;
-                if(useLoopVarInIncrement)
+                if (useLoopVarInIncrement)
                     algo = "std::transform";
                 else
                     algo = "std::distance";
@@ -2017,23 +2017,23 @@ void CheckStl::useStlAlgorithm()
             }
 
             // Check for conditionals
-            const Token * condBodyTok = singleConditionalInScope(bodyTok, loopVar->varId());
-            if(condBodyTok) {
-                const Token * beginCondTok = condBodyTok->previous()->link();
+            const Token *condBodyTok = singleConditionalInScope(bodyTok, loopVar->varId());
+            if (condBodyTok) {
+                const Token *beginCondTok = condBodyTok->previous()->link();
                 // Check for single assign
                 assignTok = singleAssignInScope(condBodyTok, loopVar->varId(), useLoopVarInAssign);
-                if(assignTok) {
+                if (assignTok) {
                     unsigned int assignVarId = assignTok->astOperand1()->varId();
                     std::string algo;
-                    if(assignVarId == loopVar->varId()) {
-                        if(useLoopVarInAssign)
+                    if (assignVarId == loopVar->varId()) {
+                        if (useLoopVarInAssign)
                             algo = "std::transform";
                         else
                             algo = "std::replace_if";
                     } else {
-                        if(addByOne(assignTok, assignVarId))
+                        if (addByOne(assignTok, assignVarId))
                             algo = "std::count_if";
-                        else if(accumulateBoolLiteral(assignTok, assignVarId))
+                        else if (accumulateBoolLiteral(assignTok, assignVarId))
                             algo = "std::any_of, std::all_of, std::none_of, or std::accumulate";
                         else
                             algo = "std::accumulate";
@@ -2044,15 +2044,15 @@ void CheckStl::useStlAlgorithm()
 
                 // Check for container call
                 memberAccessTok = singleMemberCallInScope(condBodyTok, loopVar->varId(), useLoopVarInMemCall);
-                if(memberAccessTok) {
-                    const Token * memberCallTok = memberAccessTok->astOperand2();
+                if (memberAccessTok) {
+                    const Token *memberCallTok = memberAccessTok->astOperand2();
                     unsigned int contVarId = memberAccessTok->astOperand1()->varId();
-                    if(contVarId == loopVar->varId())
+                    if (contVarId == loopVar->varId())
                         continue;
-                    if(memberCallTok->str() == "push_back" || 
+                    if (memberCallTok->str() == "push_back" ||
                         memberCallTok->str() == "push_front" ||
                         memberCallTok->str() == "emplace_back") {
-                        if(useLoopVarInMemCall)
+                        if (useLoopVarInMemCall)
                             useStlAlgorithmError(memberAccessTok, "std::copy_if");
                         // There is no transform_if to suggest
                     }
@@ -2061,9 +2061,9 @@ void CheckStl::useStlAlgorithm()
 
                 // Check for increment in loop
                 incrementTok = singleIncrementInScope(condBodyTok, loopVar->varId(), useLoopVarInIncrement);
-                if(incrementTok) {
+                if (incrementTok) {
                     std::string algo;
-                    if(useLoopVarInIncrement)
+                    if (useLoopVarInIncrement)
                         algo = "std::transform";
                     else
                         algo = "std::count_if";
@@ -2072,10 +2072,10 @@ void CheckStl::useStlAlgorithm()
                 }
 
                 // Check early return
-                if(isEarlyExit(condBodyTok)) {
-                    const Token * loopVar2 = Token::findmatch(condBodyTok, "%varid%", condBodyTok->link(), loopVar->varId());
+                if (isEarlyExit(condBodyTok)) {
+                    const Token *loopVar2 = Token::findmatch(condBodyTok, "%varid%", condBodyTok->link(), loopVar->varId());
                     std::string algo;
-                    if(loopVar2)
+                    if (loopVar2)
                         algo = "std::find_if";
                     else
                         algo = "std::any_of";
@@ -2083,7 +2083,6 @@ void CheckStl::useStlAlgorithm()
                     continue;
                 }
             }
-
         }
     }
 }

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2020,32 +2020,40 @@ static bool hasVarIds(const Token * tok, unsigned int var1, unsigned int var2)
 {
     if(tok->astOperand1()->varId() == tok->astOperand2()->varId())
         return false;
-    unsigned int varids[] = {var1, var2};
-    unsigned int * varidsEnd = varids+2;
-    if(std::find(varids, varidsEnd, tok->astOperand1()->varId()) == varidsEnd)
-        return false;
-    if(std::find(varids, varidsEnd, tok->astOperand2()->varId()) == varidsEnd)
-        return false;
-    return true;
+    if(tok->astOperand1()->varId() == var1)
+        return true;
+    if(tok->astOperand1()->varId() == var2)
+        return true;
+    if(tok->astOperand2()->varId() == var1)
+        return true;
+    if(tok->astOperand2()->varId() == var2)
+        return true;
+    return false;
+}
+
+static std::string flipMinMax(const std::string& algo)
+{
+    if(algo == "std::max_element")
+        return "std::min_element";
+    if(algo == "std::min_element")
+        return "std::max_element";
+    return algo;
 }
 
 static std::string minmaxCompare(const Token * condTok, unsigned int loopVar, unsigned int assignVar, bool invert=false)
 {
-    static const std::vector<std::string> minmaxAlgos = {
-        "std::max_element", "std::min_element"
-    };
     if(!Token::Match(condTok, "<|<=|>=|>"))
         return "std::accumulate";
     if(!hasVarIds(condTok, loopVar, assignVar))
         return "std::accumulate";
-    int algo = 0;
+    std::string algo = "std::max_element";
     if(Token::Match(condTok, "<|<="))
-        algo = 1;
+        algo = "std::min_element";
     if(condTok->astOperand1()->varId() == assignVar)
-        algo = (algo + 1) % 2;
+        algo = flipMinMax(algo);
     if(invert)
-        algo = (algo + 1) % 2;
-    return minmaxAlgos[algo];
+        algo = flipMinMax(algo);
+    return algo;
 }
 
 void CheckStl::useStlAlgorithm()

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1761,7 +1761,7 @@ static bool isEarlyExit(const Token* start)
     const Token * tok = Token::findmatch(start, "return|throw|break", endToken);
     if(!tok)
         return false;
-    const Token * endStatement = Token::findmatch(tok, "; }", endToken);
+    const Token * endStatement = Token::findsimplematch(tok, "; }", endToken);
     if(!endStatement)
         return false;
     if(endStatement->next() != endToken)
@@ -1805,9 +1805,9 @@ static const Token* singleMemberCallInScope(const Token* start, unsigned int var
     const Token * endToken = start->link();
     if(!Token::Match(start->next(), "%var% . %name% ("))
         return nullptr;
-    if(!Token::Match(start->tokAt(4)->link(), ") ; }"))
+    if(!Token::simpleMatch(start->linkAt(4), ") ; }"))
         return nullptr;
-    const Token * endStatement = start->tokAt(4)->link()->next();
+    const Token * endStatement = start->linkAt(4)->next();
     if(endStatement->next() != endToken)
         return nullptr;
 
@@ -1840,13 +1840,13 @@ static const Token* singleConditionalInScope(const Token* start, unsigned int va
     if(start->str() != "{")
         return nullptr;
     const Token * endToken = start->link();
-    if(!Token::Match(start->next(), "if ("))
+    if(!Token::simpleMatch(start->next(), "if ("))
         return nullptr;
-    if(!Token::Match(start->tokAt(2)->link(), ") {"))
+    if(!Token::simpleMatch(start->linkAt(2), ") {"))
         return nullptr;
-    const Token * bodyTok = start->tokAt(2)->link()->next();
+    const Token * bodyTok = start->linkAt(2)->next();
     const Token * endBodyTok = bodyTok->link();
-    if(!Token::Match(endBodyTok, "} }"))
+    if(!Token::simpleMatch(endBodyTok, "} }"))
         return nullptr;
     if(endBodyTok->next() != endToken)
         return nullptr;
@@ -1889,7 +1889,7 @@ static bool accumulateBoolLiteral(const Token * tok, unsigned int varid)
 static bool accumulateBool(const Token * tok, unsigned int varid)
 {
     // TODO: Missing %oreq%
-    if(Token::Match(tok, "&=")) {
+    if(Token::simpleMatch(tok, "&=")) {
         return true;
     }
     if(Token::Match(tok, "= %varid% %oror%|%or%|&&|&", varid)) {

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1981,11 +1981,12 @@ static bool addByOne(const Token * tok, unsigned int varid)
 
 static bool accumulateBool(const Token * tok, unsigned int varid)
 {
-    if(Token::Match(tok, "=|&=|%or%= %bool% ;") && 
+    // TODO: Missing %oreq%
+    if(Token::Match(tok, "=|&= %bool% ;") && 
         tok->tokAt(1)->hasKnownIntValue()) {
         return true;
     }
-    if(Token::Match(tok, "= %varid% &|%oror%|%or%|&& %bool% ;", varid) && 
+    if(Token::Match(tok, "= %varid% %oror%|%or%|&&|& %bool% ;", varid) && 
         tok->tokAt(3)->hasKnownIntValue()) {
         return true;
     }

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1979,7 +1979,7 @@ static bool addByOne(const Token * tok, unsigned int varid)
     return false;
 }
 
-static bool accumulateBool(const Token * tok, unsigned int varid)
+static bool accumulateBoolLiteral(const Token * tok, unsigned int varid)
 {
     // TODO: Missing %oreq%
     if(Token::Match(tok, "=|&= %bool% ;") && 
@@ -1988,6 +1988,18 @@ static bool accumulateBool(const Token * tok, unsigned int varid)
     }
     if(Token::Match(tok, "= %varid% %oror%|%or%|&&|& %bool% ;", varid) && 
         tok->tokAt(3)->hasKnownIntValue()) {
+        return true;
+    }
+    return false;
+}
+
+static bool accumulateBool(const Token * tok, unsigned int varid)
+{
+    // TODO: Missing %oreq%
+    if(Token::Match(tok, "&=")) {
+        return true;
+    }
+    if(Token::Match(tok, "= %varid% %oror%|%or%|&&|&", varid)) {
         return true;
     }
     return false;
@@ -2030,6 +2042,8 @@ void CheckStl::useStlAlgorithm()
                 } else {
                     if(addByOne(assignTok, assignVarId))
                         algo = "std::distance";
+                    else if(accumulateBool(assignTok, assignVarId))
+                        algo = "std::any_of, std::all_of, std::none_of, or std::accumulate";
                     else
                         algo = "std::accumulate";
                 }
@@ -2087,7 +2101,7 @@ void CheckStl::useStlAlgorithm()
                     } else {
                         if(addByOne(assignTok, assignVarId))
                             algo = "std::count_if";
-                        else if(accumulateBool(assignTok, assignVarId))
+                        else if(accumulateBoolLiteral(assignTok, assignVarId))
                             algo = "std::any_of, std::all_of, std::none_of, or std::accumulate";
                         else
                             algo = "std::accumulate";

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1921,8 +1921,8 @@ void CheckStl::loopAlgo()
             const Token * assignTok = singleAssignInScope(bodyTok, loopVar->varId(), useLoopVarInAssign);
             if(assignTok) {
                 unsigned int assignVarId = assignTok->astOperand1()->varId();
+                std::string algo;
                 if(assignVarId == loopVar->varId()) {
-                    std::string algo;
                     if(useLoopVarInAssign)
                         algo = "std::transform";
                     else if(Token::Match(assignTok->next(), "%var%|%bool%|%num%|%char% ;"))
@@ -1931,8 +1931,20 @@ void CheckStl::loopAlgo()
                         algo = "std::generate";
                     else
                         algo = "std::fill or std::generate";
-                    useStlAlgorithmError(assignTok, algo);
+                } else {
+                    algo = "std::accumulate";
+                    if(Token::Match(assignTok, "+= %any% ;") && 
+                        assignTok->tokAt(1)->hasKnownIntValue() && 
+                        assignTok->tokAt(1)->getValue(1)) {
+                        algo = "std::distance";
+                    }
+                    if(Token::Match(assignTok, "= %varid% + %any% ;", assignVarId) && 
+                        assignTok->tokAt(3)->hasKnownIntValue() && 
+                        assignTok->tokAt(3)->getValue(1)) {
+                        algo = "std::distance";
+                    }
                 }
+                useStlAlgorithmError(assignTok, algo);
                 continue;
             }
 

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2005,7 +2005,7 @@ void CheckStl::useStlAlgorithm()
                 continue;
             const Token * bodyTok = tok->next()->link()->next();
             const Token *splitTok = tok->next()->astOperand2();
-            if (splitTok->str() != ":")
+            if (!Token::simpleMatch(splitTok, ":"))
                 continue;
             const Token * loopVar = splitTok->previous();
             if(!Token::Match(loopVar, "%var%"))

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1902,14 +1902,11 @@ static bool hasVarIds(const Token * tok, unsigned int var1, unsigned int var2)
 {
     if(tok->astOperand1()->varId() == tok->astOperand2()->varId())
         return false;
-    if(tok->astOperand1()->varId() == var1)
-        return true;
-    if(tok->astOperand1()->varId() == var2)
-        return true;
-    if(tok->astOperand2()->varId() == var1)
-        return true;
-    if(tok->astOperand2()->varId() == var2)
-        return true;
+    if(tok->astOperand1()->varId() == var1 || tok->astOperand1()->varId() == var2) {
+        if(tok->astOperand2()->varId() == var1 || tok->astOperand2()->varId() == var2) {
+            return true;
+        }
+    }
     return false;
 }
 

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1979,6 +1979,19 @@ static bool addByOne(const Token * tok, unsigned int varid)
     return false;
 }
 
+static bool accumulateBool(const Token * tok, unsigned int varid)
+{
+    if(Token::Match(tok, "=|&=|%or%= %bool% ;") && 
+        tok->tokAt(1)->hasKnownIntValue()) {
+        return true;
+    }
+    if(Token::Match(tok, "= %varid% &|%oror%|%or%|&& %bool% ;", varid) && 
+        tok->tokAt(3)->hasKnownIntValue()) {
+        return true;
+    }
+    return false;
+}
+
 void CheckStl::useStlAlgorithm()
 {
     if (!mSettings->isEnabled(Settings::STYLE))
@@ -2071,9 +2084,12 @@ void CheckStl::useStlAlgorithm()
                         else
                             algo = "std::replace_if";
                     } else {
-                        algo = "std::accumulate";
                         if(addByOne(assignTok, assignVarId))
                             algo = "std::count_if";
+                        else if(accumulateBool(assignTok, assignVarId))
+                            algo = "std::any_of, std::all_of, std::none_of, or std::accumulate";
+                        else
+                            algo = "std::accumulate";
                     }
                     useStlAlgorithmError(assignTok, algo);
                     continue;

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -89,6 +89,7 @@ public:
         checkStl.redundantCondition();
         checkStl.missingComparison();
         checkStl.readingEmptyStlContainer();
+        checkStl.loopAlgo();
     }
 
     /** Accessing container out of bounds using ValueFlow */
@@ -184,6 +185,9 @@ public:
 
     /** @brief Reading from empty stl container (using valueflow) */
     void readingEmptyStlContainer2();
+
+    /** @brief Look for loops that can replaced with std algorithms */
+    void loopAlgo();
 private:
     void readingEmptyStlContainer_parseUsage(const Token* tok, const Library::Container* container, std::map<unsigned int, const Library::Container*>& empty, bool noerror);
 
@@ -223,6 +227,8 @@ private:
 
     void readingEmptyStlContainerError(const Token* tok, const ValueFlow::Value *value=nullptr);
 
+    void useStlAlgorithmError(const Token* tok, const std::string &algoName);
+
     void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         CheckStl c(nullptr, settings, errorLogger);
         c.outOfBoundsError(nullptr, nullptr, nullptr);
@@ -257,6 +263,7 @@ private:
         c.uselessCallsRemoveError(nullptr, "remove");
         c.dereferenceInvalidIteratorError(nullptr, "i");
         c.readingEmptyStlContainerError(nullptr);
+        c.useStlAlgorithmError(nullptr, "");
     }
 
     static std::string myName() {

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -183,7 +183,8 @@ public:
 
     /** @brief Look for loops that can replaced with std algorithms */
     void useStlAlgorithm();
-private:
+
+  private:
     void missingComparisonError(const Token* incrementToken1, const Token* incrementToken2);
     void string_c_strThrowError(const Token* tok);
     void string_c_strError(const Token* tok);
@@ -220,7 +221,7 @@ private:
 
     void readingEmptyStlContainerError(const Token* tok, const ValueFlow::Value *value=nullptr);
 
-    void useStlAlgorithmError(const Token* tok, const std::string &algoName);
+    void useStlAlgorithmError(const Token *tok, const std::string &algoName);
 
     void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         CheckStl c(nullptr, settings, errorLogger);

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -89,7 +89,7 @@ public:
         checkStl.redundantCondition();
         checkStl.missingComparison();
         checkStl.readingEmptyStlContainer();
-        checkStl.loopAlgo();
+        checkStl.useStlAlgorithm();
     }
 
     /** Accessing container out of bounds using ValueFlow */
@@ -187,7 +187,7 @@ public:
     void readingEmptyStlContainer2();
 
     /** @brief Look for loops that can replaced with std algorithms */
-    void loopAlgo();
+    void useStlAlgorithm();
 private:
     void readingEmptyStlContainer_parseUsage(const Token* tok, const Library::Container* container, std::map<unsigned int, const Library::Container*>& empty, bool noerror);
 

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -279,7 +279,8 @@ public:
                "- using auto pointer (auto_ptr)\n"
                "- useless calls of string and STL functions\n"
                "- dereferencing an invalid iterator\n"
-               "- reading from empty STL container\n";
+               "- reading from empty STL container\n"
+               "- consider using an STL algorithm instead of raw loop\n";
     }
 };
 /// @}

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -149,6 +149,7 @@ private:
         TEST_CASE(loopAlgoAccumulateAssign);
         TEST_CASE(loopAlgoContainerInsert);
         TEST_CASE(loopAlgoIncrement);
+        TEST_CASE(loopAlgoConditional);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3366,31 +3367,31 @@ private:
               "    for(int x:v)\n"
               "        x = 1;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::fill algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = x + 1;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo(int a, int b) {\n"
               "    for(int x:v)\n"
               "        x = a + b;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::fill or std::generate algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill or std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x += 1;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = f();\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::generate algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v) {\n"
@@ -3423,28 +3424,28 @@ private:
               "    for(int x:v)\n"
               "        n += x;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::accumulate algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = n + x;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::accumulate algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n += 1;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = n + 1;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
@@ -3460,42 +3461,42 @@ private:
               "    for(int x:v)\n"
               "        c.push_back(x);\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::copy algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(f(x));\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(x + 1);\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(x);\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::copy algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(f(x));\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(x + 1);\n"
               "}\n",true);
-        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3518,26 +3519,115 @@ private:
               "    for(int x:v)\n"
               "        n++;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        ++n;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x++;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        ++x;\n"
               "}\n",true);
-        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+    }
+
+    void loopAlgoConditional() {
+      check("bool pred(int x);\n"
+            "void foo() {\n"
+            "    for(int x:v) {\n"
+            "        if (pred(x)) {\n"
+            "            x = 1; \n"
+            "        }\n"
+            "    }\n"
+            "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::replace_if algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            n += x; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            n += 1; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::count_if algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            n++; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::count_if algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+            "void foo() {\n"
+            "    for(int x:v) {\n"
+            "        if (pred(x)) {\n"
+            "            x = x + 1; \n"
+            "        }\n"
+            "    }\n"
+            "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+            "void foo() {\n"
+            "    std::vector<int> c;\n"
+            "    for(int x:v) {\n"
+            "        if (pred(x)) {\n"
+            "            c.push_back(x); \n"
+            "        }\n"
+            "    }\n"
+            "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::copy_if algorithm instead of a raw loop.\n", errout.str());
+
+        // There is no transform_if
+        check("bool pred(int x);\n"
+            "void foo() {\n"
+            "    std::vector<int> c;\n"
+            "    for(int x:v) {\n"
+            "        if (pred(x)) {\n"
+            "            c.push_back(x + 1); \n"
+            "        }\n"
+            "    }\n"
+            "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool pred(int x);\n"
+            "void foo() {\n"
+            "    for(int x:v) {\n"
+            "        x++;\n"
+            "        if (pred(x)) {\n"
+            "            x = 1; \n"
+            "        }\n"
+            "    }\n"
+            "}\n",true);
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3455,6 +3455,38 @@ private:
               "}\n",true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
+        check("bool f(int);\n"
+              "void foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v)\n"
+              "        b &= f(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool f(int);\n"
+              "void foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v)\n"
+              "        b |= f(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool f(int);\n"
+              "void foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v)\n"
+              "        b = b && f(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool f(int);\n"
+              "void foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v)\n"
+              "        b = b || f(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int& x:v)\n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -148,6 +148,7 @@ private:
         TEST_CASE(loopAlgoElementAssign);
         TEST_CASE(loopAlgoAccumulateAssign);
         TEST_CASE(loopAlgoContainerInsert);
+        TEST_CASE(loopAlgoIncrement);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3509,6 +3510,34 @@ private:
               "        c.push_back(0);\n"
               "}\n",true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void loopAlgoIncrement() {
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n++;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        ++n;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x++;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        ++x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
     }
 };
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3401,6 +3401,14 @@ private:
               "}\n",true);
         ASSERT_EQUALS("", errout.str());
 
+        check("void foo() {\n"
+              "    for(int x:v) {\n"
+              "        x = 1;\n"
+              "        f();\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
         // There should be probably be a message for unconditional break
         check("void foo() {\n"
               "    for(int x:v) {\n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3586,47 +3586,69 @@ private:
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::count_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
-            "void foo() {\n"
-            "    for(int x:v) {\n"
-            "        if (pred(x)) {\n"
-            "            x = x + 1; \n"
-            "        }\n"
-            "    }\n"
-            "}\n",true);
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            x = x + 1; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
-            "void foo() {\n"
-            "    std::vector<int> c;\n"
-            "    for(int x:v) {\n"
-            "        if (pred(x)) {\n"
-            "            c.push_back(x); \n"
-            "        }\n"
-            "    }\n"
-            "}\n",true);
+              "void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            c.push_back(x); \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::copy_if algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            return false; \n"
+              "        }\n"
+              "    }\n"
+              "    return true;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
+        
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            return false; \n"
+              "        }\n"
+              "        return true;\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
 
         // There is no transform_if
         check("bool pred(int x);\n"
-            "void foo() {\n"
-            "    std::vector<int> c;\n"
-            "    for(int x:v) {\n"
-            "        if (pred(x)) {\n"
-            "            c.push_back(x + 1); \n"
-            "        }\n"
-            "    }\n"
-            "}\n",true);
+              "void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            c.push_back(x + 1); \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
         ASSERT_EQUALS("", errout.str());
 
         check("bool pred(int x);\n"
-            "void foo() {\n"
-            "    for(int x:v) {\n"
-            "        x++;\n"
-            "        if (pred(x)) {\n"
-            "            x = 1; \n"
-            "        }\n"
-            "    }\n"
-            "}\n",true);
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        x++;\n"
+              "        if (pred(x)) {\n"
+              "            x = 1; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
         ASSERT_EQUALS("", errout.str());
     }
 };

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -147,6 +147,7 @@ private:
         TEST_CASE(readingEmptyStlContainer);
         TEST_CASE(loopAlgoElementAssign);
         TEST_CASE(loopAlgoAccumulateAssign);
+        TEST_CASE(loopAlgoContainerInsert);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3448,6 +3449,64 @@ private:
               "    int n = 0;\n"
               "    for(int& x:v)\n"
               "        n = ++x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void loopAlgoContainerInsert() {
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_back(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::copy algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_back(f(x));\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_back(x + 1);\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_front(x);\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::copy algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_front(f(x));\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_front(x + 1);\n"
+              "}\n",true);
+        ASSERT_EQUALS("(style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_back(v);\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo() {\n"
+              "    std::vector<int> c;\n"
+              "    for(int x:v)\n"
+              "        c.push_back(0);\n"
               "}\n",true);
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3219,7 +3219,7 @@ private:
               true);
         ASSERT_EQUALS("", errout.str());
 
-        // There should be probably be a message for unconditional break
+        // There should probably be a message for unconditional break
         check("void foo() {\n"
               "    for(int& x:v) {\n"
               "        x = 1;\n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -145,7 +145,8 @@ private:
         TEST_CASE(dereference_auto);
 
         TEST_CASE(readingEmptyStlContainer);
-        TEST_CASE(loopAlgo);
+        TEST_CASE(loopAlgoElementAssign);
+        TEST_CASE(loopAlgoAccumulateAssign);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3358,7 +3359,7 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void loopAlgo() {
+    void loopAlgoElementAssign() {
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = 1;\n"
@@ -3388,6 +3389,67 @@ private:
               "        x = f();\n"
               "}\n",true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::generate algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v) {\n"
+              "        f();\n"
+              "        x = 1;\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+        // There should be probably be a message for unconditional break
+        check("void foo() {\n"
+              "    for(int x:v) {\n"
+              "        x = 1;\n"
+              "        break;\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x = ++x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+    }
+
+    void loopAlgoAccumulateAssign() {
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n += x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = n + x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n += 1;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = n + 1;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Considering using std::distance algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int& x:v)\n"
+              "        n = ++x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -145,6 +145,7 @@ private:
         TEST_CASE(dereference_auto);
 
         TEST_CASE(readingEmptyStlContainer);
+        TEST_CASE(loopAlgo);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3355,6 +3356,38 @@ private:
               "  }\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void loopAlgo() {
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x = 1;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::fill algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x = x + 1;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo(int a, int b) {\n"
+              "    for(int x:v)\n"
+              "        x = a + b;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::fill or std::generate algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x += 1;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::transform algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    for(int x:v)\n"
+              "        x = f();\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:3]: (style) Considering using std::generate algorithm instead of a raw loop.\n", errout.str());
     }
 };
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3659,6 +3659,41 @@ private:
 
         check("bool pred(int x);\n"
               "bool foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            break; \n"
+              "        }\n"
+              "    }\n"
+              "    return true;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "void f();\n"
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            f(); \n"
+              "            break; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "void f(int x);\n"
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            f(x); \n"
+              "            break; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::find_if algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
               "    bool b = false;\n"
               "    for(int x:v) {\n"
               "        if (pred(x)) {\n"
@@ -3723,6 +3758,18 @@ private:
               "        x++;\n"
               "        if (pred(x)) {\n"
               "            x = 1; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool pred(int x);\n"
+              "void f();\n"
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            if(x) { return; }\n"
+              "            break; \n"
               "        }\n"
               "    }\n"
               "}\n",true);

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3164,35 +3164,41 @@ private:
         ASSERT_EQUALS("[test.cpp:18]: (error, inconclusive) Invalid iterator 'it' used.\n", errout.str());
     }
 
-    void loopAlgoElementAssign() {
+    void loopAlgoElementAssign()
+    {
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = 1;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = x + 1;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo(int a, int b) {\n"
               "    for(int x:v)\n"
               "        x = a + b;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill or std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x += 1;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = f();\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
@@ -3200,7 +3206,8 @@ private:
               "        f();\n"
               "        x = 1;\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
@@ -3208,7 +3215,8 @@ private:
               "        x = 1;\n"
               "        f();\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         // There should be probably be a message for unconditional break
@@ -3217,44 +3225,50 @@ private:
               "        x = 1;\n"
               "        break;\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x = ++x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
-
     }
 
-    void loopAlgoAccumulateAssign() {
+    void loopAlgoAccumulateAssign()
+    {
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n += x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = n + x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n += 1;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = n + 1;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("bool f(int);\n"
@@ -3262,7 +3276,8 @@ private:
               "    bool b = false;\n"
               "    for(int x:v)\n"
               "        b &= f(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool f(int);\n"
@@ -3270,7 +3285,8 @@ private:
               "    bool b = false;\n"
               "    for(int x:v)\n"
               "        b |= f(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool f(int);\n"
@@ -3278,7 +3294,8 @@ private:
               "    bool b = false;\n"
               "    for(int x:v)\n"
               "        b = b && f(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool f(int);\n"
@@ -3286,112 +3303,130 @@ private:
               "    bool b = false;\n"
               "    for(int x:v)\n"
               "        b = b || f(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int& x:v)\n"
               "        n = ++x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
     }
 
-    void loopAlgoContainerInsert() {
+    void loopAlgoContainerInsert()
+    {
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(f(x));\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(x + 1);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(x);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(f(x));\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_front(x + 1);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(v);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
               "    for(int x:v)\n"
               "        c.push_back(0);\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
     }
 
-    void loopAlgoIncrement() {
+    void loopAlgoIncrement()
+    {
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n++;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        ++n;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        x++;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    for(int x:v)\n"
               "        ++x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
     }
 
-    void loopAlgoConditional() {
-      check("bool pred(int x);\n"
-            "void foo() {\n"
-            "    for(int x:v) {\n"
-            "        if (pred(x)) {\n"
-            "            x = 1; \n"
-            "        }\n"
-            "    }\n"
-            "}\n",true);
+    void loopAlgoConditional()
+    {
+        check("bool pred(int x);\n"
+              "void foo() {\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            x = 1; \n"
+              "        }\n"
+              "    }\n"
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::replace_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3402,7 +3437,8 @@ private:
               "            n += x; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3413,7 +3449,8 @@ private:
               "            n += 1; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::count_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3424,7 +3461,8 @@ private:
               "            n++; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::count_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3434,7 +3472,8 @@ private:
               "            x = x + 1; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3445,7 +3484,8 @@ private:
               "            c.push_back(x); \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::copy_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3456,7 +3496,8 @@ private:
               "        }\n"
               "    }\n"
               "    return true;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3467,7 +3508,8 @@ private:
               "        }\n"
               "    }\n"
               "    return true;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3479,7 +3521,8 @@ private:
               "            break; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3491,7 +3534,8 @@ private:
               "            break; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:5]: (style) Consider using std::find_if algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3504,7 +3548,8 @@ private:
               "    }\n"
               "    if(b) {}\n"
               "    return true;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3516,7 +3561,8 @@ private:
               "        }\n"
               "    }\n"
               "    return true;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
 
         check("bool pred(int x);\n"
@@ -3528,9 +3574,10 @@ private:
               "        }\n"
               "    }\n"
               "    return true;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
-        
+
         check("bool pred(int x);\n"
               "bool foo() {\n"
               "    for(int x:v) {\n"
@@ -3539,7 +3586,8 @@ private:
               "        }\n"
               "        return true;\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         // There is no transform_if
@@ -3551,7 +3599,8 @@ private:
               "            c.push_back(x + 1); \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         check("bool pred(int x);\n"
@@ -3562,7 +3611,8 @@ private:
               "            x = 1; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
 
         check("bool pred(int x);\n"
@@ -3574,44 +3624,51 @@ private:
               "            break; \n"
               "        }\n"
               "    }\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("", errout.str());
     }
 
-    void loopAlgoMinMax() {
+    void loopAlgoMinMax()
+    {
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = x > n ? x : n;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::max_element algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = x < n ? x : n;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::min_element algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = x > n ? n : x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::min_element algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = x < n ? n : x;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::max_element algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo(int m) {\n"
               "    int n = 0;\n"
               "    for(int x:v)\n"
               "        n = x > m ? x : n;\n"
-              "}\n",true);
+              "}\n",
+              true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
     }
 };

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -150,6 +150,7 @@ private:
         TEST_CASE(loopAlgoContainerInsert);
         TEST_CASE(loopAlgoIncrement);
         TEST_CASE(loopAlgoConditional);
+        TEST_CASE(loopAlgoMinMax);
     }
 
     void check(const char code[], const bool inconclusive=false, const Standards::cppstd_t cppstandard=Standards::CPP11) {
@@ -3774,6 +3775,43 @@ private:
               "    }\n"
               "}\n",true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void loopAlgoMinMax() {
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = x > n ? x : n;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::max_element algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = x < n ? x : n;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::min_element algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = x > n ? n : x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::min_element algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo() {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = x < n ? n : x;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::max_element algorithm instead of a raw loop.\n", errout.str());
+
+        check("void foo(int m) {\n"
+              "    int n = 0;\n"
+              "    for(int x:v)\n"
+              "        n = x > m ? x : n;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::accumulate algorithm instead of a raw loop.\n", errout.str());
     }
 };
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3167,42 +3167,42 @@ private:
     void loopAlgoElementAssign()
     {
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x = 1;\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x = x + 1;\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo(int a, int b) {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x = a + b;\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::fill or std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x += 1;\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x = f();\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::generate algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        f();\n"
               "        x = 1;\n"
               "    }\n"
@@ -3211,7 +3211,7 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        x = 1;\n"
               "        f();\n"
               "    }\n"
@@ -3221,7 +3221,7 @@ private:
 
         // There should be probably be a message for unconditional break
         check("void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        x = 1;\n"
               "        break;\n"
               "    }\n"
@@ -3230,7 +3230,7 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x = ++x;\n"
               "}\n",
               true);
@@ -3402,14 +3402,14 @@ private:
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::distance algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        x++;\n"
               "}\n",
               true);
         ASSERT_EQUALS("[test.cpp:3]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
-              "    for(int x:v)\n"
+              "    for(int& x:v)\n"
               "        ++x;\n"
               "}\n",
               true);
@@ -3420,7 +3420,7 @@ private:
     {
         check("bool pred(int x);\n"
               "void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        if (pred(x)) {\n"
               "            x = 1; \n"
               "        }\n"
@@ -3467,7 +3467,7 @@ private:
 
         check("bool pred(int x);\n"
               "void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        if (pred(x)) {\n"
               "            x = x + 1; \n"
               "        }\n"
@@ -3605,7 +3605,7 @@ private:
 
         check("bool pred(int x);\n"
               "void foo() {\n"
-              "    for(int x:v) {\n"
+              "    for(int& x:v) {\n"
               "        x++;\n"
               "        if (pred(x)) {\n"
               "            x = 1; \n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3624,6 +3624,43 @@ private:
               "    return true;\n"
               "}\n",true);
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            b = true;\n"
+              "        }\n"
+              "    }\n"
+              "    if(b) {}\n"
+              "    return true;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            b |= true;\n"
+              "        }\n"
+              "    }\n"
+              "    return true;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
+
+        check("bool pred(int x);\n"
+              "bool foo() {\n"
+              "    bool b = false;\n"
+              "    for(int x:v) {\n"
+              "        if (pred(x)) {\n"
+              "            b &= true;\n"
+              "        }\n"
+              "    }\n"
+              "    return true;\n"
+              "}\n",true);
+        ASSERT_EQUALS("[test.cpp:6]: (style) Consider using std::any_of, std::all_of, std::none_of, or std::accumulate algorithm instead of a raw loop.\n", errout.str());
         
         check("bool pred(int x);\n"
               "bool foo() {\n"


### PR DESCRIPTION
So this suggest std algorithms for loops where it is possible. In Sean Parent's [Better Code](http://sean-parent.stlab.cc/presentations/2013-09-11-cpp-seasoning/cpp-seasoning.pdf) talk he mentions the problems with raw loops:

* Difficult to reason about and difficult to prove post conditions
* Error prone and likely to fail under non-obvious conditions
* Introduce non-obvious performance problems
* Complicates reasoning about the surrounding code

There are a lot messages in cppcheck itself recommending an algorithm. However, this can require using a lambda. We dont really use lambdas in cppcheck currently. We could consider adding these to the suppression list. Or maybe we could have a configuration from the user that they want to use lambdas, and then only recommend algorithms when the user wants to use lambdas. I am not sure.