### PR TITLE
python.cfg: Add macros DL_IMPORT and DL_EXPORT

### DIFF
--- a/cfg/python.cfg
+++ b/cfg/python.cfg
@@ -102,4 +102,7 @@
     <pure/>
     <use-retval/>
   </function>
+  <!-- Deprecated DL_IMPORT and DL_EXPORT macros -->
+  <define name="DL_IMPORT(RTYPE)" value="RTYPE"/>
+  <define name="DL_EXPORT(RTYPE)" value="RTYPE"/>
 </def>


### PR DESCRIPTION
daca@home issues `unknownMacro` errors for these (deprecated) macros.