### PR TITLE
donate-cpu.py: Fix Python3 compatibility problem with f.read().decode()

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -196,7 +196,13 @@ def hasInclude(path, inc):
             filename = os.path.join(root, name)
             try:
                 f = open(filename, 'rt')
-                filedata = f.read().decode(encoding='utf-8', errors='ignore')
+                filedata = f.read()
+                try:
+                    # Python2 needs to decode the data first
+                    filedata = filedata.decode(encoding='utf-8', errors='ignore')
+                except AttributeError:
+                    # Python3 directly reads the data into a string object that has no decode()
+                    pass
                 f.close()
                 if filedata.find('\n#include ' + inc) >= 0:
                     return True


### PR DESCRIPTION
With Python3 f.read() directly returns a string object that has no
decode() function. As a workaround AttributeError exceptions during
calling the decode() function are ignored and the data read from the file
is left unchanged.
With Python2 calling the decode() function is necessary and still done.