### PR TITLE
qt.cfg: Define "qreal" as "double"

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1279,6 +1279,8 @@
   <define name="Q_UNUSED(X)" value="(void)X;"/>
   <define name="foreach(A,B)" value="for(A:B)"/>
   <define name="emit(X)" value="(X)"/>
+  <!-- https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef -->
+  <define name="qreal" value="double"/>
   <podtype name="qint8" sign="s" size="1"/>
   <podtype name="qint16" sign="s" size="2"/>
   <podtype name="qint32" sign="s" size="4"/>


### PR DESCRIPTION
By default "qreal" is a typedef for "double".
Reference: https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef