### PR TITLE
Fix issue 4744: ValueFlow: known integer result 

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -283,6 +283,9 @@ static const Token * skipValueInConditionalExpression(const Token * const valuet
         if (prevIsLhs || !Token::Match(tok, "%oror%|&&|?|:"))
             continue;
 
+        if (tok->hasKnownIntValue())
+            return tok;
+
         // Is variable protected in LHS..
         bool bailout = false;
         visitAstNodes(tok->astOperand1(), [&](const Token *tok2) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -289,7 +289,7 @@ static const Token * skipValueInConditionalExpression(const Token * const valuet
             if (tok2->str() == ".")
                 return ChildrenToVisit::none;
             // A variable is seen..
-            if (tok2 != valuetok && tok2->variable() && (tok2->varId() == valuetok->varId() || !tok2->variable()->isArgument())) {
+            if (tok2 != valuetok && tok2->variable() && (tok2->varId() == valuetok->varId() || (!tok2->variable()->isArgument() && !tok2->hasKnownIntValue()))) {
                 // TODO: limit this bailout
                 bailout = true;
                 return ChildrenToVisit::done;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -289,7 +289,8 @@ static const Token * skipValueInConditionalExpression(const Token * const valuet
             if (tok2->str() == ".")
                 return ChildrenToVisit::none;
             // A variable is seen..
-            if (tok2 != valuetok && tok2->variable() && (tok2->varId() == valuetok->varId() || (!tok2->variable()->isArgument() && !tok2->hasKnownIntValue()))) {
+            if (tok2 != valuetok && tok2->variable() &&
+                (tok2->varId() == valuetok->varId() || (!tok2->variable()->isArgument() && !tok2->hasKnownIntValue()))) {
                 // TODO: limit this bailout
                 bailout = true;
                 return ChildrenToVisit::done;

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -688,6 +688,19 @@ private:
                "}";
         ASSERT_EQUALS(false, testValueOfX(code, 3U, 0));
 
+        code  = "bool f() {\n"
+                "    bool a = (4 == 3);\n"
+                "    bool b = (3 == 3);\n"
+                "    return a || b;\n"
+                "}\n";
+        values = tokenValues(code, "%oror%");
+        ASSERT_EQUALS(1, values.size());
+        if (!values.empty()) {
+            ASSERT_EQUALS(true, values.front().isIntValue());
+            ASSERT_EQUALS(true, values.front().isKnown());
+            ASSERT_EQUALS(1, values.front().intvalue);
+        }
+
         // function call => calculation
         code  = "void f(int x, int y) {\n"
                 "    a = x + y;\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -688,11 +688,11 @@ private:
                "}";
         ASSERT_EQUALS(false, testValueOfX(code, 3U, 0));
 
-        code  = "bool f() {\n"
-                "    bool a = (4 == 3);\n"
-                "    bool b = (3 == 3);\n"
-                "    return a || b;\n"
-                "}\n";
+        code = "bool f() {\n"
+               "    bool a = (4 == 3);\n"
+               "    bool b = (3 == 3);\n"
+               "    return a || b;\n"
+               "}\n";
         values = tokenValues(code, "%oror%");
         ASSERT_EQUALS(1, values.size());
         if (!values.empty()) {


### PR DESCRIPTION
This fixes valueflow to have a value for `||` operator here:

```cpp
bool f()
{
	bool a = (4 == 3); // <-- 0
	bool b = (3 == 3); // <-- 1
	return a || b; // <-- 1
}
```
