### PR TITLE
Extend specifications for the C/C++ standard library

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -442,6 +442,7 @@
   <!-- size_t wcsftime(wchar_t* ptr, size_t maxsize, const wchar_t* format, const struct tm* timeptr); -->
   <function name="wcsftime,std::wcsftime">
     <pure/>
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -450,11 +451,12 @@
     </arg>
     <arg nr="2">
       <not-uninit/>
+      <valid>0:</valid>
     </arg>
     <arg nr="3">
       <not-null/>
       <not-uninit/>
-      <valid>0:</valid>
+      <formatstr/>
     </arg>
     <arg nr="4">
       <not-null/>
@@ -554,6 +556,7 @@
   <!-- int feclearexcept(int excepts); -->
   <function name="feclearexcept,std::feclearexcept">
     <pure/>
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -563,6 +566,7 @@
   </function>
   <!-- int fegetenv(fenv_t* envp); -->
   <function name="fegetenv,std::fegetenv">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -572,6 +576,7 @@
   </function>
   <!-- int fegetexceptflag(fexcept_t* flagp, int excepts); -->
   <function name="fegetexceptflag,std::fegetexceptflag">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -592,6 +597,7 @@
   </function>
   <!-- int feholdexcept(fenv_t* envp); -->
   <function name="feholdexcept,std::feholdexcept">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -601,6 +607,7 @@
   </function>
   <!-- int feraiseexcept(int excepts); -->
   <function name="feraiseexcept,std::feraiseexcept">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -610,6 +617,7 @@
   </function>
   <!-- int fesetenv(const fenv_t* envp); -->
   <function name="fesetenv,std::fesetenv">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -620,6 +628,7 @@
   </function>
   <!-- int fesetexceptflag(const fexcept_t* flagp, int excepts); -->
   <function name="fesetexceptflag,std::fesetexceptflag">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -633,6 +642,7 @@
   </function>
   <!-- int fesetround(int rdir); -->
   <function name="fesetround,std::fesetround">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -642,6 +652,7 @@
   </function>
   <!-- int fetestexcept(int excepts); -->
   <function name="fetestexcept,std::fetestexcept">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -651,6 +662,7 @@
   </function>
   <!-- int feupdateenv(const fenv_t* envp); -->
   <function name="feupdateenv,std::feupdateenv">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -860,6 +872,7 @@
   <!-- int atexit(void (*func)(void)); -->
   <function name="atexit,std::atexit">
     <pure/>
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1175,6 +1188,7 @@
   <!-- div_t div(int num, int denom); -->
   <function name="div,std::div">
     <pure/>
+    <use-retval/>
     <returnValue type="div_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1189,6 +1203,7 @@
   <!-- imaxdiv_t imaxdiv (intmax_t numer, intmax_t denom); -->
   <function name="imaxdiv,std::imaxdiv">
     <pure/>
+    <use-retval/>
     <returnValue type="imaxdiv_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1514,6 +1529,7 @@
   </function>
   <!-- int fclose(FILE * stream); -->
   <function name="fclose,std::fclose">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1545,6 +1561,7 @@
   </function>
   <!-- int fflush(FILE *stream); -->
   <function name="fflush,std::fflush">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1555,6 +1572,7 @@
   <!-- int fgetc(FILE *stream); -->
   <!-- int getc(FILE *stream); -->
   <function name="fgetc,std::fgetc,getc,std::getc">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1566,6 +1584,7 @@
   <!-- wint_t fgetwc(FILE * stream); -->
   <!-- wint_t getwc(FILE* stream); -->
   <function name="fgetwc,std::fgetwc,getwc,std::getwc">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1576,6 +1595,7 @@
   </function>
   <!-- int fgetpos(FILE* stream, fpos_t *ptr); -->
   <function name="fgetpos,std::fgetpos">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1808,6 +1828,7 @@
       <strz/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1816,6 +1837,7 @@
   <!--                 const char *restrict filename,-->
   <!--                 const char *restrict mode); -->
   <function name="fopen_s">
