### PR TITLE
TestOther: Shorter test cases

### DIFF
--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -651,32 +651,28 @@ private:
               "   double x = 3.0 / 0.0 + 1.0;\n"
               "   printf(\"%f\", x);\n"
               "}");
-        ASSERT_EQUALS(
-            "[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
 
         check("void f()\n"
               "{\n"
               "   double x = 3.0 / 0.0 - 1.0;\n"
               "   printf(\"%f\", x);\n"
               "}");
-        ASSERT_EQUALS(
-            "[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
 
         check("void f()\n"
               "{\n"
               "   double x = 1.0 + 3.0 / 0.0;\n"
               "   printf(\"%f\", x);\n"
               "}");
-        ASSERT_EQUALS(
-            "[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
 
         check("void f()\n"
               "{\n"
               "   double x = 1.0 - 3.0 / 0.0;\n"
               "   printf(\"%f\", x);\n"
               "}");
-        ASSERT_EQUALS(
-            "[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Using NaN/Inf in a computation.\n", errout.str());
 
         check("void f()\n"
               "{\n"
@@ -4780,371 +4776,255 @@ private:
     }
 
     void checkSignOfUnsignedVariable() {
-        check(
-            "void foo() {\n"
-            "  for(unsigned char i = 10; i >= 0; i--)"
-            "    printf(\"%u\", i);\n"
-            "}");
+        check("void foo() {\n"
+              "  for(unsigned char i = 10; i >= 0; i--) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'i' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "void foo(bool b) {\n"
-            "  for(unsigned int i = 10; b || i >= 0; i--)"
-            "    printf(\"%u\", i);\n"
-            "}");
+        check("void foo(bool b) {\n"
+              "  for(unsigned int i = 10; b || i >= 0; i--) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'i' can't be negative so it is unnecessary to test it.\n", errout.str());
 
         {
-            const char code[] =
-                "bool foo(unsigned int x) {\n"
-                "  if (x < 0)"
-                "    return true;\n"
-                "  return false;\n"
-                "}";
+            const char code[] = "void foo(unsigned int x) {\n"
+                                "  if (x < 0) {}\n"
+                                "}";
             check(code, nullptr, false, false, true, false);
             ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
             check(code, nullptr, false, false, true, true);
             ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
         }
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (x < 0u)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (x < 0u) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x) {\n"
-            "  if (x < 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x) {\n"
+              "  if (x < 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
         {
-            const char code[] =
-                "bool foo(unsigned x) {\n"
-                "  int y = 0;\n"
-                "  if (x < y)"
-                "    return true;\n"
-                "  return false;\n"
-                "}";
+            const char code[] = "void foo(unsigned x) {\n"
+                                "  int y = 0;\n"
+                                "  if (x < y) {}\n"
+                                "}";
             check(code, nullptr, false, false, true, false);
             ASSERT_EQUALS("[test.cpp:3]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
             check(code, nullptr, false, false, true, true);
             ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
         }
-        check(
-            "bool foo(unsigned x) {\n"
-            "  int y = 0;\n"
-            "  if (b)\n"
-            "    y = 1;\n"
-            "  if (x < y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned x) {\n"
+              "  int y = 0;\n"
+              "  if (b)\n"
+              "    y = 1;\n"
+              "  if (x < y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (0 > x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (0 > x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (0UL > x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (0UL > x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x) {\n"
-            "  if (0 > x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x) {\n"
+              "  if (0 > x) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (x >= 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(unsigned int x, unsigned y) {\n"
-            "  if (x - y >= 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, unsigned y) {\n"
+              "  if (x - y >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x-y' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (x >= 0ull)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (x >= 0ull) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(int x) {\n"
-            "  if (x >= 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x) {\n"
+              "  if (x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (0 <= x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (0 <= x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(unsigned int x) {\n"
-            "  if (0ll <= x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x) {\n"
+              "  if (0ll <= x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(int x) {\n"
-            "  if (0 <= x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x) {\n"
+              "  if (0 <= x) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (x < 0 && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (x < 0 && y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (x < 0 && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (x < 0 && y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (0 > x && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (0 > x && y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (0 > x && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (0 > x && y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (x >= 0 && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (x >= 0 && y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (x >= 0 && y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (x >= 0 && y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (y && x < 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (y && x < 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (y && x < 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (y && x < 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (y && 0 > x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (y && 0 > x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (y && 0 > x)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (y && 0 > x) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (y && x >= 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (y && x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (y && x >= 0)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (y && x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (x < 0 || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (x < 0 || y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (x < 0 || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (x < 0 || y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (0 > x || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (0 > x || y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (0 > x || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (0 > x || y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(unsigned int x, bool y) {\n"
-            "  if (x >= 0 || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(unsigned int x, bool y) {\n"
+              "  if (x >= 0 || y) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) Unsigned expression 'x' can't be negative so it is unnecessary to test it.\n", errout.str());
 
-        check(
-            "bool foo(int x, bool y) {\n"
-            "  if (x >= 0 || y)"
-            "    return true;\n"
-            "  return false;\n"
-            "}");
+        check("void foo(int x, bool y) {\n"
+              "  if (x >= 0 || y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
         // #3233 - FP when template is used (template parameter is numeric constant)
         {
-            const char code[] =
-                "template<int n> void foo(unsigned int x) {\n"
-                "  if (x <= n);\n"
-                "}\n"
-                "foo<0>();";
+            const char code[] = "template<int n> void foo(unsigned int x) {\n"
+                                "  if (x <= n);\n"
+                                "}\n"
+                                "foo<0>();";
             check(code, nullptr, false, false);
             ASSERT_EQUALS("", errout.str());
             check(code, nullptr, false, true);
             ASSERT_EQUALS("", errout.str());
         }
 
-        check(
-            "template<int n> void foo(unsigned int x) {\n"
-            "if (x <= 0);\n"
-            "}\n");
+        check("template<int n> void foo(unsigned int x) {\n"
+              "if (x <= 0);\n"
+              "}\n");
         ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
 
         // #8836
-        check(
-            "uint32_t value = 0xFUL;\n"
-            "void f() {\n"
-            "  if (value < 0u)\n"
-            "  {\n"
-            "    value = 0u;\n"
-            "  }\n"
-            "}\n");
+        check("uint32_t value = 0xFUL;\n"
+              "void f() {\n"
+              "  if (value < 0u)\n"
+              "  {\n"
+              "    value = 0u;\n"
+              "  }\n"
+              "}\n");
         ASSERT_EQUALS("[test.cpp:3]: (style) Checking if unsigned expression 'value' is less than zero.\n", errout.str());
     }
 
     void checkSignOfPointer() {
-        check(
-            "bool foo(int* x) {\n"
-            "  if (x >= 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
 
         {
-            const char code[] =
-                "bool foo(int* x) {\n"
-                "  int y = 0;\n"
-                "  if (x >= y)"
-                "    bar();\n"
-                "}";
+            const char code[] = "void foo(int* x) {\n"
+                                "  int y = 0;\n"
+                                "  if (x >= y) {}\n"
+                                "}";
             check(code, nullptr, false, false, true, false);
             ASSERT_EQUALS("[test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
             check(code, nullptr, false, false, true, true);
             ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
         }
-        check(
-            "bool foo(int* x) {\n"
-            "  if (*x >= 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (*x >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x) {\n"
-            "  if (x < 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (x < 0) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
 
         {
-            const char code[] =
-                "bool foo(int* x) {\n"
-                "  unsigned y = 0u;\n"
-                "  if (x < y)"
-                "    bar();\n"
-                "}";
+            const char code[] = "void foo(int* x) {\n"
+                                "  unsigned y = 0u;\n"
+                                "  if (x < y) {}\n"
+                                "}";
 
             check(code, nullptr, false, false, true, false);
             ASSERT_EQUALS("[test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
@@ -5152,381 +5032,318 @@ private:
             ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
         }
 
-        check(
-            "bool foo(int* x) {\n"
-            "  if (*x < 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (*x < 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x, int* y) {\n"
-            "  if (x - y < 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x, int* y) {\n"
+              "  if (x - y < 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x, int* y) {\n"
-            "  if (x - y <= 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x, int* y) {\n"
+              "  if (x - y <= 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x, int* y) {\n"
-            "  if (x - y > 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x, int* y) {\n"
+              "  if (x - y > 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x, int* y) {\n"
-            "  if (x - y >= 0)"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x, int* y) {\n"
+              "  if (x - y >= 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 <= x)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 <= x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first) {\n"
-            "  if (first.ptr >= 0) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first) {\n"
+              "  if (first.ptr >= 0) {} \n"
+              "}");
         ASSERT_EQUALS("[test.cpp:5]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if((first.ptr - second.ptr) >= 0) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if((first.ptr - second.ptr) >= 0) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first) {\n"
-            "  if((first.ptr) >= 0) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first) {\n"
+              "  if((first.ptr) >= 0) {} \n"
+              "}");
         ASSERT_EQUALS("[test.cpp:5]: (style) A pointer can not be negative so it is either pointless or an error to check if it is not.\n", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if(0 <= first.ptr - second.ptr) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if(0 <= first.ptr - second.ptr) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if(0 <= (first.ptr - second.ptr)) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if(0 <= (first.ptr - second.ptr)) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if(first.ptr - second.ptr < 0) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if(first.ptr - second.ptr < 0) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if((first.ptr - second.ptr) < 0) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if((first.ptr - second.ptr) < 0) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if(0 > first.ptr - second.ptr) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if(0 > first.ptr - second.ptr) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct S {\n"
-            "  int* ptr;\n"
-            "};\n"
-            "void foo(S* first, S* second) {\n"
-            "  if(0 > (first.ptr - second.ptr)) {} \n"
-            "}");
+        check("struct S {\n"
+              "  int* ptr;\n"
+              "};\n"
+              "void foo(S* first, S* second) {\n"
+              "  if(0 > (first.ptr - second.ptr)) {} \n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(int* x) {\n"
-            "  if (0 <= x[0])"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (0 <= x[0]) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 <= x.y)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 <= x.y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 <= x->y)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 <= x->y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x, Bar* y) {\n"
-            "  if (0 <= x->y - y->y )"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x, Bar* y) {\n"
+              "  if (0 <= x->y - y->y ) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 > x)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 > x) {}\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
 
-        check(
-            "bool foo(int* x) {\n"
-            "  if (0 > x[0])"
-            "    bar();\n"
-            "}");
+        check("void foo(int* x) {\n"
+              "  if (0 > x[0]) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 > x.y)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 > x.y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "bool foo(Bar* x) {\n"
-            "  if (0 > x->y)"
-            "    bar();\n"
-            "}");
+        check("void foo(Bar* x) {\n"
+              "  if (0 > x->y) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  int (*t)(void *a, void *b);\n"
-            "  if (t(a, b) < 0)\n"
-            "    bar();\n"
-            "}");
+        check("void foo() {\n"
+              "  int (*t)(void *a, void *b);\n"
+              "  if (t(a, b) < 0) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  int (*t)(void *a, void *b);\n"
-            "  if (0 > t(a, b))\n"
-            "    bar();\n"
-            "}");
+        check("void foo() {\n"
+              "  int (*t)(void *a, void *b);\n"
+              "  if (0 > t(a, b)) {}\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "struct object_info { int *typep; };\n"
-            "void packed_object_info(struct object_info *oi) {\n"
-            "  if (oi->typep < 0);\n"
-            "}");
+        check("struct object_info { int *typep; };\n"
+              "void packed_object_info(struct object_info *oi) {\n"
+              "  if (oi->typep < 0);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
 
-        check(
-            "struct object_info { int typep[10]; };\n"
-            "void packed_object_info(struct object_info *oi) {\n"
-            "  if (oi->typep < 0);\n"
-            "}");
+        check("struct object_info { int typep[10]; };\n"
+              "void packed_object_info(struct object_info *oi) {\n"
+              "  if (oi->typep < 0);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (style) A pointer can not be negative so it is either pointless or an error to check if it is.\n", errout.str());
 
-        check(
-            "struct object_info { int *typep; };\n"
-            "void packed_object_info(struct object_info *oi) {\n"
-            "  if (*oi->typep < 0);\n"
-            "}");
+        check("struct object_info { int *typep; };\n"
+              "void packed_object_info(struct object_info *oi) {\n"
+              "  if (*oi->typep < 0);\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
     }
 
     void checkForSuspiciousSemicolon1() {
-        check(
-            "void foo() {\n"
-            "  for(int i = 0; i < 10; ++i);\n"
-            "}");
+        check("void foo() {\n"
+              "  for(int i = 0; i < 10; ++i);\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
         // Empty block
-        check(
-            "void foo() {\n"
-            "  for(int i = 0; i < 10; ++i); {\n"
-            "  }\n"
-            "}");
+        check("void foo() {\n"
+              "  for(int i = 0; i < 10; ++i); {\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning, inconclusive) Suspicious use of ; at the end of 'for' statement.\n", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  while (!quit); {\n"
-            "    do_something();\n"
-            "  }\n"
-            "}");
+        check("void foo() {\n"
+              "  while (!quit); {\n"
+              "    do_something();\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning, inconclusive) Suspicious use of ; at the end of 'while' statement.\n", errout.str());
     }
 
     void checkForSuspiciousSemicolon2() {
-        check(
-            "void foo() {\n"
-            "  if (i == 1); {\n"
-            "    do_something();\n"
-            "  }\n"
-            "}");
+        check("void foo() {\n"
+              "  if (i == 1); {\n"
+              "    do_something();\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning, inconclusive) Suspicious use of ; at the end of 'if' statement.\n", errout.str());
 
         // Seen this in the wild
-        check(
-            "void foo() {\n"
-            "  if (Match());\n"
-            "  do_something();\n"
-            "}");
+        check("void foo() {\n"
+              "  if (Match());\n"
+              "  do_something();\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  if (Match());\n"
-            "  else\n"
-            "    do_something();\n"
-            "}");
+        check("void foo() {\n"
+              "  if (Match());\n"
+              "  else\n"
+              "    do_something();\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  if (i == 1)\n"
-            "       ;\n"
-            "  {\n"
-            "    do_something();\n"
-            "  }\n"
-            "}");
+        check("void foo() {\n"
+              "  if (i == 1)\n"
+              "       ;\n"
+              "  {\n"
+              "    do_something();\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo() {\n"
-            "  if (i == 1);\n"
-            "\n"
-            "  {\n"
-            "    do_something();\n"
-            "  }\n"
-            "}");
+        check("void foo() {\n"
+              "  if (i == 1);\n"
+              "\n"
+              "  {\n"
+              "    do_something();\n"
+              "  }\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
     }
 
 
     void checkInvalidFree() {
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = malloc(1024);\n"
-            "  free(a + 10);\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = malloc(1024);\n"
+              "  free(a + 10);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = malloc(1024);\n"
-            "  free(a - 10);\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = malloc(1024);\n"
+              "  free(a - 10);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = malloc(1024);\n"
-            "  free(10 + a);\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = malloc(1024);\n"
+              "  free(10 + a);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char[1024];\n"
-            "  delete[] (a + 10);\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char[1024];\n"
+              "  delete[] (a + 10);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char;\n"
-            "  delete a + 10;\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char;\n"
+              "  delete a + 10;\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char;\n"
-            "  bar(a);\n"
-            "  delete a + 10;\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char;\n"
+              "  bar(a);\n"
+              "  delete a + 10;\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char;\n"
-            "  char *b; b = new char;\n"
-            "  bar(a);\n"
-            "  delete a + 10;\n"
-            "  delete b + 10;\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char;\n"
+              "  char *b; b = new char;\n"
+              "  bar(a);\n"
+              "  delete a + 10;\n"
+              "  delete b + 10;\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:6]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char;\n"
-            "  char *b; b = new char;\n"
-            "  bar(a, b);\n"
-            "  delete a + 10;\n"
-            "  delete b + 10;\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char;\n"
+              "  char *b; b = new char;\n"
+              "  bar(a, b);\n"
+              "  delete a + 10;\n"
+              "  delete b + 10;\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
 
-        check(
-            "void foo(char *p) {\n"
-            "  char *a; a = new char;\n"
-            "  bar()\n"
-            "  delete a + 10;\n"
-            "}");
+        check("void foo(char *p) {\n"
+              "  char *a; a = new char;\n"
+              "  bar()\n"
+              "  delete a + 10;\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(size_t xx) {\n"
-            "  char *ptr; ptr = malloc(42);\n"
-            "  ptr += xx;\n"
-            "  free(ptr - xx - 1);\n"
-            "}");
+        check("void foo(size_t xx) {\n"
+              "  char *ptr; ptr = malloc(42);\n"
+              "  ptr += xx;\n"
+              "  free(ptr - xx - 1);\n"
+              "}");
         ASSERT_EQUALS("[test.cpp:4]: (error, inconclusive) Invalid memory address freed.\n", errout.str());
 
-        check(
-            "void foo(size_t xx) {\n"
-            "  char *ptr; ptr = malloc(42);\n"
-            "  std::cout << ptr;\n"
-            "  ptr = otherPtr;\n"
-            "  free(otherPtr - xx - 1);\n"
-            "}");
+        check("void foo(size_t xx) {\n"
+              "  char *ptr; ptr = malloc(42);\n"
+              "  std::cout << ptr;\n"
+              "  ptr = otherPtr;\n"
+              "  free(otherPtr - xx - 1);\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
     }
 
@@ -6908,273 +6725,246 @@ private:
     }
 
     void raceAfterInterlockedDecrement() {
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    whatever();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    whatever();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (counter)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (counter)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (!counter)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (!counter)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (counter > 0)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (counter > 0)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (0 < counter)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (0 < counter)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (counter == 0)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (counter == 0)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (0 == counter)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (0 == counter)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (0 != counter)\n"
-            "        return;\n"
-            "    destroy()\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (0 != counter)\n"
+                                  "        return;\n"
+                                  "    destroy()\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (counter != 0)\n"
-            "        return;\n"
-            "    destroy()\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (counter != 0)\n"
+                                  "        return;\n"
+                                  "    destroy()\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (counter <= 0)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (counter <= 0)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    InterlockedDecrement(&counter);\n"
-            "    if (0 >= counter)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    InterlockedDecrement(&counter);\n"
+                                  "    if (0 >= counter)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (newCount)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (newCount)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (!newCount)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (!newCount)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (newCount > 0)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (newCount > 0)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (0 < newCount)\n"
-            "        return;\n"
-            "    destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (0 < newCount)\n"
+                                  "        return;\n"
+                                  "    destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (newCount == 0)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (newCount == 0)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (0 == newCount)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (0 == newCount)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (0 != newCount)\n"
-            "        return;\n"
-            "    destroy()\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (0 != newCount)\n"
+                                  "        return;\n"
+                                  "    destroy()\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (newCount != 0)\n"
-            "        return;\n"
-            "    destroy()\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (newCount != 0)\n"
+                                  "        return;\n"
+                                  "    destroy()\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (newCount <= 0)\n"
-            "        destroy();\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (newCount <= 0)\n"
+                                  "        destroy();\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "void f() {\n"
-            "    int counter = 0;\n"
-            "    int newCount = InterlockedDecrement(&counter);\n"
-            "    if (0 >= newCount)\n"
-            "        destroy;\n"
-            "}\n");
+        checkInterlockedDecrement("void f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    int newCount = InterlockedDecrement(&counter);\n"
+                                  "    if (0 >= newCount)\n"
+                                  "        destroy;\n"
+                                  "}\n");
         ASSERT_EQUALS("", errout.str());
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    } else {\n"
-            "        return counter;\n"
-            "    }\n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    } else {\n"
+                                  "        return counter;\n"
+                                  "    }\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (::InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    } else {\n"
-            "        return counter;\n"
-            "    }\n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (::InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    } else {\n"
+                                  "        return counter;\n"
+                                  "    }\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    }\n"
-            "    return counter;\n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    }\n"
+                                  "    return counter;\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (::InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    }\n"
-            "    return counter;\n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (::InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    }\n"
+                                  "    return counter;\n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    } else\n"
-            "        return counter;\n"
-            "    \n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    } else\n"
+                                  "        return counter;\n"
+                                  "    \n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
 
-        checkInterlockedDecrement(
-            "int f() {\n"
-            "    int counter = 0;\n"
-            "    if (::InterlockedDecrement(&counter) == 0) {\n"
-            "        destroy();\n"
-            "        return 0;\n"
-            "    } else\n"
-            "        return counter;\n"
-            "    \n"
-            "}\n");
+        checkInterlockedDecrement("int f() {\n"
+                                  "    int counter = 0;\n"
+                                  "    if (::InterlockedDecrement(&counter) == 0) {\n"
+                                  "        destroy();\n"
+                                  "        return 0;\n"
+                                  "    } else\n"
+                                  "        return counter;\n"
+                                  "    \n"
+                                  "}\n");
         ASSERT_EQUALS("[test.cpp:7]: (error) Race condition: non-interlocked access after InterlockedDecrement(). Use InterlockedDecrement() return value instead.\n", errout.str());
     }
 
@@ -7673,12 +7463,10 @@ private:
     // #7846 - Syntax error when using C++11 braced-initializer in default argument
     void cpp11FunctionArgInit() {
         // syntax error is not expected
-        ASSERT_NO_THROW(check(
-                            "\n void foo(int declaration = {}) {"
-                            "\n   for (int i = 0; i < 10; i++) {}"
-                            "\n }"
-                            "\n  "
-                        ));
+        ASSERT_NO_THROW(check("\n void foo(int declaration = {}) {"
+                              "\n   for (int i = 0; i < 10; i++) {}\n"
+                              "\n }"
+                              "\n  "));
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
* Remove newlines after check(
* Remove unneeded statements after if-statements

As an example, the previous test case

	check(
	    "bool foo(int x) {\n"
	    "  if (x < 0)"
	    "    return true;\n"
	    "  return false;\n"
	    "}");

is changed to

	check("void foo(int x) {\n"
	      "  if (x < 0) {}\n"
	      "}");