### PR TITLE
Extend specifications for the POSIX library

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -13,6 +13,7 @@
       <not-null/>
       <not-uninit/>
       <not-bool/>
+      <strz/>
     </arg>
   </function>
   <!-- http://man7.org/linux/man-pages/man3/a64l.3.html -->
@@ -35,6 +36,7 @@
   <function name="accept">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -57,6 +59,7 @@
     <arg nr="1">
       <not-uninit/>
       <not-null/>
+      <strz/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -68,6 +71,7 @@
   <function name="adjtime">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -103,6 +107,7 @@
   <function name="connect">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
       <not-uninit/>
       <not-bool/>
@@ -119,6 +124,7 @@
   <function name="dlopen">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="void*"/>
     <arg nr="1">
       <not-uninit/>
@@ -145,6 +151,7 @@
   <function name="dlclose">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -161,11 +168,12 @@
       <not-uninit/>
     </arg>
   </function>
-  <!-- int dup(int fildes1, int filedes2);
+  <!-- int dup2(int fildes1, int filedes2);
      see http://pubs.opengroup.org/onlinepubs/9699919799/functions/dup.html -->
   <function name="dup2">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
       <not-bool/>
       <not-uninit/>
@@ -214,6 +222,7 @@
   <function name="FD_ISSET">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -249,6 +258,7 @@
   <function name="fdatasync">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -266,10 +276,12 @@
     <arg nr="1">
       <not-uninit/>
       <not-null/>
+      <strz/>
     </arg>
     <arg nr="2">
       <not-uninit/>
       <not-null/>
+      <strz/>
     </arg>
     <arg nr="3">
       <not-uninit/>
@@ -281,6 +293,7 @@
   <function name="fsync">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -291,10 +304,12 @@
   <function name="truncate">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
       <not-uninit/>
+      <strz/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -305,6 +320,7 @@
   <function name="ftruncate">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -318,6 +334,7 @@
   <function name="flock">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -327,16 +344,31 @@
       <not-bool/>
     </arg>
   </function>
-  <!-- int symlink(const char *oldpath, const char *newpath); -->
-  <function name="symlink">
+  <function name="dprintf">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2"><formatstr/></arg>
+    <arg nr="variadic"/>
+  </function>
+  <!-- int symlink(const char *oldpath, const char *newpath); -->
+  <function name="symlink,symlinkat">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <use-retval/>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -345,11 +377,11 @@
   <!-- int open(const char *pathname, int flags) -->
   <!-- int open(const char *pathname, int flags, mode_t mode); -->
   <function name="open">
-    <!-- TODO: add use-retval when cppcheck suppresses redundant messages
-    because of violations to alloc/dealloc and use-retval configuration-->
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -368,6 +400,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -380,6 +413,7 @@
   <function name="sleep">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="unsigned int"/>
     <arg nr="1">
       <not-uninit/>
@@ -390,6 +424,7 @@
   <!-- int usleep(useconds_t useconds); -->
   <function name="usleep">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <leak-ignore/>
     <arg nr="1">
@@ -412,11 +447,13 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="faccessat">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -433,8 +470,10 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="acct">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -534,10 +573,12 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <arg nr="1">
       <not-null/>
       <not-uninit/>
+      <strz/>
     </arg>
     <arg nr="2">
       <not-uninit/>
       <not-bool/>
+      <strz/>
     </arg>
     <warn severity="portability">Non reentrant function 'getservbyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyname_r'.</warn>
   </function>
@@ -553,6 +594,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <arg nr="2">
       <not-uninit/>
       <not-bool/>
+      <strz/>
     </arg>
     <warn severity="portability">Non reentrant function 'getservbyport' called. For threadsafe applications it is recommended to use the reentrant replacement function 'getservbyport_r'.</warn>
   </function>
@@ -571,6 +613,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <leak-ignore/>
     <returnValue type="struct netent *"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -607,6 +650,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <leak-ignore/>
     <returnValue type="struct hostent *"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -620,6 +664,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <leak-ignore/>
     <returnValue type="struct hostent *"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -652,6 +697,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="brk">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -662,6 +708,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="sbrk">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="void *"/>
     <arg nr="1">
       <not-uninit/>
@@ -671,6 +718,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="closedir">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
       <not-null/>
       <not-uninit/>
