### PR TITLE
Add null pointer check to fix SEGFAULT

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2960,7 +2960,7 @@ static void valueFlowAfterMove(TokenList *tokenlist, SymbolDatabase* symboldatab
                 (parent->str() == "return" || // MOVED in return statement
                  parent->str() == "(")) // MOVED in self assignment, isOpenParenthesisMemberFunctionCallOfVarId == true
                 continue;
-            if (parent && parent->astOperand1()->varId() == varId)
+            if (parent && parent->astOperand1() && parent->astOperand1()->varId() == varId)
                 continue;
             const Variable *var = varTok->variable();
             if (!var)

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -495,6 +495,20 @@ private:
                "    return h(std::move(x));\n"
                "}";
         ASSERT_EQUALS(false, testValueOfX(code, 5U, ValueFlow::Value::MovedVariable));
+
+        code = "struct X {\n"
+               "};\n"
+               "struct Data {\n"
+               "  template<typename Fun>\n"
+               "  void foo(Fun f) {}\n"
+               "};\n"
+               "Data g(X value) { return Data(); }\n"
+               "void f() {\n"
+               "   X x;\n"
+               "   g(std::move(x)).foo([=](int value) mutable {;});\n"
+               "   X y=x;\n"
+               "}";
+        TODO_ASSERT_EQUALS(true, false, testValueOfX(code, 11U, ValueFlow::Value::MovedVariable));
     }
 
     void valueFlowCalculations() {


### PR DESCRIPTION
I have got the following SEGFAULT:
```
0   cppcheck                      	0x0000000103013ddc Token::varId() const + 12 (token.h:576)
1   cppcheck                      	0x0000000103674b58 valueFlowAfterMove(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) + 7752 (valueflow.cpp:2963)
2   cppcheck                      	0x0000000103668856 ValueFlow::setValues(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) + 358 (valueflow.cpp:4634)
3   cppcheck                      	0x00000001035be2ba Tokenizer::simplifyTokenList2() + 1226 (tokenize.cpp:4062)
4   cppcheck                      	0x00000001032e0bc4 CppCheck::checkFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_istream<char, std::__1::char_traits<char> >&) + 47380 (cppcheck.cpp:423)
5   cppcheck                      	0x00000001032d51d0 CppCheck::check(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) + 1152 (cppcheck.cpp:83)
6   cppcheck                      	0x0000000102facc3a CppCheckExecutor::check_internal(CppCheck&, int, char const* const*) + 10458 (cppcheckexecutor.cpp:871)
7   cppcheck                      	0x0000000102fa9d86 CppCheckExecutor::check(int, char const* const*) + 502 (cppcheckexecutor.cpp:198)
8   cppcheck                      	0x0000000102f8545f main + 95 (main.cpp:95)
9   libdyld.dylib                 	0x00007fff7da1b015 start + 1
```

I this PR I'm proposing the fix of this problem.