+    <use-retval/>
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -1827,12 +1849,14 @@
       <strz/>
     </arg>
     <arg nr="3">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
   </function>
   <!-- int fprintf(FILE *stream, const char *format, ...); -->
   <function name="fprintf,std::fprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1845,9 +1869,11 @@
       <formatstr/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vfprintf(FILE *stream, const char *format, va_list arg); -->
   <function name="vfprintf,std::vfprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1863,6 +1889,7 @@
   </function>
   <!-- int vfwprintf(FILE *stream, const wchar_t *format, va_list arg); -->
   <function name="vfwprintf,std::vfwprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1872,11 +1899,13 @@
     </arg>
     <arg nr="2">
       <not-uninit/>
+      <formatstr/>
     </arg>
     <arg nr="3"/>
   </function>
   <!-- int fputc(int c, FILE *stream); -->
   <function name="fputc,std::fputc">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1892,6 +1921,7 @@
   </function>
   <!-- wint_t fputwc(wchar_t wc, FILE * stream); -->
   <function name="fputwc,std::fputwc">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1906,6 +1936,7 @@
   </function>
   <!-- int fputs(const char *string, FILE* stream); -->
   <function name="fputs,std::fputs">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1921,6 +1952,7 @@
   </function>
   <!-- int fputws(const wchar_t* ws, FILE* stream); -->
   <function name="fputws,std::fputws">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1935,6 +1967,7 @@
   </function>
   <!-- size_t fread(void *ptr, size_t size, size_t nobj, FILE *stream); -->
   <function name="fread,std::fread">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -1973,6 +2006,7 @@
       <strz/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1990,9 +2024,11 @@
       <not-uninit/>
     </arg>
     <arg nr="2">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="3">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2085,6 +2121,7 @@
   </function>
   <!-- int fscanf(FILE *stream, const char *format, ...); -->
   <function name="fscanf,std::fscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2096,9 +2133,11 @@
       <formatstr/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vfscanf(FILE *stream, const char * format, va_list arg); -->
   <function name="vfscanf,std::vfscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2112,6 +2151,7 @@
   </function>
   <!-- int vfwscanf(FILE *stream, const wchar_t * format, va_list arg); -->
   <function name="vfwscanf,std::vfwscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2126,6 +2166,7 @@
   </function>
   <!-- int fseek(FILE* stream, long int offset, int origin); -->
   <function name="fseek,std::fseek">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2142,6 +2183,7 @@
   </function>
   <!-- int fsetpos(FILE *stream, const fpos_t *ptr); -->
   <function name="fsetpos,std::fsetpos">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2156,6 +2198,7 @@
   </function>
   <!-- char * fgets(char *buffer, int n, FILE *stream); -->
   <function name="fgets,std::fgets">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2175,6 +2218,7 @@
   </function>
   <!-- wchar_t* fgetws(wchar_t* ws, int num, FILE* stream); -->
   <function name="fgetws,std::fgetws">
+    <use-retval/>
     <returnValue type="wchar_t*"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2205,6 +2249,7 @@
   </function>
   <!-- int fwide(FILE* stream, int mode); -->
   <function name="fwide,std::fwide">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2218,6 +2263,7 @@
   </function>
   <!-- size_t fwrite(const void *ptr, size_t size, size_t nobj, FILE *stream); -->
   <function name="fwrite,std::fwrite">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2241,10 +2287,12 @@
   </function>
   <!-- int mblen(const char *string, size_t size); -->
   <function name="mblen,std::mblen">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="2">
@@ -2254,10 +2302,15 @@
   </function>
   <!-- int mbtowc(wchar_t* pwc, const char* pmb, size_t max); -->
   <function name="mbtowc,std::mbtowc">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
     <arg nr="2">
+      <strz/>
       <not-uninit/>
     </arg>
     <arg nr="3">
