### PR TITLE
donate-cpu.py: Improved detection of wxWidgets code in scanPackage.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -213,7 +213,7 @@ def scanPackage(workPath, cppcheck, jobs):
     print('Analyze..')
     os.chdir(workPath)
     libraries = ' --library=posix'
-    if hasInclude('temp', '<wx/string.h>'):
+    if hasInclude('temp', '<wx/') or hasInclude('temp', '"wx/'):
         libraries += ' --library=wxwidgets'
     if hasInclude('temp', '<QString>'):
         libraries += ' --library=qt'


### PR DESCRIPTION
Nearly all wxWidgets tools use `#include <wx/...` or `#include "wx/...`
This pull request aims to detect more wxWidgets code in `donate-cpu.py::scanPackage()` and reduce the number of `unknownMacros` warnings from daca2 on wxWidgets code.