### PR TITLE
donate-cpu-server.py: Enhance time output to show long running checks.

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -255,8 +255,11 @@ def diffMessageIdTodayReport(resultPath, messageId):
 
 def timeReport(resultPath):
     text = 'Time report\n\n'
+    text += 'Great difference between versions:\n'
     text += 'Package ' + OLD_VERSION + ' Head\n'
 
+    textLongRunning = ''
+    longRunningThreshold = 60.0 * 30.0
     totalTime184 = 0.0
     totalTimeHead = 0.0
     for filename in glob.glob(resultPath + '/*'):
@@ -272,7 +275,14 @@ def timeReport(resultPath):
                 text += filename[filename.find('/')+1:] + ' ' + splitline[2] + ' ' + splitline[1] + '\n'
             elif thead>1 and thead*2 < t184:
                 text += filename[filename.find('/')+1:] + ' ' + splitline[2] + ' ' + splitline[1] + '\n'
+            if t184 > longRunningThreshold or thead > longRunningThreshold:
+                textLongRunning += filename[filename.rfind('/')+1:] + ' ' + splitline[2] + ' ' + splitline[1] + '\n'
             break
+
+    text += '\n'
+    text += 'Long running checks:\n'
+    text += 'Package ' + OLD_VERSION + ' Head\n'
+    text += textLongRunning
 
     text += '\nTotal time: ' + str(totalTime184) + ' ' + str(totalTimeHead)
     return text


### PR DESCRIPTION
Currently there are some very long running checks (several hours) for packages that are not that huge (smaller than 2 MB). So i thought it is worth to list those checks that run for a long time to maybe find performance issues when looking at them.
The threshhold is currently set to 30 * 60 seconds (half an hour).