@@ -2267,10 +2320,12 @@
   </function>
   <!-- size_t mbrlen(const char* pmb, size_t max, mbstate_t* ps); -->
   <function name="mbrlen,std::mbrlen">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2296,6 +2351,7 @@
   </function>
   <!-- int mbsinit(const mbstate_t* ps); -->
   <function name="mbsinit,std::mbsinit">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2305,16 +2361,22 @@
   </function>
   <!-- wint_t getwchar(void); -->
   <function name="getwchar,std::getwchar">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
   </function>
   <!-- size_t mbstowcs(wchar_t *ws, const char *s, size_t n); -->
   <function name="mbstowcs,std::mbstowcs">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2325,9 +2387,13 @@
   </function>
   <!-- size_t mbsrtowcs(wchar_t* dest, const char** src, size_t max, mbstate_t* ps); -->
   <function name="mbsrtowcs,std::mbsrtowcs">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
     <arg nr="2">
       <not-null/>
       <not-uninit/>
@@ -2353,6 +2419,7 @@
   </function>
   <!-- int wctomb(char *s, wchar_t wchar); -->
   <function name="wctomb,std::wctomb">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2365,10 +2432,15 @@
   </function>
   <!-- size_t wcstombs(char *mbstr, const wchar_t *wcstr, size_t n);-->
   <function name="wcstombs,std::wcstombs">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
     <arg nr="2">
+      <strz/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2379,12 +2451,14 @@
   </function>
   <!-- int getchar(void); -->
   <function name="getchar,std::getchar">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
   </function>
   <!-- int ungetc(int c, FILE *stream); -->
   <function name="ungetc,std::ungetc">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2399,6 +2473,7 @@
   </function>
   <!-- wint_t ungetwc(wint_t c, FILE *stream); -->
   <function name="ungetwc,std::ungetwc">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2424,6 +2499,7 @@
   </function>
   <!-- char *gets(char *buffer); -->
   <function name="gets,std::gets">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -2435,6 +2511,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- char *gets_s(char *buffer, rsize_t size); -->
   <function name="gets_s,std::gets_s">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3062,6 +3139,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- lldiv_t lldiv(long long int num, long long int denom); -->
   <function name="lldiv,std::lldiv">
     <pure/>
+    <use-retval/>
     <returnValue type="lldiv_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3075,6 +3153,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- struct tm * localtime(const time_t *tp); -->
   <function name="localtime,std::localtime">
+    <use-retval/>
     <returnValue type="struct tm *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3085,6 +3164,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- struct tm *localtime_s(const time_t *restrict time, struct tm *restrict result) -->
   <function name="localtime_s,std::localtime_s">
+    <use-retval/>
     <returnValue type="struct tm *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3845,6 +3925,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- errno_t memset_s( void *dest, rsize_t destsz, int ch, rsize_t count ) -->
   <function name="memset_s">
+    <use-retval/>
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -3903,6 +3984,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- time_t mktime(struct tm *tp); -->
   <!-- time_t mkxtime(struct tmx *tp); -->
   <function name="mktime,std::mktime,mkxtime">
+    <use-retval/>
     <returnValue type="time_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4108,6 +4190,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int printf(const char *format, ...); -->
   <function name="printf,std::printf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4116,9 +4199,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <formatstr/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vprintf(const char *format, va_list arg); -->
   <function name="vprintf,std::vprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4130,6 +4215,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int vwprintf(const wchar_t *format, va_list arg); -->
   <function name="vwprintf,std::vwprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4190,6 +4276,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int putc(int c, FILE *stream); -->
   <function name="putc,std::putc">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4205,6 +4292,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- wint_t putwc(wchar_t wc, FILE* stream); -->
   <function name="putwc,std::putwc">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4218,6 +4306,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int puthchar(int c); -->
   <function name="putchar,std::putchar">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4229,6 +4318,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- wint_t putwchar(wchar_t wc); -->
   <function name="putwchar,std::putwchar">
+    <use-retval/>
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4238,6 +4328,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int puts(const char *string); -->
   <function name="puts,std::puts">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4250,6 +4341,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- void *realloc(void *block, size_t newsize); -->
   <function name="realloc,std::realloc">
