### PR TITLE
Unify reportError() output across addons

### DIFF
--- a/addons/cert.py
+++ b/addons/cert.py
@@ -22,7 +22,7 @@ def reportError(token, severity, msg, id):
         VERIFY_ACTUAL.append(str(token.linenr) + ':' + id)
     else:
         sys.stderr.write(
-            '[' + token.file + ':' + str(token.linenr) + '] (' + severity + '): ' + msg + ' [' + id + ']\n')
+            '[' + token.file + ':' + str(token.linenr) + '] (' + severity + ') CERT: ' + msg + ' [' + id + ']\n')
 
 def simpleMatch(token, pattern):
     for p in pattern.split(' '):

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1924,8 +1924,8 @@ class MisraChecker:
                 return
             formattedMsg = cppcheckdata.reportError(args.template,
                                                     callstack=[(location.file, location.linenr)],
-                                                    severity='style',
-                                                    message = errmsg,
+                                                    severity= 'style',
+                                                    message = 'MISRA: ' + errmsg,
                                                     errorId = id,
                                                     suppressions = self.dumpfileSuppressions)
             if formattedMsg:

--- a/addons/namingng.py
+++ b/addons/namingng.py
@@ -117,9 +117,12 @@ def process(dumpfiles, configfile, debugprint=False):
 
                         if debugprint:
                             print("Variable Name: " + str(var.nameToken.str))
-                            print("original Type Name: " + str(var.nameToken.valueType.originalTypeName))
-                            print("Type Name: " + var.nameToken.valueType.type)
-                            print("Sign: " + str(var.nameToken.valueType.sign))
+                            if var.nameToken.valueType is not None:
+                                print("original Type Name: " + str(var.nameToken.valueType.originalTypeName))
+                                print("Type Name: " + var.nameToken.valueType.type)
+                                print("Sign: " + str(var.nameToken.valueType.sign))
+                            else:
+                                print("valueType: None")
                             print("variable type: " + varType)
                             print("\n")
                             print("\t-- {} {}".format(varType, str(var.nameToken.str)))

--- a/addons/namingng.py
+++ b/addons/namingng.py
@@ -36,7 +36,7 @@ class dataStruct:
         self.str = string
 
 def reportError(filename, linenr, severity, msg):
-    message = "[{filename}:{linenr}] ( {severity} ) naming.py: {msg}\n".format(
+    message = "[{filename}:{linenr}]: ({severity}) Naming: {msg}\n".format(
         filename=filename,
         linenr=linenr,
         severity=severity,

--- a/addons/namingng.py
+++ b/addons/namingng.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
     parser.add_argument("--configfile", type=str, default="naming.json",
                         help="Naming check config file")
     parser.add_argument("--verify", action="store_true", default=False,
-                        help="verify this script. Bust be executed in test folder !")
+                        help="verify this script. Must be executed in test folder !")
 
     args = parser.parse_args()
     errors = process(args.dumpfiles, args.configfile, args.debugprint)
@@ -226,12 +226,12 @@ if __name__ == "__main__":
             print("Not enough errors found")
             sys.exit(1)
         target = [
-         '[namingng_test.c:8] ( style ) naming.py: Variable badui32 violates naming convention\n',
-         '[namingng_test.c:11] ( style ) naming.py: Variable a violates naming convention\n',
-         '[namingng_test.c:29] ( style ) naming.py: Variable badui32 violates naming convention\n',
-         '[namingng_test.c:20] ( style ) naming.py: Function ui16bad_underscore violates naming convention\n',
-         '[namingng_test.c:25] ( style ) naming.py: Function u32Bad violates naming convention\n',
-         '[namingng_test.c:37] ( style ) naming.py: Function Badui16 violates naming convention\n']
+         '[namingng_test.c:8]: (style) Naming: Variable badui32 violates naming convention\n',
+         '[namingng_test.c:11]: (style) Naming: Variable a violates naming convention\n',
+         '[namingng_test.c:29]: (style) Naming: Variable badui32 violates naming convention\n',
+         '[namingng_test.c:20]: (style) Naming: Function ui16bad_underscore violates naming convention\n',
+         '[namingng_test.c:25]: (style) Naming: Function u32Bad violates naming convention\n',
+         '[namingng_test.c:37]: (style) Naming: Function Badui16 violates naming convention\n']
         diff = set(errors) - set(target)
         if len(diff):
             print("Not the right errors found {}".format(str(diff)))


### PR DESCRIPTION
cert.py,misra.py,namingng.py: unify reportError() output, to be able to catch all output with one regex in Eclipse