### PR TITLE
Fix FP with const argument when doing a variable and cast

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1042,6 +1042,11 @@ bool isLikelyStreamRead(bool cpp, const Token *op)
     return (!parent->astOperand1()->valueType() || !parent->astOperand1()->valueType()->isIntegral());
 }
 
+bool isCPPCast(const Token* tok)
+{
+    return tok && Token::simpleMatch(tok->previous(), "> (") && tok->astOperand2() && tok->astOperand1() && tok->astOperand1()->str().find("_cast") != std::string::npos;
+}
+
 bool isConstVarExpression(const Token *tok)
 {
     if (!tok)
@@ -1052,7 +1057,7 @@ bool isConstVarExpression(const Token *tok)
         std::vector<const Token *> args = getArguments(tok);
         return std::all_of(args.begin(), args.end(), &isConstVarExpression);
     }
-    if (Token::simpleMatch(tok->previous(), "> (") && tok->astOperand2() && tok->astOperand1()->str().find("_cast") != std::string::npos) {
+    if (isCPPCast(tok)) {
         return isConstVarExpression(tok->astOperand2());
     }
     if (Token::Match(tok, "( %type%"))

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -160,6 +160,8 @@ const Token *findLambdaEndToken(const Token *first);
  */
 bool isLikelyStreamRead(bool cpp, const Token *op);
 
+bool isCPPCast(const Token* tok);
+
 bool isConstVarExpression(const Token *tok);
 
 /**

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2798,11 +2798,14 @@ void CheckOther::checkConstArgument()
                 continue;
             if (!tok->hasKnownIntValue())
                 continue;
-            if (Token::Match(tok, "%var%"))
-                continue;
             if (Token::Match(tok, "++|--"))
                 continue;
             if (isConstVarExpression(tok))
+                continue;
+            const Token * tok2 = tok;
+            if (isCPPCast(tok2))
+                tok2 = tok2->astOperand2();
+            if (Token::Match(tok2, "%var%"))
                 continue;
             constArgumentError(tok, tok->astParent()->previous(), &tok->values().front());
         }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7554,6 +7554,13 @@ private:
               "    g(x + 1);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void g(int);\n"
+              "void f() {\n"
+              "    char i = 1;\n"
+              "    g(static_cast<int>(i));\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
This fixes the FP with:

```cpp
void g(int);
void f() {
    char i = 1;
    g(static_cast<int>(i));
}
```
