### PR TITLE
Fix issue 8709: crash with switch statement with followVar

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -204,7 +204,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
         if (const Variable * var2 = tok2->variable()) {
             if(!var2->scope())
                 return tok;
-            // If type is `case` then we haven't found the correct variable declaration
+            // FIXME This is a quick fix. Fix SymbolDatabase so typeStartToken points at the variable declaration and not a case statement
             if(Token::simpleMatch(var2->typeStartToken(), "case"))
                 return tok;
             const Token * endToken2 = var2->scope() != tok->scope() ? var2->scope()->bodyEnd : endToken;

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -204,6 +204,9 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
         if (const Variable * var2 = tok2->variable()) {
             if(!var2->scope())
                 return tok;
+            // If type is `case` then we haven't found the correct variable declaration
+            if(Token::simpleMatch(var2->typeStartToken(), "case"))
+                return tok;
             const Token * endToken2 = var2->scope() != tok->scope() ? var2->scope()->bodyEnd : endToken;
             if (!var2->isLocal() && !var2->isConst() && !var2->isArgument())
                 return tok;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4572,6 +4572,16 @@ private:
               "  int32_t c = int32_t(a / b);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        // Issue #8709
+        check("a b;\n"
+              "void c() {\n"
+              "  switch (d) { case b:; }\n"
+              "  double e(b);\n"
+              "  if(e <= 0) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
     }
 
     void checkSignOfUnsignedVariable() {


### PR DESCRIPTION
This will fix the crash with:

```
a b;
void c() {
  switch (d) { case b:; }
  double e(b);
  if(e <= 0) {}
}
```