### PR TITLE
Fix FN: Invalid string argument with pointer to pointer

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -127,7 +127,7 @@ void CheckFunctions::invalidFunctionUsage()
                 }
 
                 if (mSettings->library.isargstrz(functionToken, argnr)) {
-                    if (Token::Match(argtok, "& %var%") && argtok->next() && argtok->next()->valueType()) {
+                    if (Token::Match(argtok, "& %var% !![") && argtok->next() && argtok->next()->valueType()) {
                         const ValueType * valueType = argtok->next()->valueType();
                         const Variable * variable = argtok->next()->variable();
                         if (valueType->type == ValueType::Type::CHAR && !variable->isGlobal() &&

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -502,6 +502,9 @@ private:
         check("size_t f() { char x[] = \"Hello world\"; return strlen(&x[0]) }");
         ASSERT_EQUALS("", errout.str());
 
+        check("size_t f() { char* x = \"Hello world\"; return strlen(&x[0]) }");
+        ASSERT_EQUALS("", errout.str());
+
         check("struct S {\n"
               "  char x;\n"
               "};\n"
@@ -525,6 +528,13 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("const char x = '\\0'; size_t f() { char y = x; return strlen(&y); }");
+        ASSERT_EQUALS("", errout.str());
+
+        check("size_t f() {\n"
+              "  char * a = \"Hello world\";\n"
+              "  char ** b = &a;\n"
+              "  return strlen(&b[0][0]);\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
 
         // #5225


### PR DESCRIPTION
If the address is taken inside an array, the address is not of a single
character, so do not warn about this.

Originally found in real world code.