### PR TITLE
Fix issue 8839: FP knownConditionTrueFalse - condition inside a while-clause

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1145,6 +1145,7 @@ static void valueFlowTerminatingCondition(TokenList *tokenlist, SymbolDatabase* 
             const Scope * condScope = nullptr;
             for(const Scope * parent = condTok->scope();parent;parent = parent->nestedIn) {
                 if (parent->type == Scope::eIf || 
+                    parent->type == Scope::eWhile ||
                     parent->type == Scope::eSwitch) {
                     condScope = parent;
                     break;

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2673,6 +2673,16 @@ private:
               "    return std::time(0) > maxtime;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void foo(double param) {\n"
+              "  while(bar()) {\n"
+              "    if (param<0.)\n"
+              "       return;\n"
+              "  }\n"
+              "  if (param<0.)\n"
+              "    return;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {


### PR DESCRIPTION
Fixes:

```cpp
void foo(double param) {
  while(bar())
  {
    if (param<0.)
       return;
  }
  if (param<0.)
    return;
}
```