### PR TITLE
runastyle

### DIFF
--- a/runastyle
+++ b/runastyle
@@ -6,13 +6,13 @@
 
 # If project management wishes to take a newer astyle version into use
 # just change this string to match the start of astyle version string.
-ASTYLE_VERSION="Artistic Style Version 3.0.1"
+ASTYLE_VERSION="3.0.1"
 ASTYLE="${ASTYLE-astyle}"
 
-DETECTED_VERSION=$($ASTYLE --version 2>&1)
-if [[ "$DETECTED_VERSION" != ${ASTYLE_VERSION}* ]]; then
-    echo "You should use: ${ASTYLE_VERSION}"
-    echo "Detected: ${DETECTED_VERSION}"
+DETECTED_VERSION=$($ASTYLE --version 2>&1 | awk '{ print $NF; }')
+if [ "$DETECTED_VERSION" != "${ASTYLE_VERSION}" ]; then
+    echo "You should use version: ${ASTYLE_VERSION}"
+    echo "Detected version: ${DETECTED_VERSION}"
     exit 1
 fi
 

--- a/runastyle
+++ b/runastyle
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 # The version check in this script is used to avoid commit battles
 # between different developers that use different astyle versions as
@@ -10,11 +9,11 @@
 ASTYLE_VERSION="Artistic Style Version 3.0.1"
 ASTYLE="astyle"
 
-DETECTED_VERSION=`$ASTYLE --version 2>&1`
+DETECTED_VERSION=$($ASTYLE --version 2>&1)
 if [[ "$DETECTED_VERSION" != ${ASTYLE_VERSION}* ]]; then
-    echo "You should use: ${ASTYLE_VERSION}";
+    echo "You should use: ${ASTYLE_VERSION}"
     echo "Detected: ${DETECTED_VERSION}"
-    exit 1;
+    exit 1
 fi
 
 RCFILE=.astylerc
