### PR TITLE
Ticket #8632: Parenthesize ternary operator operands containing < to avoid wrongly thinking a template instantiation is met.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10162,6 +10162,8 @@ void Tokenizer::prepareTernaryOpForAST()
                     break;
                 else if (tok2->str() == ",")
                     parenthesesNeeded = true;
+                else if (tok2->str() == "<")
+                    parenthesesNeeded = true;
                 else if (tok2->str() == "?") {
                     depth++;
                     parenthesesNeeded = true;

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -1138,7 +1138,7 @@ private:
                             "template <class T, unsigned S> class C3 {};\n"
                             "template <class T, unsigned S> C3<T, S>::C3(const C3<T, S> &v) { C1<T *> c1; }\n"
                             "C3<int,6> c3;";
-        const char exp[] = "template < class T > void f ( ) { x = y ? C1 < int > :: allocate ( 1 ) : 0 ; } "
+        const char exp[] = "template < class T > void f ( ) { x = y ? ( C1 < int > :: allocate ( 1 ) ) : 0 ; } "
                            "C3<int,6> c3 ; "
                            "class C3<int,6> { } ; "
                            "C3<int,6> :: C3<int,6> ( const C3<int,6> & v ) { C1<int*> c1 ; } "

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -8110,6 +8110,8 @@ private:
         ASSERT_EQUALS("a ? ( 1 ? ( a , b ) : 3 ) : d ;", tokenizeAndStringify("a ? 1 ? a, b : 3 : d;"));
 
         ASSERT_EQUALS("a ? ( std :: map < int , int > ( ) ) : 0 ;", tokenizeAndStringify("typedef std::map<int,int> mymap; a ? mymap() : 0;"));
+
+        ASSERT_EQUALS("a ? ( b < c ) : d > e", tokenizeAndStringify("a ? b < c : d > e"));
     }
 
     std::string testAst(const char code[],bool verbose=false) {


### PR DESCRIPTION
We generate incorrect AST for expressions like  ```a ? b < c : d > e```

because compileTerm ends up called on b, and it wrongly thinks ```b < c : d >``` is a template. Since the middle expression is parsed as if parenthesized according to the standard, the easiest is to patch prepareTernaryOpForAST, rather than going finding why < ends up linked to >. This is what this patch does.