### PR TITLE
Enabling checking code with comments

### DIFF
--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -2243,8 +2243,7 @@ static bool preprocessToken(simplecpp::TokenList &output, const simplecpp::Token
         }
         output.takeTokens(value);
     } else {
-        if (!tok->comment)
-            output.push_back(new simplecpp::Token(*tok));
+        output.push_back(new simplecpp::Token(*tok));
         *tok1 = tok->next;
     }
     return true;
@@ -2385,8 +2384,7 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
             } else if (ifstates.top() == TRUE && rawtok->str() == INCLUDE) {
                 TokenList inc1(files);
                 for (const Token *inctok = rawtok->next; sameline(rawtok,inctok); inctok = inctok->next) {
-                    if (!inctok->comment)
-                        inc1.push_back(new Token(*inctok));
+                    inc1.push_back(new Token(*inctok));
                 }
                 TokenList inc2(files);
                 if (!inc1.empty() && inc1.cfront()->name) {
@@ -2555,8 +2553,6 @@ void simplecpp::preprocess(simplecpp::TokenList &output, const simplecpp::TokenL
             } else if (rawtok->str() == UNDEF) {
                 if (ifstates.top() == TRUE) {
                     const Token *tok = rawtok->next;
-                    while (sameline(rawtok,tok) && tok->comment)
-                        tok = tok->next;
                     if (sameline(rawtok, tok))
                         macros.erase(tok->str());
                 }

--- a/lib/check.h
+++ b/lib/check.h
@@ -67,6 +67,10 @@ public:
     virtual void runChecks(const Tokenizer *, const Settings *, ErrorLogger *) {
     }
 
+    /** run checks, the token list is not simplified and still contains comments */
+    virtual void runChecksWithComments(const Tokenizer *, const Settings *, ErrorLogger *) {
+    }
+
     /** run checks, the token list is simplified */
     virtual void runSimplifiedChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) = 0;
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -228,8 +228,6 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         if (mSettings.dump && fdump.is_open()) {
             mSettings.nomsg.dump(fdump);
         }
-        tokens1.removeComments();
-        preprocessor.removeComments();
 
         if (!mSettings.buildDir.empty()) {
             // Get toolinfo
@@ -371,6 +369,12 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 // skip rest of iteration if just checking configuration
                 if (mSettings.checkConfiguration)
                     continue;
+
+                // Run checks on raw tokens with comments
+                checkRawTokensWithComments(mTokenizer);
+
+                // After the comments have been checked, remove them
+                mTokenizer.removeComments();
 
                 // Check raw tokens
                 checkRawTokens(mTokenizer);
@@ -533,6 +537,28 @@ void CppCheck::checkRawTokens(const Tokenizer &tokenizer)
     // Execute rules for "raw" code
     executeRules("raw", tokenizer);
 }
+
+//---------------------------------------------------------------------------
+// CppCheck - A function that checks a raw token list with comments in
+//---------------------------------------------------------------------------
+void CppCheck::checkRawTokensWithComments(const Tokenizer &tokenizer)
+{	
+    // call all "runChecksWithComments" in all registered Check classes
+    for (std::list<Check *>::const_iterator it = Check::instances().begin(); it != Check::instances().end(); ++it) {
+        if (mSettings.terminated())
+            return;
+
+        if (tokenizer.isMaxTime())
+            return;
+
+        Timer timerRunChecks((*it)->name() + "::runChecks", mSettings.showtime, &S_timerResults);
+        (*it)->runChecksWithComments(&tokenizer, &mSettings, this);
+	}
+
+	// Execute rules for "rawWithComments" code
+	executeRules("rawWithComments", tokenizer);
+}
+
 
 //---------------------------------------------------------------------------
 // CppCheck - A function that checks a normal token list

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -163,6 +163,12 @@ private:
      */
     void checkRawTokens(const Tokenizer &tokenizer);
 
+     /**
+     * @brief Check raw tokens before comments are removed
+     * @param tokenizer tokenizer instance
+     */
+    void checkRawTokensWithComments(const Tokenizer & tokenizer);
+
     /**
      * @brief Check normal tokens
      * @param tokenizer tokenizer instance

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -635,8 +635,6 @@ simplecpp::TokenList Preprocessor::preprocess(const simplecpp::TokenList &tokens
         }
     }
 
-    tokens2.removeComments();
-
     // ensure that guessed define macros without value are not used in the code
     if (!validateCfg(cfg, macroUsage))
         return simplecpp::TokenList(files);
@@ -679,8 +677,6 @@ std::string Preprocessor::getcode(const std::string &filedata, const std::string
     std::istringstream istr(filedata);
     simplecpp::TokenList tokens1(istr, files, Path::simplifyPath(filename), &outputList);
     inlineSuppressions(tokens1);
-    tokens1.removeComments();
-    removeComments();
     setDirectives(tokens1);
 
     reportOutput(outputList, true);
@@ -905,13 +901,11 @@ unsigned int Preprocessor::calculateChecksum(const simplecpp::TokenList &tokens1
     std::ostringstream ostr;
     ostr << toolinfo << '\n';
     for (const simplecpp::Token *tok = tokens1.cfront(); tok; tok = tok->next) {
-        if (!tok->comment)
-            ostr << tok->str();
+        ostr << tok->str();
     }
     for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
         for (const simplecpp::Token *tok = it->second->cfront(); tok; tok = tok->next) {
-            if (!tok->comment)
-                ostr << tok->str();
+            ostr << tok->str();
         }
     }
     return crc32(ostr.str());

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -454,9 +454,15 @@ static int multiComparePercent(const Token *tok, const char*& haystack, unsigned
                 return 1;
         }
         // Comparison operator (%comp%)
-        else {
+        else if (haystack[1] == 'm') {
             haystack += 4;
             if (tok->isComparisonOp())
+                return 1;
+        }
+        // Commented out token (%comment%)
+        else {
+            haystack += 7;
+            if (tok->isComment())
                 return 1;
         }
     }

--- a/lib/token.h
+++ b/lib/token.h
@@ -977,7 +977,7 @@ private:
         fIsLiteral              = (1 << 21),
         fIsTemplateArg          = (1 << 22),
         fIsAttributeNodiscard   = (1 << 23), // __attribute__ ((warn_unused_result)), [[nodiscard]]
-        fIsCommentedOut			= (1 << 24),
+        fIsCommentedOut         = (1 << 24),
     };
 
     unsigned int mFlags;

--- a/lib/token.h
+++ b/lib/token.h
@@ -446,7 +446,12 @@ public:
     void isEnumType(const bool value) {
         setFlag(fIsEnumType, value);
     }
-
+    bool isComment() const {
+        return getFlag(fIsCommentedOut);
+    }
+    void isComment(const bool value) {
+        setFlag(fIsCommentedOut, value);
+    }
     bool isBitfield() const {
         return mBits > 0;
     }
@@ -972,6 +977,7 @@ private:
         fIsLiteral              = (1 << 21),
         fIsTemplateArg          = (1 << 22),
         fIsAttributeNodiscard   = (1 << 23), // __attribute__ ((warn_unused_result)), [[nodiscard]]
+        fIsCommentedOut			= (1 << 24),
     };
 
     unsigned int mFlags;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7867,6 +7867,20 @@ void Tokenizer::eraseDeadCode(Token *begin, const Token *end)
     }
 }
 
+void Tokenizer::removeComments()
+{
+    while (list.front() && list.front()->isComment())
+    {
+        list.front()->deleteThis();
+    }
+
+    for (Token* tok = list.front(); tok && tok->next(); tok = tok->next())
+    {
+        while (tok->next() && tok->next()->isComment())
+            tok->deleteNext();
+    }
+}
+
 //---------------------------------------------------------------------------
 
 void Tokenizer::syntaxError(const Token *tok) const

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4133,6 +4133,9 @@ void Tokenizer::dump(std::ostream &out) const
             else if (tok->tokType() == Token::eLogicalOp)
                 out << " isLogicalOp=\"True\"";
         }
+        else if (tok->isComment())
+            out << " isComment=\"True\"";
+
         if (tok->link())
             out << " link=\"" << tok->link() << '\"';
         if (tok->varId() > 0U)

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -178,6 +178,11 @@ public:
     static void eraseDeadCode(Token *begin, const Token *end);
 
     /**
+     * Removes all tokens that are commented out.
+     */
+    void removeComments();
+
+    /**
      * Simplify '* & ( %name% ) =' or any combination of '* &' and '()'
      * parentheses around '%name%' to '%name% ='
      */

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -283,6 +283,17 @@ void TokenList::createTokens(const simplecpp::TokenList *tokenList)
     for (const simplecpp::Token *tok = tokenList->cfront(); tok; tok = tok->next) {
 
         std::string str = tok->str();
+        bool singleLineComment = str[0] == '/' && str[1] == '/';
+        bool multiLineComment = str[0] == '/' && str[1] == '*' && str.compare(str.length() - 2, 2, "*/") == 0;
+
+        if (singleLineComment)
+        {
+            str = str.substr(2);
+        }
+        if (multiLineComment)
+        {
+            str = str.substr(2, str.length()-4);
+        }
 
         // Replace hexadecimal value with decimal
         // TODO: Remove this
@@ -318,6 +329,7 @@ void TokenList::createTokens(const simplecpp::TokenList *tokenList)
         mTokensFrontBack.back->linenr(tok->location.line);
         mTokensFrontBack.back->col(tok->location.col);
         mTokensFrontBack.back->isExpandedMacro(!tok->macro.empty());
+        mTokensFrontBack.back->isComment(multiLineComment || singleLineComment);
     }
 
     if (mSettings && mSettings->relativePaths) {


### PR DESCRIPTION
This pull request contains a few changes that go together.  

- Changes to SimpleCPP and cppcheck preprocessor were required to make sure comment tokens survive preprocessing, which is required if we want to write checks for raw tokens plus comments.
- Changes to token and tokenlist to mark comment tokens and remove their comment markers (// and /**/)
- Changes to Tokenizer to enable removing commented tokens (formerly done by simplecpp and preprocesser), and match comment tokens with Token::Match()
- Changes to cppcheck and check to add and run a new class of checks and rules for "rawTokensWithComments"