@@ -681,7 +729,9 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="strfry">
     <noreturn>false</noreturn>
     <returnValue type="char *"/>
+    <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-bool/>
     </arg>
@@ -690,12 +740,14 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="strsep">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="char *"/>
     <arg nr="1">
       <not-uninit/>
       <not-null/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -707,6 +759,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <returnValue type="char *"/>
     <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -718,6 +771,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <returnValue type="char *"/>
     <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -733,6 +787,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <returnValue type="wchar_t *"/>
     <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -742,8 +797,10 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="mkstemp">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -753,8 +810,10 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
   <function name="mkdtemp">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="char *"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -767,6 +826,7 @@ The obsolescent function 'usleep' is called. POSIX.1-2001 declares usleep() func
     <leak-ignore/>
     <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -778,6 +838,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="getcwd">
     <noreturn>false</noreturn>
     <returnValue type="char *"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -792,8 +853,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="mkdir">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -806,8 +869,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="rmdir">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -817,8 +882,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="chdir">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -828,8 +895,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="chroot">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -839,12 +908,15 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="link">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -854,8 +926,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="unlink">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -865,8 +939,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="stat">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -879,8 +955,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="lstat">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -893,8 +971,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="fstat">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="2">
@@ -906,8 +986,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="chmod">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -920,6 +1002,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="fchmod">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -933,8 +1016,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="chown">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -950,8 +1035,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="lchown">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -967,6 +1054,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="fchown">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -983,6 +1071,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="times">
     <noreturn>false</noreturn>
     <returnValue type="clock_t"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-uninit/>
@@ -994,7 +1083,9 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1009,7 +1100,9 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1024,6 +1117,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="DIR *"/>
     <use-retval/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -1056,10 +1150,12 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="FILE *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -1067,6 +1163,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int pclose(FILE *stream); -->
   <function name="pclose">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1078,6 +1175,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int socket(int domain, int type, int protocol); -->
   <function name="socket">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1093,6 +1191,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int nice(int incr); -->
   <function name="nice">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <leak-ignore/>
     <arg nr="1">
@@ -1109,6 +1208,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int close(int fildes); -->
   <function name="close">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1119,6 +1219,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="confstr">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="size_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1136,6 +1237,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="fpathconf">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="long int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1149,8 +1251,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pathconf">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="long int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1163,6 +1267,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="sysconf">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="long int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1178,6 +1283,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -1225,6 +1331,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="rand_r">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -1240,10 +1347,12 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -1257,10 +1366,12 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1269,9 +1380,30 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <valid>0:</valid>
     </arg>
   </function>
+  <function name="pread">
+    <leak-ignore/>
+    <use-retval/>
+    <returnValue type="ssize_t"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <minsize type="argvalue" arg="3"/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- ssize_t read(int fd, void *buf, size_t count); -->
   <function name="read">
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1285,10 +1417,33 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <valid>0:</valid>
     </arg>
   </function>
+  <function name="pwrite">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <use-retval/>
+    <returnValue type="ssize_t"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <minsize type="argvalue" arg="3"/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- ssize_t write(int fildes, const void *buf, size_t nbyte); -->
   <function name="write">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1305,6 +1460,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- ssize_t recv(int sockfd, void *buf, size_t len, int flags); -->
   <function name="recv">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1323,6 +1479,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
                         struct sockaddr *src_addr, socklen_t *addrlen); -->
   <function name="recvfrom">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1343,6 +1500,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags); -->
   <function name="recvmsg">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1354,6 +1512,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- ssize_t send(int sockfd, const void *buf, size_t len, int flags); -->
   <function name="send">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1372,6 +1531,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
                       const struct sockaddr *dest_addr, socklen_t addrlen); -->
   <function name="sendto">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1392,6 +1552,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags); -->
   <function name="sendmsg">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <arg nr="1">
       <not-uninit/>
@@ -1460,6 +1621,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int munmap(void *addr, size_t length); -->
   <function name="munmap">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1491,6 +1653,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="fcntl">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1507,6 +1670,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="ioctl">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -1663,6 +1827,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int setpgid(pid_t pid, pid_t pgid); -->
   <function name="setpgid">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1675,6 +1840,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int pipe(int fildes[2]); -->
   <function name="pipe">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1689,6 +1855,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pselect">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-bool/>
