### PR TITLE
--suppress on line 0

### DIFF
--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -143,6 +143,15 @@ public:
      * and if it's possible at all */
     bool isUnusedFunctionCheckEnabled() const;
 
+    /**
+     * @brief Errors and warnings are directed here.
+     *
+     * @param msg Errors messages are normally in format
+     * "[filepath:line number] Message", e.g.
+     * "[main.cpp:4] Uninitialized member variable"
+     */
+    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) override;
+
 private:
 
     /** @brief There has been an internal error => Report information message */
@@ -181,15 +190,6 @@ private:
      * @param tokenizer tokenizer
      */
     void executeRules(const std::string &tokenlist, const Tokenizer &tokenizer);
-
-    /**
-     * @brief Errors and warnings are directed here.
-     *
-     * @param msg Errors messages are normally in format
-     * "[filepath:line number] Message", e.g.
-     * "[main.cpp:4] Uninitialized member variable"
-     */
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) override;
 
     /**
      * @brief Information about progress is directed here.

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -143,15 +143,6 @@ public:
      * and if it's possible at all */
     bool isUnusedFunctionCheckEnabled() const;
 
-    /**
-     * @brief Errors and warnings are directed here.
-     *
-     * @param msg Errors messages are normally in format
-     * "[filepath:line number] Message", e.g.
-     * "[main.cpp:4] Uninitialized member variable"
-     */
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) override;
-
 private:
 
     /** @brief There has been an internal error => Report information message */
@@ -190,6 +181,15 @@ private:
      * @param tokenizer tokenizer
      */
     void executeRules(const std::string &tokenlist, const Tokenizer &tokenizer);
