### PR TITLE
insecureCmdLineArgs: Fixed FN in case strdup() copies argv[].

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1833,9 +1833,9 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                 if (tok->varId() == argvVarid)
                     break;
 
-				// Update varid in case the input is copied by strdup()
-				if (Token::Match(tok, "strdup ( %varid%", argvVarid) && tok->tokAt(-2) )
-					argvVarid = tok->tokAt(-2)->varId();
+                // Update varid in case the input is copied by strdup()
+                if (Token::Match(tok, "strdup ( %varid%", argvVarid) && tok->tokAt(-2))
+                    argvVarid = tok->tokAt(-2)->varId();
 
                 // Match common patterns that can result in a buffer overrun
                 // e.g. strcpy(buffer, argv[0])
@@ -1846,8 +1846,8 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                     else
                         continue; // Ticket #7964
                     if (Token::Match(tok, "* %varid%", argvVarid) ||     // e.g. strcpy(buf, * ptr)
-						Token::Match(tok, "%varid% [", argvVarid) ||     // e.g. strcpy(buf, argv[1])
-						Token::Match(tok, "%varid%", argvVarid) )        // e.g. strcpy(buf, pointer)
+                        Token::Match(tok, "%varid% [", argvVarid) ||     // e.g. strcpy(buf, argv[1])
+                        Token::Match(tok, "%varid%", argvVarid))         // e.g. strcpy(buf, pointer)
                         cmdLineArgsError(tok);
                 }
             }

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1834,7 +1834,7 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                     break;
 
                 // Update varid in case the input is copied by strdup()
-                if (Token::Match(tok, "strdup ( %varid%", argvVarid) && tok->tokAt(-2))
+                if (Token::Match(tok->tokAt(-2), "%var% = strdup ( %varid%", argvVarid))
                     argvVarid = tok->tokAt(-2)->varId();
 
                 // Match common patterns that can result in a buffer overrun

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -1833,6 +1833,10 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                 if (tok->varId() == argvVarid)
                     break;
 
+				// Update varid in case the input is copied by strdup()
+				if (Token::Match(tok, "strdup ( %varid%", argvVarid) && tok->tokAt(-2) )
+					argvVarid = tok->tokAt(-2)->varId();
+
                 // Match common patterns that can result in a buffer overrun
                 // e.g. strcpy(buffer, argv[0])
                 if (Token::Match(tok, "strcpy|strcat (")) {
@@ -1841,7 +1845,9 @@ void CheckBufferOverrun::checkInsecureCmdLineArgs()
                         tok = nextArgument;
                     else
                         continue; // Ticket #7964
-                    if (Token::Match(tok, "* %varid%", argvVarid) || Token::Match(tok, "%varid% [", argvVarid))
+                    if (Token::Match(tok, "* %varid%", argvVarid) ||     // e.g. strcpy(buf, * ptr)
+						Token::Match(tok, "%varid% [", argvVarid) ||     // e.g. strcpy(buf, argv[1])
+						Token::Match(tok, "%varid%", argvVarid) )        // e.g. strcpy(buf, pointer)
                         cmdLineArgsError(tok);
                 }
             }

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -235,7 +235,7 @@ private:
         TEST_CASE(executionPaths5);   // Ticket #2920 - False positive when size is unknown
         TEST_CASE(executionPaths6);   // unknown types
 
-        TEST_CASE(cmdLineArgs1);
+        TEST_CASE(insecureCmdLineArgs);
         TEST_CASE(checkBufferAllocatedWithStrlen);
 
         TEST_CASE(scope);   // handling different scopes
@@ -3750,7 +3750,32 @@ private:
         ASSERT_EQUALS("[test.cpp:4]: (error) Array 'a[10]' accessed at index 1000, which is out of bounds.\n", errout.str());
     }
 
-    void cmdLineArgs1() {
+    void insecureCmdLineArgs() {
+        check("int main(int argc, char *argv[])\n"
+              "{\n"
+              "    if(argc>1)\n"
+              "    {\n"
+              "        char buf[2];\n"
+              "        char *p = strdup(argv[1]);\n"
+              "        strcpy(buf,p);\n"
+              "        free(p);\n"
+              "    }\n"
+              "    return 0;\n"
+			"}");
+		ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());    
+		
+		check("int main(int argc, char *argv[])\n"
+              "{\n"
+              "    if(argc>1)\n"
+              "    {\n"
+              "        char buf[2] = {'\\0','\\0'};\n"
+              "        char *p = strdup(argv[1]);\n"
+              "        strcat(buf,p);\n"
+              "        free(p);\n"
+              "    }\n"
+              "    return 0;\n"
+			"}");
+		ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());
 
         check("int main(const int argc, char* argv[])\n"
               "{\n"

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3761,10 +3761,10 @@ private:
               "        free(p);\n"
               "    }\n"
               "    return 0;\n"
-			"}");
-		ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());    
-		
-		check("int main(int argc, char *argv[])\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());
+
+        check("int main(int argc, char *argv[])\n"
               "{\n"
               "    if(argc>1)\n"
               "    {\n"
@@ -3774,8 +3774,8 @@ private:
               "        free(p);\n"
               "    }\n"
               "    return 0;\n"
-			"}");
-		ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());
+              "}");
+        ASSERT_EQUALS("[test.cpp:7]: (error) Buffer overrun possible for long command line arguments.\n", errout.str());
 
         check("int main(const int argc, char* argv[])\n"
               "{\n"


### PR DESCRIPTION
Test case
```C++
#include <iostream>
#include <cstring>
int main(int argc, char *argv[])
{
	if(argc>1)
	{
		char buf[3];
		char *p = strdup(argv[1]);
		strcpy(buf,p);
		free(p);
	}
	return 0;
}

```
Executing the example with `argv[1] `longer than `buf` leads to a crash
```bash
$ g++ insecureCmdLineArgs.cpp && ./a.out abce
Checking insecureCmdLineArgs.cpp ...
(information) Cppcheck cannot find all the include files (use --check-config for details)
*** stack smashing detected ***: <unknown> terminated
Aborted
```

Having this PR applied and check with Cppcheck gives 
```bash
[insecureCmdLineArgs.cpp:9]: (error) Buffer overrun possible for long command line arguments.
```