@@ -1715,6 +1882,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="select">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-bool/>
@@ -1735,11 +1903,13 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- pid_t setpgrp(void); -->
   <function name="setpgrp">
+    <use-retval/>
     <returnValue type="pid_t"/>
     <noreturn>false</noreturn>
   </function>
   <!-- int setregid(gid_t rgid, gid_t egid); -->
   <function name="setregid">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1752,6 +1922,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int setreuid(uid_t ruid, uid_t euid); -->
   <function name="setreuid">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1764,6 +1935,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int setfsuid(uid_t fsuid); -->
   <function name="setfsuid">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1774,6 +1946,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int setfsgid(uid_t fsgid); -->
   <function name="setfsgid">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1785,11 +1958,12 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- pid_t setsid(void); -->
   <function name="setsid">
     <returnValue type="pid_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
-    <!-- it is a good idea to do: <use-retval/> -->
   </function>
   <!-- char *getwd(char *path_name);-->
   <function name="getwd">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1802,6 +1976,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://pubs.opengroup.org/onlinepubs/009695399/basedefs/arpa/inet.h.html -->
   <!-- uint32_t htonl(uint32_t); -->
   <function name="htonl">
+    <use-retval/>
     <returnValue type="uint32_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1811,6 +1986,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- uint16_t htons(uint16_t); -->
   <function name="htons">
+    <use-retval/>
     <returnValue type="uint16_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1820,6 +1996,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- uint32_t ntohl(uint32_t); -->
   <function name="ntohl">
+    <use-retval/>
     <returnValue type="uint32_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1829,6 +2006,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- uint16_t ntohs(uint16_t); -->
   <function name="ntohs">
+    <use-retval/>
     <returnValue type="uint16_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1841,6 +2019,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="inet_addr">
     <leak-ignore/>
     <pure/>
+    <use-retval/>
     <returnValue type="in_addr_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1854,6 +2033,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="inet_ntoa">
     <leak-ignore/>
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -1862,6 +2042,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int      mq_close(mqd_t); -->
   <function name="mq_close">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1871,6 +2052,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int      mq_getattr(mqd_t, struct mq_attr *); -->
   <function name="mq_getattr">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1882,6 +2064,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int      mq_notify(mqd_t, const struct sigevent *); -->
   <function name="mq_notify">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1894,11 +2077,23 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- mqd_t    mq_open(const char *, int, ...); -->
   <function name="mq_open">
+    <use-retval/>
     <returnValue type="mqd_t"/>
+    <arg nr="1">
+      <strz/>
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="any"/>
     <noreturn>false</noreturn>
   </function>
   <!-- ssize_t  mq_receive(mqd_t, char *, size_t, unsigned *); -->
   <function name="mq_receive">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1910,6 +2105,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int      mq_send(mqd_t, const char *, size_t, unsigned); -->
   <function name="mq_send">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1922,6 +2118,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int      mq_setattr(mqd_t, const struct mq_attr *restrict,-->
   <!--             struct mq_attr *restrict); -->
   <function name="mq_setattr">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1934,6 +2131,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- ssize_t  mq_timedreceive(mqd_t, char *restrict, size_t,-->
   <!--             unsigned *restrict, const struct timespec *restrict); -->
   <function name="mq_timedreceive">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1946,6 +2144,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int      mq_timedsend(mqd_t, const char *, size_t, unsigned,-->
   <!--             const struct timespec *); -->
   <function name="mq_timedsend">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1957,9 +2156,11 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int      mq_unlink(const char *); -->
   <function name="mq_unlink">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -1985,6 +2186,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int     dbm_delete(DBM *, datum); -->
   <function name="dbm_delete">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -2043,9 +2245,11 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- DBM    *dbm_open(const char *, int, mode_t); -->
   <function name="dbm_open">
+    <use-retval/>
     <returnValue type="DBM *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2059,6 +2263,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int     dbm_store(DBM *, datum, datum, int); -->
   <function name="dbm_store">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -2090,17 +2295,21 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int getaddrinfo(const char * nodename, const char * servname, const struct addrinfo * hints, struct addrinfo ** res); -->
   <function name="getaddrinfo">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="3">
       <not-uninit/>
     </arg>
     <arg nr="4">
