### PR TITLE
Fix issue 8741: Require pure when following variables in isSameExpression

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -270,17 +270,17 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token * varTok1 = followVariableExpression(tok1, cpp, tok2);
         if (varTok1->str() == tok2->str()) {
             followVariableExpressionError(tok1, varTok1, errors);
-            return isSameExpression(cpp, macro, varTok1, tok2, library, pure, errors);
+            return isSameExpression(cpp, macro, varTok1, tok2, library, true, errors);
         }
         const Token * varTok2 = followVariableExpression(tok2, cpp, tok1);
         if (tok1->str() == varTok2->str()) {
             followVariableExpressionError(tok2, varTok2, errors);
-            return isSameExpression(cpp, macro, tok1, varTok2, library, pure, errors);
+            return isSameExpression(cpp, macro, tok1, varTok2, library, true, errors);
         }
         if (varTok1->str() == varTok2->str()) {
             followVariableExpressionError(tok1, varTok1, errors);
             followVariableExpressionError(tok2, varTok2, errors);
-            return isSameExpression(cpp, macro, varTok1, varTok2, library, pure, errors);
+            return isSameExpression(cpp, macro, varTok1, varTok2, library, true, errors);
         }
     }
     if (tok1->varId() != tok2->varId() || tok1->str() != tok2->str() || tok1->originalName() != tok2->originalName()) {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4265,6 +4265,12 @@ private:
               "    if(b && !a) { }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "  const bool b = g();\n"
+              "  if (!b && g()) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateVarExpression() {


### PR DESCRIPTION
This fixes the FP in:

```cpp
void f()
{
  const bool was_seed = isSeed ();
  // ...
  if (!was_seed && isSeed()) {}
}
```