### PR TITLE
Fix #8230: FP unknown evaluation order on comma expression in while c…

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2672,8 +2672,8 @@ void CheckOther::checkEvaluationOrder()
                     const Token *par = parent;
                     while (Token::simpleMatch(par,","))
                         par = par->astParent();
-                    // not function => break
-                    if (!(par && par->str() == "(" && par->astOperand2()))
+                    // not function or in a while clause => break
+                    if (!(par && par->str() == "(" && par->astOperand2() && par->strAt(-1) != "while"))
                         break;
                     // control flow (if|while|etc) => break
                     if (Token::simpleMatch(par->link(),") {"))

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7051,6 +7051,28 @@ private:
               "  dostuff((t=1,t),2);\n"
               "}", "test.c");
         ASSERT_EQUALS("", errout.str());
+
+        // #8230
+        check("void hprf(const char* fp) {\n"
+              "    do\n"
+              "        ;\n"
+              "    while (++fp, (*fp) <= 0177);\n"
+              "}\n", "test.c");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void hprf(const char* fp) {\n"
+              "    do\n"
+              "        ;\n"
+              "    while (i++, ++fp, (*fp) <= 0177);\n"
+              "}\n", "test.c");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(const char* fp) {\n"
+              "    do\n"
+              "        ;\n"
+              "    while (f(++fp, (*fp) <= 7));\n"
+              "}\n", "test.c");
+        ASSERT_EQUALS("[test.c:4]: (error) Expression '++fp,(*fp)<=7' depends on order of evaluation of side effects\n", errout.str());
     }
 
     void testEvaluationOrderSizeof() {


### PR DESCRIPTION
…lause

The while part of a do-while loop looks almost like a function call, so
extend the check for function calls to ignore while-statements.

Note that there was only an FP when checking c-code, since the check is
disabled for c++-code. Therefore, make sure the test cases are run on a
c-file.