### PR TITLE
checkautovariables: eliminate false positives on assignment of &ptr->item

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -179,7 +179,7 @@ static bool isAddressOfLocalVariableRecursive(const Token *expr)
         const Token *op = expr->astOperand1();
         bool deref = false;
         while (Token::Match(op, ".|[")) {
-            if (op->str() == "[")
+            if (op->str() == "[" || op->originalName() == "->")
                 deref = true;
             op = op->astOperand1();
         }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1315,6 +1315,16 @@ private:
               "}");
 
         ASSERT_EQUALS("", errout.str());
+
+        check("struct s { void *p; };\n"
+              "extern struct s* f(void);\n"
+              "void g(void **q)\n"
+              "{\n"
+              "    struct s *r = f();\n"
+              "    *q = &r->p;\n"
+              "}\n");
+
+        ASSERT_EQUALS("", errout.str());
     }
 
     void testconstructor() { // Ticket #5478 - crash while checking a constructor


### PR DESCRIPTION
Even if `ptr` is a local variable, the object `ptr->item` might be not.  So taking address of `ptr->item` is definitely not unsafe in general.

This commit fixes false positives triggered by commit [1.85-249-gf42648fe2](https://github.com/danmar/cppcheck/commit/f42648fe2262170d065d1cc0e5e5b8a487c99435) on the following code of sssd:

https://github.com/SSSD/sssd/blob/d409df33/src/sbus/request/sbus_request.c#L359