### PR TITLE
Print test case name in assert

### DIFF
--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -103,17 +103,10 @@ bool TestFixture::prepareTest(const char testname[])
     return false;
 }
 
-void TestFixture::teardownTest()
-{
-    mTestname.clear();
-}
-
 std::string TestFixture::getLocationStr(const char * const filename, const unsigned int linenr) const
 {
     std::ostringstream ret;
-    ret << filename << ':' << linenr << ':' << classname;
-    if (!mTestname.empty())
-        ret << ':' << mTestname;
+    ret << filename << ':' << linenr << ':' << classname << ':' << mTestname;
     return ret.str();
 }
 

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -102,6 +102,13 @@ bool TestFixture::prepareTest(const char testname[])
     return false;
 }
 
+std::string TestFixture::getLocationStr(const char * const filename, const unsigned int linenr) const
+{
+    std::ostringstream ret;
+    ret << filename << ':' << linenr;
+    return ret.str();
+}
+
 static std::string writestr(const std::string &str, bool gccStyle = false)
 {
     std::ostringstream ostr;
@@ -130,7 +137,7 @@ void TestFixture::assert_(const char * const filename, const unsigned int linenr
 {
     if (!condition) {
         ++fails_counter;
-        errmsg << filename << ':' << linenr << ": Assertion failed." << std::endl << "_____" << std::endl;
+        errmsg << getLocationStr(filename, linenr) << ": Assertion failed." << std::endl << "_____" << std::endl;
     }
 }
 
@@ -138,7 +145,7 @@ void TestFixture::assertEquals(const char * const filename, const unsigned int l
 {
     if (expected != actual) {
         ++fails_counter;
-        errmsg << filename << ':' << linenr << ": Assertion failed. " << std::endl
+        errmsg << getLocationStr(filename, linenr) << ": Assertion failed. " << std::endl
                << "Expected: " <<  std::endl
                << writestr(expected)  << std::endl
                << "Actual: " << std::endl
@@ -219,7 +226,7 @@ void TestFixture::todoAssertEquals(const char * const filename, const unsigned i
                                    const std::string &actual) const
 {
     if (wanted == actual) {
-        errmsg << filename << ':' << linenr << ": Assertion succeeded unexpectedly. "
+        errmsg << getLocationStr(filename, linenr) << ": Assertion succeeded unexpectedly. "
                << "Result: " << writestr(wanted, true)  << std::endl << "_____" << std::endl;
 
         ++succeeded_todos_counter;
@@ -241,7 +248,7 @@ void TestFixture::todoAssertEquals(const char * const filename, const unsigned i
 void TestFixture::assertThrow(const char * const filename, const unsigned int linenr) const
 {
     ++fails_counter;
-    errmsg << filename << ':' << linenr << ": Assertion succeeded. "
+    errmsg << getLocationStr(filename, linenr) << ": Assertion succeeded. "
            << "The expected exception was thrown" << std::endl << "_____" << std::endl;
 
 }
@@ -249,7 +256,7 @@ void TestFixture::assertThrow(const char * const filename, const unsigned int li
 void TestFixture::assertThrowFail(const char * const filename, const unsigned int linenr) const
 {
     ++fails_counter;
-    errmsg << filename << ':' << linenr << ": Assertion failed. "
+    errmsg << getLocationStr(filename, linenr) << ": Assertion failed. "
            << "The expected exception was not thrown"  << std::endl << "_____" << std::endl;
 
 }
@@ -257,7 +264,7 @@ void TestFixture::assertThrowFail(const char * const filename, const unsigned in
 void TestFixture::assertNoThrowFail(const char * const filename, const unsigned int linenr) const
 {
     ++fails_counter;
-    errmsg << filename << ':' << linenr << ": Assertion failed. "
+    errmsg << getLocationStr(filename, linenr) << ": Assertion failed. "
            << "Unexpected exception was thrown"  << std::endl << "_____" << std::endl;
 
 }

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -90,6 +90,7 @@ bool TestFixture::prepareTest(const char testname[])
     // Check if tests should be executed
     if (testToRun.empty() || testToRun == testname) {
         // Tests will be executed - prepare them
+        mTestname = testname;
         ++countTests;
         if (quiet_tests) {
             std::putchar('.'); // Use putchar to write through redirection of std::cout/cerr
@@ -102,10 +103,17 @@ bool TestFixture::prepareTest(const char testname[])
     return false;
 }
 
+void TestFixture::teardownTest()
+{
+    mTestname.clear();
+}
+
 std::string TestFixture::getLocationStr(const char * const filename, const unsigned int linenr) const
 {
     std::ostringstream ret;
-    ret << filename << ':' << linenr;
+    ret << filename << ':' << linenr << ':' << classname;
+    if (!mTestname.empty())
+        ret << ':' << mTestname;
     return ret.str();
 }
 

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -106,7 +106,7 @@ bool TestFixture::prepareTest(const char testname[])
 std::string TestFixture::getLocationStr(const char * const filename, const unsigned int linenr) const
 {
     std::ostringstream ret;
-    ret << filename << ':' << linenr << ':' << classname << ':' << mTestname;
+    ret << filename << ':' << linenr << '(' << classname << "::" << mTestname << ')';
     return ret.str();
 }
 

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -49,7 +49,6 @@ protected:
     virtual void run() = 0;
 
     bool prepareTest(const char testname[]);
-    void teardownTest();
     std::string getLocationStr(const char * const filename, const unsigned int linenr) const;
 
     void assert_(const char * const filename, const unsigned int linenr, const bool condition) const;
@@ -97,7 +96,7 @@ public:
 extern std::ostringstream errout;
 extern std::ostringstream output;
 
-#define TEST_CASE( NAME )  if ( prepareTest(#NAME) ) { setVerbose(false); NAME(); teardownTest(); }
+#define TEST_CASE( NAME )  if ( prepareTest(#NAME) ) { setVerbose(false); NAME(); }
 #define ASSERT( CONDITION )  assert_(__FILE__, __LINE__, CONDITION)
 #define ASSERT_EQUALS( EXPECTED , ACTUAL )  assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL)
 #define ASSERT_EQUALS_WITHOUT_LINENUMBERS( EXPECTED , ACTUAL )  assertEqualsWithoutLineNumbers(__FILE__, __LINE__, EXPECTED, ACTUAL)

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -40,6 +40,7 @@ private:
     bool mVerbose;
     std::string mTemplateFormat;
     std::string mTemplateLocation;
+    std::string mTestname;
 
 protected:
     std::string testToRun;
@@ -48,6 +49,7 @@ protected:
     virtual void run() = 0;
 
     bool prepareTest(const char testname[]);
+    void teardownTest();
     std::string getLocationStr(const char * const filename, const unsigned int linenr) const;
 
     void assert_(const char * const filename, const unsigned int linenr, const bool condition) const;
@@ -95,7 +97,7 @@ public:
 extern std::ostringstream errout;
 extern std::ostringstream output;
 
-#define TEST_CASE( NAME )  if ( prepareTest(#NAME) ) { setVerbose(false); NAME(); }
+#define TEST_CASE( NAME )  if ( prepareTest(#NAME) ) { setVerbose(false); NAME(); teardownTest(); }
 #define ASSERT( CONDITION )  assert_(__FILE__, __LINE__, CONDITION)
 #define ASSERT_EQUALS( EXPECTED , ACTUAL )  assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL)
 #define ASSERT_EQUALS_WITHOUT_LINENUMBERS( EXPECTED , ACTUAL )  assertEqualsWithoutLineNumbers(__FILE__, __LINE__, EXPECTED, ACTUAL)

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -48,6 +48,7 @@ protected:
     virtual void run() = 0;
 
     bool prepareTest(const char testname[]);
+    std::string getLocationStr(const char * const filename, const unsigned int linenr) const;
 
     void assert_(const char * const filename, const unsigned int linenr, const bool condition) const;
 


### PR DESCRIPTION
I sometimes find myself wondering which test cases I have broken when I fiddle with some check (since I then can try running these specific tests in the debugger, or make a small change and see if the tests pass). This PR adds the testclass and the test case names to the file and line number. I took special care to cover the case where an assert would be placed directly in the ```run()```-function, i.e., not inside a test case (from what I could see, no such case exists). If there is no need to handle this case, the code can be simplified (there wouldn't be need for the ```teardownTest()```-function for example).

The exact format for how to print the test name is very much up for discussion. 