### PR TITLE
Refactor indexOf() in Cppcheck's graphical user interface

### DIFF
--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -1131,12 +1131,13 @@ void ResultsTree::saveErrors(Report *report, QStandardItem *fileItem) const
 static int indexOf(const QList<ErrorItem> &list, const ErrorItem &item)
 {
     for (int i = 0; i < list.size(); i++) {
-        if (list[i].errorId == item.errorId &&
-            list[i].errorPath == item.errorPath &&
-            list[i].file0 == item.file0 &&
-            list[i].message == item.message &&
-            list[i].inconclusive == item.inconclusive &&
-            list[i].severity == item.severity) {
+        const ErrorItem &ei(list[i]);
+        if (ei.errorId == item.errorId &&
+            ei.errorPath == item.errorPath &&
+            ei.file0 == item.file0 &&
+            ei.message == item.message &&
+            ei.inconclusive == item.inconclusive &&
+            ei.severity == item.severity) {
             return i;
         }
     }


### PR DESCRIPTION
An index access operation was repeated six times in the function “indexOf”.
Replace it by the use of a reference variable.