### PR TITLE
Fix issue 8910: Regression: ValueFlow: wrong conditional tokvalue

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -545,7 +545,8 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value, const Setti
                 if (value2.isTokValue() && (!parent->isComparisonOp() || value2.tokvalue->tokType() != Token::eString || value1.isTokValue()))
                     continue;
                 if (value1.isKnown() || value2.isKnown() || value1.varId == 0U || value2.varId == 0U ||
-                    (value1.varId == value2.varId && value1.varvalue == value2.varvalue && value1.isIntValue() && value2.isIntValue())) {
+                    (value1.varId == value2.varId && value1.varvalue == value2.varvalue && value1.isIntValue() &&
+                     value2.isIntValue())) {
                     ValueFlow::Value result(0);
                     combineValueProperties(value1, value2, &result);
                     const float floatValue1 = value1.isIntValue() ? value1.intvalue : value1.floatValue;
@@ -3119,8 +3120,20 @@ static void valueFlowAfterAssign(TokenList *tokenlist, SymbolDatabase* symboldat
 
             if (std::any_of(values.begin(), values.end(), std::mem_fn(&ValueFlow::Value::isTokValue))) {
                 std::list<ValueFlow::Value> tokvalues;
-                std::copy_if(values.begin(), values.end(), std::back_inserter(tokvalues), std::mem_fn(&ValueFlow::Value::isTokValue));
-                valueFlowForward(const_cast<Token *>(nextExpression), endOfVarScope, var, varid, tokvalues, constValue, false, tokenlist, errorLogger, settings);
+                std::copy_if(values.begin(),
+                             values.end(),
+                             std::back_inserter(tokvalues),
+                             std::mem_fn(&ValueFlow::Value::isTokValue));
+                valueFlowForward(const_cast<Token *>(nextExpression),
+                                 endOfVarScope,
+                                 var,
+                                 varid,
+                                 tokvalues,
+                                 constValue,
+                                 false,
+                                 tokenlist,
+                                 errorLogger,
+                                 settings);
                 values.remove_if(std::mem_fn(&ValueFlow::Value::isTokValue));
             }
             valueFlowForward(const_cast<Token *>(nextExpression), endOfVarScope, var, varid, values, constValue, false, tokenlist, errorLogger, settings);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -649,6 +649,16 @@ private:
               "  delete static_cast<SwFmtFld*>(&pTxtFld->GetAttr());\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        // #8910
+        check("void f() {\n"
+              "    char stack[512];\n"
+              "    RGNDATA *data;\n"
+              "    if (data_size > sizeof (stack)) data = malloc (data_size);\n"
+              "    else data = (RGNDATA *)stack;\n"
+              "    if ((char *)data != stack) free (data);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void testinvaliddealloc_C() {


### PR DESCRIPTION
This fixes issue in:

```cpp
void f()
{
    char stack[512];
    RGNDATA *data;

    if (data_size > sizeof (stack))
        data = malloc (data_size);
    else
        data = (RGNDATA *)stack;

    if ((char *)data != stack)
            free (data); // <- data is not stack
}
```

It seems the `ProgramMemory` can't handle two known values(such as int and tok) together. So instead `ValueFlowAfterAssign` runs `ValueFlowForward` with tok values and then runs it with the other values.