### PR TITLE
Lifetime: Support analysis with functions that do not return a reference

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -622,7 +622,7 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
             }
         }
         for (const ValueFlow::Value& val:tok->values()) {
-            if (!val.isLifetimeValue())
+            if (!val.isLocalLifetimeValue())
                 continue;
             // Skip temporaries for now
             if (val.tokvalue == tok)
@@ -675,28 +675,6 @@ void CheckAutoVariables::checkVarLifetime()
             continue;
         checkVarLifetimeScope(scope->bodyStart, scope->bodyEnd);
     }
-}
-
-static std::string lifetimeType(const Token *tok, const ValueFlow::Value* val)
-{
-    std::string result;
-    if (!val)
-        return "object";
-    switch (val->lifetimeKind) {
-    case ValueFlow::Value::Lambda:
-        result = "lambda";
-        break;
-    case ValueFlow::Value::Iterator:
-        result = "iterator";
-        break;
-    case ValueFlow::Value::Object:
-        if (astIsPointer(tok))
-            result = "pointer";
-        else
-            result = "object";
-        break;
-    }
-    return result;
 }
 
 static std::string lifetimeMessage(const Token *tok, const ValueFlow::Value *val, ErrorPath &errorPath)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2630,17 +2630,17 @@ static const Token *findSimpleReturn(const Function *f)
     return returnTok;
 }
 
-static int getArgumentPos(const Variable * var, const Function* f)
+static int getArgumentPos(const Variable *var, const Function *f)
 {
     auto arg_it = std::find_if(f->argumentList.begin(), f->argumentList.end(), [&](const Variable &v) {
-                return v.nameToken() == var->nameToken();
+        return v.nameToken() == var->nameToken();
     });
     if (arg_it == f->argumentList.end())
         return -1;
     return std::distance(f->argumentList.begin(), arg_it);
 }
 
