### PR TITLE
Fix issue 8736: Iterators to containers from different expressions (a.begin().x == b.begin().x)

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -467,9 +467,9 @@ static const Token * getIteratorExpression(const Token * tok)
         if (iter2)
             return iter2;
     } else if (Token::Match(tok, "begin|cbegin|rbegin|crbegin|end|cend|rend|crend (")) {
-        if (Token::Match(tok->previous(), ". %name% ( )"))
+        if (Token::Match(tok->previous(), ". %name% ( ) !!."))
             return tok->previous()->astOperand1();
-        if (Token::Match(tok, "%name% ( !!)"))
+        if (Token::Match(tok, "%name% ( !!)") && !Token::simpleMatch(tok->linkAt(1), ") ."))
             return tok->next()->astOperand2();
     }
     return nullptr;

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -705,6 +705,12 @@ private:
               "    if(f().begin()+1 == f().end()+1) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "  if (a.begin().x == b.begin().x) {}\n"
+              "  if (begin(a).x == begin(b).x) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void iteratorSameExpression() {


### PR DESCRIPTION
This fixes FP with:

```cpp
void f()
{
  if ( mellA.begin()->id3l()==mellB.begin()->id3l()) {}
}
```