### PR TITLE
Add pcre requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pcre,ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.39.tar.bz2 -H sha256:b858099f82483031ee02092711689e7245586ada49e534a06e678b8ea9549e8b


### PR DESCRIPTION
This will allow cppcheck to be installed with `cget install danmar/cppcheck -DHAVE_RULES=On` and it will install pcre library along with it. This document [here](https://cget.readthedocs.io/en/latest/src/requirements.html) describes the format of the requirements file.