### PR TITLE
fix typp on manual.docbook Newline is \n instead of \t

### DIFF
--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -853,7 +853,7 @@ multiline.c:3: note: Null pointer dereference
         </varlistentry>
 
         <varlistentry>
-          <term>\t</term>
+          <term>\n</term>
 
           <listitem>
             <para>Newline</para>


### PR DESCRIPTION
This pull request fixes typo in manual.docbook 
- change Newline term from <term>\t</term> to <term>\n</term>