+    <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -4262,6 +4354,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- void *reallocarray(void *ptr, size_t nmemb, size_t size); -->
   <function name="reallocarray,std::reallocarray">
+    <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -4278,6 +4371,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int remove(const char *filename); -->
   <function name="remove,std::remove">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4289,6 +4383,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int rename(const char *oldname, const char *newname); -->
   <function name="rename,std::rename">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4378,6 +4473,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- void (*signal(int sig, void (*func)(int)))(int); -->
   <function name="signal,std::signal">
+    <use-retval/>
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
@@ -4386,6 +4482,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int raise(int sig); -->
   <function name="raise,std::raise">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <arg nr="1">
@@ -4394,6 +4491,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int scanf(const char *format, ...); -->
   <function name="scanf,std::scanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4403,9 +4501,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vsscanf(const char *s, const char *format, va_list arg); -->
   <function name="vsscanf,std::vsscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4421,6 +4521,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int vswscanf(const wchar_t *s, const wchar_t *format, va_list arg); -->
   <function name="vswscanf,std::vswscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4436,6 +4537,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int vscanf(const char *format, va_list arg); -->
   <function name="vscanf,std::vscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4447,6 +4549,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int vscanf(const wchar_t *format, va_list arg); -->
   <function name="vwscanf,std::vwscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4470,6 +4573,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int setvbuf(FILE* stream, char *buf, int mode, size_t size); -->
   <function name="setvbuf,std::setvbuf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4629,6 +4733,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- size_t strftime(char *s, size_t max, const char *fmt, const struct tm *p); -->
   <!-- size_t strfxtime(char *s, size_t max, const char *fmt, const struct tmx *p); -->
   <function name="strftime,std::strftime,strfxtime">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4640,6 +4745,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:</valid>
     </arg>
     <arg nr="3">
+      <formatstr/>
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4684,6 +4790,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- errno_t strncpy_s(char *restrict dest, rsize_t destsz, const char *restrict src, rsize_t count); // since C11 -->
   <!-- errno_t wcsncpy_s(wchar_t *restrict dest, rsize_t destsz, const wchar_t *restrict src, rsize_t n); // since C11 -->
   <function name="strncpy_s,wcsncpy_s">
+    <use-retval/>
     <noreturn>false</noreturn>
     <returnValue type="errno_t"/>
     <leak-ignore/>
@@ -4744,6 +4851,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- errno_t strcat_s(char *restrict dest, rsize_t destsz, const char *restrict src); // since C11-->
   <!-- errno_t wcscat_s(wchar_t *restrict dest, rsize_t destsz, const wchar_t *restrict src); // since C11-->
   <function name="strcat_s,wcscat_s">
+    <use-retval/>
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4765,6 +4873,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- errno_t strncat_s(char *restrict dest, rsize_t destsz, const char *restrict src, rsize_t count); // since C11 -->
   <function name="strncat_s">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="errno_t"/>
     <leak-ignore/>
     <arg nr="1">
@@ -4900,6 +5009,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- size_t strxfrm(char *ds, const char *ss, size_t n); -->
   <function name="strxfrm,std::strxfrm">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4915,6 +5025,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- size_t wcsxfrm(wchar_t *s1, const wchar_t *s2, size_t n); -->
   <function name="wcsxfrm,std::wcsxfrm">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -4968,6 +5079,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- char* setlocale(int category, const char* locale); -->
   <function name="setlocale,std::setlocale">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5134,6 +5246,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- char *strtok(char *s, const char *ct); -->
   <function name="strtok,std::strtok">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5147,6 +5260,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- float strtof(const char *s, char **endp); -->
   <function name="strtof,std::strtof">
+    <use-retval/>
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5159,6 +5273,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- double strtod(const char *s, char **endp); -->
   <function name="strtod,std::strtod">
+    <use-retval/>
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5280,6 +5395,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- time_t time(time_t *tp); -->
   <function name="time,std::time">
+    <use-retval/>
     <returnValue type="time_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5289,6 +5405,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- char *tmpnam(char *s); -->
   <function name="tmpnam,std::tmpnam">
