### PR TITLE
test: false positive for address of member in struct

### DIFF
--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -96,6 +96,7 @@ private:
         TEST_CASE(returnLocalVariable4); // x+y
         TEST_CASE(returnLocalVariable5); // cast
         TEST_CASE(returnLocalVariable6); // valueflow
+        TEST_CASE(returnLocalVariable7); // struct
 
         // return reference..
         TEST_CASE(returnReference1);
@@ -773,6 +774,19 @@ private:
               "    return p;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Address of auto-variable 'x' returned\n", errout.str());
+    }
+
+    void returnLocalVariable7() {
+        check("struct s {\n"
+              "    int f;\n"
+              "};\n"
+              "int *foo(int *v) {\n"
+              "    struct s *p = malloc(sizeof *p);\n"
+              "    p->f = *v;\n"
+              "    int *r = &p->f;\n"
+              "    return r;\n"
+              "}");
+        TODO_ASSERT_EQUALS("", "[test.cpp:8]: (error) Address of auto-variable 'p->f' returned\n", errout.str());
     }
 
     void returnReference1() {


### PR DESCRIPTION
triggers :

  (error) Address of auto-variable 'p->f' returned

when using a local variable to hold the address of a member of
a local struct pointer.

using parenthesis to clarify precedence (ex: &(p->f)) or not using
an intermediate variable seems to workaround the issue, but the
later might be just due to an incomplete implementation.