### PR TITLE
qt config test: Use pkg-config to retrieve Qt settings.

### DIFF
--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -7,11 +7,10 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
-class QString {
-public:
-    int size();
-    char &operator[](int pos);
-};
+#include <QObject>
+#include <QString>
+#include <QtPlugin>
+
 
 void QString1(QString s)
 {
@@ -27,3 +26,13 @@ int QString2()
     // cppcheck-suppress reademptycontainer
     return s.size();
 }
+
+// Verify that Qt macros do not result in syntax errors, false positives or other issues.
+class MacroTest1: public QObject {
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "com.foo.bar" FILE "test.json")
+
+public:
+    explicit MacroTest1(QObject *parent = 0);
+    ~MacroTest1();
+};


### PR DESCRIPTION
To be able to use real Qt-Code in "test/cfg/qt.cpp" and still do a
syntax check the Qt settings are read out via pkg-config now if it is
available. This way the test now can contain Qt macros and functions and
the syntax check can still be used.
Additionally the same options as for the other tests are used now for
the Qt config tests.
Installing the package "qtbase5-dev" should be enough to enable the
syntax checks (already installed for travis tests).