### PR TITLE
Fix issue 8743: FP when derefencing iterators

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -457,6 +457,8 @@ static const Token * getIteratorExpression(const Token * tok)
 {
     if (!tok)
         return nullptr;
+    if (tok->isUnaryOp("*"))
+        return nullptr;
     if (!tok->isName()) {
         const Token *iter1 = getIteratorExpression(tok->astOperand1());
         if (iter1)

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -709,6 +709,13 @@ private:
               "  if (begin(a).x == begin(b).x) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "  std::list<int*> a;\n"
+              "  std::list<int*> b;\n"
+              "  if (*a.begin() == *b.begin()) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void iteratorSameExpression() {


### PR DESCRIPTION
This fixes the issue here:

```cpp
void f()
{
  std::list<int*> a;
  std::list<int*> b;
  if (*a.begin() == *b.begin()) {}
}
```