### PR TITLE
qt.cfg: Add Q_DECLARE_TR_FUNCTIONS() and others

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1247,6 +1247,27 @@
       <strz/>
     </arg>
   </function>
+  <!-- QString QCoreApplication::translate(const char *context, const char *sourceText, const char *disambiguation = nullptr, int n = -1) //static -->
+  <function name="QCoreApplication::translate">
+    <noreturn>false</noreturn>
+    <returnValue type="QString"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+      <not-bool/>
+    </arg>
+    <arg nr="3" default="NULL">
+      <not-bool/>
+    </arg>
+    <arg nr="4" default="-1">
+    </arg>
+  </function>
   <container id="qtContainer" opLessAllowed="false">
     <type templateParameter="0"/>
     <size>
@@ -1310,8 +1331,10 @@
   <define name="Q_CLASSINFO(Name, Value)" value=""/>
   <define name="Q_DECL_EXPORT" value=""/>
   <define name="Q_DECL_IMPORT" value=""/>
+  <define name="QT_DECLARE_DEPRECATED_TR_FUNCTIONS(context)" value="static inline QString trUtf8(const char *sourceText, const char *disambiguation = Q_NULLPTR, int n = -1) { return QCoreApplication::translate(#context, sourceText, disambiguation, n); }"/>
   <define name="Q_DECLARE_FLAGS(x,y)" value=""/>
   <define name="Q_DECLARE_PRIVATE(Class)" value="inline Class##Private* d_func() { return reinterpret_cast&lt;Class##Private*&gt;(qGetPtrHelper(d_ptr)); } inline const Class##Private d_func() const { return reinterpret_cast&lt;const Class##Private *&gt;(qGetPtrHelper(d_ptr)); } friend class Class##Private;"/>
+  <define name="Q_DECLARE_TR_FUNCTIONS(context)" value="public: static inline QString tr(const char *sourceText, const char *disambiguation = Q_NULLPTR, int n = -1) { return QCoreApplication::translate(#context, sourceText, disambiguation, n); } QT_DECLARE_DEPRECATED_TR_FUNCTIONS(context) private:"/>
   <define name="Q_DISABLE_COPY(C)" value="C(C&amp;);C&amp; operator=(const C&amp;);"/>
   <define name="Q_ENUM(X)" value=""/>
   <define name="Q_ENUMS(X)" value=""/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -50,12 +50,14 @@ public:
 
 void MacroTest2_test()
 {
+    // TODO: remove suppression when #9002 is fixed
     // cppcheck-suppress checkLibraryFunction
     QString str = MacroTest2::tr("hello");
     QByteArray ba = str.toLatin1();
     printf(ba.data());
 
 #ifndef QT_NO_DEPRECATED
+    // TODO: remove suppression when #9002 is fixed
     // cppcheck-suppress checkLibraryFunction
     str = MacroTest2::trUtf8("test2");
     ba = str.toLatin1();

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -12,6 +12,7 @@
 #include <QtPlugin>
 #include <QFile>
 #include <cstdio>
+#include <QCoreApplication>
 
 
 void QString1(QString s)
@@ -38,6 +39,29 @@ public:
     explicit MacroTest1(QObject *parent = 0);
     ~MacroTest1();
 };
+
+class MacroTest2 {
+    Q_DECLARE_TR_FUNCTIONS(MacroTest2)
+
+public:
+    MacroTest2();
+    ~MacroTest2();
+};
+
+void MacroTest2_test()
+{
+    // cppcheck-suppress checkLibraryFunction
+    QString str = MacroTest2::tr("hello");
+    QByteArray ba = str.toLatin1();
+    printf(ba.data());
+
+#ifndef QT_NO_DEPRECATED
+    // cppcheck-suppress checkLibraryFunction
+    str = MacroTest2::trUtf8("test2");
+    ba = str.toLatin1();
+    printf(ba.data());
+#endif
+}
 
 void validCode(int * pIntPtr)
 {


### PR DESCRIPTION
Add unknownMacro Q_DECLARE_TR_FUNCTIONS found via daca@home.
Add function QCoreApplication::translate() and macro
QT_DECLARE_DEPRECATED_TR_FUNCTIONS() the unknownMacro depends on.
Reference:
https://doc.qt.io/qt-5/qcoreapplication.html#Q_DECLARE_TR_FUNCTIONS
https://doc.qt.io/qt-5/qcoreapplication.html#translate