### PR TITLE
donate-cpu-server.py: Add logging of uncaught exceptions (to file and…

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -10,8 +10,38 @@ import time
 from threading import Thread
 import sys
 import urllib
+import logging
+import logging.handlers
 
 OLD_VERSION = '1.86'
+
+
+# Set up logging
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+# Logging to console
+handler_stream = logging.StreamHandler()
+logger.addHandler(handler_stream)
+# Log errors to a rotating file
+logfile = sys.path[0]
+if logfile:
+    logfile += '/'
+logfile += 'donate-cpu-server.log'
+handler_file = logging.handlers.RotatingFileHandler(filename=logfile, maxBytes=100*1024, backupCount=1)
+handler_file.setLevel(logging.ERROR)
+logger.addHandler(handler_file)
+
+
+# Set up an exception hook for all uncaught exceptions so they can be logged
+def handle_uncaught_exception(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    logging.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
+
+
+sys.excepthook = handle_uncaught_exception
 
 
 def strDateTime():


### PR DESCRIPTION
… console)

Two logging handlers are added. One just prints all output with at least INFO severity to the console. The other only prints ERROR severity and above to a rotating file. The file size is limited to 100 kB. Since one backup file is used that results in a maximum disk usage of 200 kB.
The log file is saved in the directory where the server script is.
Hopefully this way some issues can be found more easily.
Tested locally.