### PR TITLE
Show line number when suggesting std::transform or std::copy

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1998,7 +1998,7 @@ void CheckStl::useStlAlgorithm()
                         algo = "std::copy";
                     else
                         algo = "std::transform";
-                    useStlAlgorithmError(assignTok, algo);
+                    useStlAlgorithmError(memberCallTok, algo);
                 }
                 continue;
             }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3324,7 +3324,7 @@ private:
               "        c.push_back(x);\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3332,7 +3332,7 @@ private:
               "        c.push_back(f(x));\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3340,7 +3340,7 @@ private:
               "        c.push_back(x + 1);\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3348,7 +3348,7 @@ private:
               "        c.push_front(x);\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::copy algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3356,7 +3356,7 @@ private:
               "        c.push_front(f(x));\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"
@@ -3364,7 +3364,7 @@ private:
               "        c.push_front(x + 1);\n"
               "}\n",
               true);
-        ASSERT_EQUALS("(style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::transform algorithm instead of a raw loop.\n", errout.str());
 
         check("void foo() {\n"
               "    std::vector<int> c;\n"


### PR DESCRIPTION
This fixes a bug where the source location wasn't shown when suggesting std::transform or std::copy with container inserts.