### PR TITLE
Donate CPU: Add scripts under /test for testing

### DIFF
--- a/tools/test/run_donate_cpu_client_tests.sh
+++ b/tools/test/run_donate_cpu_client_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Script for verifying that the donate-cpu.py script works under different circumstances (Python
+# version, parameters, ...).
+# Good for checking if everything still works before committing changes to donate-cpu.py.
+
+# Detect and report errors
+errors_occurred=0
+
+error_occurred() {
+  echo "#######################################################################"
+  echo "ERROR: On line $(caller), errorcode: $?" >&2
+  echo "#######################################################################"
+  errors_occurred=1
+}
+
+trap error_occurred ERR
+
+# Run tests
+client_script=../donate-cpu.py
+test_package=ftp://ftp.se.debian.org/debian/pool/main/0/0xffff/0xffff_0.8.orig.tar.gz
+
+for python_exec in "python" "python3"
+do
+    echo "Testing with ${python_exec} ..."
+    ${python_exec} ${client_script} --package=${test_package}
+    ${python_exec} ${client_script} --package=${test_package} -j1
+    ${python_exec} ${client_script} --package=${test_package} -j2
+    ${python_exec} ${client_script} --package=${test_package} --bandwidth-limit=250k
+    ${python_exec} ${client_script} --package=${test_package} -j2 --bandwidth-limit=0.5M
+done
+
+# Report result and exit accordingly
+if [ $errors_occurred -eq 0 ]; then
+  echo "All tests successfully finished."
+  exit 0
+else
+  echo "#######################################################################"
+  echo "ERRORS OCCURRED! See error messages above for details."
+  echo "#######################################################################"
+  exit 1
+fi

--- a/tools/test/start_donate_cpu_client_productive.sh
+++ b/tools/test/start_donate_cpu_client_productive.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Runs the daca@home client against the real server and thus produces real results.
+#
+# The donate-cpu.py script is stopped once per day to pull updates and then starts again after a
+# short pause (until midnight is reached). Exception: If an analysis runs longer than the period
+# for detection lasts, the donate-cpu.py script is not stopped that day.
+#
+# Should any error occur then the script also pulls updates and restarts donate-cpu.py.
+
+cppcheck_tools_path=..
+
+while :
+do
+    git pull
+    python "${cppcheck_tools_path}/donate-cpu.py" --bandwidth-limit=1m --stop-time=23:55
+    sleep 10
+done

--- a/tools/test/start_donate_cpu_client_test_local.sh
+++ b/tools/test/start_donate_cpu_client_test_local.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cppcheck_tools_path=..
+
+while :
+do
+    python "${cppcheck_tools_path}/donate-cpu.py" --test --bandwidth-limit=2m
+    sleep 2
+done

--- a/tools/test/start_donate_cpu_server_test_local.sh
+++ b/tools/test/start_donate_cpu_server_test_local.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Script for setting up everything that is needed and then running donate-cpu-server.py as
+# a local server for testing.
+# To start a real server instead of a local one simply remove the "--test" parameter.
+
+# You can move this script to another location but then you have to set this path accordingly.
+cppcheck_tools_path=..
+
+# Paths that should not be changed:
+dacaathome_path=~/daca@home
+donatedresults_path=${dacaathome_path}/donated-results
+
+if [ ! -d "${dacaathome_path}" ]
+then
+    mkdir "${dacaathome_path}"
+fi
+
+if [ ! -d "${donatedresults_path}" ]
+then
+    mkdir "${donatedresults_path}"
+fi
+
+if [ ! -f "${dacaathome_path}/packages.txt" ]
+then
+    python "${cppcheck_tools_path}/daca2-getpackages.py" > "${dacaathome_path}/packages.txt"
+fi
+
+while :
+do
+    python "${cppcheck_tools_path}/donate-cpu-server.py" --test
+done


### PR DESCRIPTION
Indirectly the scripts (at first the server test script) also document what needs to be done to setup daca@home.
The productive client script can be used by everyone who wants to support daca@home, not only for testing. But i still think it is good to have it under /test to not lose too much clarity / lucidity in the /tools directory.