### PR TITLE
donate-cpu-server.py: Fix date/time in report is not found.

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -67,7 +67,8 @@ def latestReport(latestResults):
         added = 0
         for line in open(filename,'rt'):
             line = line.strip()
-            if line.startswith('2018-'):
+            current_year = datetime.date.today().year
+            if line.startswith(str(current_year) + '-') or line.startswith(str(current_year - 1) + '-'):
                 datestr = line
             #elif line.startswith('cppcheck:'):
             #    cppcheck = line[9:]


### PR DESCRIPTION
Instead of searching for a specific year (which could change) the script searches now for the current and last year to find the date and time information in the results.