### PR TITLE
Fix crashes in followVarExpression

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -162,7 +162,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
     if (tok->astParent() && tok->isUnaryOp("*"))
         return tok;
     // Skip following variables if it is used in an assignment
-    if (Token::Match(tok->astParent(), "%assign%") || Token::Match(tok->next(), "%assign%"))
+    if (Token::Match(tok->astTop(), "%assign%") || Token::Match(tok->next(), "%assign%"))
         return tok;
     const Variable * var = tok->variable();
     const Token * varTok = getVariableInitExpression(var);
@@ -198,6 +198,8 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
         }
 
         if (const Variable * var2 = tok2->variable()) {
+            if(!var2->scope())
+                return tok;
             const Token * endToken2 = var2->scope() != tok->scope() ? var2->scope()->bodyEnd : endToken;
             if (!var2->isLocal() && !var2->isConst() && !var2->isArgument())
                 return tok;

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -164,6 +164,9 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
     // Skip following variables if it is used in an assignment
     if (Token::Match(tok->astTop(), "%assign%") || Token::Match(tok->next(), "%assign%"))
         return tok;
+    // Skip references
+    if (Token::Match(tok->astTop(), "& %var%;") && Token::Match(tok->astTop()->astOperand1(), "%type%"))
+        return tok;
     const Variable * var = tok->variable();
     const Token * varTok = getVariableInitExpression(var);
     if (!varTok)

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4554,6 +4554,13 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("template <typename T>\n"
+              "T f() {\n"
+              "  T a = T();\n"
+              "}\n"
+              "int &a = f<int&>();\n");
+        ASSERT_EQUALS("", errout.str());
+
         // Issue #8713
         check("class A {\n"
               "  int64_t B = 32768;\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4546,6 +4546,25 @@ private:
               "        (void)b;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        // Issue #8712
+        check("void f() {\n"
+              "  unsigned char d;\n"
+              "  d = d % 5;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        // Issue #8713
+        check("class A {\n"
+              "  int64_t B = 32768;\n"
+              "  P<uint8_t> m = MakeP<uint8_t>(B);\n"
+              "};\n"
+              "void f() {\n"
+              "  uint32_t a = 42;\n"
+              "  uint32_t b = uint32_t(A ::B / 1024);\n"
+              "  int32_t c = int32_t(a / b);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkSignOfUnsignedVariable() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6848,6 +6848,14 @@ private:
               "  while (a=x(), a==123) {}\n"
               "}", "test.c");
         ASSERT_EQUALS("", errout.str());
+
+        // # 8717
+        check("void f(int argc, char *const argv[]) {\n"
+              "    char **local_argv = safe_malloc(sizeof (*local_argv));\n"
+              "    int local_argc = 0;\n"
+              "    local_argv[local_argc++] = argv[0];\n"
+              "}\n", "test.c");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void testEvaluationOrderSelfAssignment() {


### PR DESCRIPTION
This fixes the crashes for issue 8712 and 8713. It also fixes the FP in 8717 as well.