### PR TITLE
runastyle: Fix wildcard expansion happening too soon

### DIFF
--- a/runastyle
+++ b/runastyle
@@ -26,20 +26,20 @@ function formatCplusplusRecursive {
 	"$ASTYLE" --options=$RCFILE --recursive "$1"
 }
 
-formatCplusplus cli/*.cpp
-formatCplusplus cli/*.h
-formatCplusplus democlient/*.cpp
-formatCplusplus gui/*.cpp
-formatCplusplus gui/*.h
+formatCplusplus "cli/*.cpp"
+formatCplusplus "cli/*.h"
+formatCplusplus "democlient/*.cpp"
+formatCplusplus "gui/*.cpp"
+formatCplusplus "gui/*.h"
 formatCplusplusRecursive "gui/test/*.cpp"
 formatCplusplusRecursive "gui/test/*.h"
-formatCplusplus lib/*.cpp
-formatCplusplus lib/*.h
-formatCplusplus test/*.cpp
-formatCplusplus test/cfg/*.c
-formatCplusplus test/cfg/*.cpp
-formatCplusplus test/*.h
-formatCplusplus tools/*.cpp
+formatCplusplus "lib/*.cpp"
+formatCplusplus "lib/*.h"
+formatCplusplus "test/*.cpp"
+formatCplusplus "test/cfg/*.c"
+formatCplusplus "test/cfg/*.cpp"
+formatCplusplus "test/*.h"
+formatCplusplus "tools/*.cpp"
 formatCplusplusRecursive "tools/*.h"
 formatCplusplusRecursive "samples/*.c"
 formatCplusplusRecursive "samples/*.cpp"


### PR DESCRIPTION
At least under Windows with Cygwin i see a problem.
For lines like `formatCplusplus lib/*.cpp` the wildcard is replaced by ONE filename before the function is called.
This results in only one file being formatted in the corresponding directory.
The fix seems quite simple. Just use quotes for all function parameters like this: `formatCplusplus "lib/*.cpp"`
The wildcard is preserved and only expanded in the function body, so all matching files get formatted.