-std::string lifetimeType(const Token *tok, const ValueFlow::Value* val)
+std::string lifetimeType(const Token *tok, const ValueFlow::Value *val)
 {
     std::string result;
     if (!val)
@@ -2797,8 +2797,10 @@ struct LifetimeStore {
     ValueFlow::Value::LifetimeKind type;
     ErrorPath errorPath;
 
-    LifetimeStore(const Token *argtok, const std::string& message, ValueFlow::Value::LifetimeKind type = ValueFlow::Value::Object)
-    : argtok(argtok), message(message), type(type), errorPath()
+    LifetimeStore(const Token *argtok,
+                  const std::string &message,
+                  ValueFlow::Value::LifetimeKind type = ValueFlow::Value::Object)
+        : argtok(argtok), message(message), type(type), errorPath()
     {}
 
     template <class Predicate>
@@ -2835,7 +2837,7 @@ struct LifetimeStore {
         if (argtok->values().empty()) {
             ErrorPath er;
             er.emplace_back(argtok, message);
-            const Variable * var = getLifetimeVariable(argtok, er);
+            const Variable *var = getLifetimeVariable(argtok, er);
             if (var && var->isArgument()) {
                 ValueFlow::Value value;
                 value.valueType = ValueFlow::Value::LIFETIME;
@@ -2966,7 +2968,7 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
                 continue;
             if (!v.tokvalue)
                 continue;
-            const Variable * var = v.tokvalue->variable();
+            const Variable *var = v.tokvalue->variable();
             if (!var)
                 continue;
             if (!var->isArgument())
@@ -2974,7 +2976,7 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             int n = getArgumentPos(var, f);
             if (n < 0)
                 continue;
-            const Token * argtok = getArguments(tok).at(n);
+            const Token *argtok = getArguments(tok).at(n);
             LifetimeStore ls{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object};
             ls.errorPath = v.errorPath;
             ls.errorPath.emplace_front(returnTok, "Return " + lifetimeType(returnTok, &v) + ".");
@@ -2983,7 +2985,6 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             } else if (v.isArgumentLifetimeValue()) {
                 ls.byVal(tok->next(), tokenlist, errorLogger, settings);
             }
-
         }
     }
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4921,6 +4921,7 @@ ValueFlow::Value::Value(const Token *c, long long val)
       conditional(false),
       defaultArg(false),
       lifetimeKind(Object),
+      lifetimeScope(Local),
       valueKind(ValueKind::Possible)
 {
     errorPath.emplace_back(c, "Assuming that condition '" + c->expressionString() + "' is not redundant");

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2962,7 +2962,7 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
         if (!returnTok)
             return;
         for (const ValueFlow::Value &v : returnTok->values()) {
-            if (!v.isArgumentLifetimeValue())
+            if (!v.isLifetimeValue())
                 continue;
             if (!v.tokvalue)
                 continue;
@@ -2980,7 +2980,7 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             ls.errorPath.emplace_front(returnTok, "Return " + lifetimeType(returnTok, &v) + ".");
             if (var->isReference() || var->isRValueReference()) {
                 ls.byRef(tok->next(), tokenlist, errorLogger, settings);
-            } else {
+            } else if (v.isArgumentLifetimeValue()) {
                 ls.byVal(tok->next(), tokenlist, errorLogger, settings);
             }
 

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -40,7 +40,7 @@ namespace ValueFlow {
         typedef std::pair<const Token *, std::string> ErrorPathItem;
         typedef std::list<ErrorPathItem> ErrorPath;
 
-        explicit Value(long long val = 0) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), moveKind(NonMovedVariable), varvalue(val), condition(nullptr), varId(0U), conditional(false), defaultArg(false), lifetimeKind(Object), valueKind(ValueKind::Possible) {}
+        explicit Value(long long val = 0) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), moveKind(NonMovedVariable), varvalue(val), condition(nullptr), varId(0U), conditional(false), defaultArg(false), lifetimeKind(Object), lifetimeScope(Local), valueKind(ValueKind::Possible) {}
         Value(const Token *c, long long val);
 
         bool operator==(const Value &rhs) const {

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -40,7 +40,21 @@ namespace ValueFlow {
         typedef std::pair<const Token *, std::string> ErrorPathItem;
         typedef std::list<ErrorPathItem> ErrorPath;
 
-        explicit Value(long long val = 0) : valueType(INT), intvalue(val), tokvalue(nullptr), floatValue(0.0), moveKind(NonMovedVariable), varvalue(val), condition(nullptr), varId(0U), conditional(false), defaultArg(false), lifetimeKind(Object), lifetimeScope(Local), valueKind(ValueKind::Possible) {}
+        explicit Value(long long val = 0)
+            : valueType(INT),
+              intvalue(val),
+              tokvalue(nullptr),
+              floatValue(0.0),
+              moveKind(NonMovedVariable),
+              varvalue(val),
+              condition(nullptr),
+              varId(0U),
+              conditional(false),
+              defaultArg(false),
+              lifetimeKind(Object),
+              lifetimeScope(Local),
+              valueKind(ValueKind::Possible)
+        {}
         Value(const Token *c, long long val);
 
         bool operator==(const Value &rhs) const {
@@ -108,13 +122,9 @@ namespace ValueFlow {
             return valueType == LIFETIME;
         }
 
-        bool isLocalLifetimeValue() const {
-            return valueType == LIFETIME && lifetimeScope == Local;
-        }
+        bool isLocalLifetimeValue() const { return valueType == LIFETIME && lifetimeScope == Local; }
 
-        bool isArgumentLifetimeValue() const {
-            return valueType == LIFETIME && lifetimeScope == Argument;
-        }
+        bool isArgumentLifetimeValue() const { return valueType == LIFETIME && lifetimeScope == Argument; }
 
         /** int value */
         long long intvalue;
@@ -146,8 +156,8 @@ namespace ValueFlow {
         bool defaultArg;
 
         enum LifetimeKind {Object, Lambda, Iterator} lifetimeKind;
-        
-        enum LifetimeScope {Local, Argument} lifetimeScope;
+
+        enum LifetimeScope { Local, Argument } lifetimeScope;
 
         static const char * toString(MoveKind moveKind) {
             switch (moveKind) {
@@ -217,6 +227,6 @@ namespace ValueFlow {
 
 const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPath &errorPath);
 
-std::string lifetimeType(const Token *tok, const ValueFlow::Value* val);
+std::string lifetimeType(const Token *tok, const ValueFlow::Value *val);
 
 #endif // valueflowH

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -108,6 +108,14 @@ namespace ValueFlow {
             return valueType == LIFETIME;
         }
 
+        bool isLocalLifetimeValue() const {
+            return valueType == LIFETIME && lifetimeScope == Local;
+        }
+
+        bool isArgumentLifetimeValue() const {
+            return valueType == LIFETIME && lifetimeScope == Argument;
+        }
+
         /** int value */
         long long intvalue;
 
@@ -138,6 +146,8 @@ namespace ValueFlow {
         bool defaultArg;
 
         enum LifetimeKind {Object, Lambda, Iterator} lifetimeKind;
+        
+        enum LifetimeScope {Local, Argument} lifetimeScope;
 
         static const char * toString(MoveKind moveKind) {
             switch (moveKind) {
@@ -206,5 +216,7 @@ namespace ValueFlow {
 }
 
 const Variable *getLifetimeVariable(const Token *tok, ValueFlow::Value::ErrorPath &errorPath);
+
+std::string lifetimeType(const Token *tok, const ValueFlow::Value* val);
 
 #endif // valueflowH

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1760,7 +1760,9 @@ private:
               "    std::vector<int> v;\n"
               "    return by_value(v.begin());\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:7] -> [test.cpp:7] -> [test.cpp:3] -> [test.cpp:3] -> [test.cpp:6] -> [test.cpp:7]: (error) Returning object that points to local variable 'v' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:7] -> [test.cpp:7] -> [test.cpp:3] -> [test.cpp:3] -> [test.cpp:6] -> [test.cpp:7]: (error) Returning object that points to local variable 'v' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto by_ref(int& x) {\n"
               "    return [&] { return x; };\n"
@@ -1769,7 +1771,9 @@ private:
               "    int i = 0;\n"
               "    return by_ref(i);\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:5] -> [test.cpp:6]: (error) Returning object that points to local variable 'i' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:5] -> [test.cpp:6]: (error) Returning object that points to local variable 'i' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f(int x) {\n"
               "    int a;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1752,6 +1752,16 @@ private:
             "[test.cpp:3] -> [test.cpp:3] -> [test.cpp:2] -> [test.cpp:3]: (error) Returning object that points to local variable 'a' that will be invalid when returning.\n",
             errout.str());
 
+        check("template<class T>\n"
+              "auto by_value(T x) {\n"
+              "    return [=] { return x; };\n"
+              "}\n"
+              "auto g() {\n"
+              "    std::vector<int> v;\n"
+              "    return by_value(v.begin());\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:7] -> [test.cpp:7] -> [test.cpp:3] -> [test.cpp:3] -> [test.cpp:6] -> [test.cpp:7]: (error) Returning object that points to local variable 'v' that will be invalid when returning.\n", errout.str());
+
         check("auto f(int x) {\n"
               "    int a;\n"
               "    std::tie(a) = x;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1762,6 +1762,15 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:7] -> [test.cpp:7] -> [test.cpp:3] -> [test.cpp:3] -> [test.cpp:6] -> [test.cpp:7]: (error) Returning object that points to local variable 'v' that will be invalid when returning.\n", errout.str());
 
+        check("auto by_ref(int& x) {\n"
+              "    return [&] { return x; };\n"
+              "}\n"
+              "auto f() {\n"
+              "    int i = 0;\n"
+              "    return by_ref(i);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:6] -> [test.cpp:5] -> [test.cpp:6]: (error) Returning object that points to local variable 'i' that will be invalid when returning.\n", errout.str());
+
         check("auto f(int x) {\n"
               "    int a;\n"
               "    std::tie(a) = x;\n"


### PR DESCRIPTION
This will warn for this case:

```cpp
auto by_ref(int& x) {
    return [&] { return x; };
}
auto f() {
    int i = 0;
    return by_ref(i);
}
```

And also for this case:

```cpp
template<class T>
auto by_value(T x) {
    return [=] { return x; };
}

auto g() {
    std::vector<int> v;
    return by_value(v.begin());
}
```