### PR TITLE
library.cpp: Let tinyxml2 print a helpful error message when XML is bad

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -127,6 +127,9 @@ Library::Error Library::load(const char exename[], const char path[])
         return Error(OK); // ignore duplicates
     }
 
+    if (error != tinyxml2::XML_ERROR_FILE_NOT_FOUND)
+        doc.PrintError();
+
     return Error(error == tinyxml2::XML_ERROR_FILE_NOT_FOUND ? FILE_NOT_FOUND : BAD_XML);
 }
 
@@ -140,8 +143,10 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
 {
     const tinyxml2::XMLElement * const rootnode = doc.FirstChildElement();
 
-    if (rootnode == nullptr)
+    if (rootnode == nullptr) {
+        doc.PrintError();
         return Error(BAD_XML);
+    }
 
     if (strcmp(rootnode->Name(),"def") != 0)
         return Error(UNSUPPORTED_FORMAT, rootnode->Name());

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -127,10 +127,12 @@ Library::Error Library::load(const char exename[], const char path[])
         return Error(OK); // ignore duplicates
     }
 
-    if (error != tinyxml2::XML_ERROR_FILE_NOT_FOUND)
+    if (error == tinyxml2::XML_ERROR_FILE_NOT_FOUND)
+        return Error(FILE_NOT_FOUND);
+    else {
         doc.PrintError();
-
-    return Error(error == tinyxml2::XML_ERROR_FILE_NOT_FOUND ? FILE_NOT_FOUND : BAD_XML);
+        return Error(BAD_XML);
+    }
 }
 
 bool Library::loadxmldata(const char xmldata[], std::size_t len)


### PR DESCRIPTION
In case the XML code of a library configuration is invalid Cppcheck now additionally prints out some helpful error description like this:
"Error=XML_ERROR_MISMATCHED_ELEMENT ErrorID=16 (0x10) Line number=304: XMLElement name=noreturn"