### PR TITLE
Fix issue 8987: False positive knownConditionTrueFalse

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1331,7 +1331,7 @@ void CheckCondition::alwaysTrueFalse()
             if (!(constIfWhileExpression || constValExpr || compExpr || returnStatement))
                 continue;
 
-            if (returnStatement && scope->function && !Token::simpleMatch(scope->function->retDef, "bool"))
+            if (returnStatement && (!scope->function || !Token::simpleMatch(scope->function->retDef, "bool")))
                 continue;
 
             if (returnStatement && isConstVarExpression(tok))

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2872,6 +2872,15 @@ private:
               "  else return 42;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("long X::g(bool unknown, int& result) {\n"
+              "    long ret = 0;\n"
+              "    bool f = false;\n"
+              "    f = f || unknown;\n"
+              "    f ? result = 42 : ret = -1;\n"
+              "    return ret;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void multiConditionAlwaysTrue() {


### PR DESCRIPTION
This fixes:

```cpp
long X::g(bool unknown, int& result)
{
    long ret = 0;
    bool f = false;
    f = f || unknown;
    f ? result = 42 : ret = -1;
    return ret;
}
```