### PR TITLE
Fix FPs and crashes with byDerefCopy

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2649,7 +2649,7 @@ struct LifetimeStore {
             const Variable *var = getLifetimeVariable(tok2, errorPath);
             if (!var)
                 continue;
-            for (const Token *tok3 = tok; tok != var->declEndToken(); tok3 = tok3->previous()) {
+            for (const Token *tok3 = tok; tok3 && tok3 != var->declEndToken(); tok3 = tok3->previous()) {
                 if (tok3->varId() == var->declarationId()) {
                     LifetimeStore{tok3, message, type} .byVal(tok, tokenlist, errorLogger, settings, pred);
                     break;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2699,8 +2699,9 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
         const bool isPointer = endTypeTok && Token::simpleMatch(endTypeTok->previous(), "*");
         Token *vartok = tok->tokAt(-2);
         std::vector<const Token *> args = getArguments(tok);
-        if (args.size() == 2 && astCanonicalType(args[0]) == astCanonicalType(args[1]) &&
-            (((astIsIterator(args[0]) && astIsIterator(args[1])) || (astIsPointer(args[0]) && astIsPointer(args[1]))))) {
+        std::size_t n = args.size();
+        if (n > 1 && astCanonicalType(args[n - 2]) == astCanonicalType(args[n - 1]) &&
+            (((astIsIterator(args[n - 2]) && astIsIterator(args[n - 1])) || (astIsPointer(args[n - 2]) && astIsPointer(args[n - 1]))))) {
             LifetimeStore{args.back(), "Added to container '" + vartok->str() + "'.", ValueFlow::Value::Object} .byDerefCopy(
                 vartok, tokenlist, errorLogger, settings);
         } else if (!args.empty() && astIsPointer(args.back()) == isPointer) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2701,7 +2701,8 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
         std::vector<const Token *> args = getArguments(tok);
         std::size_t n = args.size();
         if (n > 1 && astCanonicalType(args[n - 2]) == astCanonicalType(args[n - 1]) &&
-            (((astIsIterator(args[n - 2]) && astIsIterator(args[n - 1])) || (astIsPointer(args[n - 2]) && astIsPointer(args[n - 1]))))) {
+            (((astIsIterator(args[n - 2]) && astIsIterator(args[n - 1])) ||
+              (astIsPointer(args[n - 2]) && astIsPointer(args[n - 1]))))) {
             LifetimeStore{args.back(), "Added to container '" + vartok->str() + "'.", ValueFlow::Value::Object} .byDerefCopy(
                 vartok, tokenlist, errorLogger, settings);
         } else if (!args.empty() && astIsPointer(args.back()) == isPointer) {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1421,6 +1421,17 @@ private:
             errout.str());
 
         check("struct A {\n"
+              "    std::vector<int*> m;\n"
+              "    void f() {\n"
+              "        int x;\n"
+              "        std::vector<int*> v;\n"
+              "        v.push_back(&x);\n"
+              "        m.insert(m.end(), v.begin(), v.end());\n"
+              "    }\n"
+              "};\n");
+        ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:6] -> [test.cpp:6] -> [test.cpp:4] -> [test.cpp:7]: (error) Non-local variable 'm' will use object that points to local variable 'x'.\n", errout.str());
+
+        check("struct A {\n"
               "    std::vector<std::string> v;\n"
               "    void f() {\n"
               "        char s[3];\n"
@@ -1482,6 +1493,16 @@ private:
               "    std::vector<char> v;\n"
               "    return g([&]() { return v.data(); });\n"
               "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("std::vector<int> g();\n"
+              "struct A {\n"
+              "    std::vector<int> m;\n"
+              "    void f() {\n"
+              "        std::vector<int> v = g();\n"
+              "        m.insert(m.end(), v.begin(), v.end());\n"
+              "    }\n"
+              "};\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1429,7 +1429,9 @@ private:
               "        m.insert(m.end(), v.begin(), v.end());\n"
               "    }\n"
               "};\n");
-        ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:6] -> [test.cpp:6] -> [test.cpp:4] -> [test.cpp:7]: (error) Non-local variable 'm' will use object that points to local variable 'x'.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:6] -> [test.cpp:6] -> [test.cpp:6] -> [test.cpp:4] -> [test.cpp:7]: (error) Non-local variable 'm' will use object that points to local variable 'x'.\n",
+            errout.str());
 
         check("struct A {\n"
               "    std::vector<std::string> v;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1506,6 +1506,17 @@ private:
               "    }\n"
               "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("class A {\n"
+              "    int f( P p ) {\n"
+              "        std::vector< S > maps;\n"
+              "        m2.insert( m1.begin(), m1.end() );\n"
+              "    }\n"
+              "    struct B {};\n"
+              "    std::map< S, B > m1;\n"
+              "    std::map< S, B > m2;\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetime() {


### PR DESCRIPTION
This fixes the FP in:

```cpp
struct A {
    std::vector<int*> m;
    void f() {
        int x;
        std::vector<int*> v;
        v.push_back(&x);
        m.insert(m.end(), v.begin(), v.end());
    }
};
```

This also fixes the crash in issue 8874:

```cpp
class MapGridCtrl
{
    int Filter( Predicate pred )
    {
        std::vector< wxString > maps;
        m_maps_unused.insert( m_maps.begin(), m_maps.end() );
    }

    struct MapData {};

    std::map< wxString, MapData > m_maps;
    std::map< wxString, MapData > m_maps_unused;
};
```