### PR TITLE
Implemented running checks with comments intact

### DIFF
--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -1057,7 +1057,8 @@ void simplecpp::TokenList::removeComments()
                 deleteToken(tok1->previous);
             }
             tok->next = tok1;
-            tok1->previous = tok;
+            if (tok1)
+                tok1->previous = tok;
         }
         tok = tok->next;
     }

--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -1031,36 +1031,35 @@ void simplecpp::TokenList::removeComments()
 {
     Token *tok = frontToken;
 
-	if (tok && tok->comment)
-	{
-		leadingComment = tok;
-		tok = tok->next;
-		leadingComment->next = nullptr;
-	}
-	while (tok && tok->comment)
-	{
-		leadingComment->setstr(leadingComment->str() + '\n' + tok->str());
-		tok = tok->next;
-		deleteToken(tok->previous);
-	}
+    if (tok && tok->comment) {
+        leadingComment = tok;
+        tok = tok->next;
+        leadingComment->next = nullptr;
+    }
+	
+    while (tok && tok->comment) {
+        leadingComment->setstr(leadingComment->str() + '\n' + tok->str());
+        tok = tok->next;
+        deleteToken(tok->previous);
+    }
 
-	frontToken = tok;
+    frontToken = tok;
 
     while (tok) {
-		Token *tok1 = tok->next;
+        Token *tok1 = tok->next;
         if (tok1 && tok1->comment) {
-			tok->commentToken = tok1;
-			tok1 = tok1->next;
+            tok->commentToken = tok1;
+            tok1 = tok1->next;
 
-			while (tok1 && tok1->comment){
-				tok->commentToken->setstr(tok->commentToken->str() + '\n' + tok1->str());
-				tok1 = tok1->next;
-				deleteToken(tok1->previous);
-			}
-			tok->next = tok1;
-			tok1->previous = tok;
-		}
-		tok = tok->next;
+            while (tok1 && tok1->comment) {
+                tok->commentToken->setstr(tok->commentToken->str() + '\n' + tok1->str());
+                tok1 = tok1->next;
+                deleteToken(tok1->previous);
+            }
+            tok->next = tok1;
+            tok1->previous = tok;
+        }
+        tok = tok->next;
     }
 }
 
@@ -2269,8 +2268,8 @@ static bool preprocessToken(simplecpp::TokenList &output, const simplecpp::Token
         }
         output.takeTokens(value);
     } else {
-		output.push_back(new simplecpp::Token(*tok));
-		*tok1 = tok->next;
+        output.push_back(new simplecpp::Token(*tok));
+        *tok1 = tok->next;
     }
     return true;
 }

--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -1040,7 +1040,8 @@ void simplecpp::TokenList::removeComments()
     while (tok && tok->comment) {
         leadingComment->setstr(leadingComment->str() + '\n' + tok->str());
         tok = tok->next;
-        deleteToken(tok->previous);
+        if (tok)
+            deleteToken(tok->previous);
     }
 
     frontToken = tok;
@@ -1054,7 +1055,8 @@ void simplecpp::TokenList::removeComments()
             while (tok1 && tok1->comment) {
                 tok->commentToken->setstr(tok->commentToken->str() + '\n' + tok1->str());
                 tok1 = tok1->next;
-                deleteToken(tok1->previous);
+                if (tok1)
+                    deleteToken(tok1->previous);
             }
             tok->next = tok1;
             if (tok1)

