### PR TITLE
findLambdaEndToken handle explicit type

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -939,20 +939,12 @@ const Token *findLambdaEndToken(const Token *first)
 {
     if (!first || first->str() != "[")
         return nullptr;
-    const Token* tok = first->link();
-    if (Token::simpleMatch(tok, "] {"))
-        return tok->linkAt(1);
-    if (!Token::simpleMatch(tok, "] ("))
-        return nullptr;
-    tok = tok->linkAt(1)->next();
-    if (tok && tok->str() == "constexpr")
-        tok = tok->next();
-    if (tok && tok->str() == "mutable")
-        tok = tok->next();
-    if (tok && tok->originalName() == "->")
-        tok = tok->tokAt(2);
-    if (tok && tok->str() == "{")
-        return tok->link();
+    const Token * tok = first;
+
+    if (tok->astOperand1() && tok->astOperand1()->str() == "(")
+        tok = tok->astOperand1();
+    if (tok->astOperand1() && tok->astOperand1()->str() == "{")
+        return tok->astOperand1()->link();
     return nullptr;
 }
 

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -949,6 +949,8 @@ const Token *findLambdaEndToken(const Token *first)
         tok = tok->next();
     if (tok && tok->str() == "mutable")
         tok = tok->next();
+    if (tok && tok->originalName() == "->")
+        tok = tok->tokAt(2);
     if (tok && tok->str() == "{")
         return tok->link();
     return nullptr;

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -126,7 +126,6 @@ std::vector<const Token *> getArguments(const Token *ftok);
 
 /**
  * find lambda function end token
- * \todo handle explicit return type
  * \param first The [ token
  * \return nullptr or the }
  */

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -680,6 +680,8 @@ static void compilePrecedence2(Token *&tok, AST_state& state)
                 if (Token::simpleMatch(squareBracket->link(), "] (")) {
                     Token* const roundBracket = squareBracket->link()->next();
                     Token* curlyBracket = roundBracket->link()->next();
+                    if (curlyBracket && curlyBracket->str() == "mutable")
+                        curlyBracket = curlyBracket->next();
                     if (curlyBracket && curlyBracket->originalName() == "->") {
                         while (Token::Match(curlyBracket, "%name%|.|::|&|*"))
                             curlyBracket = curlyBracket->next();

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -49,8 +49,10 @@ private:
     }
 
     void findLambdaEndToken() {
+        ASSERT(nullptr == ::findLambdaEndToken(nullptr));
         ASSERT_EQUALS(false, findLambdaEndToken("void f() { }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[]{ }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[]{ return 0 }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[](){ }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[&](){ }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[&, i](){ }"));
@@ -62,6 +64,11 @@ private:
         ASSERT_EQUALS(true, findLambdaEndToken("[](void) mutable -> int { return -1 }"));
         ASSERT_EQUALS(false, findLambdaEndToken("[](void) foo -> int { return -1 }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> int { return -1 }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> int* { return x }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> const * int { return x }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) mutable -> const * int { return x }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> const ** int { return x }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> const * const* int { return x }"));
     }
 
     bool isReturnScope(const char code[], int offset) {

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -33,9 +33,31 @@ public:
 private:
 
     void run() override {
+        TEST_CASE(findLambdaEndToken);
         TEST_CASE(isReturnScope);
         TEST_CASE(isVariableChanged);
         TEST_CASE(isVariableChangedByFunctionCall);
+    }
+
+    bool findLambdaEndToken(const char code[]) {
+        Settings settings;
+        Tokenizer tokenizer(&settings, this);
+        std::istringstream istr(code);
+        tokenizer.tokenize(istr, "test.cpp");
+        const Token * const tokEnd = ::findLambdaEndToken(tokenizer.tokens());
+        return tokEnd && tokEnd->next() == nullptr;
+    }
+
+    void findLambdaEndToken() {
+        ASSERT_EQUALS(false, findLambdaEndToken("void f() { }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[]{ }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](){ }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[&](){ }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[&, i](){ }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) { return -1 }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) { return a + b }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) mutable { return a + b }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) constexpr { return a + b }"));
     }
 
     bool isReturnScope(const char code[], int offset) {

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -58,6 +58,10 @@ private:
         ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) { return a + b }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) mutable { return a + b }"));
         ASSERT_EQUALS(true, findLambdaEndToken("[](int a, int b) constexpr { return a + b }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) -> int { return -1 }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) mutable -> int { return -1 }"));
+        ASSERT_EQUALS(false, findLambdaEndToken("[](void) foo -> int { return -1 }"));
+        ASSERT_EQUALS(true, findLambdaEndToken("[](void) constexpr -> int { return -1 }"));
     }
 
     bool isReturnScope(const char code[], int offset) {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -8551,6 +8551,8 @@ private:
         ASSERT_EQUALS("{([cd,(return 0return", testAst("return [](int a, int b) -> int { return 0; }(c, d);"));
         ASSERT_EQUALS("x{([=", testAst("x = [&]()->std::string const & {};"));
         ASSERT_EQUALS("f{([=", testAst("f = []() -> foo* {};"));
+        ASSERT_EQUALS("f{([=", testAst("f = [](void) mutable -> foo* {};"));
+        ASSERT_EQUALS("f{([=", testAst("f = []() mutable {};"));
 
         ASSERT_EQUALS("x{([= 0return", testAst("x = [](){return 0; };"));
 


### PR DESCRIPTION
As mentioned in #1451. It fixes the two TODO-test cases in #1451 (perhaps I should have added it to that PR directly?).