### PR TITLE
Ticket #8734: Skip static member variables in CheckUninitVar.

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -170,7 +170,8 @@ void CheckUninitVar::checkStruct(const Token *tok, const Variable &structvar)
             for (std::list<Variable>::const_iterator it = scope2->varlist.begin(); it != scope2->varlist.end(); ++it) {
                 const Variable &var = *it;
 
-                if (var.hasDefault() || var.isArray() || (!mTokenizer->isC() && var.isClass() && (!var.type() || var.type()->needInitialization != Type::True)))
+                if (var.isStatic() || var.hasDefault() || var.isArray() ||
+                    (!mTokenizer->isC() && var.isClass() && (!var.type() || var.type()->needInitialization != Type::True)))
                     continue;
 
                 // is the variable declared in a inner union?

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -75,6 +75,7 @@ private:
         TEST_CASE(uninitvar_pointertoarray);
         TEST_CASE(uninitvar_cpp11ArrayInit); // #7010
         TEST_CASE(uninitvar_rangeBasedFor); // #7078
+        TEST_CASE(uninitvar_static); // #8734
         TEST_CASE(trac_4871);
         TEST_CASE(syntax_error); // Ticket #5073
         TEST_CASE(trac_5970);
@@ -3807,6 +3808,21 @@ private:
                        "        expr->operate();\n"
                        "        expr->operate();\n"
                        "    }\n"
+                       "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void uninitvar_static() { // #8734
+        checkUninitVar("struct X { "
+                       "  typedef struct { int p; } P_t; "
+                       "  static int arr[]; "
+                       "}; "
+                       "int X::arr[] = {42}; "
+                       "void f() { "
+                       "  std::vector<X::P_t> result; "
+                       "  X::P_t P; "
+                       "  P.p = 0; "
+                       "  result.push_back(P); "
                        "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
We should not report this warning for static members.