### PR TITLE
Multipass valueFlow

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2368,7 +2368,7 @@ static void valueFlowAfterAssign(TokenList *tokenlist, SymbolDatabase* symboldat
                 continue;
 
             // Lhs should be a variable
-            if (!tok->astOperand1() || !tok->astOperand1()->varId())
+            if (!tok->astOperand1() || !tok->astOperand1()->varId() || tok->astOperand1()->hasKnownValue())
                 continue;
             const unsigned int varid = tok->astOperand1()->varId();
             if (aliased.find(varid) != aliased.end())
@@ -3331,6 +3331,9 @@ static void valueFlowFunctionReturn(TokenList *tokenlist, ErrorLogger *errorLogg
         if (tok->str() != "(" || !tok->astOperand1() || !tok->astOperand1()->function())
             continue;
 
+        if (tok->hasKnownValue())
+            continue;
+
         // Arguments..
         std::vector<MathLib::bigint> parvalues;
         if (tok->astOperand2()) {
@@ -3558,6 +3561,8 @@ static void valueFlowContainerSize(TokenList *tokenlist, SymbolDatabase* symbold
         if (!var->valueType() || !var->valueType()->container)
             continue;
         if (!Token::Match(var->nameToken(), "%name% ;"))
+            continue;
+        if (var->nameToken()->hasKnownValue())
             continue;
         ValueFlow::Value value(0);
         if (var->valueType()->container->size_templateArgNo >= 0) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3711,7 +3711,7 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
     valueFlowPointerAlias(tokenlist);
     valueFlowFunctionReturn(tokenlist, errorLogger);
 
-    std::size_t limit = 10;
+    std::size_t limit = 4;
     std::size_t n = 0;
     while(n < getTotalValues(tokenlist) && limit > 0) {
         limit--;

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -82,6 +82,7 @@ private:
         TEST_CASE(nullpointer28); // #6491
         TEST_CASE(nullpointer30); // #6392
         TEST_CASE(nullpointer31); // #8482
+        TEST_CASE(nullpointer32); // #8460
         TEST_CASE(nullpointer_addressOf); // address of
         TEST_CASE(nullpointerSwitch); // #2626
         TEST_CASE(nullpointer_cast); // #4692
@@ -1374,6 +1375,18 @@ private:
               "    (void)f->x;\n"
               "}\n", true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void nullpointer32() { // #8460
+        check("int f(int * ptr) {\n"
+              "  if(ptr)\n"
+              "  { return 0;}\n"
+              "  else{\n"
+              "    int *p1 = ptr;\n"
+              "    return *p1;\n"
+              "  }\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:6]: (warning) Either the condition 'ptr' is redundant or there is possible null pointer dereference: p1.\n", errout.str());
     }
 
     void nullpointer_addressOf() { // address of


### PR DESCRIPTION
This runs the valueFlow passes multiple times until there is no new values added or a limit is reached(currently set to 10). Running the passes multiple times can push more values through. I found this can fix issue [8460](https://trac.cppcheck.net/ticket/8460):

```cpp
int f(int * ptr) {
  if(ptr)
  { return 0;}
  else{
    int *p1 = ptr;
    return *p1;
  }
}
```

This is because `valueFlowAfterAssign` needs to be ran after `valueFlowAfterCondition`. Of course, there could be values missed by simply moving `valueFlowAfterAssign` after. Instead of trying to pick the best order for the passes, we can just run them multiple times until there are no new values added.

This should probably be merged after the release. 