+    <use-retval/>
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5298,6 +5415,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- errno_t tmpnam_s(char *filename_s, rsize_t maxsize); -->
   <function name="tmpnam_s">
+    <use-retval/>
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5593,6 +5711,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- size_t mbrtowc(wchar_t* pwc, const char* pmb, size_t max, mbstate_t* ps); -->
   <function name="mbrtowc,std::mbrtowc">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5609,6 +5728,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- wchar_t* wcstok(wchar_t *s, const wchar_t *ct, wchar_t **ptr); -->
   <function name="wcstok,std::wcstok">
+    <use-retval/>
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5715,6 +5835,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int wprintf(const wchar_t *format, ...); -->
   <function name="wprintf,std::wprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5723,9 +5844,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <formatstr/>
       <not-null/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int sprintf(char *s, const char *format, ...); -->
   <function name="sprintf,std::sprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5739,9 +5862,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int swprintf(wchar_t *s, size_t n, const wchar_t *format, ...); -->
   <function name="swprintf,std::swprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5757,9 +5882,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vsprintf(char *s, const char *format, va_list arg); -->
   <function name="vsprintf,std::vsprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5775,6 +5902,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int vswprintf(wchar_t *s, size_t n, const wchar_t *format, va_list arg); -->
   <function name="vswprintf,std::vswprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5794,6 +5922,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int fwprintf(FILE* stream, const wchar_t* format, ...); -->
   <function name="fwprintf,std::fwprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5806,9 +5935,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int snprintf(char *s, size_t n, const char *format, ...); -->
   <function name="snprintf,std::snprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5826,9 +5957,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int vsnprintf(char *s, size_t n, const char *format, va_list arg); -->
   <function name="vsnprintf,std::vsnprintf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5849,6 +5982,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   </function>
   <!-- int wscanf(const wchar_t *format, ...); -->
   <function name="wscanf,std::wscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5858,9 +5992,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int sscanf(const char *string, const char * format, ...); -->
   <function name="sscanf,std::sscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5873,9 +6009,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int fwscanf(FILE* stream, const wchar_t* format, ...); -->
   <function name="fwscanf,std::fwscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5887,9 +6025,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <formatstr/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int swscanf(const wchar_t *string, const wchar_t *format, ...); -->
   <function name="swscanf,std::swscanf">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -5901,13 +6041,16 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <formatstr/>
       <not-uninit/>
     </arg>
+    <arg nr="variadic"/>
   </function>
   <!-- int system(const char *command); -->
   <function name="system,std::system">
+    <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1">
+      <strz/>
       <not-uninit/>
     </arg>
   </function>
@@ -6002,6 +6145,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- size_t c16rtomb ( char * pmb, char16_t c16, mbstate_t * ps ); -->
   <!-- size_t c32rtomb ( char * pmb, char32_t c32, mbstate_t * ps ); -->
   <function name="c16rtomb,c32rtomb">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -6017,6 +6161,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- size_t mbrtoc16 ( char16_t * pc16, const char * pmb, size_t max, mbstate_t * ps); -->
   <!-- size_t mbrtoc32 ( char32_t * pc32, const char * pmb, size_t max, mbstate_t * ps); -->
   <function name="mbrtoc16,mbrtoc32">
+    <use-retval/>
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
@@ -6031,6 +6176,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="4">
       <not-null/>
       <not-uninit/>
+    </arg>
+  </function>
+  <function name="at_quick_exit,std::at_quick_exit">
+    <use-retval/>
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-null/>
     </arg>
   </function>
   <!-- template< class T > void swap( T& a, T& b );-->


### PR DESCRIPTION
Several descriptions of functions from the standard library of the programming languages “C” and “C++” can be extended.
* Mark return values as relevant for source code analysis.
* Tag some parameters for the usage of null-terminated strings.
* Categorise a few arguments as format strings.
* Tag some parameters additionally as variadic.

-----

Should any software development considerations (or open issues) be taken better into account for the shown possible adjustments?