### PR TITLE
 Lifetime: Follow functions that return references 

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -606,7 +606,10 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
         if (returnRef && Token::simpleMatch(tok->astParent(), "return")) {
             ErrorPath errorPath;
             const Variable *var = getLifetimeVariable(tok, errorPath);
-            if (var && var->isLocal() && !var->isArgument() && isInScope(var->nameToken(), tok->scope())) {
+            if (var && 
+                !var->isGlobal() && 
+                !var->isStatic() && 
+                !var->isReference() && !var->isRValueReference() && isInScope(var->nameToken(), tok->scope())) {
                 errorReturnReference(tok, errorPath);
                 continue;
             }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -606,10 +606,8 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
         if (returnRef && Token::simpleMatch(tok->astParent(), "return")) {
             ErrorPath errorPath;
             const Variable *var = getLifetimeVariable(tok, errorPath);
-            if (var && 
-                !var->isGlobal() && 
-                !var->isStatic() && 
-                !var->isReference() && !var->isRValueReference() && isInScope(var->nameToken(), tok->scope())) {
+            if (var && !var->isGlobal() && !var->isStatic() && !var->isReference() && !var->isRValueReference() &&
+                isInScope(var->nameToken(), tok->scope())) {
                 errorReturnReference(tok, errorPath);
                 continue;
             }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2603,14 +2603,15 @@ static bool valueFlowForward(Token * const               startToken,
     return true;
 }
 
-static const Token * findSimpleReturn(const Function* f)
+static const Token *findSimpleReturn(const Function *f)
 {
-    const Scope * scope = f->functionScope;
+    const Scope *scope = f->functionScope;
     if (!scope)
         return nullptr;
-    const Token * returnTok = nullptr;
+    const Token *returnTok = nullptr;
     for (const Token *tok = scope->bodyStart; tok && tok != scope->bodyEnd; tok = tok->next()) {
-        if (tok->str() == "{" && tok->scope() && (tok->scope()->type == Scope::eLambda || tok->scope()->type == Scope::eClass)) {
+        if (tok->str() == "{" && tok->scope() &&
+            (tok->scope()->type == Scope::eLambda || tok->scope()->type == Scope::eClass)) {
             tok = tok->link();
             continue;
         }
@@ -2644,25 +2645,25 @@ const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPat
                 return getLifetimeVariable(vartok, errorPath);
         }
     } else if (Token::Match(tok->previous(), "%name% (")) {
-        const Function * f = tok->previous()->function();
+        const Function *f = tok->previous()->function();
         if (!f)
             return nullptr;
         if (!Function::returnsReference(f))
             return nullptr;
-        const Token * returnTok = findSimpleReturn(f);
+        const Token *returnTok = findSimpleReturn(f);
         if (!returnTok)
             return nullptr;
-        const Variable * argvar = getLifetimeVariable(returnTok, errorPath);
+        const Variable *argvar = getLifetimeVariable(returnTok, errorPath);
         if (!argvar)
             return nullptr;
         if (argvar->isArgument() && (argvar->isReference() || argvar->isRValueReference())) {
-            auto arg_it = std::find_if(f->argumentList.begin(), f->argumentList.end(), [&](const Variable& v) {
+            auto arg_it = std::find_if(f->argumentList.begin(), f->argumentList.end(), [&](const Variable &v) {
                 return v.nameToken() == argvar->nameToken();
             });
             if (arg_it == f->argumentList.end())
                 return nullptr;
             std::size_t n = std::distance(f->argumentList.begin(), arg_it);
-            const Token * argTok = getArguments(tok->previous()).at(n);
+            const Token *argTok = getArguments(tok->previous()).at(n);
             errorPath.emplace_back(returnTok, "Return reference.");
             errorPath.emplace_back(tok->previous(), "Called function passing '" + argTok->str() + "'.");
             return getLifetimeVariable(argTok, errorPath);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2603,21 +2603,70 @@ static bool valueFlowForward(Token * const               startToken,
     return true;
 }
 
+static const Token * findSimpleReturn(const Function* f)
+{
+    const Scope * scope = f->functionScope;
+    if (!scope)
+        return nullptr;
+    const Token * returnTok = nullptr;
+    for (const Token *tok = scope->bodyStart; tok && tok != scope->bodyEnd; tok = tok->next()) {
+        if (tok->str() == "{" && tok->scope() && (tok->scope()->type == Scope::eLambda || tok->scope()->type == Scope::eClass)) {
+            tok = tok->link();
+            continue;
+        }
+        if (!Token::simpleMatch(tok->astParent(), "return"))
+            continue;
+        // Multiple returns
+        if (returnTok)
+            return nullptr;
+        returnTok = tok;
+    }
+    return returnTok;
+}
+
 const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPath &errorPath)
 {
     if (!tok)
         return nullptr;
     const Variable *var = tok->variable();
-    if (!var)
-        return nullptr;
-    if (var->isReference() || var->isRValueReference()) {
-        if (!var->declEndToken())
+    if (var) {
+        if ((var->isReference() || var->isRValueReference())) {
+            if (!var->declEndToken())
+                return nullptr;
+            if (var->isArgument())
+                errorPath.emplace_back(var->declEndToken(), "Passed to reference.");
+            else
+                errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
+            const Token *vartok = var->declEndToken()->astOperand2();
+            if (vartok == tok)
+                return nullptr;
+            if (vartok)
+                return getLifetimeVariable(vartok, errorPath);
+        }
+    } else if (Token::Match(tok->previous(), "%name% (")) {
+        const Function * f = tok->previous()->function();
+        if (!f)
             return nullptr;
-        errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
-        const Token *vartok = var->declEndToken()->astOperand2();
-        if (vartok == tok)
+        if (!Function::returnsReference(f))
             return nullptr;
-        return getLifetimeVariable(vartok, errorPath);
+        const Token * returnTok = findSimpleReturn(f);
+        if (!returnTok)
+            return nullptr;
+        const Variable * argvar = getLifetimeVariable(returnTok, errorPath);
+        if (!argvar)
+            return nullptr;
+        if (argvar->isArgument() && (argvar->isReference() || argvar->isRValueReference())) {
+            auto arg_it = std::find_if(f->argumentList.begin(), f->argumentList.end(), [&](const Variable& v) {
+                return v.nameToken() == argvar->nameToken();
+            });
+            if (arg_it == f->argumentList.end())
+                return nullptr;
+            std::size_t n = std::distance(f->argumentList.begin(), arg_it);
+            const Token * argTok = getArguments(tok->previous()).at(n);
+            errorPath.emplace_back(returnTok, "Return reference.");
+            errorPath.emplace_back(tok->previous(), "Called function passing '" + argTok->str() + "'.");
+            return getLifetimeVariable(argTok, errorPath);
+        }
     }
     return var;
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2634,17 +2634,18 @@ const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPat
         if (var->isReference() || var->isRValueReference()) {
             if (!var->declEndToken())
                 return nullptr;
-            if (var->isArgument()) 
-            {
+            if (var->isArgument()) {
                 errorPath.emplace_back(var->declEndToken(), "Passed to reference.");
                 return var;
-            } else {
+            } else if (Token::simpleMatch(var->declEndToken(), "=")) {
                 errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
                 const Token *vartok = var->declEndToken()->astOperand2();
                 if (vartok == tok)
                     return nullptr;
                 if (vartok)
                     return getLifetimeVariable(vartok, errorPath);
+            } else {
+                return nullptr;
             }
         }
     } else if (Token::Match(tok->previous(), "%name% (")) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2630,19 +2630,22 @@ const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPat
     if (!tok)
         return nullptr;
     const Variable *var = tok->variable();
-    if (var) {
-        if ((var->isReference() || var->isRValueReference())) {
+    if (var && var->declarationId() == tok->varId()) {
+        if (var->isReference() || var->isRValueReference()) {
             if (!var->declEndToken())
                 return nullptr;
-            if (var->isArgument())
+            if (var->isArgument()) 
+            {
                 errorPath.emplace_back(var->declEndToken(), "Passed to reference.");
-            else
+                return var;
+            } else {
                 errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
-            const Token *vartok = var->declEndToken()->astOperand2();
-            if (vartok == tok)
-                return nullptr;
-            if (vartok)
-                return getLifetimeVariable(vartok, errorPath);
+                const Token *vartok = var->declEndToken()->astOperand2();
+                if (vartok == tok)
+                    return nullptr;
+                if (vartok)
+                    return getLifetimeVariable(vartok, errorPath);
+            }
         }
     } else if (Token::Match(tok->previous(), "%name% (")) {
         const Function *f = tok->previous()->function();

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -107,6 +107,7 @@ private:
         TEST_CASE(returnReference5);
         TEST_CASE(returnReference6);
         TEST_CASE(returnReference7);
+        TEST_CASE(returnReferenceFunction);
         TEST_CASE(returnReferenceLiteral);
         TEST_CASE(returnReferenceCalculation);
         TEST_CASE(returnReferenceLambda);
@@ -1094,6 +1095,44 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
+    void returnReferenceFunction() {
+        check("int& f(int& a) {\n"
+              "    return a;\n"
+              "}\n"
+              "int& hello() {\n"
+              "    int x = 0;\n"
+              "    return f(x);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:6]: (error) Reference to local variable returned.\n", errout.str());
+
+        check("int f(int& a) {\n"
+              "    return a;\n"
+              "}\n"
+              "int& hello() {\n"
+              "    int x = 0;\n"
+              "    return f(x);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int& f(int a) {\n"
+              "    return a;\n"
+              "}\n"
+              "int& hello() {\n"
+              "    int x = 0;\n"
+              "    return f(x);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Reference to local variable returned.\n", errout.str());
+
+        check("int f(int a) {\n"
+              "    return a;\n"
+              "}\n"
+              "int& hello() {\n"
+              "    int x = 0;\n"
+              "    return f(x);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
     void returnReferenceLiteral() {
         check("const std::string &a() {\n"
               "    return \"foo\";\n"
@@ -1199,7 +1238,7 @@ private:
     }
 
     void danglingReference() {
-        check("int &f( int k )\n"
+        check("int f( int k )\n"
               "{\n"
               "    static int &r = k;\n"
               "    return r;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1727,6 +1727,13 @@ private:
               "    };\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("int * f(std::vector<int>& v) {\n"
+              "    for(int & x : v)\n"
+              "        return &x;\n"
+              "    return nullptr;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeFunction() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1134,6 +1134,13 @@ private:
               "    return f(x);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("template<class T>\n"
+              "int& f(int& x, T y) {\n"
+              "    x += y;\n"
+              "    return x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void returnReferenceLiteral() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1095,7 +1095,8 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void returnReferenceFunction() {
+    void returnReferenceFunction()
+    {
         check("int& f(int& a) {\n"
               "    return a;\n"
               "}\n"
@@ -1103,7 +1104,9 @@ private:
               "    int x = 0;\n"
               "    return f(x);\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:6]: (error) Reference to local variable returned.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:6]: (error) Reference to local variable returned.\n",
+            errout.str());
 
         check("int f(int& a) {\n"
               "    return a;\n"


### PR DESCRIPTION
This will now warn for cases like this:

```cpp
int& f(int& a) {
    return a;
}
int& hello() {
    int x = 0;
    return f(x);
}
```