### PR TITLE
Add null pointer check in ProjectFileDialog::removeSuppression()

### DIFF
--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -636,6 +636,9 @@ void ProjectFileDialog::removeSuppression()
 {
     const int row = mUI.mListSuppressions->currentRow();
     QListWidgetItem *item = mUI.mListSuppressions->takeItem(row);
+    if (!item)
+        return;
+
     int suppressionIndex = getSuppressionIndex(item->text());
     if (suppressionIndex >= 0)
         mSuppressions.removeAt(suppressionIndex);


### PR DESCRIPTION
[The function “QListWidget::takeItem” is documented](https://doc.qt.io/qt-5/qlistwidget.html#takeItem "Description for QListWidget::takeItem") in the way that a null pointer can be returned. This result was not checked by the function “ProjectFileDialog::removeSuppression” so far.
Thus add a corresponding check so that an inappropriate pointer access should not happen any more here.