@@ -24,8 +23,8 @@ $ASTYLE --options=$RCFILE cli/*.h
 $ASTYLE --options=$RCFILE democlient/*.cpp
 $ASTYLE --options=$RCFILE gui/*.cpp
 $ASTYLE --options=$RCFILE gui/*.h
-$ASTYLE --options=$RCFILE -r gui/test/*.cpp
-$ASTYLE --options=$RCFILE -r gui/test/*.h
+$ASTYLE --options=$RCFILE --recursive "gui/test/*.cpp"
+$ASTYLE --options=$RCFILE --recursive "gui/test/*.h"
 $ASTYLE --options=$RCFILE lib/*.cpp
 $ASTYLE --options=$RCFILE lib/*.h
 $ASTYLE --options=$RCFILE test/*.cpp

--- a/runastyle
+++ b/runastyle
@@ -7,7 +7,7 @@
 # If project management wishes to take a newer astyle version into use
 # just change this string to match the start of astyle version string.
 ASTYLE_VERSION="Artistic Style Version 3.0.1"
-ASTYLE="astyle"
+ASTYLE="${ASTYLE-astyle}"
 
 DETECTED_VERSION=$($ASTYLE --version 2>&1)
 if [[ "$DETECTED_VERSION" != ${ASTYLE_VERSION}* ]]; then

--- a/runastyle
+++ b/runastyle
@@ -9,7 +9,7 @@
 ASTYLE_VERSION="3.0.1"
 ASTYLE="${ASTYLE-astyle}"
 
-DETECTED_VERSION=$($ASTYLE --version 2>&1 | awk '{ print $NF; }')
+DETECTED_VERSION=$("$ASTYLE" --version 2>&1 | awk '{ print $NF; }')
 if [ "$DETECTED_VERSION" != "${ASTYLE_VERSION}" ]; then
     echo "You should use version: ${ASTYLE_VERSION}"
     echo "Detected version: ${DETECTED_VERSION}"
@@ -18,25 +18,25 @@ fi
 
 RCFILE=.astylerc
 
-$ASTYLE --options=$RCFILE cli/*.cpp
-$ASTYLE --options=$RCFILE cli/*.h
-$ASTYLE --options=$RCFILE democlient/*.cpp
-$ASTYLE --options=$RCFILE gui/*.cpp
-$ASTYLE --options=$RCFILE gui/*.h
-$ASTYLE --options=$RCFILE --recursive "gui/test/*.cpp"
-$ASTYLE --options=$RCFILE --recursive "gui/test/*.h"
-$ASTYLE --options=$RCFILE lib/*.cpp
-$ASTYLE --options=$RCFILE lib/*.h
-$ASTYLE --options=$RCFILE test/*.cpp
-$ASTYLE --options=$RCFILE test/cfg/*.c
-$ASTYLE --options=$RCFILE test/cfg/*.cpp
-$ASTYLE --options=$RCFILE test/*.h
+"$ASTYLE" --options=$RCFILE cli/*.cpp
+"$ASTYLE" --options=$RCFILE cli/*.h
+"$ASTYLE" --options=$RCFILE democlient/*.cpp
+"$ASTYLE" --options=$RCFILE gui/*.cpp
+"$ASTYLE" --options=$RCFILE gui/*.h
+"$ASTYLE" --options=$RCFILE --recursive "gui/test/*.cpp"
+"$ASTYLE" --options=$RCFILE --recursive "gui/test/*.h"
+"$ASTYLE" --options=$RCFILE lib/*.cpp
+"$ASTYLE" --options=$RCFILE lib/*.h
+"$ASTYLE" --options=$RCFILE test/*.cpp
+"$ASTYLE" --options=$RCFILE test/cfg/*.c
+"$ASTYLE" --options=$RCFILE test/cfg/*.cpp
+"$ASTYLE" --options=$RCFILE test/*.h
 
-$ASTYLE --options=$RCFILE --recursive "tools/*.cpp"
-$ASTYLE --options=$RCFILE --recursive "tools/*.h"
+"$ASTYLE" --options=$RCFILE --recursive "tools/*.cpp"
+"$ASTYLE" --options=$RCFILE --recursive "tools/*.h"
 
-$ASTYLE --options=$RCFILE --recursive "samples/*.c"
-$ASTYLE --options=$RCFILE --recursive "samples/*.cpp"
+"$ASTYLE" --options=$RCFILE --recursive "samples/*.c"
+"$ASTYLE" --options=$RCFILE --recursive "samples/*.cpp"
 
 # Convert tabs to spaces.. even in strings
 # sed -i "s/\t/ /g" test/test*.cpp
@@ -45,13 +45,13 @@ $ASTYLE --options=$RCFILE --recursive "samples/*.cpp"
 # TODO: use other tool than xmllint? use tabs instead of spaces?
 for CFGFILE in cfg/*.cfg
 do
-   xmllint --format -o ${CFGFILE}_ ${CFGFILE}
-   mv -f ${CFGFILE}_ ${CFGFILE}
+   xmllint --format -o "${CFGFILE}_" "$CFGFILE"
+   mv -f "${CFGFILE}_" "$CFGFILE"
 done
 for PLATFORMFILE in platforms/*.xml
 do
-   xmllint --format -o ${PLATFORMFILE}_ ${PLATFORMFILE}
-   mv -f ${PLATFORMFILE}_ ${PLATFORMFILE}
+   xmllint --format -o "${PLATFORMFILE}_" "$PLATFORMFILE"
+   mv -f "${PLATFORMFILE}_" "$PLATFORMFILE"
 done
 
 xmllint --format -o man/cppcheck.1.xml_ man/cppcheck.1.xml 


### PR DESCRIPTION
several improvements to help with users that have a development workstation without a native version of astyle with the expected version

patch 2 is the most important and less intrusive change towards that objective but the whole series completes the feature, including parts of patch 4 that will allow for example users with spaces on their username to point to a binary no their home directories.

I decided against splitting the changes on 2 patches for simplicity and because I was expecting the whole series might be squashed for merging anyway