### PR TITLE
Fix warnings

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -372,17 +372,17 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token * varTok1 = followVariableExpression(tok1, cpp, tok2);
         if (varTok1->str() == tok2->str()) {
             followVariableExpressionError(tok1, varTok1, errors);
-            return isSameExpression(cpp, macro, varTok1, tok2, library, true, errors);
+            return isSameExpression(cpp, macro, varTok1, tok2, library, true, followVar, errors);
         }
         const Token * varTok2 = followVariableExpression(tok2, cpp, tok1);
         if (tok1->str() == varTok2->str()) {
             followVariableExpressionError(tok2, varTok2, errors);
-            return isSameExpression(cpp, macro, tok1, varTok2, library, true, errors);
+            return isSameExpression(cpp, macro, tok1, varTok2, library, true, followVar, errors);
         }
         if (varTok1->str() == varTok2->str()) {
             followVariableExpressionError(tok1, varTok1, errors);
             followVariableExpressionError(tok2, varTok2, errors);
-            return isSameExpression(cpp, macro, varTok1, varTok2, library, true, errors);
+            return isSameExpression(cpp, macro, varTok1, varTok2, library, true, followVar, errors);
         }
     }
     if (tok1->varId() != tok2->varId() || tok1->str() != tok2->str() || tok1->originalName() != tok2->originalName()) {

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -488,20 +488,6 @@ static bool ifvar(const Token *tok, unsigned int varid, const std::string &comp,
     return (vartok && vartok->varId() == varid);
 }
 
-static bool alwaysTrue(const Token *tok)
-{
-    if (!tok)
-        return false;
-    if (tok->hasKnownIntValue() &&
-        tok->values().front().intvalue != 0)
-        return true;
-    if (tok->str() == "||")
-        return alwaysTrue(tok->astOperand1()) || alwaysTrue(tok->astOperand2());
-    if (tok->str() == "true")
-        return true;
-    return false;
-}
-
 bool CheckMemoryLeakInFunction::test_white_list(const std::string &funcname, const Settings *settings, bool cpp)
 {
     return ((call_func_white_list.find(funcname)!=call_func_white_list.end()) || settings->library.isLeakIgnore(funcname) || (cpp && funcname == "delete"));

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -114,10 +114,10 @@ public:
     /** @brief Parse current TU and extract file info */
     Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger);
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
 private:
     /** Get error messages. Used by --errorlist */

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -100,12 +100,12 @@ public:
     };
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger);
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
     void uninitstringError(const Token *tok, const std::string &varname, bool strncpy_);
     void uninitdataError(const Token *tok, const std::string &varname);

--- a/lib/token.h
+++ b/lib/token.h
@@ -1034,9 +1034,9 @@ private:
         fAtAddress              = (1 << 24), // @ 0x4000
     };
 
-    unsigned int mFlags;
-
     Token::Type mTokType;
+
+    unsigned int mFlags;
 
     TokenImpl *mImpl;
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1158,7 +1158,7 @@ static void valueFlowSameExpressions(TokenList *tokenlist)
         if (!val.isKnown())
             continue;
 
-        if (isSameExpression(tokenlist->isCPP(), false, tok->astOperand1(), tok->astOperand2(), tokenlist->getSettings()->library, true, &val.errorPath)) {
+        if (isSameExpression(tokenlist->isCPP(), false, tok->astOperand1(), tok->astOperand2(), tokenlist->getSettings()->library, true, true, &val.errorPath)) {
             setTokenValue(tok, val, tokenlist->getSettings());
         }
     }


### PR DESCRIPTION
Fixes some warnings with Clang and GCC. The most important one is the change in valueflow.cpp where an argument was missing.