### PR TITLE
Fix issue 8905: Condition 'a==0' is always false

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1002,7 +1002,8 @@ static void valueFlowArray(TokenList *tokenlist)
     for (Token *tok = tokenlist->front(); tok; tok = tok->next()) {
         if (tok->varId() > 0U) {
             // array
-            if (tok->variable() && tok->variable()->isArray() && !tok->variable()->isArgument() && !tok->variable()->isStlType()) {
+            if (tok->variable() && tok->variable()->isArray() && !tok->variable()->isArgument() &&
+                !tok->variable()->isStlType()) {
                 ValueFlow::Value value{1};
                 value.setKnown();
                 setTokenValue(tok, value, tokenlist->getSettings());

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1002,7 +1002,7 @@ static void valueFlowArray(TokenList *tokenlist)
     for (Token *tok = tokenlist->front(); tok; tok = tok->next()) {
         if (tok->varId() > 0U) {
             // array
-            if (tok->variable() && tok->variable()->isArray() && !tok->variable()->isStlType()) {
+            if (tok->variable() && tok->variable()->isArray() && !tok->variable()->isArgument() && !tok->variable()->isStlType()) {
                 ValueFlow::Value value{1};
                 value.setKnown();
                 setTokenValue(tok, value, tokenlist->getSettings());

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2715,6 +2715,9 @@ private:
               "    if (!(strcmp(x, y) == 0)) { return; }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(const int a[]){ if (a == 0){} }");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {


### PR DESCRIPTION
This fixes the FP in:

```cpp
void f(const int a[]){ if (a == 0){} }
```