+      <strz/>
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -2118,6 +2327,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int uname(struct utsname *buf); -->
   <function name="uname">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -2143,6 +2353,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="struct passwd *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -2156,15 +2367,17 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- char *strtok_r(char *str, const char *delim, char **saveptr); -->
   <function name="strtok_r">
-    <!-- strtok may modify the first argument, so using the return value is not mandatory -->
+    <use-retval/>
     <noreturn>false</noreturn>
     <returnValue type="char *"/>
     <pure/>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2179,6 +2392,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="4">
@@ -2202,6 +2416,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int getpwuid_r(uid_t, struct passwd *, char *, size_t, struct passwd **); -->
   <function name="getpwuid_r">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -2222,6 +2437,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int catclose(nl_catd); -->
   <function name="catclose">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2250,8 +2466,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- nl_catd catopen(const char *, int); -->
   <function name="catopen">
     <returnValue type="nl_catd"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2264,6 +2482,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int   poll(struct pollfd [], nfds_t, int); -->
   <function name="poll">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2279,11 +2498,13 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int regcomp(regex_t *, const char *, int); -->
   <function name="regcomp">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-null/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="3">
@@ -2310,12 +2531,14 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    regexec(const regex_t *, const char *, size_t, regmatch_t [restrict], int); -->
   <function name="regexec">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2342,6 +2565,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_get_priority_max(int); -->
   <function name="sched_get_priority_max">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2351,6 +2575,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_get_priority_min(int); -->
   <function name="sched_get_priority_min">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2360,6 +2585,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_getparam(pid_t, struct sched_param *); -->
   <function name="sched_getparam">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2372,6 +2598,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_getscheduler(pid_t); -->
   <function name="sched_getscheduler">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2382,6 +2609,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="sched_rr_get_interval">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1">
       <not-uninit/>
     </arg>
@@ -2393,6 +2621,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_setparam(pid_t, const struct sched_param *); -->
   <function name="sched_setparam">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2405,6 +2634,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int    sched_setscheduler(pid_t, int, const struct sched_param *); -->
   <function name="sched_setscheduler">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2419,6 +2649,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int    sched_yield(void); -->
   <function name="sched_yield">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
   </function>
@@ -2426,6 +2657,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!--      LEGACY in POSIX.1-2001, removed in POSIX.1-2008-->
   <function name="ecvt">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2446,6 +2678,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!--    LEGACY in POSIX.1-2001, removed in POSIX.1-2008-->
   <function name="fcvt">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2482,6 +2715,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- off_t lseek(int fildes, off_t offset, int whence); -->
   <function name="lseek">
     <returnValue type="off_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2497,6 +2731,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int nanosleep(const struct timespec *rqtp, struct timespec *rmtp); -->
   <function name="nanosleep">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2518,6 +2753,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- char *getpass(const char *prompt); -->
   <function name="getpass">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2535,8 +2771,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int putenv(char *string); -->
   <function name="putenv">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -2545,12 +2783,15 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int setenv(const char *envname, const char *envval, int overwrite); -->
   <function name="setenv">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2561,8 +2802,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int unsetenv(const char *name); -->
   <function name="unsetenv">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -2572,6 +2815,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="localtime,std::localtime">
     <noreturn>false</noreturn>
     <returnValue type="struct tm *"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -2584,6 +2828,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="localtime_r">
     <noreturn>false</noreturn>
     <returnValue type="struct tm *"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1">
       <not-null/>
@@ -2597,6 +2842,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- struct dirent *readdir(DIR *dirp); -->
   <function name="readdir">
     <returnValue type="struct dirent *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2609,6 +2855,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result); -->
   <function name="readdir_r">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2626,9 +2873,11 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- ssize_t readlink(const char *path, char *buf, size_t bufsiz); -->
   <function name="readlink">
     <returnValue type="ssize_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2645,9 +2894,12 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int readlinkat(int dirfd, const char *pathname, char *buf, size_t bufsiz); -->
   <function name="readlinkat">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
