### PR TITLE
Extend constStatement checker

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1478,6 +1478,8 @@ void CheckOther::constStatementError(const Token *tok, const std::string &type, 
     std::string msg;
     if (Token::simpleMatch(tok, "=="))
         msg = "Found suspicious equality comparison. Did you intend to assign a value instead?";
+    else if (Token::Match(tok, ",|%cop%"))
+        msg = "Found suspicious operator '" + tok->str() + "'";
     else
         msg = "Redundant code: Found a statement that begins with " + type + " constant.";
     reportError(tok, Severity::warning, "constStatement", msg, CWE398, inconclusive);

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1390,7 +1390,7 @@ void CheckOther::charBitOpError(const Token *tok)
 // Incomplete statement..
 //---------------------------------------------------------------------------
 
-static bool isConstStatement(const Token * tok)
+static bool isConstStatement(const Token *tok)
 {
     if (!tok)
         return false;
@@ -1398,7 +1398,9 @@ static bool isConstStatement(const Token * tok)
         return false;
     if (Token::Match(tok, "%bool%|%num%|%str%|%char%|nullptr|NULL"))
         return true;
-    if (Token::Match(tok, "*|&|&&") && (Token::Match(tok->previous(), "::|.") || Token::Match(tok->astOperand1(), "%type%") || Token::Match(tok->astOperand2(), "%type%")))
+    if (Token::Match(tok, "*|&|&&") &&
+        (Token::Match(tok->previous(), "::|.") || Token::Match(tok->astOperand1(), "%type%") ||
+         Token::Match(tok->astOperand2(), "%type%")))
         return false;
     if (Token::Match(tok, "<<|>>"))
         return false;
@@ -1415,10 +1417,10 @@ static bool isConstStatement(const Token * tok)
     return false;
 }
 
-static bool isVoidStmt(const Token * tok)
+static bool isVoidStmt(const Token *tok)
 {
-    const Token * tok2 = tok;
-    while(tok2->astOperand1())
+    const Token *tok2 = tok;
+    while (tok2->astOperand1())
         tok2 = tok2->astOperand1();
     if (Token::simpleMatch(tok2->previous(), ")") && Token::simpleMatch(tok2->previous()->link(), "( void"))
         return true;
@@ -1427,13 +1429,14 @@ static bool isVoidStmt(const Token * tok)
     return Token::Match(tok2->previous(), "delete|throw|return");
 }
 
-static bool isConstTop(const Token* tok)
+static bool isConstTop(const Token *tok)
 {
     if (!tok)
         return false;
     if (tok == tok->astTop())
         return true;
-    if (Token::simpleMatch(tok->astParent(), ";") && tok->astTop() && Token::Match(tok->astTop()->previous(), "for|if (") && Token::simpleMatch(tok->astTop()->astOperand2(), ";")) {
+    if (Token::simpleMatch(tok->astParent(), ";") && tok->astTop() &&
+        Token::Match(tok->astTop()->previous(), "for|if (") && Token::simpleMatch(tok->astTop()->astOperand2(), ";")) {
         if (Token::simpleMatch(tok->astParent()->astParent(), ";"))
             return tok->astParent()->astOperand2() == tok;
         else
@@ -1448,13 +1451,14 @@ void CheckOther::checkIncompleteStatement()
         return;
 
     for (const Token *tok = mTokenizer->tokens(); tok; tok = tok->next()) {
-        const Scope * scope = tok->scope();
+        const Scope *scope = tok->scope();
         if (scope && !scope->isExecutable())
             continue;
         if (!isConstTop(tok))
             continue;
-        const Token * rtok = nextAfterAstRightmostLeaf(tok);
-        if (!Token::simpleMatch(tok->astParent(), ";") && !Token::simpleMatch(rtok, ";") && !Token::Match(tok->previous(), ";|}|{ %any% ;"))
+        const Token *rtok = nextAfterAstRightmostLeaf(tok);
+        if (!Token::simpleMatch(tok->astParent(), ";") && !Token::simpleMatch(rtok, ";") &&
+            !Token::Match(tok->previous(), ";|}|{ %any% ;"))
             continue;
         // Skipe statement expressions
         if (Token::Match(rtok, "; } )"))

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1414,7 +1414,7 @@ void CheckOther::checkIncompleteStatement()
             !Token::Match(tok->previous(), ";|}|{ %any% ;"))
             continue;
         // Skipe statement expressions
-        if (Token::Match(rtok, "; } )"))
+        if (Token::simpleMatch(rtok, "; } )"))
             continue;
         if (!isConstStatement(tok))
             continue;

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -101,7 +101,6 @@ public:
 
         checkOther.checkInvalidFree();
         checkOther.checkRedundantCopy();
-        // checkOther.checkSuspiciousEqualityComparison();
         checkOther.checkComparisonFunctionIsAlwaysTrueOrFalse();
         checkOther.checkAccessOfMovedVariable();
     }
@@ -148,9 +147,6 @@ public:
 
     /** @brief %Check for code like 'case A||B:'*/
     void checkSuspiciousCaseInSwitch();
-
-    /** @brief %Check for code like 'case A||B:'*/
-    void checkSuspiciousEqualityComparison();
 
     /** @brief %Check for objects that are destroyed immediately */
     void checkMisusedScopedObject();
@@ -241,7 +237,6 @@ private:
     void redundantCopyInSwitchError(const Token *tok1, const Token* tok2, const std::string &var);
     void redundantBitwiseOperationInSwitchError(const Token *tok, const std::string &varname);
     void suspiciousCaseInSwitchError(const Token* tok, const std::string& operatorString);
-    void suspiciousEqualityComparisonError(const Token* tok);
     void selfAssignmentError(const Token *tok, const std::string &varname);
     void misusedScopeObjectError(const Token *tok, const std::string &varname);
     void duplicateBranchError(const Token *tok1, const Token *tok2, ErrorPath errors);
@@ -306,7 +301,6 @@ private:
         c.redundantAssignmentInSwitchError(nullptr, nullptr, "var");
         c.redundantCopyInSwitchError(nullptr, nullptr, "var");
         c.suspiciousCaseInSwitchError(nullptr,  "||");
-        c.suspiciousEqualityComparisonError(nullptr);
         c.selfAssignmentError(nullptr,  "varname");
         c.clarifyCalculationError(nullptr,  "+");
         c.clarifyStatementError(nullptr);

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -101,7 +101,7 @@ public:
 
         checkOther.checkInvalidFree();
         checkOther.checkRedundantCopy();
-        checkOther.checkSuspiciousEqualityComparison();
+        // checkOther.checkSuspiciousEqualityComparison();
         checkOther.checkComparisonFunctionIsAlwaysTrueOrFalse();
         checkOther.checkAccessOfMovedVariable();
     }
@@ -228,7 +228,7 @@ private:
     void cstyleCastError(const Token *tok);
     void invalidPointerCastError(const Token* tok, const std::string& from, const std::string& to, bool inconclusive);
     void passedByValueError(const Token *tok, const std::string &parname, bool inconclusive);
-    void constStatementError(const Token *tok, const std::string &type);
+    void constStatementError(const Token *tok, const std::string &type, bool inconclusive);
     void signedCharArrayIndexError(const Token *tok);
     void unknownSignCharArrayIndexError(const Token *tok);
     void charBitOpError(const Token *tok);
@@ -298,7 +298,7 @@ private:
         c.checkCastIntToCharAndBackError(nullptr, "func_name");
         c.cstyleCastError(nullptr);
         c.passedByValueError(nullptr, "parametername", false);
-        c.constStatementError(nullptr,  "type");
+        c.constStatementError(nullptr,  "type", false);
         c.signedCharArrayIndexError(nullptr);
         c.unknownSignCharArrayIndexError(nullptr);
         c.charBitOpError(nullptr);

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -298,7 +298,7 @@ private:
         c.checkCastIntToCharAndBackError(nullptr, "func_name");
         c.cstyleCastError(nullptr);
         c.passedByValueError(nullptr, "parametername", false);
-        c.constStatementError(nullptr,  "type", false);
+        c.constStatementError(nullptr, "type", false);
         c.signedCharArrayIndexError(nullptr);
         c.unknownSignCharArrayIndexError(nullptr);
         c.charBitOpError(nullptr);

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -83,6 +83,7 @@ public:
         checkOther.checkFuncArgNamesDifferent();
         checkOther.checkShadowVariables();
         checkOther.checkConstArgument();
+        checkOther.checkIncompleteStatement();
     }
 
     /** @brief Run checks against the simplified token list */
@@ -93,7 +94,6 @@ public:
         checkOther.clarifyCalculation();
         checkOther.clarifyStatement();
         checkOther.checkPassByReference();
-        checkOther.checkIncompleteStatement();
         checkOther.checkCastIntToCharAndBack();
 
         checkOther.checkMisusedScopedObject();

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -52,7 +52,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(&tokens2);
         tokenizer.simplifyTokens1("");
-        tokenizer.simplifyTokenList2();
 
         // Check for incomplete statements..
         CheckOther checkOther(&tokenizer, &settings, this);

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -33,10 +33,11 @@ public:
 private:
     Settings settings;
 
-    void check(const char code[]) {
+    void check(const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
+        settings.inconclusive = inconclusive;
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -81,6 +82,8 @@ private:
         TEST_CASE(cpp11init2);          // #8449
         TEST_CASE(block);               // ({ do_something(); 0; })
         TEST_CASE(mapindex);
+        TEST_CASE(commaoperator);
+        TEST_CASE(redundantstmts);
     }
 
     void test1() {
@@ -297,6 +300,40 @@ private:
               "  map[{\"1\",\"2\"}]=0;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    // #8827
+    void commaoperator() {
+        check("void foo(int,const char*,int);\n"
+              "void f(int value) {\n"
+              "    foo(42,\"test\",42),(value&42);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Found suspicious operator ','\n", errout.str());
+    }
+
+    // #8451
+    void redundantstmts() {
+        check("void f1(int x) {\n"
+              "    1;\n"
+              "    (1);\n"
+              "    (char)1;\n"
+              "    ((char)1);\n"
+              "    !x;\n"
+              "    (!x);\n"
+              "    (unsigned int)!x;\n"
+              "    ~x;\n"
+              "}\n", true);
+        ASSERT_EQUALS("[test.cpp:2]: (warning) Redundant code: Found a statement that begins with numeric constant.\n"
+                      "[test.cpp:3]: (warning) Redundant code: Found a statement that begins with numeric constant.\n"
+                      "[test.cpp:4]: (warning) Redundant code: Found a statement that begins with string constant.\n"
+                      "[test.cpp:5]: (warning) Redundant code: Found a statement that begins with string constant.\n"
+                      "[test.cpp:6]: (warning, inconclusive) Found suspicious operator '!'\n"
+                      "[test.cpp:7]: (warning, inconclusive) Found suspicious operator '!'\n"
+                      "[test.cpp:9]: (warning, inconclusive) Found suspicious operator '~'\n", errout.str());
+
+        check("void f1(int x) { x; }", true);
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Unused variable value 'x'\n", errout.str());
+
     }
 };
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -2732,7 +2732,7 @@ private:
 
         // #4711 lambda functions
         check("int f() {\n"
-              "    return g([](int x){x+1; return x;});\n"
+              "    return g([](int x){(void)x+1; return x;});\n"
               "}", nullptr, false, false, false);
         ASSERT_EQUALS("", errout.str());
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1979,7 +1979,7 @@ private:
               "    switch (a)\n"
               "    {\n"
               "    case 2:\n"
-              "        y;\n"
+              "        (void)y;\n"
               "    case 3:\n"
               "        ++y;\n"
               "    }\n"
@@ -2033,7 +2033,7 @@ private:
               "    switch (a)\n"
               "    {\n"
               "    case 2:\n"
-              "        y;\n"
+              "        (void)y;\n"
               "    case 3:\n"
               "        --y;\n"
               "    }\n"
@@ -2749,7 +2749,7 @@ private:
               "             __v = ((unsigned short int) ((((__x) >> 8) & 0xff) | (((__x) & 0xff) << 8)));\n"
               "         else\n"
               "             __asm__ (\"rorw $8, %w0\" : \"=r\" (__v) : \"0\" (__x) : \"cc\");\n"
-              "         __v;\n"
+              "         (void)__v;\n"
               "     }));\n"
               "}", nullptr, false, false, false);
         ASSERT_EQUALS("", errout.str());
@@ -5463,13 +5463,13 @@ private:
         check("void foo()\n"
               "{\n"
               "   int a; a = 123;\n"
-              "   a << -1;\n"
+              "   (void)(a << -1);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Shifting by a negative value is undefined behaviour\n", errout.str());
         check("void foo()\n"
               "{\n"
               "   int a; a = 123;\n"
-              "   a >> -1;\n"
+              "   (void)(a >> -1);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Shifting by a negative value is undefined behaviour\n", errout.str());
         check("void foo()\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -2733,7 +2733,11 @@ private:
         // #4711 lambda functions
         check("int f() {\n"
               "    return g([](int x){(void)x+1; return x;});\n"
-              "}", nullptr, false, false, false);
+              "}",
+              nullptr,
+              false,
+              false,
+              false);
         ASSERT_EQUALS("", errout.str());
 
         // #4756


### PR DESCRIPTION
This reworks constStatement to find more issues. It catches issue [8827](https://trac.cppcheck.net/ticket/8827):

```cpp
extern void foo(int,const char*,int);
void f(int value)
{
        foo(42,"test",42),(value&42);
}
```

It also catches from issue [8451](https://trac.cppcheck.net/ticket/8451):

```cpp
void f1(int x) {
    1;
    (1);
    (char)1;
    ((char)1);
    !x;
    (!x);
    ~x;
}
```

And also:

```cpp
void f(int x) {
    x;
}
```

The other examples are not caught due to incomplete AST.