### PR TITLE
gnu.cfg: Add support for gettext() and some related functions

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -719,6 +719,55 @@
       <valid>0:</valid>
     </arg>
   </function>
+  <!-- https://www.gnu.org/software/libc/manual/html_node/Translation-with-gettext.html -->
+  <!-- char * gettext (const char *msgid); -->
+  <function name="gettext">
+    <noreturn>false</noreturn>
+    <returnValue type="char *"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- char * dgettext (const char *domainname, const char *msgid); -->
+  <function name="dgettext">
+    <noreturn>false</noreturn>
+    <returnValue type="char *"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- char * dcgettext (const char *domainname, const char *msgid, int category) -->
+  <function name="dcgettext">
+    <noreturn>false</noreturn>
+    <returnValue type="char *"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <resource>
     <dealloc>close</dealloc>
     <alloc init="true">epoll_create</alloc>

--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -749,7 +749,7 @@
       <not-bool/>
     </arg>
   </function>
-  <!-- char * dcgettext (const char *domainname, const char *msgid, int category) -->
+  <!-- char * dcgettext (const char *domainname, const char *msgid, int category); -->
   <function name="dcgettext">
     <noreturn>false</noreturn>
     <returnValue type="char *"/>


### PR DESCRIPTION
Reference (beside some other web sites):
https://www.gnu.org/software/libc/manual/html_node/Translation-with-gettext.html