### PR TITLE
Fix issue 8883: False positive: returnDanglingLifetime with local struct or class

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -655,6 +655,18 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
             checkVarLifetimeScope(lambdaEndToken->link(), lambdaEndToken);
             tok = lambdaEndToken;
         }
+        if (tok->str() == "{" && tok->scope()) {
+            // Check functions in local classes
+            if (tok->scope()->type == Scope::eClass || 
+                tok->scope()->type == Scope::eStruct || 
+                tok->scope()->type == Scope::eUnion) {
+                for(const Function& f:tok->scope()->functionList) {
+                    if (f.functionScope)
+                        checkVarLifetimeScope(f.functionScope->bodyStart, f.functionScope->bodyEnd);
+                }
+                tok = tok->link();
+            }
+        }
     }
 }
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1643,6 +1643,14 @@ private:
               "    return d;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    struct a {\n"
+              "        std::vector<int> v;\n"
+              "        auto g() { return v.end(); }\n"
+              "    };\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeFunction() {


### PR DESCRIPTION
This fixes the FP in:

```cpp
void f() {
    struct a {
        std::vector<int> v;
        auto g() { return v.end(); }
    };
}
```