### PR TITLE
Track variable lifetime through function calls

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2561,6 +2561,9 @@ struct LifetimeStore
         value.tokvalue = var->nameToken();
         value.errorPath = errorPath;
         value.lifetimeKind = type;
+        // Dont add the value a second time
+        if(std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
+            return;
         setTokenValue(tok, value, tokenlist->getSettings());
         valueFlowForwardLifetime(tok, tokenlist, errorLogger, settings);
     }
@@ -2590,8 +2593,10 @@ struct LifetimeStore
             value.tokvalue = var->nameToken();
             value.errorPath = errorPath;
             value.lifetimeKind = type;
+            // Dont add the value a second time
+            if(std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
+                continue;
             setTokenValue(tok, value, tokenlist->getSettings());
-
             valueFlowForwardLifetime(tok, tokenlist, errorLogger, settings);
         }
     }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2622,12 +2622,12 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
         return;
     if (Token::Match(tok->tokAt(-2), "std :: ref|cref|tie|front_inserter|back_inserter")) {
         for (const Token *argtok : getArguments(tok)) {
-            LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object}.byRef(
+            LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object} .byRef(
                 tok->next(), tokenlist, errorLogger, settings);
         }
     } else if (Token::Match(tok->tokAt(-2), "std :: make_tuple|tuple_cat|make_pair|make_reverse_iterator|next|prev|move")) {
         for (const Token *argtok : getArguments(tok)) {
-            LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object}.byVal(
+            LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object} .byVal(
                 tok->next(), tokenlist, errorLogger, settings);
         }
     }
