### PR TITLE
Fix issue 8722: Avoid duplicate messages due for followVar

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -578,10 +578,16 @@ void CheckCondition::multiCondition2()
                         if (firstCondition->str() == "&&") {
                             tokens1.push(firstCondition->astOperand1());
                             tokens1.push(firstCondition->astOperand2());
-                        } else if (isOppositeCond(false, mTokenizer->isCPP(), firstCondition, cond2, mSettings->library, true, &errorPath)) {
+                        } else if (
+                            !firstCondition->hasKnownValue() &&
+                            !cond2->hasKnownValue() && 
+                            isOppositeCond(false, mTokenizer->isCPP(), firstCondition, cond2, mSettings->library, true, &errorPath)) {
                             if (!isAliased(vars))
                                 oppositeInnerConditionError(firstCondition, cond2, errorPath);
-                        } else if (isSameExpression(mTokenizer->isCPP(), true, firstCondition, cond2, mSettings->library, true, &errorPath)) {
+                        } else if (
+                            !firstCondition->hasKnownValue() &&
+                            !cond2->hasKnownValue() && 
+                            isSameExpression(mTokenizer->isCPP(), true, firstCondition, cond2, mSettings->library, true, &errorPath)) {
                             identicalInnerConditionError(firstCondition, cond2, errorPath);
                         }
                     }
@@ -596,7 +602,10 @@ void CheckCondition::multiCondition2()
                         if (secondCondition->str() == "||" || secondCondition->str() == "&&") {
                             tokens2.push(secondCondition->astOperand1());
                             tokens2.push(secondCondition->astOperand2());
-                        } else if (isSameExpression(mTokenizer->isCPP(), true, cond1, secondCondition, mSettings->library, true, &errorPath)) {
+                        } else if (
+                            !cond1->hasKnownValue() && 
+                            !secondCondition->hasKnownValue() && 
+                            isSameExpression(mTokenizer->isCPP(), true, cond1, secondCondition, mSettings->library, true, &errorPath)) {
                             if (!isAliased(vars))
                                 identicalConditionAfterEarlyExitError(cond1, secondCondition, errorPath);
                         }

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -578,17 +578,13 @@ void CheckCondition::multiCondition2()
                         if (firstCondition->str() == "&&") {
                             tokens1.push(firstCondition->astOperand1());
                             tokens1.push(firstCondition->astOperand2());
-                        } else if (
-                            !firstCondition->hasKnownValue() &&
-                            !cond2->hasKnownValue() && 
-                            isOppositeCond(false, mTokenizer->isCPP(), firstCondition, cond2, mSettings->library, true, &errorPath)) {
-                            if (!isAliased(vars))
-                                oppositeInnerConditionError(firstCondition, cond2, errorPath);
-                        } else if (
-                            !firstCondition->hasKnownValue() &&
-                            !cond2->hasKnownValue() && 
-                            isSameExpression(mTokenizer->isCPP(), true, firstCondition, cond2, mSettings->library, true, &errorPath)) {
-                            identicalInnerConditionError(firstCondition, cond2, errorPath);
+                        } else if (!firstCondition->hasKnownValue()) {
+                            if(isOppositeCond(false, mTokenizer->isCPP(), firstCondition, cond2, mSettings->library, true, &errorPath)) {
+                                if (!isAliased(vars))
+                                    oppositeInnerConditionError(firstCondition, cond2, errorPath);
+                            } else if (isSameExpression(mTokenizer->isCPP(), true, firstCondition, cond2, mSettings->library, true, &errorPath)) {
+                                identicalInnerConditionError(firstCondition, cond2, errorPath);
+                            }
                         }
                     }
                 } else {
@@ -602,9 +598,7 @@ void CheckCondition::multiCondition2()
                         if (secondCondition->str() == "||" || secondCondition->str() == "&&") {
                             tokens2.push(secondCondition->astOperand1());
                             tokens2.push(secondCondition->astOperand2());
-                        } else if (
-                            !cond1->hasKnownValue() && 
-                            !secondCondition->hasKnownValue() && 
+                        } else if ((!cond1->hasKnownValue() || !secondCondition->hasKnownValue()) && 
                             isSameExpression(mTokenizer->isCPP(), true, cond1, secondCondition, mSettings->library, true, &errorPath)) {
                             if (!isAliased(vars))
                                 identicalConditionAfterEarlyExitError(cond1, secondCondition, errorPath);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2523,28 +2523,25 @@ private:
         check("void f() {\n"
               "  int val = 0;\n"
               "  if (val < 0) continue;\n"
-              "  if ((val > 0)) {}\n"
+              "  if (val > 0) {}\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
-                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "  int val = 0;\n"
               "  if (val < 0) {\n"
-              "    if ((val > 0)) {}\n"
+              "    if (val > 0) {}\n"
               "  }\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
-                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "  int val = 0;\n"
               "  if (val < 0) {\n"
-              "    if ((val < 0)) {}\n"
+              "    if (val < 0) {}\n"
               "  }\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
-                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val < 0' is always false.\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkInvalidTestForOverflow() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -104,6 +104,7 @@ private:
         TEST_CASE(clarifyCondition8);
 
         TEST_CASE(alwaysTrue);
+        TEST_CASE(multiConditionAlwaysTrue);
 
         TEST_CASE(checkInvalidTestForOverflow);
         TEST_CASE(checkConditionIsAlwaysTrueOrFalseInsideIfWhile);
@@ -2516,6 +2517,34 @@ private:
               "    {}\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!b' is always true\n", errout.str());
+    }
+
+    void multiConditionAlwaysTrue() {
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) continue;\n"
+              "  if ((val > 0)) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) {\n"
+              "    if ((val > 0)) {}\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) {\n"
+              "    if ((val < 0)) {}\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val < 0' is always false.\n", errout.str());
     }
 
     void checkInvalidTestForOverflow() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -141,6 +141,7 @@ private:
         TEST_CASE(duplicateVarExpressionUnique);
         TEST_CASE(duplicateVarExpressionAssign);
         TEST_CASE(duplicateVarExpressionCrash);
+        TEST_CASE(multiConditionSameExpression);
 
         TEST_CASE(checkSignOfUnsignedVariable);
         TEST_CASE(checkSignOfPointer);
@@ -4594,6 +4595,34 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+    }
+
+    void multiConditionSameExpression() {
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) continue;\n"
+              "  if ((val > 0)) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) {\n"
+              "    if ((val > 0)) {}\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val > 0' is always false.\n", errout.str());
+
+        check("void f() {\n"
+              "  int val = 0;\n"
+              "  if (val < 0) {\n"
+              "    if ((val < 0)) {}\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The expression 'val < 0' is always false.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (style) The expression 'val < 0' is always false.\n", errout.str());
     }
 
     void checkSignOfUnsignedVariable() {


### PR DESCRIPTION
This:

```cpp
void f() {
  int val = 0;
  if (val < 0) continue;
  if (val > 0) {}
}
```

will only report one message:

```
$ ./bin/cppcheck --enable=all 8722.cpp
Checking 8722.cpp ...
[8722.cpp:2] -> [8722.cpp:3]: (style) The expression 'val < 0' is always false.
[8722.cpp:2] -> [8722.cpp:4]: (style) The expression 'val > 0' is always false.
```