### PR TITLE
Fix issue 8932: False positive knownConditionTrueFalse - valueflow ignores operator <

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1153,7 +1153,7 @@ static void valueFlowSameExpressions(TokenList *tokenlist)
         if (tok->astOperand1()->isLiteral() || tok->astOperand2()->isLiteral())
             continue;
 
-        if (astIsFloat(tok->astOperand1(), true) || astIsFloat(tok->astOperand2(), true))
+        if (!astIsIntegral(tok->astOperand1(), false) && !astIsIntegral(tok->astOperand2(), false))
             continue;
 
         ValueFlow::Value val;

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2774,6 +2774,17 @@ private:
 
         check("void f(const int a[]){ if (a == 0){} }");
         ASSERT_EQUALS("", errout.str());
+
+        check("struct S {\n"
+              "  bool operator<(const S&);\n"
+              "};\n"
+              "int main() {\n"
+              "  S s;\n"
+              "  bool c = s<s;\n"
+              "  if (c) return 0;\n"
+              "  else return 42;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {


### PR DESCRIPTION
This fixes issue with:

```cpp
struct S
{
  bool operator<(const S&);
};
int main() {
  S s;
  bool c = s<s;
  if (c)
    return 0;
  else
    return 42;
}
```