### PR TITLE
Fix issue 8730: False positive: Opposite expression on both sides of &&

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -212,6 +212,9 @@ static const Token * followVariableExpression(const Token * tok, bool cpp)
                 return tok;
             if (!var2->isConst() && isVariableChanged(tok2, endToken2, tok2->varId(), false, nullptr, cpp))
                 return tok;
+        // Recognized as a variable but the declaration is unknown
+        } else if(tok2->varId() > 0) {
+            return tok;
         }
     }
     return varTok;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4256,6 +4256,14 @@ private:
 
         check("bool f(unsigned i){ return (x > 0) && (x & (x-1)) == 0; }");
         ASSERT_EQUALS("", errout.str());
+
+        check("void A::f(bool a, bool c)\n"
+              "{\n"
+              "    const bool b = a;\n"
+              "    if(c) { a = false; } \n"
+              "    if(b && !a) { }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateVarExpression() {


### PR DESCRIPTION
Fix FP:

```cpp
void A::f(bool a, bool c)
{
        const bool b = a;

        if(c) { a = false; } 

        if(b && !a) { }
}
```