### PR TITLE
test: avoid a mutable comparator for test

### DIFF
--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -33,7 +33,7 @@ std::ostringstream output;
  **/
 
 struct CompareFixtures {
-    bool operator()(const TestFixture* lhs, const TestFixture* rhs) {
+    bool operator()(const TestFixture* lhs, const TestFixture* rhs) const {
         return lhs->classname < rhs->classname;
     }
 };


### PR DESCRIPTION
some STL implementations of set (like the ones in mojave) will complain otherwise (through a used defined warning) with : 

  the specified comparator type does not provide a const call operator