### PR TITLE
Fix issue 8698: Check for same expression in condition check to avoid duplicate messages

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1214,6 +1214,8 @@ void CheckCondition::alwaysTrueFalse()
                 continue;
             if (Token::Match(tok, "%oror%|&&"))
                 continue;
+            if (Token::Match(tok, "%comp%") && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand1(), tok->astOperand2(), mSettings->library, true))
+                continue;
 
             const bool constIfWhileExpression =
                 tok->astParent() && Token::Match(tok->astTop()->astOperand1(), "if|while") &&


### PR DESCRIPTION
This will now produce a single error message:

```cpp
void f()
{
  int x = 3;
  if (x == 3) {}
}
```

With this output:

```
$ ./bin/cppcheck --enable=all 8698.cpp
Checking 8698.cpp ...
[8698.cpp:3] -> [8698.cpp:4]: (style) The expression 'x == 3' is always true because 'x' and '3' represent the same value.
```