### PR TITLE
test/cfg/runtests.sh: Qt test: Fix syntax check when "-fPIC" is required

### DIFF
--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -42,6 +42,8 @@ else
     QTCONFIG_RETURNCODE=$?
     set -e
     if [ $QTCONFIG_RETURNCODE -eq 0 ]; then
+        QTBUILDCONFIG=$(pkg-config --variable=qt_config Qt5Core)
+        [[ $QTBUILDCONFIG =~ (^|[[:space:]])reduce_relocations($|[[:space:]]) ]] && QTCONFIG="${QTCONFIG} -fPIC"
         set +e
         echo -e "#include <QString>" | ${CXX} ${CXX_OPT} ${QTCONFIG} -x c++ -
         QTCHECK_RETURNCODE=$?


### PR DESCRIPTION
On linux systems (like travis) Qt often seems to be built with the option "reduce_relocations" which requires an application using it to specify the option "-fPIC".