### PR TITLE
Check conditions in return statements

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -853,6 +853,17 @@ bool isVariableChanged(const Token *start, const Token *end, const unsigned int 
     return false;
 }
 
+bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp)
+{
+    if(!var)
+        return false;
+    if(!var->scope())
+        return false;
+    if(!var->declEndToken())
+        return false;
+    return isVariableChanged(var->declEndToken()->next(), var->scope()->bodyEnd, var->declarationId(), var->isGlobal(), settings, cpp);
+}
+
 int numberOfArguments(const Token *start)
 {
     int arguments=0;

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -859,9 +859,12 @@ bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp)
         return false;
     if(!var->scope())
         return false;
-    if(!var->declEndToken())
+    const Token * start = var->declEndToken();
+    if(!start)
         return false;
-    return isVariableChanged(var->declEndToken()->next(), var->scope()->bodyEnd, var->declarationId(), var->isGlobal(), settings, cpp);
+    if(Token::Match(start, "; %varid% =", var->declarationId()))
+        start = start->tokAt(2);
+    return isVariableChanged(start->next(), var->scope()->bodyEnd, var->declarationId(), var->isGlobal(), settings, cpp);
 }
 
 int numberOfArguments(const Token *start)

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -30,6 +30,7 @@
 class Library;
 class Settings;
 class Token;
+class Variable;
 
 /** Is expression a 'signed char' if no promotion is used */
 bool astIsSignedChar(const Token *tok);