@@ -2689,10 +2689,10 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
             for (const Token * tok2 = lam.bodyTok; tok2 != lam.bodyTok->link(); tok2 = tok2->next()) {
                 ErrorPath errorPath;
                 if (captureByRef) {
-                    LifetimeStore{tok2, "Lambda captures variable by reference here.", ValueFlow::Value::Lambda}.byRef(
+                    LifetimeStore{tok2, "Lambda captures variable by reference here.", ValueFlow::Value::Lambda} .byRef(
                         tok, tokenlist, errorLogger, settings, isCapturingVariable);
                 } else if (captureByValue) {
-                    LifetimeStore{tok2, "Lambda captures variable by value here.", ValueFlow::Value::Lambda}.byVal(
+                    LifetimeStore{tok2, "Lambda captures variable by value here.", ValueFlow::Value::Lambda} .byVal(
                         tok, tokenlist, errorLogger, settings, isCapturingVariable);
                 }
             }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2468,19 +2468,19 @@ static bool valueFlowForward(Token * const               startToken,
     return true;
 }
 
-static const Variable * getLifetimeVariable(const Token * tok, ErrorPath& errorPath)
+static const Variable *getLifetimeVariable(const Token *tok, ErrorPath &errorPath)
 {
-    const Variable * var = tok->variable();
+    const Variable *var = tok->variable();
     if (!var)
         return nullptr;
     if (var->isReference() || var->isRValueReference()) {
-        for (const ValueFlow::Value& v:tok->values()) {
+        for (const ValueFlow::Value &v : tok->values()) {
             if (!v.isLifetimeValue())
                 continue;
             if (v.tokvalue == tok)
                 continue;
             errorPath.insert(errorPath.end(), v.errorPath.begin(), v.errorPath.end());
-            const Variable * var2 = getLifetimeVariable(v.tokvalue, errorPath);
+            const Variable *var2 = getLifetimeVariable(v.tokvalue, errorPath);
             if (var2)
                 return var2;
         }
@@ -2494,17 +2494,17 @@ static bool isNotLifetimeValue(const ValueFlow::Value& val)
     return !val.isLifetimeValue();
 }
 
-static void valueFlowLifetimeFunction(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings);
+static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings);
 
 static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
 {
-    const Token * parent = tok->astParent();
-    while(parent && parent->isArithmeticalOp())
+    const Token *parent = tok->astParent();
+    while (parent && parent->isArithmeticalOp())
         parent = parent->astParent();
-    if(!parent)
+    if (!parent)
         return;
     // Assignment
-    if(parent->str() == "=" && !parent->astParent()) {
+    if (parent->str() == "=" && !parent->astParent()) {
         // Lhs should be a variable
         if (!parent->astOperand1() || !parent->astOperand1()->varId())
             return;
@@ -2512,7 +2512,7 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
         if (!var || (!var->isLocal() && !var->isGlobal() && !var->isArgument()))
             return;
 
-        const Token * const endOfVarScope = var->typeStartToken()->scope()->bodyEnd;
+        const Token *const endOfVarScope = var->typeStartToken()->scope()->bodyEnd;
 
         // Rhs values..
         if (!parent->astOperand2() || parent->astOperand2()->values().empty())
@@ -2528,31 +2528,30 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
             changeKnownToPossible(values);
 
         // Skip RHS
-        const Token * nextExpression = nextAfterAstRightmostLeaf(parent);
+        const Token *nextExpression = nextAfterAstRightmostLeaf(parent);
 
         // Only forward lifetime values
         values.remove_if(&isNotLifetimeValue);
         valueFlowForward(const_cast<Token *>(nextExpression), endOfVarScope, var, var->declarationId(), values, false, false, tokenlist, errorLogger, settings);
-    // Function call
-    } else if(Token::Match(parent->previous(), "%name% (")) {
+        // Function call
+    } else if (Token::Match(parent->previous(), "%name% (")) {
         valueFlowLifetimeFunction(const_cast<Token *>(parent->previous()), tokenlist, errorLogger, settings);
     }
 }
 
-struct LifetimeStore
-{
+struct LifetimeStore {
     const Token *argtok;
     std::string message;
     ValueFlow::Value::LifetimeKind type;
 
-    template<class Predicate>
-    void byRef(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings, Predicate pred) const
+    template <class Predicate>
+    void byRef(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings, Predicate pred) const
     {
         ErrorPath errorPath;
-        const Variable * var = getLifetimeVariable(argtok, errorPath);
+        const Variable *var = getLifetimeVariable(argtok, errorPath);
         if (!var)
             return;
-        if(!pred(var))
+        if (!pred(var))
             return;
         errorPath.emplace_back(argtok, message);
 
@@ -2562,29 +2561,29 @@ struct LifetimeStore
         value.errorPath = errorPath;
         value.lifetimeKind = type;
         // Dont add the value a second time
-        if(std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
+        if (std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
             return;
         setTokenValue(tok, value, tokenlist->getSettings());
         valueFlowForwardLifetime(tok, tokenlist, errorLogger, settings);
     }
 
-    void byRef(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings) const
+    void byRef(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings) const
     {
-        byRef(tok, tokenlist, errorLogger, settings, [](const Variable*) { return true; });
+        byRef(tok, tokenlist, errorLogger, settings, [](const Variable *) { return true; });
     }
-    
-    template<class Predicate>
-    void byVal(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings, Predicate pred) const
+
+    template <class Predicate>
+    void byVal(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings, Predicate pred) const
     {
-        for (const ValueFlow::Value& v:argtok->values()) {
+        for (const ValueFlow::Value &v : argtok->values()) {
             if (!v.isLifetimeValue())
                 continue;
-            const Token * tok3 = v.tokvalue;
+            const Token *tok3 = v.tokvalue;
             ErrorPath errorPath = v.errorPath;
-            const Variable * var = getLifetimeVariable(tok3, errorPath);
+            const Variable *var = getLifetimeVariable(tok3, errorPath);
             if (!var)
                 continue;
-            if(!pred(var))
+            if (!pred(var))
                 return;
             errorPath.emplace_back(argtok, message);
 
@@ -2594,29 +2593,29 @@ struct LifetimeStore
             value.errorPath = errorPath;
             value.lifetimeKind = type;
             // Dont add the value a second time
-            if(std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
+            if (std::find(tok->values().begin(), tok->values().end(), value) != tok->values().end())
                 continue;
             setTokenValue(tok, value, tokenlist->getSettings());
             valueFlowForwardLifetime(tok, tokenlist, errorLogger, settings);
         }
     }
 
-    void byVal(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings) const
+    void byVal(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings) const
     {
-        byVal(tok, tokenlist, errorLogger, settings, [](const Variable*) { return true; });
+        byVal(tok, tokenlist, errorLogger, settings, [](const Variable *) { return true; });
     }
 };
 
-static void valueFlowLifetimeFunction(Token * tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
+static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
 {
-    if(!Token::Match(tok, "%name% ("))
+    if (!Token::Match(tok, "%name% ("))
         return;
-    if(Token::Match(tok->tokAt(-2), "std :: ref|cref|tie|front_inserter|back_inserter")) {
+    if (Token::Match(tok->tokAt(-2), "std :: ref|cref|tie|front_inserter|back_inserter")) {
         for (const Token *argtok : getArguments(tok)) {
             LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object}
                 .byRef(tok->next(), tokenlist, errorLogger, settings);
         }
-    } else if(Token::Match(tok->tokAt(-2), "std :: make_tuple|tuple_cat|make_pair|make_reverse_iterator|next|prev|move")) {
+    } else if (Token::Match(tok->tokAt(-2), "std :: make_tuple|tuple_cat|make_pair|make_reverse_iterator|next|prev|move")) {
         for (const Token *argtok : getArguments(tok)) {
             LifetimeStore{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object}
                 .byVal(tok->next(), tokenlist, errorLogger, settings);
@@ -2663,8 +2662,8 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
 
             std::set<const Scope *> scopes;
 
-            auto isCapturingVariable = [&](const Variable* var) {
-                const Scope * scope = var->scope();
+            auto isCapturingVariable = [&](const Variable *var) {
+                const Scope *scope = var->scope();
                 if (scopes.count(scope) > 0)
                     return false;
                 if (scope->isNestedIn(bodyScope))
@@ -2745,7 +2744,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
 
         }
         // Check function calls
-        else if(Token::Match(tok, "%name% (")) {
+        else if (Token::Match(tok, "%name% (")) {
             valueFlowLifetimeFunction(tok, tokenlist, errorLogger, settings);
         }
         // Check variables

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1325,21 +1325,27 @@ private:
               "    auto it = x.begin();\n"
               "    return std::next(it);\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f() {\n"
               "    std::vector<int> x;\n"
               "    auto it = x.begin();\n"
               "    return it + 1;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning iterator to local container 'x' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning iterator to local container 'x' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f() {\n"
               "    std::vector<int> x;\n"
               "    auto it = x.begin();\n"
               "    return std::next(it + 1);\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f() {\n"
               "  static std::vector<int> x;\n"
@@ -1405,19 +1411,22 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void danglingLifetimeFunction()
-    {
+    void danglingLifetimeFunction() {
         check("auto f() {\n"
               "    int a;\n"
               "    return std::ref(a);\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f() {\n"
               "    int a;\n"
               "    return std::make_tuple(std::ref(a));\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f(int x) {\n"
               "    int a;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -123,6 +123,7 @@ private:
         TEST_CASE(danglingLifetimeLambda);
         TEST_CASE(danglingLifetimeContainer);
         TEST_CASE(danglingLifetime);
+        TEST_CASE(danglingLifetimeFunction);
         TEST_CASE(invalidLifetime);
     }
 
@@ -1320,6 +1321,20 @@ private:
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:1] -> [test.cpp:3]: (error) Returning iterator to local container 'x' that will be invalid when returning.\n", errout.str());
 
         check("auto f() {\n"
+              "    std::vector<int> x;\n"
+              "    auto it = x.begin();\n"
+              "    return std::next(it);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n", errout.str());
+
+        check("auto f() {\n"
+              "    std::vector<int> x;\n"
+              "    auto it = x.begin();\n"
+              "    return it + 1;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning iterator to local container 'x' that will be invalid when returning.\n", errout.str());
+
+        check("auto f() {\n"
               "  static std::vector<int> x;\n"
               "  return x.begin();\n"
               "}\n");
@@ -1381,6 +1396,17 @@ private:
               "    A &&a = T{1, 2, 3}[1]();\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void danglingLifetimeFunction() {
+        check("auto f() {\n"
+              "    int a;\n"
+              "    return std::ref(a);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n", errout.str());
+
+        
+
     }
 
     void invalidLifetime() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1405,7 +1405,8 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void danglingLifetimeFunction() {
+    void danglingLifetimeFunction()
+    {
         check("auto f() {\n"
               "    int a;\n"
               "    return std::ref(a);\n"
@@ -1424,7 +1425,6 @@ private:
               "    return a;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
-
     }
 
     void invalidLifetime() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1335,6 +1335,13 @@ private:
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning iterator to local container 'x' that will be invalid when returning.\n", errout.str());
 
         check("auto f() {\n"
+              "    std::vector<int> x;\n"
+              "    auto it = x.begin();\n"
+              "    return std::next(it + 1);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n", errout.str());
+
+        check("auto f() {\n"
               "  static std::vector<int> x;\n"
               "  return x.begin();\n"
               "}\n");
@@ -1405,7 +1412,18 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n", errout.str());
 
-        
+        check("auto f() {\n"
+              "    int a;\n"
+              "    return std::make_tuple(std::ref(a));\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n", errout.str());
+
+        check("auto f(int x) {\n"
+              "    int a;\n"
+              "    std::tie(a) = x;\n"
+              "    return a;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
 
     }
 


### PR DESCRIPTION
This tracks the variable lifetime through some standard c++ function calls(such as `make_tuple`, `tie`, etc). 

Right now, it uses some hard coded names for the functions. In the future, we can look at extending the library configuration so more functions can be added by the user.

Hopefully, in the future, we can do cross function analysis as well, so we can track lifetimes across functions cppcheck can see the source code for.