### PR TITLE
Donate CPU: Only extract relevant source files from archives #8716

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -26,10 +26,11 @@ import sys
 import socket
 import time
 import re
+import tarfile
 
 def checkRequirements():
     result = True
-    for app in ['g++', 'git', 'make', 'wget', 'tar']:
+    for app in ['g++', 'git', 'make', 'wget']:
         try:
             subprocess.call([app, '--version'])
         except OSError:
@@ -156,7 +157,16 @@ def unpackPackage(workPath, tgz):
     removeTree(tempPath)
     os.mkdir(tempPath)
     os.chdir(tempPath)
-    subprocess.call(['tar', 'xzvf', tgz])
+    if tarfile.is_tarfile(tgz):
+        tf = tarfile.open(tgz)
+        for member in tf:
+            if member.name.startswith(('/', '..')):
+                # Skip dangerous file names
+                continue
+            elif member.name.lower().endswith(('.c', '.cl', '.cpp', '.cxx', '.cc', '.c++', '.h', '.hpp', '.hxx', '.hh', '.tpp', '.txx')):
+                tf.extract(member.name)
+                print(member.name)
+        tf.close()
     os.chdir(workPath)
 
 


### PR DESCRIPTION
Use python tarfile instead of tar to extract the packages.
Only extract source files of interest.
Skip dangerous files that could overwrite files outside the temp folder.
Fixes https://trac.cppcheck.net/ticket/8716
Tested with Python 2 and 3 under Cygwin/Windows 7 and Ubuntu/Linux.