### PR TITLE
CheckStl: add missing error ID iterators2

### DIFF
--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -242,7 +242,7 @@ private:
         c.outOfBoundsError(nullptr, nullptr, nullptr);
         c.invalidIteratorError(nullptr, "iterator");
         c.iteratorsError(nullptr, "container1", "container2");
-        c.iteratorsError(nullptr, nullptr, "container1", "container2");
+        c.iteratorsError(nullptr, nullptr, "container0", "container1");
         c.iteratorsError(nullptr, nullptr, "container");
         c.iteratorsCmpError(nullptr, nullptr, nullptr, "container1", "container2");
         c.iteratorsCmpError(nullptr, nullptr, nullptr, "container");


### PR DESCRIPTION
due to equal arguments...

  * iterators1 (`CheckStl::iteratorsError(const Token*, const std::string&, const std::string&)`) and
  * iterators2 (`CheckStl::iteratorsError(const Token*, const Token*, const std::string&, const std::string&)`)

... produced equal messages. Equal messages were filtered-out `CppCheck::reportErr(const ErrorLogger::ErrorMessage&)`.
So the error iterators2 disapeared from the error list.