### PR TITLE
donate-cpu-server.py: Fix wrong number of "+" diffs in latest results.

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -73,7 +73,7 @@ def latestReport(latestResults):
             #    cppcheck = line[9:]
             elif line.startswith('count: '):
                 count = line.split(' ')[1:]
-            elif line.startswith('head '):
+            elif line.startswith('head ') and not line.startswith('head results:'):
                 added += 1
             elif line.startswith(OLD_VERSION + ' '):
                 lost += 1


### PR DESCRIPTION
This should fix the issue that the number after the "+" in the "Diff" column is always one too large.