### PR TITLE
Fix issue 8884: Regression: False positive: Variable 'f' is reassigned a value before the old one has been used

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -490,6 +490,9 @@ void CheckOther::checkRedundantAssignment()
 
                 if (!nextAssign)
                     continue;
+                
+                if (nextAssign == tok)
+                    continue;
 
                 // there is redundant assignment. Is there a case between the assignments?
                 bool hasCase = false;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5968,6 +5968,14 @@ private:
               "        memptr = 0;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (style) Variable 'memptr' is reassigned a value before the old one has been used.\n", errout.str());
+
+        // issue #8884
+        check("template <class F, class... Ts>\n"
+              "auto foo(F f, Ts... xs) {\n"
+              "    auto x = f(xs...);\n"
+              "    return x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void redundantVarAssignment_struct() {


### PR DESCRIPTION
This fixes the regression with:

```cpp
template <class F, class... Ts>
auto foo(F f, Ts... xs)
{
    auto x = f(xs...);
    return x;
}
```