+      <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
@@ -2667,6 +2919,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- char *asctime_r(const struct tm *tm, char *buf); -->
   <function name="asctime_r">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2682,6 +2935,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- char *ctime_r(const time_t *timep, char *buf); -->
   <function name="ctime_r">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2697,6 +2951,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- struct tm *gmtime_r(const time_t *timep, struct tm *result); -->
   <function name="gmtime_r">
     <returnValue type="struct tm *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2725,6 +2980,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int clock_settime(clockid_t clock_id, const struct timespec *tp); -->
   <function name="clock_settime">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2737,6 +2993,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int killpg(int pgrp, int sig); -->
   <function name="killpg">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2749,6 +3006,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int kill(pid_t pid, int sig); -->
   <function name="kill">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2761,6 +3019,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int clock_gettime(clockid_t clock_id, struct timespec *tp); -->
   <function name="clock_gettime">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2773,6 +3032,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int clock_getres(clockid_t clock_id, struct timespec *res); -->
   <function name="clock_getres">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -2784,6 +3044,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- char* tmpnam(char *s); -->
   <function name="tmpnam,tmpnam_r">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2833,6 +3094,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- useconds_t ualarm(useconds_t useconds, useconds_t interval); -->
   <function name="ualarm">
     <returnValue type="useconds_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -2884,6 +3146,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2929,6 +3192,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2990,6 +3254,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- sighandler_t bsd_signal(int signum, sighandler_t handler); -->
   <function name="bsd_signal">
     <returnValue type="sighandler_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
@@ -3004,12 +3269,14 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- pid_t fork(void); -->
   <function name="fork">
     <returnValue type="pid_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
   </function>
   <!-- pid_t vfork(void); -->
   <function name="vfork">
     <returnValue type="pid_t"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <warn severity="style" reason="Obsolescent" alternatives="fork"/>
@@ -3017,24 +3284,161 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void)); -->
   <function name="pthread_atfork">
     <returnValue type="int"/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <arg nr="3"/>
-  </function>
-  <!-- int pthread_cond_signal(pthread_cond_t *cond);
-       int pthread_cond_broadcast(pthread_cond_t *cond); -->
-  <function name="pthread_cond_signal,pthread_cond_broadcast">
-    <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_attr_getdetachstate,pthread_attr_getinheritsched,pthread_attr_getschedparam,pthread_attr_getschedpolicy,pthread_attr_getscope,pthread_attr_setschedparam,pthread_cond_init,pthread_cond_wait,pthread_condattr_getclock,pthread_condattr_getpshared,pthread_mutex_getprioceiling,pthread_mutex_timedlock,pthread_mutexattr_getprioceiling,pthread_mutexattr_getprotocol,pthread_mutexattr_getpshared,pthread_mutexattr_getrobust,pthread_mutexattr_gettype,pthread_once,pthread_rwlock_init,pthread_rwlock_timedrdlock,pthread_rwlock_timedwrlock,pthread_rwlockattr_getpshared">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
       <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_attr_setdetachstate,pthread_attr_setinheritsched,pthread_attr_setschedpolicy,pthread_attr_setscope,pthread_barrierattr_setpshared,pthread_condattr_setclock,pthread_condattr_setpshared,pthread_key_create,pthread_mutexattr_setprioceiling,pthread_mutexattr_setprotocol,pthread_mutexattr_setpshared,pthread_mutexattr_setrobust,pthread_mutexattr_settype,pthread_rwlockattr_setpshared,pthread_spin_init">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_getcpuclockid,pthread_setcancelstate,pthread_setcanceltype,pthread_setspecific">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_setschedprio">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_attr_getstack,pthread_cond_timedwait">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_attr_setstack,pthread_barrier_init">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_getschedparam">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_mutex_setprioceiling">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_setschedparam">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_barrier_destroy,pthread_barrier_wait,pthread_barrierattr_destroy,pthread_barrierattr_init,pthread_cond_broadcast,pthread_cond_destroy,pthread_cond_signal,pthread_condattr_destroy,pthread_condattr_init,pthread_mutex_consistent,pthread_mutexattr_destroy,pthread_mutexattr_init,pthread_rwlock_destroy,pthread_rwlock_rdlock,pthread_rwlock_tryrdlock,pthread_rwlock_trywrlock,pthread_rwlock_unlock,pthread_rwlock_wrlock,pthread_rwlockattr_destroy,pthread_rwlockattr_init,pthread_spin_destroy,pthread_spin_lock,pthread_spin_trylock,pthread_spin_unlock">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-null/>
