### PR TITLE
WIP donate-cpu.py: Swap "head results" and "diff" output.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -411,10 +411,10 @@ while True:
     output = 'cppcheck: ' + ' '.join(cppcheckVersions) + '\n'
     output += 'count:' + count + '\n'
     output += 'elapsed-time:' + elapsedTime + '\n'
-    if 'head' in cppcheckVersions:
-        output += 'head results:\n' + resultsToDiff[cppcheckVersions.index('head')]
     if not crash:
         output += 'diff:\n' + diffResults(workpath, cppcheckVersions[0], resultsToDiff[0], cppcheckVersions[1], resultsToDiff[1]) + '\n'
+    if 'head' in cppcheckVersions:
+        output += 'head results:\n' + resultsToDiff[cppcheckVersions.index('head')]
     if packageUrl:
         print('=========================================================')
         print(output)


### PR DESCRIPTION
As mentioned in https://trac.cppcheck.net/ticket/8881 the "diff" output could be truncated or dropped if the "head results" output is very long. This is already a problem for several packages (for example for http://cppcheck.osuosl.org:8000/gdal).
Since i guess that the "diff" output is more important and normally is way smaller than the "head results" this commit just swaps them so the "diff" output comes first. Thus it is very unlikely that the "diff" output is truncated or dropped.