### PR TITLE
threadexecutor.h: Disable THREADING_MODEL_FORK for Cygwin (trac 8973)

### DIFF
--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -27,7 +27,7 @@
 #include <map>
 #include <string>
 
-#if (defined(__GNUC__) || defined(__sun)) && !defined(__MINGW32__)
+#if (defined(__GNUC__) || defined(__sun)) && !defined(__MINGW32__) && !defined(__CYGWIN__)
 #define THREADING_MODEL_FORK
 #elif defined(_WIN32)
 #define THREADING_MODEL_WIN


### PR DESCRIPTION
The fork implementation in Cygwin seems to be not very reliable.
See also the Cygwin documentation here: https://cygwin.com/faq/faq.html#faq.using.fixing-fork-failures
More details in the ticket https://trac.cppcheck.net/ticket/8973