### PR TITLE
qt.cfg: Add configuration and tests for macro Q_NULLPTR

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1286,6 +1286,7 @@
   <define name="Q_ENUMS(X)" value=""/>
   <define name="Q_FLAGS(X)" value=""/>
   <define name="Q_INTERFACES(X)" value=""/>
+  <define name="Q_NULLPTR" value="NULL"/>
   <define name="Q_OBJECT" value=""/>
   <define name="Q_PROPERTY(X)" value=""/>
   <define name="Q_Q(Class)" value="Class * const q = q_func()"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -38,10 +38,14 @@ public:
     ~MacroTest1();
 };
 
-void validCode()
+void validCode(int * pIntPtr)
 {
-    if (QFile::exists("test"))
-    {}
+    if (QFile::exists("test")) {
+    }
+
+    if (pIntPtr != Q_NULLPTR) {
+        *pIntPtr = 5;
+    }
 }
 
 void ignoredReturnValue()
@@ -51,4 +55,18 @@ void ignoredReturnValue()
     QFile file1("test");
     // cppcheck-suppress ignoredReturnValue
     file1.exists();
+}
+
+void nullPointer(int * pIntPtr)
+{
+    int * pNullPtr = Q_NULLPTR;
+    // cppcheck-suppress nullPointer
+    *pNullPtr = 1;
+
+    if (pIntPtr != Q_NULLPTR) {
+        *pIntPtr = 2;
+    } else {
+        // cppcheck-suppress nullPointerRedundantCheck
+        *pIntPtr = 3;
+    }
 }


### PR DESCRIPTION
Qt defines `Q_NULLPTR` with `nullptr` if it is available, otherwise with `NULL`.
Since there seems to be no (sane) way to configure it the same way in the library configuration it is just defined with `NULL`.