### PR TITLE
donate-cpu.py: Improve header detection by using regex.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -216,7 +216,7 @@ def hasInclude(path, includes):
                     # Python3 directly reads the data into a string object that has no decode()
                     pass
                 f.close()
-                re_includes = map(lambda x: re.escape(x), includes)
+                re_includes = [re.escape(inc) for inc in includes]
                 if re.search('\n#[ \t]*include[ \t]+(' + '|'.join(re_includes) + ')', filedata):
                     return True
             except IOError:

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -37,7 +37,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.5"
+CLIENT_VERSION = "1.1.6"
 
 
 def checkRequirements():
@@ -216,9 +216,9 @@ def hasInclude(path, includes):
                     # Python3 directly reads the data into a string object that has no decode()
                     pass
                 f.close()
-                for inc in includes:
-                    if filedata.find('\n#include ' + inc) >= 0:
-                        return True
+                re_includes = map(lambda x: re.escape(x), includes)
+                if re.search('\n#[ \t]*include[ \t]+(' + '|'.join(re_includes) + ')', filedata):
+                    return True
             except IOError:
                 pass
     return False


### PR DESCRIPTION
This detects more includes / headers. For example includes like
"# include <gtk/gtk.h>" with a space before "include" as it is used in
the package http://cppcheck.osuosl.org:8000/gbatnav are now also
detected.
The regex search also searches all includes for one library in one go
instead of one include per loop.
Tested with several packages to make sure libraries that were detected
before are still detected.