### PR TITLE
Fix possible out of bounds access on arguments

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2981,8 +2981,11 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             if (n < 0)
                 continue;
             std::vector<const Token *> args = getArguments(tok);
-            if (n >= args.size())
+            if (n >= args.size()) {
+                if (tokenlist->getSettings()->debugwarnings)
+                    bailout(tokenlist, errorLogger, tok, "Argument mismatch: Function '" + tok->str() + "' returning lifetime from argument index " + std::to_string(n) + " but only " + std::to_string(args.size()) + " arguments are available.");
                 continue;
+            }
             const Token *argtok = args[n];
             LifetimeStore ls{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object};
             ls.errorPath = v.errorPath;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2980,7 +2980,10 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             int n = getArgumentPos(var, f);
             if (n < 0)
                 continue;
-            const Token *argtok = getArguments(tok).at(n);
+            std::vector<const Token *> args = getArguments(tok);
+            if (n >= args.size())
+                continue;
+            const Token *argtok = args[n];
             LifetimeStore ls{argtok, "Passed to '" + tok->str() + "'.", ValueFlow::Value::Object};
             ls.errorPath = v.errorPath;
             ls.errorPath.emplace_front(returnTok, "Return " + lifetimeType(returnTok, &v) + ".");

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2983,7 +2983,12 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
             std::vector<const Token *> args = getArguments(tok);
             if (n >= args.size()) {
                 if (tokenlist->getSettings()->debugwarnings)
-                    bailout(tokenlist, errorLogger, tok, "Argument mismatch: Function '" + tok->str() + "' returning lifetime from argument index " + std::to_string(n) + " but only " + std::to_string(args.size()) + " arguments are available.");
+                    bailout(tokenlist,
+                            errorLogger,
+                            tok,
+                            "Argument mismatch: Function '" + tok->str() + "' returning lifetime from argument index " +
+                                std::to_string(n) + " but only " + std::to_string(args.size()) +
+                                " arguments are available.");
                 continue;
             }
             const Token *argtok = args[n];


### PR DESCRIPTION
This fixes the access throwing an exception for some cases. I dont have a real reduced test case for this yet. Is it possible to add some special logging when this occurs?