### PR TITLE
Add a check target to cmake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,4 +23,7 @@ if (BUILD_TESTS)
 
     add_test(NAME testrunner COMMAND testrunner WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
+    add_custom_target(check COMMAND $<TARGET_FILE:testrunner> -q WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+    add_dependencies(check testrunner)
+
 endif()


### PR DESCRIPTION
This adds a check target that will build and run the tests through the testrunner.