### PR TITLE
donate-cpu.py: Align multi line output in diff (trac #8868)

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -247,7 +247,7 @@ def splitResults(results):
                 ret.append(w.strip())
             w = ''
         if w is not None:
-            w += line + '\n'
+            w += ' ' * 5 + line + '\n'
     if w is not None:
         ret.append(w.strip())
     return ret


### PR DESCRIPTION
This is a very simple/stupid fix that just inserts 5 spaces for every line except the first.