+    </arg>
+  </function>
+  <function name="pthread_getspecific">
+    <returnValue type="void*"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_cancel,pthread_key_delete,pthread_setconcurrency">
+    <returnValue type="int"/>
+    <use-retval/>
+    <noreturn>false</noreturn>
+    <arg nr="1">
       <not-uninit/>
     </arg>
   </function>
   <!-- int pthread_create(pthread_t * thread, const pthread_attr_t * attr, void *(*start_routine)(void*), void * arg); -->
   <function name="pthread_create">
     <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-null/>
@@ -3046,6 +3450,8 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <arg nr="4"/>
   </function>
   <function name="pthread_detach">
+    <returnValue type="int"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -3053,6 +3459,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <function name="pthread_equal">
     <noreturn>false</noreturn>
+    <returnValue type="int"/>
     <use-retval/>
     <arg nr="1">
       <not-uninit/>
@@ -3068,14 +3475,8 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_join(pthread_t thread, void **value_ptr); -->
   <function name="pthread_join">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
-    <arg nr="1">
-      <not-uninit/>
-    </arg>
-    <arg nr="2"/>
-  </function>
-  <function name="pthread_kill">
-    <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
     </arg>
@@ -3083,18 +3484,39 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-uninit/>
     </arg>
   </function>
+  <function name="pthread_kill">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="pthread_getconcurrency">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="int"/>
+  </function>
   <function name="pthread_self">
     <noreturn>false</noreturn>
     <use-retval/>
+    <returnValue type="pthread_t"/>
   </function>
   <function name="pthread_attr_destroy">
     <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
     </arg>
   </function>
   <function name="pthread_attr_init">
     <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
     </arg>
@@ -3103,6 +3525,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pthread_attr_setstackaddr">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3119,6 +3542,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pthread_attr_getstackaddr">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3134,6 +3558,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_attr_setguardsize(pthread_attr_t *attr, size_t guardsize); -->
   <function name="pthread_attr_setstacksize,pthread_attr_setguardsize">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <leak-ignore/>
     <arg nr="1">
@@ -3150,6 +3575,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_attr_getguardsize(const pthread_attr_t *attr, size_t *guardsize); -->
   <function name="pthread_attr_getstacksize,pthread_attr_getguardsize">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <leak-ignore/>
     <arg nr="1">
@@ -3164,6 +3590,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_mutex_init(pthread_mutex_t *restrict mutex, const pthread_mutexattr_t *restrict attr); -->
   <function name="pthread_mutex_init">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3175,6 +3602,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int pthread_mutex_destroy(pthread_mutex_t *mutex); -->
   <function name="pthread_mutex_destroy">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3185,6 +3613,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pthread_mutex_lock">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3195,6 +3624,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pthread_mutex_trylock">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3205,6 +3635,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <function name="pthread_mutex_unlock">
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-null/>
@@ -3416,9 +3847,11 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- char *realpath(const char *path, char *resolved_path); -->
   <function name="realpath">
     <returnValue type="char *"/>
+    <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
       <not-null/>
     </arg>
@@ -3440,6 +3873,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int fseeko(FILE *stream, off_t offset, int whence); -->
   <function name="fseeko">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3470,6 +3904,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int execv(const char *path, char *const argv[]); 
        int execvp(const char *file, char *const argv[]); -->
   <function name="execv,execvp">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3485,6 +3920,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- pid_t wait(int *stat_loc); -->
   <function name="wait">
+    <use-retval/>
     <returnValue type="pid_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3494,6 +3930,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- pid_t waitpid(pid_t pid, int *stat_loc, int options); -->
   <function name="waitpid">
+    <use-retval/>
     <returnValue type="pid_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3540,6 +3977,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://pubs.opengroup.org/onlinepubs/9699919799/functions/shmctl.html -->
   <!-- int shmctl(int shmid, int cmd, struct shmid_ds *buf); -->
   <function name="shmctl">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3554,6 +3992,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://pubs.opengroup.org/onlinepubs/009695399/functions/shmget.html -->
   <!-- int shmget(key_t key, size_t size, int shmflg); -->
   <function name="shmget">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3572,6 +4011,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/shmat.2.html -->
   <!-- void *shmat(int shmid, const void *shmaddr, int shmflg); -->
   <function name="shmat">
