### PR TITLE
gtk.cfg: Add internationalization macros / functions

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -8,6 +8,13 @@
   <define name="G_CALLBACK(cb)" value="cb"/>
   <define name="G_LIKELY(expr)" value="(expr)"/>
   <define name="G_UNLIKELY(expr)" value="(expr)"/>
+  <!-- https://developer.gnome.org/glib/stable/glib-I18N.html -->
+  <!-- Using something similar to the gi18n-lib.h macro value here to avoid dependencies to gettext() -->
+  <define name="_(string)" value="((char *) g_dgettext(NULL, string))"/>
+  <define name="Q_(string)" value="g_dpgettext(NULL, string, 0)"/>
+  <define name="N_(string)" value="(string)"/>
+  <define name="C_(context, string)" value="g_dpgettext (NULL, context &quot;\004&quot; string, strlen (context) + 1)"/>
+  <define name="NC_(context, string)" value="(string)"/>
   <memory>
     <alloc init="true">g_thread_new</alloc>
     <alloc init="true">g_thread_try_new</alloc>
@@ -1826,9 +1833,19 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- const gchar * g_dgettext (const gchar *domain, const gchar *msgid); -->
   <function name="g_dgettext">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
+    <arg nr="1">
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <strz/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_direct_equal">
     <leak-ignore/>
@@ -1850,9 +1867,23 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- const gchar * g_dpgettext (const gchar *domain, const gchar *msgctxtid, gsize msgidoffset); -->
   <function name="g_dpgettext">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
+    <arg nr="1">
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <strz/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <valid>0:</valid>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_dpgettext2">
     <leak-ignore/>

--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<!-- THIS FILE IS GENERATED AUTOMATICALLY. See https://github.com/scriptum/cppcheck-libs -->
+<!-- This file once has been generated automatically. See https://github.com/scriptum/cppcheck-libs -->
+<!-- Now it is maintained and extended manually. -->
 <def format="2">
   <define name="g_return_if_fail(expr)" value="do{if(!(expr)){return;}}while(0)"/>
   <define name="g_return_val_if_fail(expr, val)" value="do{if(!(expr)){return val;}}while(0)"/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -19,4 +19,8 @@ void validCode(int argInt)
     if G_LIKELY(argInt == 0) {
     } else if (G_LIKELY(argInt == -1)) {
     }
+
+    printf("%s", _("test"));
+    printf("%s", Q_("a|test"));
+    printf("%s", N_("test"));
 }


### PR DESCRIPTION
Reference: https://developer.gnome.org/glib/stable/glib-I18N.html
Found via Donate CPU / daca@home.
Update header comment in gtk.cfg since it is now only edited manually.