### PR TITLE
Fix issue 8865: FP with dangling lifetime

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -616,7 +616,8 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
             } else if (isDeadScope(val.tokvalue, tok->scope())) {
                 errorInvalidLifetime(tok, &val);
                 break;
-            } else if (tok->variable() && tok->variable()->declarationId() == tok->varId() && !tok->variable()->isLocal() && !tok->variable()->isArgument() &&
+            } else if (tok->variable() && tok->variable()->declarationId() == tok->varId() &&
+                       !tok->variable()->isLocal() && !tok->variable()->isArgument() &&
                        isInScope(val.tokvalue, tok->scope())) {
                 errorDanglngLifetime(tok, &val);
                 break;

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -616,7 +616,7 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
             } else if (isDeadScope(val.tokvalue, tok->scope())) {
                 errorInvalidLifetime(tok, &val);
                 break;
-            } else if (tok->variable() && !tok->variable()->isLocal() && !tok->variable()->isArgument() &&
+            } else if (tok->variable() && tok->variable()->declarationId() == tok->varId() && !tok->variable()->isLocal() && !tok->variable()->isArgument() &&
                        isInScope(val.tokvalue, tok->scope())) {
                 errorDanglngLifetime(tok, &val);
                 break;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1501,6 +1501,14 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("void f() {\n"
+              "    struct b {\n"
+              "        uint32_t f[6];\n"
+              "    } d;\n"
+              "    uint32_t *a = d.f;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         // Make sure we dont hang
         check("struct A;\n"
               "void f() {\n"


### PR DESCRIPTION
This fixes:

```cpp
void f(uint32_t event, unsigned long op, const xen_ulong_t *args)
{
    struct __packed {
        uint32_t op;
        uint32_t args[6];
    } d;
    uint32_t *a = d.args;
}
```