+    <use-retval/>
     <noreturn>false</noreturn>
     <returnValue type="void *"/>
     <leak-ignore/>
@@ -3587,6 +4027,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/shmat.2.html -->
   <!-- int shmdt(const void *shmaddr);-->
   <function name="shmdt">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3597,6 +4038,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/setrlimit.2.html -->
   <!-- int getrlimit(int resource, struct rlimit *rlim); -->
   <function name="getrlimit">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3611,6 +4053,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/setrlimit.2.html -->
   <!-- int setrlimit(int resource, const struct rlimit *rlim); -->
   <function name="setrlimit">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3626,9 +4069,11 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/glob.3.html -->
   <!-- int glob(const char *pattern, int flags, int (*errfunc) (const char *epath, int eerrno), glob_t *pglob);-->
   <function name="glob">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
       <not-null/>
     </arg>
@@ -3734,6 +4179,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-null/>
     </arg>
     <arg nr="3">
+      <strz/>
       <not-uninit/>
       <not-null/>
       <not-bool/>
@@ -3742,6 +4188,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/setitimer.2.html-->
   <!-- int getitimer(int which, struct itimerval *curr_value); -->
   <function name="getitimer">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3757,6 +4204,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/setitimer.2.html-->
   <!-- int setitimer(int which, const struct itimerval *new_value, struct itimerval *old_value); -->
   <function name="setitimer">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3771,22 +4219,81 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-bool/>
     </arg>
   </function>
-  <!-- http://man7.org/linux/man-pages/man2/sigaction.2.html -->
-  <!-- int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact); -->
-  <function name="sigaction">
+  <function name="sigtimedwait">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="sigwait">
+    <use-retval/>
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <function name="sigwaitinfo">
+    <use-retval/>
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- http://man7.org/linux/man-pages/man2/sigaction.2.html -->
+  <!-- int sigaction(int signum, const struct sigaction *act, struct sigaction *oldact); -->
+  <function name="sigaction">
+    <use-retval/>
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-bool/>
       <not-uninit/>
     </arg>
     <arg nr="3">
       <not-bool/>
+      <not-uninit/>
     </arg>
   </function>
   <!-- http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaltstack.html -->
   <!-- int sigaltstack(const stack_t *restrict ss, stack_t *restrict oss); -->
   <function name="sigaltstack">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3811,6 +4318,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://pubs.opengroup.org/onlinepubs/9699919799/functions/sigsetjmp.html -->
   <!-- int sigsetjmp(sigjmp_buf env, int savemask); -->
   <function name="sigsetjmp,_setjmp">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1"/>
@@ -3836,6 +4344,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
        sigset_t *restrict oset); -->
   <function name="pthread_sigmask,sigprocmask">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="int"/>
     <arg nr="1">
       <not-uninit/>
@@ -3851,6 +4360,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man2/getrusage.2.html-->
   <!-- int getrusage(int who, struct rusage *usage);-->
   <function name="getrusage">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3865,6 +4375,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/sigsetops.3.html -->
   <!-- int sigemptyset(sigset_t *set); -->
   <function name="sigemptyset">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3876,6 +4387,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/sigsetops.3.html -->
   <!-- int sigfillset(sigset_t *set); -->
   <function name="sigfillset">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3887,6 +4399,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/sigsetops.3.html -->
   <!-- int sigaddset(sigset_t *set, int signum); -->
   <function name="sigaddset">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3901,6 +4414,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/sigsetops.3.html -->
   <!-- int sigdelset(sigset_t *set, int signum);-->
   <function name="sigdelset">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3915,6 +4429,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://pubs.opengroup.org/onlinepubs/000095399/functions/sigismember.html -->
   <!-- int sigismember(const sigset_t *set, int signum);-->
   <function name="sigismember">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3936,15 +4451,40 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
                        const posix_spawnattr_t *restrict attrp,
                        char *const argv[restrict], char * const envp[restrict]); -->
   <function name="posix_spawn,posix_spawnp">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <arg nr="1">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <strz/>
+      <not-null/>
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="5">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
     <arg nr="6">
       <not-bool/>
