### PR TITLE
Enable checking duplicate expressions across associative operators

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -562,7 +562,7 @@ bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * cons
     return false;
 }
 
-bool isConstExpression(const Token *tok, const Library& library, bool pure)
+bool isConstExpression(const Token *tok, const Library& library, bool pure, bool cpp)
 {
     if (!tok)
         return true;
@@ -576,12 +576,12 @@ bool isConstExpression(const Token *tok, const Library& library, bool pure)
         return false;
     if(tok->isAssignmentOp())
         return false;
-    if(Token::Match(tok, "<<|>>"))
+    if(isLikelyStreamRead(cpp, tok))
         return false;
     // bailout when we see ({..})
     if (tok->str() == "{")
         return false;
-    return isConstExpression(tok->astOperand1(), library, pure) && isConstExpression(tok->astOperand2(), library, pure);
+    return isConstExpression(tok->astOperand1(), library, pure, cpp) && isConstExpression(tok->astOperand2(), library, pure, cpp);
 }
 
 bool isWithoutSideEffects(bool cpp, const Token* tok)

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -574,6 +574,10 @@ bool isConstExpression(const Token *tok, const Library& library, bool pure)
     }
     if (tok->tokType() == Token::eIncDecOp)
         return false;
+    if(tok->isAssignmentOp())
+        return false;
+    if(Token::Match(tok, "<<|>>"))
+        return false;
     // bailout when we see ({..})
     if (tok->str() == "{")
         return false;

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -75,7 +75,7 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
 
 bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * const tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 
-bool isConstExpression(const Token *tok, const Library& library, bool pure);
+bool isConstExpression(const Token *tok, const Library& library, bool pure, bool cpp);
 
 bool isWithoutSideEffects(bool cpp, const Token* tok);
 

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2010,19 +2010,16 @@ void CheckOther::checkDuplicateExpression()
                            isWithoutSideEffects(mTokenizer->isCPP(), tok->astOperand1())) {
                     oppositeExpressionError(tok, tok, tok->str(), errorPath);
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
-                    if (styleEnabled && tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand2(), tok->astOperand1()->astOperand2(), mSettings->library, true, false, &errorPath) && isWithoutSideEffects(mTokenizer->isCPP(), tok->astOperand2()))
+                    if (styleEnabled && tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand2(), tok->astOperand1()->astOperand2(), mSettings->library, true, true, &errorPath) && isWithoutSideEffects(mTokenizer->isCPP(), tok->astOperand2()))
                         duplicateExpressionError(tok->astOperand2(), tok->astOperand1()->astOperand2(), tok, errorPath);
-                    else if (tok->astOperand2()) {
+                    else if (tok->astOperand2() && isConstExpression(tok->astOperand1(), mSettings->library, true)) {
                         const Token *ast1 = tok->astOperand1();
                         while (ast1 && tok->str() == ast1->str()) {
-                            if (isSameExpression(mTokenizer->isCPP(), true, ast1->astOperand1(), tok->astOperand2(), mSettings->library, true, false, &errorPath) && isWithoutSideEffects(mTokenizer->isCPP(), ast1->astOperand1()))
-                                // TODO: warn if variables are unchanged. See #5683
+                            if (isSameExpression(mTokenizer->isCPP(), true, ast1->astOperand1(), tok->astOperand2(), mSettings->library, true, true, &errorPath) && 
+                                isWithoutSideEffects(mTokenizer->isCPP(), ast1->astOperand1()) && 
+                                isWithoutSideEffects(mTokenizer->isCPP(), ast1->astOperand2()))
                                 // Probably the message should be changed to 'duplicate expressions X in condition or something like that'.
-                                ;//duplicateExpressionError(ast1->astOperand1(), tok->astOperand2(), tok, errorPath);
-                            else if (styleEnabled && isSameExpression(mTokenizer->isCPP(), true, ast1->astOperand2(), tok->astOperand2(), mSettings->library, true, false, &errorPath) && isWithoutSideEffects(mTokenizer->isCPP(), ast1->astOperand2()))
-                                duplicateExpressionError(ast1->astOperand2(), tok->astOperand2(), tok, errorPath);
-                            if (!isConstExpression(ast1->astOperand2(), mSettings->library, true))
-                                break;
+                                duplicateExpressionError(ast1->astOperand1(), tok->astOperand2(), tok, errorPath);
                             ast1 = ast1->astOperand1();
                         }
                     }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2012,7 +2012,7 @@ void CheckOther::checkDuplicateExpression()
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
                     if (styleEnabled && tok->astOperand2() && tok->str() == tok->astOperand1()->str() && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand2(), tok->astOperand1()->astOperand2(), mSettings->library, true, true, &errorPath) && isWithoutSideEffects(mTokenizer->isCPP(), tok->astOperand2()))
                         duplicateExpressionError(tok->astOperand2(), tok->astOperand1()->astOperand2(), tok, errorPath);
-                    else if (tok->astOperand2() && isConstExpression(tok->astOperand1(), mSettings->library, true)) {
+                    else if (tok->astOperand2() && isConstExpression(tok->astOperand1(), mSettings->library, true, mTokenizer->isCPP())) {
                         const Token *ast1 = tok->astOperand1();
                         while (ast1 && tok->str() == ast1->str()) {
                             if (isSameExpression(mTokenizer->isCPP(), true, ast1->astOperand1(), tok->astOperand2(), mSettings->library, true, true, &errorPath) && 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3544,11 +3544,17 @@ private:
         check("void foo() {\n"
               "    if (x!=2 || y!=3 || x!=2) {}\n"
               "}");
-        TODO_ASSERT_EQUALS("error", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (style) Same expression on both sides of '||'.\n", errout.str());
 
         check("void foo() {\n"
               "    if (x!=2 && (x=y) && x!=2) {}\n"
               "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // #5683
+        check("void f(bool b, unsigned int *i) {\n"
+              "    *i = 0 << 7 | 1 << (b ? 6 : 0) | 0 << 0;\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
 
         check("void foo() {\n"
@@ -4014,6 +4020,12 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("bool f(bool a, bool b) {\n"
+              "    const bool c = a;\n"
+              "    return a && b && c;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Same expression on both sides of '&&' because 'a' and 'c' represent the same value.\n", errout.str());
     }
 
     void duplicateExpression8() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3551,12 +3551,6 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
-        // #5683
-        check("void f(bool b, unsigned int *i) {\n"
-              "    *i = 0 << 7 | 1 << (b ? 6 : 0) | 0 << 0;\n"
-              "}\n");
-        ASSERT_EQUALS("", errout.str());
-
         check("void foo() {\n"
               "    if (a && b || a && b) {}\n"
               "}");


### PR DESCRIPTION
This re-enables the check and fixes the FPs in issue [5683](https://trac.cppcheck.net/ticket/5683) and [5682](https://trac.cppcheck.net/ticket/5682). It also enables followVar for the check.