### PR TITLE
fix newline from backslash t to backslash n in manual-ja.docbook

### DIFF
--- a/man/manual-ja.docbook
+++ b/man/manual-ja.docbook
@@ -709,7 +709,7 @@ multiline.c:3: note: Null pointer dereference
         </varlistentry>
 
         <varlistentry>
-          <term>\t</term>
+          <term>\n</term>
 
           <listitem>
             <para>改行</para>


### PR DESCRIPTION
fix newline in translation of manual docbook also
see https://github.com/danmar/cppcheck/pull/1442