### PR TITLE
Fix FP issue 8801: Condition 'a+b' is always true

### DIFF
--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2603,6 +2603,13 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("int f() {\n"
+              "    const int a = 50;\n"
+              "    const int b = 52;\n"
+              "    return a+b;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("bool& g();\n"
               "bool f() {\n"
               "    bool & b = g();\n"


### PR DESCRIPTION
Fixes FP in:

```cpp
int f(void)
{
    const int a = 50;
    const int b = 52;   
    return a+b;
}
```