### PR TITLE
enable AA_UseHighDpiPixmaps

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
     QApplication app(argc, argv);


### PR DESCRIPTION
enables AA_UseHighDpiPixmaps for less pixeled icons on 4K displays.