### PR TITLE
Fix FP in lifetime anlaysis: Dont decay std array

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2840,7 +2840,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
             const Variable * var = getLifetimeVariable(tok, errorPath);
             if (!var)
                 continue;
-            if (var->isArray() && !var->isArgument() && tok->astParent() &&
+            if (var->isArray() && !var->isStlType() && !var->isArgument() && tok->astParent() &&
                 (astIsPointer(tok->astParent()) || Token::Match(tok->astParent(), "%assign%|return"))) {
                 errorPath.emplace_back(tok, "Array decayed to pointer here.");
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1501,6 +1501,13 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        // Dont decay std::array
+        check("std::array<char, 1> f() {\n"
+              "    std::array<char, 1> x;\n"
+              "    return x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());        
+
         // Make sure we dont hang
         check("struct A;\n"
               "void f() {\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1506,7 +1506,7 @@ private:
               "    std::array<char, 1> x;\n"
               "    return x;\n"
               "}\n");
-        ASSERT_EQUALS("", errout.str());        
+        ASSERT_EQUALS("", errout.str());
 
         // Make sure we dont hang
         check("struct A;\n"


### PR DESCRIPTION
This will fix FP with:

```cpp
std::array<char, 1> f() {
    std::array<char, 1> x;
    return x;
}
```