### PR TITLE
 triage: Fix warnings and Windows issues; some enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,6 +168,12 @@ script:
   - echo $CXXFLAGS
   - make -s -j2
   - cd ../
+# Build triage
+  - cd ./tools/triage
+  - git clean -dfx .
+  - qmake
+  - make -s -j2
+  - cd ../../
 
 notifications:
   irc:

--- a/tools/triage/mainwindow.h
+++ b/tools/triage/mainwindow.h
@@ -12,7 +12,7 @@ class MainWindow : public QMainWindow {
     Q_OBJECT
 
 public:
-    explicit MainWindow(QWidget *parent = 0);
+    explicit MainWindow(QWidget *parent = Q_NULLPTR);
     MainWindow(const MainWindow &) = delete;
     ~MainWindow();
     MainWindow &operator=(const MainWindow &) = delete;
@@ -23,6 +23,10 @@ public slots:
 
 private:
     Ui::MainWindow *ui;
+
+    bool runProcess(const QString &programName, const QStringList & arguments);
+    bool wget(const QString url);
+    bool unpackArchive(const QString archiveName);
 };
 
 #endif // MAINWINDOW_H

--- a/tools/triage/readme.txt
+++ b/tools/triage/readme.txt
@@ -1,0 +1,18 @@
+triage tool
+This tool lets you comfortably look at Cppcheck analysis results for daca packages. It automatically
+downloads the package, extracts it and jumps to the corresponding source code for a Cppcheck
+message.
+
+triage uses "wget" and "tar"
+On Linux the tool can be directly run since the programs should be installed.
+On Windows something like Cygwin is necessary and the directory containing the executables must be
+in the PATH environment variable (for example "C:\cygwin\bin").
+
+Usage:
+After triage has been started you have to load a daca results file via the "Load" button.
+The file must contain the package URL line beginning with "ftp://" and the Cppcheck messages.
+When the results file has been parsed successfully you can see a list of Cppcheck messages directly
+beneath the "Load" button. Double-click any entry to let the tool show the source code and jump to
+and mark the corresponding line. If the package is not found it is downloaded and extracted
+automatically. So after the first double-click it is normal that it takes some time until the
+source code is shown.


### PR DESCRIPTION
Changes:
- Fixed compiler warnings
- Add `*.*` to file open menu so files without suffix can be opened
- Make it work under Windows
- Make wget() and unpackArchive() methods so they can access the UI
- wget() and unpackArchive() use the new method runProcess() now that also does some error handling
- Errors are shown in the status bar for easier debugging / usage
- Create the work folder "~/triage" if it does not exist
- Add readme.txt
- Let travis build the triage tool