### PR TITLE
Forward lifetimes in "for" loops

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2769,19 +2769,19 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
                          errorLogger,
                          settings);
 
-        if (tok->astTop() && Token::simpleMatch(tok->astTop()->previous(), "for (") && Token::simpleMatch(tok->astTop()->link(), ") {")) {
-            const Token* start = tok->astTop()->link()->next();
+        if (tok->astTop() && Token::simpleMatch(tok->astTop()->previous(), "for (") &&
+            Token::simpleMatch(tok->astTop()->link(), ") {")) {
+            const Token *start = tok->astTop()->link()->next();
             valueFlowForward(const_cast<Token *>(start),
-                         start->link(),
-                         var,
-                         var->declarationId(),
-                         values,
-                         false,
-                         false,
-                         tokenlist,
-                         errorLogger,
-                         settings);
-
+                             start->link(),
+                             var,
+                             var->declarationId(),
+                             values,
+                             false,
+                             false,
+                             tokenlist,
+                             errorLogger,
+                             settings);
         }
         // Function call
     } else if (Token::Match(parent->previous(), "%name% (")) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2729,7 +2729,7 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
     if (!parent)
         return;
     // Assignment
-    if (parent->str() == "=" && !parent->astParent()) {
+    if (parent->str() == "=" && (!parent->astParent() || Token::simpleMatch(parent->astParent(), ";"))) {
         // Lhs should be a variable
         if (!parent->astOperand1() || !parent->astOperand1()->varId())
             return;
@@ -2768,6 +2768,21 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
                          tokenlist,
                          errorLogger,
                          settings);
+
+        if (tok->astTop() && Token::simpleMatch(tok->astTop()->previous(), "for (") && Token::simpleMatch(tok->astTop()->link(), ") {")) {
+            const Token* start = tok->astTop()->link()->next();
+            valueFlowForward(const_cast<Token *>(start),
+                         start->link(),
+                         var,
+                         var->declarationId(),
+                         values,
+                         false,
+                         false,
+                         tokenlist,
+                         errorLogger,
+                         settings);
+
+        }
         // Function call
     } else if (Token::Match(parent->previous(), "%name% (")) {
         valueFlowLifetimeFunction(const_cast<Token *>(parent->previous()), tokenlist, errorLogger, settings);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1538,6 +1538,16 @@ private:
             "[test.cpp:6] -> [test.cpp:6] -> [test.cpp:6] -> [test.cpp:4] -> [test.cpp:7]: (error) Non-local variable 'm' will use object that points to local variable 'x'.\n",
             errout.str());
 
+        check("std::vector<int>::iterator f(std::vector<int> v) {\n"
+              "    for(auto it = v.begin();it != v.end();it++) {\n"
+              "        return it;\n"
+              "    }\n"
+              "    return {};\n"
+              "}\n");
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:1] -> [test.cpp:3]: (error) Returning iterator to local container 'v' that will be invalid when returning.\n",
+            errout.str());
+
         check("struct A {\n"
               "    std::vector<std::string> v;\n"
               "    void f() {\n"


### PR DESCRIPTION
This will now warn for cases like this:

```cpp
std::vector<int>::iterator f(std::vector<int> v) {
    for(auto it = v.begin();it != v.end();it++) {
        return it;
    }
    return {};
}
```