--- a/externals/simplecpp/simplecpp.h
+++ b/externals/simplecpp/simplecpp.h
@@ -131,7 +131,7 @@ namespace simplecpp {
         Location location;
         Token *previous;
         Token *next;
-		Token *commentToken;
+        Token *commentToken;
 
         const Token *previousSkipComments() const {
             const Token *tok = this->previous;
@@ -265,7 +265,7 @@ namespace simplecpp {
 
         Token *frontToken;
         Token *backToken;
-		Token *leadingComment;
+        Token *leadingComment;
         std::vector<std::string> &files;
     };
 

--- a/externals/simplecpp/simplecpp.h
+++ b/externals/simplecpp/simplecpp.h
@@ -97,12 +97,12 @@ namespace simplecpp {
     class SIMPLECPP_LIB Token {
     public:
         Token(const TokenString &s, const Location &loc) :
-            location(loc), previous(NULL), next(NULL), string(s) {
+            location(loc), previous(NULL), next(NULL), commentToken(NULL), string(s) {
             flags();
         }
 
         Token(const Token &tok) :
-            macro(tok.macro), location(tok.location), previous(NULL), next(NULL), string(tok.string) {
+            macro(tok.macro), location(tok.location), previous(NULL), next(NULL), commentToken(tok.commentToken), string(tok.string) {
             flags();
         }
 
@@ -131,6 +131,7 @@ namespace simplecpp {
         Location location;
         Token *previous;
         Token *next;
+		Token *commentToken;
 
         const Token *previousSkipComments() const {
             const Token *tok = this->previous;
@@ -264,6 +265,7 @@ namespace simplecpp {
 
         Token *frontToken;
         Token *backToken;
+		Token *leadingComment;
         std::vector<std::string> &files;
     };
 

--- a/lib/check.h
+++ b/lib/check.h
@@ -67,6 +67,10 @@ public:
     virtual void runChecks(const Tokenizer *, const Settings *, ErrorLogger *) {
     }
 
+    /** run checks, the token list is not simplified and still contains comments */
+    virtual void runChecksWithComments(const Tokenizer *, const Settings *, ErrorLogger *) {
+    }
+
     /** run checks, the token list is simplified */
     virtual void runSimplifiedChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) = 0;
 

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -164,6 +164,12 @@ private:
     void checkRawTokens(const Tokenizer &tokenizer);
 
     /**
+     * @brief Check raw tokens before comments are removed
+     * @param tokenizer tokenizer instance
+     */
+    void checkRawTokensWithComments(const Tokenizer & tokenizer);
+
+    /**
      * @brief Check normal tokens
      * @param tokenizer tokenizer instance
      */

--- a/lib/token.h
+++ b/lib/token.h
@@ -45,6 +45,7 @@ class Variable;
 struct TokensFrontBack {
     Token *front;
     Token *back;
+    Token *leadingComment;
 };
 
 /// @addtogroup Core
@@ -896,6 +897,13 @@ public:
 
     const Token *getValueTokenDeadPointer() const;
 
+    const Token *commentToken() const {
+        return mCommentToken;
+    }
+    void commentToken(Token* commentToken) {
+        mCommentToken = commentToken;
+    }
+
     /** Add token value. Return true if value is added. */
     bool addValue(const ValueFlow::Value &value);
 
@@ -1025,6 +1033,8 @@ private:
     // ValueFlow
     std::list<ValueFlow::Value>* mValues;
     static const std::list<ValueFlow::Value> mEmptyValueList;
+
+    Token* mCommentToken;
 
 public:
     void astOperand1(Token *tok);

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -311,6 +311,13 @@ void TokenList::createTokens(const simplecpp::TokenList *tokenList)
             mTokensFrontBack.back = mTokensFrontBack.front;
             mTokensFrontBack.back->str(str);
         }
+        if (tok->commentToken) {
+            Token* commentToken = new Token();
+            commentToken->str(tok->commentToken->str());
+            commentToken->linenr(tok->commentToken->location.line);
+            commentToken->fileIndex(tok->commentToken->location.fileIndex);
+            mTokensFrontBack.back->commentToken(commentToken);
+        }
 
         if (isCPP() && mTokensFrontBack.back->str() == "delete")
             mTokensFrontBack.back->isKeyword(true);


### PR DESCRIPTION
Comments are now kept as a pointer to a token in the preceding token.  This means that they are removed from the main list before preprocessing, but are kept available in case they are needed.

Comments at the head of the .cpp file are stored separately because there is no token before them to attach them to.  The pointer is part of the tokensFrontBack struct so all Tokens have access to the leading comments.