+      <not-uninit/>
     </arg>
   </function>
   <!-- int msgctl(int msqid, int cmd, struct msqid_ds *buf); -->
   <function name="msgctl">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3961,6 +4501,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int msgget(key_t key, int msgflg);-->
   <function name="msgget">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <use-retval/>
@@ -3975,6 +4516,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- ssize_t msgrcv(int msqid, void *msgp, size_t msgsz, long msgtyp,
                int msgflg); -->
   <function name="msgrcv">
+    <use-retval/>
     <returnValue type="ssize_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3997,6 +4539,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int msgsnd(int msqid, const void *msgp, size_t msgsz, int msgflg); -->
   <function name="msgsnd">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4014,9 +4557,34 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-bool/>
     </arg>
   </function>
+  <function name="renameat">
+    <use-retval/>
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-bool/>
+      <strz/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="4">
+      <not-null/>
+      <not-bool/>
+      <strz/>
+    </arg>
+  </function>
   <!-- http://man7.org/linux/man-pages/man3/tcflow.3p.html -->
   <!-- int tcflow(int fildes, int action); -->
   <function name="tcflow">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4031,6 +4599,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/tcflush.3p.html -->
   <!-- int tcflush(int fildes, int queue_selector); -->
   <function name="tcflush">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4045,6 +4614,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/tcsendbreak.3p.html -->
   <!-- int tcsendbreak(int fildes, int duration); -->
   <function name="tcsendbreak">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4059,6 +4629,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/tcgetattr.3p.html -->
   <!-- int tcgetattr(int fildes, struct termios *termios_p); -->
   <function name="tcgetattr">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4073,6 +4644,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/tcsetattr.3p.html -->
   <!-- int tcsetattr(int fildes, int optional_actions, const struct termios *termios_p); -->
   <function name="tcsetattr">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4093,6 +4665,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/cfsetispeed.3p.html -->
   <!-- int cfsetispeed(struct termios *termios_p, speed_t speed); -->
   <function name="cfsetospeed,cfsetispeed">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4108,6 +4681,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- http://man7.org/linux/man-pages/man3/tcdrain.3p.html -->
   <!-- int tcdrain(int fildes); -->
   <function name="tcdrain">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4138,6 +4712,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- int gethostname(char *name, size_t len); -->
   <function name="gethostname">
+    <use-retval/>
     <noreturn>false</noreturn>
     <returnValue type="int"/>
     <arg nr="1">
@@ -4181,6 +4756,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <dealloc>munmap</dealloc>
   </memory>
   <resource>
+    <alloc init="true">catopen</alloc>
+    <dealloc>catclose</dealloc>
+  </resource>
+  <resource>
     <alloc init="true">open</alloc>
     <alloc init="true">creat</alloc>
     <alloc init="true">socket</alloc>
@@ -4203,6 +4782,54 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <alloc init="true">mq_open</alloc>
     <dealloc>mq_close</dealloc>
   </resource>
+  <memory>
+    <alloc init="true">regcomp</alloc>
+    <dealloc>regfree</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_attr_init</alloc>
+    <dealloc>pthread_attr_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_barrier_init</alloc>
+    <dealloc>pthread_barrier_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_barrierattr_init</alloc>
+    <dealloc>pthread_barrierattr_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_cond_init</alloc>
+    <dealloc>pthread_cond_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_condattr_init</alloc>
+    <dealloc>pthread_condattr_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_key_create</alloc>
+    <dealloc>pthread_key_delete</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_mutex_init</alloc>
+    <dealloc>pthread_mutex_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_mutexattr_init</alloc>
+    <dealloc>pthread_mutexattr_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_rwlock_init</alloc>
+    <dealloc>pthread_rwlock_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_rwlockattr_init</alloc>
+    <dealloc>pthread_rwlockattr_destroy</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true">pthread_spin_init</alloc>
+    <dealloc>pthread_spin_destroy</dealloc>
+  </memory>
   <memory>
     <alloc init="true" arg="4">getaddrinfo</alloc>
     <dealloc>freeaddrinfo</dealloc>


### PR DESCRIPTION
Several descriptions of functions from the POSIX programming interface can be extended.
* Mark return values as relevant for source code analysis.
* Tag some parameters for the usage of null-terminated strings.

The meta-data can be completed for the thread API.

-----

Should any software development considerations (or open issues) be taken better into account for the shown possible adjustments?