### PR TITLE
Fix segfault in getLifetimeVariable

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2658,7 +2658,7 @@ const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPat
         if (!returnTok)
             return nullptr;
         if (returnTok == tok)
-            return var;
+            return nullptr;
         const Variable *argvar = getLifetimeVariable(returnTok, errorPath);
         if (!argvar)
             return nullptr;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2657,6 +2657,8 @@ const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPat
         const Token *returnTok = findSimpleReturn(f);
         if (!returnTok)
             return nullptr;
+        if (returnTok == tok)
+            return var;
         const Variable *argvar = getLifetimeVariable(returnTok, errorPath);
         if (!argvar)
             return nullptr;


### PR DESCRIPTION
prevent infinite recursion, eg from LibreOffice
0  0x0000555555bdc9dd in multiComparePercent (tok=0x5555570916d0, haystack=@0x7fffff7ff0a0: 0x555555d20dd9 "%name% (",
   varid=<error reading variable: Cannot access memory at address 0x7fffff7feffc>) at lib/token.cpp:354
1  0x0000555555bdd113 in Token::multiCompare (tok=0x5555570916d0, haystack=0x555555d20dd9 "%name% (", varid=0) at lib/token.cpp:499
2  0x0000555555bdd6c9 in Token::Match (tok=0x5555570916d0, pattern=0x555555d20dd9 "%name% (", varid=0) at lib/token.cpp:663
3  0x0000555555c62101 in getLifetimeVariable (tok=0x5555570921a0, errorPath=empty std::__debug::list) at lib/valueflow.cpp:2651
4  0x0000555555c62194 in getLifetimeVariable (tok=0x5555570921a0, errorPath=empty std::__debug::list) at lib/valueflow.cpp:2660
5  0x0000555555c62194 in getLifetimeVariable (tok=0x5555570921a0, errorPath=empty std::__debug::list) at lib/valueflow.cpp:2660