### PR TITLE
Complete CMake commands for integration of Qt software in Cppcheck's graphical user interface

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -9,7 +9,11 @@ if (BUILD_GUI)
         add_definitions(-DQT_DEBUG)
     endif()
 
-    include_directories(${PROJECT_SOURCE_DIR}/lib/)
+    find_package(Qt5 COMPONENTS Core Widgets PrintSupport REQUIRED)
+    include_directories("${PROJECT_SOURCE_DIR}/lib/"
+                        ${Qt5Widgets_INCLUDE_DIRS}
+                        ${Qt5Core_INCLUDE_DIRS}
+                        ${Qt5PrintSupport_INCLUDE_DIRS})
     include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/tinyxml/)
 
     file(GLOB hdrs "*.h")


### PR DESCRIPTION
A CMake script for Cppcheck's graphical user interface did not contain [build checks for the Qt software](https://blog.kitware.com/cmake-finding-qt5-the-right-way/ "Article “CMake: Finding Qt 5 the “Right Way”” by Marcus D. Hanwell from 2016-10-21") so far.
Adjust CMake commands for this purpose.