+
+    /**
+     * @brief Errors and warnings are directed here.
+     *
+     * @param msg Errors messages are normally in format
+     * "[filepath:line number] Message", e.g.
+     * "[main.cpp:4] Uninitialized member variable"
+     */
+    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) override;
 
     /**
      * @brief Information about progress is directed here.

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -611,7 +611,7 @@ std::string ErrorLogger::ErrorMessage::FileLocation::stringify() const
 {
     std::ostringstream oss;
     oss << '[' << Path::toNativeSeparators(mFileName);
-    if (line != 0)
+    if (line != Suppressions::Suppression::NO_LINE)
         oss << ':' << line;
     oss << ']';
     return oss.str();

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -146,7 +146,7 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
                 } catch (...) {
                     suppression.lineNumber = Suppressions::Suppression::NO_LINE;
                 }
-                
+
                 if (suppression.lineNumber >= Suppressions::Suppression::NO_LINE) {
                     suppression.fileName.erase(pos);
                 }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -146,8 +146,8 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
                 } catch (...) {
                     suppression.lineNumber = Suppressions::Suppression::NO_LINE;
                 }
-
-                if (suppression.lineNumber > Suppressions::Suppression::NO_LINE) {
+                
+                if (suppression.lineNumber >= Suppressions::Suppression::NO_LINE) {
                     suppression.fileName.erase(pos);
                 }
             }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -312,7 +312,7 @@ void Suppressions::dump(std::ostream & out)
         out << " errorId=\"" << ErrorLogger::toxml(suppression.errorId) << '"';
         if (!suppression.fileName.empty())
             out << " fileName=\"" << ErrorLogger::toxml(suppression.fileName) << '"';
-        if (suppression.lineNumber > Suppression::Suppression::NO_LINE)
+        if (suppression.lineNumber > Suppression::NO_LINE)
             out << " lineNumber=\"" << suppression.lineNumber << '"';
         if (!suppression.symbolName.empty())
             out << " symbolName=\"" << ErrorLogger::toxml(suppression.symbolName) << '\"';

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -147,7 +147,7 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
                     suppression.lineNumber = Suppressions::Suppression::NO_LINE;
                 }
 
-                if (suppression.lineNumber >= Suppressions::Suppression::NO_LINE) {
+                if (suppression.lineNumber > Suppressions::Suppression::NO_LINE) {
                     suppression.fileName.erase(pos);
                 }
             }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -144,10 +144,10 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
                     std::istringstream istr1(suppression.fileName.substr(pos+1));
                     istr1 >> suppression.lineNumber;
                 } catch (...) {
-                    suppression.lineNumber = 0;
+                    suppression.lineNumber = Suppressions::Suppression::NO_LINE;
                 }
 
-                if (suppression.lineNumber > 0) {
+                if (suppression.lineNumber > Suppressions::Suppression::NO_LINE) {
                     suppression.fileName.erase(pos);
                 }
             }
@@ -233,7 +233,7 @@ bool Suppressions::Suppression::isSuppressed(const Suppressions::ErrorMessage &e
         return false;
     if (!fileName.empty() && !matchglob(fileName, errmsg.getFileName()))
         return false;
-    if (lineNumber > 0 && lineNumber != errmsg.lineNumber)
+    if (lineNumber > NO_LINE && lineNumber != errmsg.lineNumber)
         return false;
     if (!symbolName.empty()) {
         for (std::string::size_type pos = 0; pos < errmsg.symbolNames.size();) {
@@ -269,7 +269,7 @@ std::string Suppressions::Suppression::getText() const
         ret = errorId;
     if (!fileName.empty())
         ret += " fileName=" + fileName;
-    if (lineNumber > 0)
+    if (lineNumber > NO_LINE)
         ret += " lineNumber=" + MathLib::toString(lineNumber);
     if (!symbolName.empty())
         ret += " symbolName=" + symbolName;
@@ -312,7 +312,7 @@ void Suppressions::dump(std::ostream & out)
         out << " errorId=\"" << ErrorLogger::toxml(suppression.errorId) << '"';
         if (!suppression.fileName.empty())
             out << " fileName=\"" << ErrorLogger::toxml(suppression.fileName) << '"';
-        if (suppression.lineNumber > 0)
+        if (suppression.lineNumber > Suppression::Suppression::NO_LINE)
             out << " lineNumber=\"" << suppression.lineNumber << '"';
         if (!suppression.symbolName.empty())
             out << " symbolName=\"" << ErrorLogger::toxml(suppression.symbolName) << '\"';

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -98,7 +98,7 @@ public:
         std::string symbolName;
         bool matched;
 
-        static const int NO_LINE = 0;
+        static const int NO_LINE = -1;
     };
 
     /**

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -98,7 +98,7 @@ public:
         std::string symbolName;
         bool matched;
 
-        static const int NO_LINE = -1;
+        enum { NO_LINE = -1 };
     };
 
     /**

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -301,7 +301,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "*", Suppressions::Suppression::NO_LINE);
+        suppressions.emplace_back("unmatchedSuppression", "*", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -309,7 +309,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "a.c", Suppressions::Suppression::NO_LINE);
+        suppressions.emplace_back("unmatchedSuppression", "a.c", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -325,7 +325,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "b.c", Suppressions::Suppression::NO_LINE);
+        suppressions.emplace_back("unmatchedSuppression", "b.c", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("[a.c:10]: (information) Unmatched suppression: abc\n", errout.str());
 

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -301,7 +301,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "*", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
+        suppressions.emplace_back("unmatchedSuppression", "*", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -309,7 +309,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "a.c", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
+        suppressions.emplace_back("unmatchedSuppression", "a.c", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -325,7 +325,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "b.c", /*Suppressions::Suppression::NO_LINE*/-1); //TODO find out why clang can't link with Suppressions::Suppression::NO_LINE
+        suppressions.emplace_back("unmatchedSuppression", "b.c", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("[a.c:10]: (information) Unmatched suppression: abc\n", errout.str());
 

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -301,7 +301,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "*", 0U);
+        suppressions.emplace_back("unmatchedSuppression", "*", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -309,7 +309,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "a.c", 0U);
+        suppressions.emplace_back("unmatchedSuppression", "a.c", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
@@ -325,7 +325,7 @@ private:
         errout.str("");
         suppressions.clear();
         suppressions.emplace_back("abc", "a.c", 10U);
-        suppressions.emplace_back("unmatchedSuppression", "b.c", 0U);
+        suppressions.emplace_back("unmatchedSuppression", "b.c", Suppressions::Suppression::NO_LINE);
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("[a.c:10]: (information) Unmatched suppression: abc\n", errout.str());
 

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -423,8 +423,11 @@ private:
         settings.inlineSuppressions = true;
         settings.addEnabled("information");
         settings.jointSuppressionReport = true;
-        std::string r = settings.nomsg.addSuppressionLine(it->first);
-        ASSERT_EQUALS("", r);
+        if (it->first.size() > 0)
+        {
+          std::string r = settings.nomsg.addSuppressionLine(it->first);
+          ASSERT_EQUALS("", r);
+        }
         Tokenizer mTokenizer(&settings, this);
 
         try

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -404,56 +404,9 @@ private:
     }
 
     void suppressionsLine0() {
-
-        const std::string filename("test.cpp");
-        std::map<std::string, std::string> files;
-        files.insert(std::make_pair(filename, ""));
-
-        std::map<std::string, std::string> tests;
-        tests.insert(std::make_pair("", "[test.cpp:0] -> [:0]: (error) syntax error\n"));
-        tests.insert(std::make_pair("syntaxError:*:0", ""));
-
-        for (auto it = tests.cbegin(); tests.cend() != it; ++it) {
-            errout.str("");
-
-            CppCheck cppCheck(*this, true);
-            Settings& settings = cppCheck.settings();
-            settings.exitCode = 1;
-            settings.inlineSuppressions = true;
-            settings.addEnabled("information");
-            settings.jointSuppressionReport = true;
-            if (it->first.size() > 0) {
-                std::string r = settings.nomsg.addSuppressionLine(it->first);
-                ASSERT_EQUALS("", r);
-            }
-            Tokenizer mTokenizer(&settings, this);
-
-            try {
-                mTokenizer.syntaxError(nullptr);
-            } catch (const InternalError& e) {
-                std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;
-                ErrorLogger::ErrorMessage::FileLocation loc;
-                if (e.token) {
-                    loc.line = e.token->linenr();
-                    const std::string fixedpath = Path::toNativeSeparators(mTokenizer.list.file(e.token));
-                    loc.setfile(fixedpath);
-                } else {
-                    ErrorLogger::ErrorMessage::FileLocation loc2;
-                    loc2.setfile(Path::toNativeSeparators(filename));
-                    locationList.push_back(loc2);
-                    loc.setfile(mTokenizer.list.getSourceFilePath());
-                }
-                locationList.push_back(loc);
-                ErrorLogger::ErrorMessage errmsg(locationList,
-                                                 mTokenizer.list.getSourceFilePath(),
-                                                 Severity::error,
-                                                 e.errorMessage,
-                                                 e.id,
-                                                 false);
-                cppCheck.reportErr(errmsg);
-            }
-            ASSERT_EQUALS(it->second, errout.str());
-        }
+        Suppressions suppressions;
+        suppressions.addSuppressionLine("syntaxError:*:0");
+        ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("syntaxError", "test.cpp", 0)));
     }
 
     void inlinesuppress() {


### PR DESCRIPTION
added the ability to use suppress on line 0, since cppcheck can yield syntax error on line 0.