### PR TITLE
Put XmlReportV2 object on the stack in ResultsView::readErrorsXml()

### DIFF
--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -331,20 +331,15 @@ void ResultsView::readErrorsXml(const QString &filename)
         return;
     }
 
-    XmlReport *report = new XmlReportV2(filename);
-
+    XmlReportV2 report(filename);
     QList<ErrorItem> errors;
-    if (report) {
-        if (report->open())
-            errors = report->read();
-        else {
-            QMessageBox msgBox;
-            msgBox.setText(tr("Failed to read the report."));
-            msgBox.setIcon(QMessageBox::Critical);
-            msgBox.exec();
-        }
-        delete report;
-        report = NULL;
+    if (report.open()) {
+        errors = report.read();
+    } else {
+        QMessageBox msgBox;
+        msgBox.setText(tr("Failed to read the report."));
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.exec();
     }
 
     ErrorItem item;


### PR DESCRIPTION
Dynamic memory allocation was used for a XmlReportV2 object in the function “ResultsView::readErrorsXml”.
Put this object on the stack instead so that this software can become a bit safer and more efficient.