### PR TITLE
Fix issue 8775: Dont follow aliased variables

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -157,6 +157,15 @@ static bool precedes(const Token * tok1, const Token * tok2)
     return tok1->progressValue() < tok2->progressValue();
 }
 
+static bool isAliased(const Token * startTok, const Token * endTok, unsigned int varid)
+{
+    for (const Token *tok = startTok; tok != endTok; tok = tok->next()) {
+        if (Token::Match(tok, "= & %varid% ;", varid))
+            return true;
+    }
+    return false;
+}
+
 /// This takes a token that refers to a variable and it will return the token
 /// to the expression that the variable is assigned to. If its not valid to
 /// make such substitution then it will return the original token.
@@ -196,6 +205,8 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
     const Token * endToken = (isInLoopCondition(tok) || isInLoopCondition(varTok) || var->scope() != tok->scope()) ? var->scope()->bodyEnd : lastTok;
     if (!var->isConst() && (!precedes(varTok, endToken) || isVariableChanged(varTok, endToken, tok->varId(), false, nullptr, cpp)))
         return tok;
+    if (precedes(varTok, endToken) && isAliased(varTok, endToken, tok->varId()))
+        return tok;
     // Start at beginning of initialization
     const Token * startToken = varTok;
     while (Token::Match(startToken, "%op%|.|(|{") && startToken->astOperand1())
@@ -221,6 +232,8 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
             if (var2->isStatic() && !var2->isConst())
                 return tok;
             if (!var2->isConst() && (!precedes(tok2, endToken2) || isVariableChanged(tok2, endToken2, tok2->varId(), false, nullptr, cpp)))
+                return tok;
+            if (precedes(tok2, endToken2) && isAliased(tok2, endToken2, tok2->varId()))
                 return tok;
             // Recognized as a variable but the declaration is unknown
         } else if (tok2->varId() > 0) {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4080,6 +4080,15 @@ private:
         check("volatile const int var = 42;\n"
               "void f() { if(var == 42) {} }\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    int a = 0;\n"
+              "    struct b c;\n"
+              "    c.a = &a;\n"
+              "    g(&c);\n"
+              "    if (a == 0) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateExpressionLoop() {


### PR DESCRIPTION
This fixes the FP with:

```cpp
void f()
{
    int avrule_cnt = 0;
    struct cil_args_verify extra_args;

    extra_args.avrule_cnt = &avrule_cnt;

    rc = cil_tree_walk(db->ast->root, &extra_args);

    if (avrule_cnt == 0) {}
}
```