### PR TITLE
Fix 8872: Crash in LifetimeStore when there is no scope for variable

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2751,6 +2751,8 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
 
             auto isCapturingVariable = [&](const Variable *var) {
                 const Scope *scope = var->scope();
+                if (!scope)
+                    return false;
                 if (scopes.count(scope) > 0)
                     return false;
                 if (scope->isNestedIn(bodyScope))

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1516,6 +1516,21 @@ private:
               "    A &&a = T{1, 2, 3}[1]();\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        // Crash #8872
+        check("struct a {\n"
+              "  void operator()(b c) override {\n"
+              "    d(c, [&] { c->e });\n"
+              "  }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct a {\n"
+              "  void operator()(b c) override {\n"
+              "    d(c, [=] { c->e });\n"
+              "  }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeFunction() {


### PR DESCRIPTION
This fixes crash in:

```cpp
struct edit_line_paste_over {
    void operator()(agi::Context *c) override {
        paste_lines(c, true, [&](AssDialogue *new_line) -> AssDialogue * {
            AssDialogue *ret = paste_over(c->parent, pasteOverOptions, new_line, static_cast<AssDialogue*>(&*pos));
            return ret;
          });
    }
};
```