### PR TITLE
travis: add job that check testrunner with valgrind.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
 #    special CXXFLAGS for maximum speed, overrides global CXXFLAGS, CHECK_CLANG is the var that controls if we download and check clang in that travis job
     - CXXFLAGS="${CXXFLAGS} -DCHECK_INTERNAL"
     - CXXFLAGS="${CXXFLAGS} -DCHECK_INTERNAL" MAKEFLAGS="HAVE_RULES=yes" SRCDIR=build VERIFY=1
+    - CXXFLAGS="-O2 -g -DLESSTHREADS" SRCDIR=build VERIFY=1 VALGRIND=yes
     - SRCDIR=build CHECK_CLANG=yes VERIFY=1
     - SRCDIR=build CHECK_LLVM=yes VERIFY=1
     - CHECK_MAKEFILE_REGEN=true
@@ -28,6 +29,8 @@ matrix:
   exclude:
     - compiler: gcc
       env: SRCDIR=build CHECK_CLANG=yes VERIFY=1
+    - compiler: clang
+      env: CXXFLAGS="-O2 -g -DLESSTHREADS" SRCDIR=build VERIFY=1 VALGRIND=yes
     - compiler: gcc
       env: SRCDIR=build CHECK_LLVM=yes VERIFY=1
     - compiler: gcc
@@ -39,11 +42,13 @@ matrix:
 before_install:
 # install needed deps
  - sudo apt-get update -qq
- - sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet
+ - sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet valgrind
 
 script:
 # fail the entire job as soon as one of the subcommands exits non-zero to save time and resources
   - set -e
+# valgrind checking of testrunner
+  - if [[ "$VALGRIND" == "yes" ]] && [[ "$CC" == "gcc" ]]; then make testrunner -j 4 ; valgrind --version ;  valgrind --leak-check=full --show-possibly-lost=no --track-origins=yes --quiet   --error-exitcode=1 ./testrunner; exit ;fi
 # download clang git, compile cppcheck, run cppcheck on clang code to look for crashes in cppcheck. if this is done, terminate build
   - if [[ "$CHECK_CLANG" == "yes" ]] && [[ "$CC" == "clang" ]]; then wget "https://github.com/llvm-mirror/clang/archive/a1f8bd3778cc5a53236a53500c6ab184e945eefa.zip" & make -j 4 & wait; unzip a1f8bd3778cc5a53236a53500c6ab184e945eefa.zip > /dev/null; touch /tmp/clang.cppcheck; cd ./clang-a1f8bd3778cc5a53236a53500c6ab184e945eefa ; ${CPPCHECK} . --max-configs=1 --enable=all --inconclusive --exception-handling --template="{callstack} ({severity}) {message} [{id}]" -iINPUTS -itest/Driver/Inputs/gen-response.c -itest/Index/index-many-logical-ops.c -itest/Sema/many-logical-ops.c --suppressions-list=../.travis_llvmcheck_suppressions -j 2 |& grep -v ".* files checked.*done" |& tee /tmp/clang.cppcheck; cd ../ ; echo "CLANG" ; ! grep "process crashed with signal\|Internal error\. compiled" /tmp/clang.cppcheck; exit; fi
 # check llvm as well

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -65,7 +65,9 @@ private:
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(deadlock_with_many_errors);
+#ifndef LESSTHREADS
         TEST_CASE(many_threads);
+#endif
         TEST_CASE(no_errors_more_files);
         TEST_CASE(no_errors_less_files);
         TEST_CASE(no_errors_equal_amount_files);
@@ -85,6 +87,7 @@ private:
         check(2, 3, 3, oss.str());
     }
 
+#ifndef LESSTHREADS
     void many_threads() {
         check(16, 100, 100,
               "int main()\n"
@@ -93,6 +96,7 @@ private:
               "  return 0;\n"
               "}");
     }
+#endif
 
     void no_errors_more_files() {
         check(2, 3, 0,


### PR DESCRIPTION
we need to skip a testthreadexecutor test for this which would eat up all ram.(implemented -DLESSTHREADS)