### PR TITLE
Fix issue 8737: FP with identical inner condition due to followVar

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -154,7 +154,7 @@ static bool precedes(const Token * tok1, const Token * tok2)
         return false;
     if(!tok2)
         return false;
-    return std::make_pair(tok1->linenr(), tok1->col()) < std::make_pair(tok2->linenr(), tok2->col());
+    return tok1->progressValue() < tok2->progressValue();
 }
 
 /// This takes a token that refers to a variable and it will return the token
@@ -163,6 +163,9 @@ static bool precedes(const Token * tok1, const Token * tok2)
 static const Token * followVariableExpression(const Token * tok, bool cpp, const Token * end = nullptr)
 {
     if (!tok)
+        return tok;
+    // Skip following variables that is across multiple files
+    if(end && end->fileIndex() != tok->fileIndex())
         return tok;
     // Skip array access
     if (Token::Match(tok, "%var% ["))

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2032,6 +2032,18 @@ private:
               "  }\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Identical inner 'if' condition is always true.\n", errout.str());
+
+        check("void f() {\n"
+              "    uint32_t value;\n"
+              "    get_value(&value);\n"
+              "    int opt_function_capable = (value >> 28) & 1;\n"
+              "    if (opt_function_capable) {\n"
+              "        value = 0;\n"
+              "        get_value (&value);\n"
+              "        if ((value >> 28) & 1) {}\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void identicalConditionAfterEarlyExit() {


### PR DESCRIPTION
This fixes the FP with:

```cpp
void f()
{
    uint32_t value;
    get_value(&value);
    int opt_function_capable = (value >> 28) & 1;

    if (opt_function_capable) {
        value = 0;
        get_value (&value);
        if ((value >> 28) & 1) {}
    }
}
```