### PR TITLE
misra addon: Fix issue with unexpected encodings in loadRuleTexts() (trac 8946)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,10 @@ matrix:
         - python3 ../misra.py -verify misra-test.c.dump
         - ${CPPCHECK} --dump misra-test.cpp
         - python3 ../misra.py -verify misra-test.cpp.dump
+        - python ../misra.py --rule-texts=misra2012_rules_dummy_ascii.txt -verify misra-test.cpp.dump
+        - python3 ../misra.py --rule-texts=misra2012_rules_dummy_ascii.txt -verify misra-test.cpp.dump
+        - python ../misra.py --rule-texts=misra2012_rules_dummy_utf8.txt -verify misra-test.cpp.dump
+        - python3 ../misra.py --rule-texts=misra2012_rules_dummy_utf8.txt -verify misra-test.cpp.dump
         - cd ../../
 # check addons/namingng.py
         - cd addons/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ matrix:
         - python3 ../misra.py --rule-texts=misra2012_rules_dummy_ascii.txt -verify misra-test.cpp.dump
         - python ../misra.py --rule-texts=misra2012_rules_dummy_utf8.txt -verify misra-test.cpp.dump
         - python3 ../misra.py --rule-texts=misra2012_rules_dummy_utf8.txt -verify misra-test.cpp.dump
+        - python ../misra.py --rule-texts=misra2012_rules_dummy_windows1250.txt -verify misra-test.cpp.dump
+        - python3 ../misra.py --rule-texts=misra2012_rules_dummy_windows1250.txt -verify misra-test.cpp.dump
         - cd ../../
 # check addons/namingng.py
         - cd addons/test

--- a/addons/test/misra2012_rules_dummy_ascii.txt
+++ b/addons/test/misra2012_rules_dummy_ascii.txt
@@ -1,0 +1,5 @@
+Appendix A Summary of guidelines
+Rule 1.1
+Text of rule 1.1
+Rule 1.2
+Text of rule 1.2

--- a/addons/test/misra2012_rules_dummy_utf8.txt
+++ b/addons/test/misra2012_rules_dummy_utf8.txt
@@ -1,0 +1,5 @@
+Appendix A Summary of guidelines
+Rule 1.1
+Text of rule 1.1, utf8 test: ∑
+Rule 1.2
+Text of rule 1.2

--- a/addons/test/misra2012_rules_dummy_windows1250.txt
+++ b/addons/test/misra2012_rules_dummy_windows1250.txt
@@ -1,0 +1,5 @@
+Appendix A Summary of guidelines
+Rule 1.1
+Text of rule 1.1, windows1250 test: ’
+Rule 1.2
+Text of rule 1.2


### PR DESCRIPTION
https://trac.cppcheck.net/ticket/8946
misra.py: Try to find a suitable codec for rule texts file.
Add tests to travis script for verifying rule text loading.
Add dummy rule text files with different encodings.