### PR TITLE
donate_cpu: use https url

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -46,7 +46,7 @@ def getCppcheck(cppcheckPath):
             subprocess.call(['git', 'checkout', '-f'])
             subprocess.call(['git', 'pull'])
         else:
-            subprocess.call(['git', 'clone', 'http://github.com/danmar/cppcheck.git', cppcheckPath])
+            subprocess.call(['git', 'clone', 'https://github.com/danmar/cppcheck.git', cppcheckPath])
             if not os.path.exists(cppcheckPath):
                 print('Failed to clone, will try again in 10 minutes..')
                 time.sleep(600)


### PR DESCRIPTION
Avoids git printing a warning about redirecting to https every time
the clone command is issued. The warning was:

    warning: redirecting to https://github.com/danmar/cppcheck.git/