### PR TITLE
Fix 8682: Dont follow volatile variables

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -171,6 +171,8 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
     // Skip array access
     if (Token::simpleMatch(varTok, "["))
         return tok;
+    if (var->isVolatile())
+        return tok;
     if (!var->isLocal() && !var->isConst())
         return tok;
     if (var->isStatic() && !var->isConst())

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4075,6 +4075,10 @@ private:
               "    if(a == 1) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("volatile const int var = 42;\n"
+              "void f() { if(var == 42) {} }\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateExpressionLoop() {


### PR DESCRIPTION
Fix issue for:

```cpp
volatile const int var = 42;
void f(void){ if(var == 42){} }
```