### PR TITLE
Diagnose invalid lifetimes

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -178,7 +178,7 @@ static bool isInLoopCondition(const Token * tok)
 }
 
 /// If tok2 comes after tok1
-static bool precedes(const Token * tok1, const Token * tok2)
+bool precedes(const Token * tok1, const Token * tok2)
 {
     if (!tok1)
         return false;

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -59,6 +59,8 @@ const Token * astIsVariableComparison(const Token *tok, const std::string &comp,
 
 const Token * nextAfterAstRightmostLeaf(const Token * tok);
 
+bool precedes(const Token * tok1, const Token * tok2);
+
 bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 
 bool isEqualKnownValue(const Token * const tok1, const Token * const tok2);

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -754,7 +754,7 @@ void CheckAutoVariables::errorInvalidLifetime(const Token *tok, const ValueFlow:
         }
     }
     errorPath.emplace_back(tok, "");
-    reportError(errorPath, Severity::error, "invalidLifetime", msg + " that is invalid.", CWE562, false);
+    reportError(errorPath, Severity::error, "invalidLifetime", msg + " that is out of scope.", CWE562, false);
 }
 
 void CheckAutoVariables::errorReturnReference(const Token *tok)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -620,7 +620,7 @@ static bool isDeadScope(const Token * tok, const Scope * scope)
     if (!scope)
         return false;
     const Variable * var = tok->variable();
-    if (var && (var->isGlobal() || var->isStatic() || var->isExtern()))
+    if (var && (!var->isLocal() || var->isStatic() || var->isExtern()))
         return false;
     if (tok->scope() && tok->scope()->bodyEnd != scope->bodyEnd && precedes(tok->scope()->bodyEnd, scope->bodyEnd))
         return true;

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -93,6 +93,7 @@ private:
     void errorReturnPointerToLocalArray(const Token *tok);
     void errorAutoVariableAssignment(const Token *tok, bool inconclusive);
     void errorReturnDanglingLifetime(const Token *tok, const ValueFlow::Value* val);
+    void errorInvalidLifetime(const Token *tok, const ValueFlow::Value* val);
     void errorReturnReference(const Token *tok);
     void errorReturnTempReference(const Token *tok);
     void errorInvalidDeallocation(const Token *tok, const ValueFlow::Value *val);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3831,6 +3831,9 @@ static void valueFlowSubFunction(TokenList *tokenlist, ErrorLogger *errorLogger,
             // passing value(s) to function
             std::list<ValueFlow::Value> argvalues(getFunctionArgumentValues(argtok));
 
+            // Dont forward lifetime values
+            argvalues.remove_if(std::mem_fn(&ValueFlow::Value::isLifetimeValue));
+
             if (argvalues.empty())
                 continue;
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1394,6 +1394,15 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("struct a {\n"
+              "  b();\n"
+              "  std::list<int> c;\n"
+              "};\n"
+              "void a::b() {\n"
+              "  c.end()\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 };

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -123,6 +123,7 @@ private:
         TEST_CASE(danglingLifetimeLambda);
         TEST_CASE(danglingLifetimeContainer);
         TEST_CASE(danglingLifetime);
+        TEST_CASE(invalidLifetime);
     }
 
 
@@ -1369,6 +1370,28 @@ private:
               "void f() {\n"
               "    using T = A[3];\n"
               "    A &&a = T{1, 2, 3}[1]();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void invalidLifetime() {
+        check("void foo(int a) {\n"
+              "    std::function<void()> f;\n"
+              "    if (a > 0) {\n"
+              "        int b = a + 1;\n"
+              "        f = [&]{ return b; };\n"
+              "    }\n"
+              "    f();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4] -> [test.cpp:7]: (error) Using lambda that captures local variable 'b' that is invalid.\n", errout.str());
+
+        check("void foo(int a) {\n"
+              "    std::function<void()> f;\n"
+              "    if (a > 0) {\n"
+              "        int b = a + 1;\n"
+              "        f = [&]{ return b; };\n"
+              "        f();\n"
+              "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1383,7 +1383,7 @@ private:
               "    }\n"
               "    f();\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4] -> [test.cpp:7]: (error) Using lambda that captures local variable 'b' that is invalid.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4] -> [test.cpp:7]: (error) Using lambda that captures local variable 'b' that is out of scope.\n", errout.str());
 
         check("void foo(int a) {\n"
               "    std::function<void()> f;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1403,6 +1403,14 @@ private:
               "  c.end()\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void b(char f[], char c[]) {\n"
+              "  std::string d(c); {\n"
+              "    std::string e;\n"
+              "    b(f, e.c_str())\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 };


### PR DESCRIPTION
This extends the lifetime check to check for variables used after they have been destroyed. So it will diagnose the lambda:

```cpp
void foo(int a) {
    std::function<void()> f;
    if (a > 0) {
        int b = a + 1;
        f = [&]{ return b; };
    }
    f();
}
```

It will warn about the call to `f` as it references variable `b` which is not in scope.