@@ -107,6 +108,8 @@ bool isVariableChangedByFunctionCall(const Token *tok, const Settings *settings,
 
 /** Is variable changed in block of code? */
 bool isVariableChanged(const Token *start, const Token *end, const unsigned int varid, bool globalvar, const Settings *settings, bool cpp);
+
+bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp);
 
 /** Determines the number of arguments - if token is a function call or macro
  * @param start token which is supposed to be the function/macro name.

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -690,15 +690,28 @@ void CheckCondition::multiCondition2()
     }
 }
 
+static std::string innerSmtString(const Token * tok)
+{
+    if(!tok)
+        return "if";
+    if(!tok->astTop())
+        return "if";
+    const Token * top = tok->astTop();
+    if(top->str() == "(" && top->astOperand1())
+        return top->astOperand1()->str();
+    return top->str();
+}
+
 void CheckCondition::oppositeInnerConditionError(const Token *tok1, const Token* tok2, ErrorPath errorPath)
 {
     const std::string s1(tok1 ? tok1->expressionString() : "x");
     const std::string s2(tok2 ? tok2->expressionString() : "!x");
+    const std::string innerSmt = innerSmtString(tok2);
     errorPath.emplace_back(ErrorPathItem(tok1, "outer condition: " + s1));
     errorPath.emplace_back(ErrorPathItem(tok2, "opposite inner condition: " + s2));
 
-    const std::string msg("Opposite inner 'if' condition leads to a dead code block.\n"
-                          "Opposite inner 'if' condition leads to a dead code block (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
+    const std::string msg("Opposite inner '" + innerSmt + "' condition leads to a dead code block.\n"
+                          "Opposite inner '" + innerSmt + "' condition leads to a dead code block (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
     reportError(errorPath, Severity::warning, "oppositeInnerCondition", msg, CWE398, false);
 }
 
@@ -706,11 +719,12 @@ void CheckCondition::identicalInnerConditionError(const Token *tok1, const Token
 {
     const std::string s1(tok1 ? tok1->expressionString() : "x");
     const std::string s2(tok2 ? tok2->expressionString() : "x");
+    const std::string innerSmt = innerSmtString(tok2);
     errorPath.emplace_back(ErrorPathItem(tok1, "outer condition: " + s1));
     errorPath.emplace_back(ErrorPathItem(tok2, "identical inner condition: " + s2));
 
-    const std::string msg("Identical inner 'if' condition is always true.\n"
-                          "Identical inner 'if' condition is always true (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
+    const std::string msg("Identical inner '" + innerSmt + "' condition is always true.\n"
+                          "Identical inner '" + innerSmt + "' condition is always true (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
     reportError(errorPath, Severity::warning, "identicalInnerCondition", msg, CWE398, false);
 }
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -574,6 +574,12 @@ void CheckCondition::multiCondition2()
 
                     // Condition..
                     const Token *cond2 = tok->str() == "if" ? condStartToken->astOperand2() : condStartToken->astOperand1();
+                    // Check if returning boolean values
+                    if (tok->str() == "return" && Token::Match(cond2, "%var% ;") && cond2->variable()) {
+                        const Variable * condVar = cond2->variable();
+                        if (condVar->isClass() || condVar->isPointer())
+                            break;
+                    }
 
                     ErrorPath errorPath;
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1263,7 +1263,7 @@ void CheckCondition::alwaysTrueFalse()
                 (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent()->astOperand1(), "if|while"));
             const bool constValExpr = tok->isNumber() && Token::Match(tok->astParent(),"%oror%|&&|?"); // just one number in boolean expression
             const bool compExpr = Token::Match(tok, "%comp%|!"); // a compare expression
-            const bool returnStatement = Token::Match(tok->astTop(), "return") &&
+            const bool returnStatement = Token::simpleMatch(tok->astTop(), "return") &&
                 Token::Match(tok->astParent(), "%oror%|&&|return");
 
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
@@ -1272,7 +1272,7 @@ void CheckCondition::alwaysTrueFalse()
             if(returnStatement && (tok->isEnumerator() || Token::simpleMatch(tok, "nullptr")))
                 continue;
 
-            if(returnStatement && tok->variable() && (
+            if(returnStatement && Token::simpleMatch(tok->astParent(), "return") && tok->variable() && (
                 !tok->variable()->isLocal() ||
                 tok->variable()->isReference() ||
                 tok->variable()->isConst() || 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1256,7 +1256,7 @@ void CheckCondition::alwaysTrueFalse()
             const bool constVarExpr = tok->isEnumerator() || Token::simpleMatch(tok, "nullptr") ||
                 (tok->variable() && (tok->variable()->isConst() || !isVariableChanged(tok->variable(), mSettings, mTokenizer->isCPP())));
             const bool returnStatement = Token::Match(tok->astTop(), "return") && !constVarExpr &&
-                (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent(), "return"));
+                Token::Match(tok->astParent(), "%oror%|&&|return");
 
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
                 continue;

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1253,7 +1253,10 @@ void CheckCondition::alwaysTrueFalse()
                 (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent()->astOperand1(), "if|while"));
             const bool constValExpr = tok->isNumber() && Token::Match(tok->astParent(),"%oror%|&&|?"); // just one number in boolean expression
             const bool compExpr = Token::Match(tok, "%comp%|!"); // a compare expression
-            const bool returnStatement = Token::Match(tok->astParent(), "return");
+            const bool constVarExpr = tok->isEnumerator() || Token::simpleMatch(tok, "nullptr") ||
+                (tok->variable() && (tok->variable()->isConst() || !isVariableChanged(tok->variable(), mSettings, mTokenizer->isCPP())));
+            const bool returnStatement = Token::Match(tok->astTop(), "return") && !constVarExpr &&
+                (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent(), "return"));
 
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
                 continue;

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -575,9 +575,13 @@ void CheckCondition::multiCondition2()
                     // Condition..
                     const Token *cond2 = tok->str() == "if" ? condStartToken->astOperand2() : condStartToken->astOperand1();
                     // Check if returning boolean values
-                    if (tok->str() == "return" && Token::Match(cond2, "%var% ;") && cond2->variable()) {
-                        const Variable * condVar = cond2->variable();
-                        if (condVar->isClass() || condVar->isPointer())
+                    if (tok->str() == "return") {
+                        const Variable * condVar = nullptr;
+                        if (Token::Match(cond2, "%var% ;"))
+                            condVar = cond2->variable();
+                        else if(Token::Match(cond2, ". %var% ;"))
+                            condVar = cond2->next()->variable();
+                        if (condVar && (condVar->isClass() || condVar->isPointer()))
                             break;
                     }
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1263,12 +1263,20 @@ void CheckCondition::alwaysTrueFalse()
                 (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent()->astOperand1(), "if|while"));
             const bool constValExpr = tok->isNumber() && Token::Match(tok->astParent(),"%oror%|&&|?"); // just one number in boolean expression
             const bool compExpr = Token::Match(tok, "%comp%|!"); // a compare expression
-            const bool constVarExpr = tok->isEnumerator() || Token::simpleMatch(tok, "nullptr") ||
-                (tok->variable() && (tok->variable()->isConst() || !isVariableChanged(tok->variable(), mSettings, mTokenizer->isCPP())));
-            const bool returnStatement = Token::Match(tok->astTop(), "return") && !constVarExpr &&
+            const bool returnStatement = Token::Match(tok->astTop(), "return") &&
                 Token::Match(tok->astParent(), "%oror%|&&|return");
 
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
+                continue;
+
+            if(returnStatement && (tok->isEnumerator() || Token::simpleMatch(tok, "nullptr")))
+                continue;
+
+            if(returnStatement && tok->variable() && (
+                !tok->variable()->isLocal() ||
+                tok->variable()->isReference() ||
+                tok->variable()->isConst() || 
+                !isVariableChanged(tok->variable(), mSettings, mTokenizer->isCPP())))
                 continue;
 
             // Don't warn in assertions. Condition is often 'always true' by intention.

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1243,7 +1243,7 @@ void CheckCondition::alwaysTrueFalse()
                 continue;
             if (Token::Match(tok, "! %num%|%bool%|%char%"))
                 continue;
-            if (Token::Match(tok, "%oror%|&&"))
+            if (Token::Match(tok, "%oror%|&&|:"))
                 continue;
             if (Token::Match(tok, "%comp%") && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand1(), tok->astOperand2(), mSettings->library, true, true))
                 continue;
@@ -1253,8 +1253,9 @@ void CheckCondition::alwaysTrueFalse()
                 (Token::Match(tok->astParent(), "%oror%|&&") || Token::Match(tok->astParent()->astOperand1(), "if|while"));
             const bool constValExpr = tok->isNumber() && Token::Match(tok->astParent(),"%oror%|&&|?"); // just one number in boolean expression
             const bool compExpr = Token::Match(tok, "%comp%|!"); // a compare expression
+            const bool returnStatement = Token::Match(tok->astParent(), "return");
 
-            if (!(constIfWhileExpression || constValExpr || compExpr))
+            if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
                 continue;
 
             // Don't warn in assertions. Condition is often 'always true' by intention.

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1269,7 +1269,7 @@ void CheckCondition::alwaysTrueFalse()
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
                 continue;
 
-            if(returnStatement && (tok->isEnumerator() || Token::simpleMatch(tok, "nullptr")))
+            if(returnStatement && (tok->isEnumerator() || Token::Match(tok, "nullptr|NULL")))
                 continue;
 
             if(returnStatement && Token::simpleMatch(tok->astParent(), "return") && tok->variable() && (

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -1440,6 +1440,13 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Opposite inner 'if' condition leads to a dead code block.\n", errout.str());
 
+        check("bool foo(int a, int b) {\n"
+              "    if(a==b)\n"
+              "        return a!=b;\n"
+              "    return false;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Opposite inner 'return' condition leads to a dead code block.\n", errout.str());
+
         check("void foo(int a, int b) {\n"
               "    if(a==b)\n"
               "        if(b!=a)\n"
@@ -2037,7 +2044,7 @@ private:
               "    if(a) { return a; }\n"
               "    return false;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (warning) Identical inner 'if' condition is always true.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (warning) Identical inner 'return' condition is always true.\n", errout.str());
 
         check("void f() {\n"
               "    uint32_t value;\n"
@@ -2056,6 +2063,12 @@ private:
         check("void f(int x) {\n"
               "  if (x > 100) { return; }\n"
               "  if (x > 100) {}\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Identical condition 'x>100', second condition is always false\n", errout.str());
+
+        check("bool f(int x) {\n"
+              "  if (x > 100) { return false; }\n"
+              "  return x > 100;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Identical condition 'x>100', second condition is always false\n", errout.str());
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2587,6 +2587,23 @@ private:
               "    return x; \n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("bool& g();\n"
+              "bool f() {\n"
+              "    bool & b = g();\n"
+              "    b = false;\n"
+              "    return b;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct A {\n"
+              "    bool b;\n"
+              "    bool f() {\n"
+              "        b = false;\n"
+              "        return b;\n"
+              "    }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2052,6 +2052,13 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("struct A { int * x; };\n"
+              "int* f(A a, int * b) {\n"
+              "    if(a.x) { return a.x; }\n"
+              "    return b;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f() {\n"
               "    uint32_t value;\n"
               "    get_value(&value);\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2447,6 +2447,13 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!x' is always true\n", errout.str());
 
+        check("bool f(bool a) {\n"
+              "  int x = 0;\n"
+              "  if (a) { return false; }\n" // <- this is just here to fool simplifyKnownVariabels
+              "  return !x;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!x' is always true\n", errout.str());
+
         check("void f() {\n" // #6898 (Token::expressionString)
               "  int x = 0;\n"
               "  A(x++ == 1);\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2046,6 +2046,12 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (warning) Identical inner 'return' condition is always true.\n", errout.str());
 
+        check("int* f(int* a, int * b) {\n"
+              "    if(a) { return a; }\n"
+              "    return b;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f() {\n"
               "    uint32_t value;\n"
               "    get_value(&value);\n"
@@ -2447,12 +2453,11 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!x' is always true\n", errout.str());
 
-        check("bool f(bool a) {\n"
-              "  int x = 0;\n"
-              "  if (a) { return false; }\n" // <- this is just here to fool simplifyKnownVariabels
-              "  return !x;\n"
+        check("bool f(int x) {\n"
+              "  if(x == 0) { x++; return x == 0; } \n"
+              "  return false;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!x' is always true\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (style) Condition 'x==0' is always false\n", errout.str());
 
         check("void f() {\n" // #6898 (Token::expressionString)
               "  int x = 0;\n"
@@ -2556,6 +2561,25 @@ private:
               "    {}\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (style) Condition '!b' is always true\n", errout.str());
+
+        check("bool f() { return nullptr; }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("enum E { A };\n"
+              "bool f() { return A; }\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f() { \n"
+              "    const int x = 0;\n"
+              "    return x; \n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f() { \n"
+              "    int x = 0;\n"
+              "    return x; \n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2033,6 +2033,12 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Identical inner 'if' condition is always true.\n", errout.str());
 
+        check("bool f(bool a) {\n"
+              "    if(a) { return a; }\n"
+              "    return false;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:2]: (warning) Identical inner 'if' condition is always true.\n", errout.str());
+
         check("void f() {\n"
               "    uint32_t value;\n"
               "    get_value(&value);\n"


### PR DESCRIPTION
Right now, we just check in `if` and `while` statements, but this will check in `return` as well. It can catch issues such as:

```cpp
bool f(bool a) {
    if(a) return a;
    return false;
}
```