### PR TITLE
libcerror.cfg: Add libcerror configuration file.

### DIFF
--- a/cfg/libcerror.cfg
+++ b/cfg/libcerror.cfg
@@ -1,0 +1,128 @@
+<?xml version="1.0"?>
+<!-- Official repository: https://github.com/libyal/libcerror -->
+<!-- Typically included by: #include <libcerror.h> -->
+<def format="2">
+  <!-- int libcerror_error_initialize( libcerror_error_t **error,
+                                       int error_domain,
+                                       int error_code ); -->
+  <function name="libcerror_error_initialize">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- void libcerror_error_set( libcerror_error_t **error,
+                                 int error_domain,
+                                 int error_code,
+                                 const char *format_string,
+                                 ... ); -->
+  <function name="libcerror_error_set">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+    <formatstr/>
+    <arg nr="4">
+      <not-null/>
+      <not-uninit/>
+      <formatstr/>
+      <strz/>
+    </arg>
+  </function>
+  <!-- void libcerror_error_free( libcerror_error_t **error ); -->
+  <function name="libcerror_error_free">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- int libcerror_error_resize( libcerror_internal_error_t *internal_error ); -->
+  <function name="libcerror_error_resize">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- int libcerror_error_fprint( libcerror_error_t *error, FILE *stream ); -->
+  <!-- int libcerror_error_backtrace_fprint( libcerror_error_t *error, FILE *stream ); -->
+  <function name="libcerror_error_fprint,libcerror_error_backtrace_fprint">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- int libcerror_error_sprint( libcerror_error_t *error, char *string, size_t size ); -->
+  <!-- int libcerror_error_backtrace_sprint( libcerror_error_t *error, char *string, size_t size ); -->
+  <function name="libcerror_error_sprint,libcerror_error_backtrace_sprint">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-null/>
+      <minsize type="argvalue" arg="3"/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
+  </function>
+  <!-- void libcerror_system_set_error( libcerror_error_t **error,
+                                        int error_domain,
+                                        int error_code,
+                                        uint32_t system_error_code,
+                                        const char *format_string,
+                                        ... ); -->
+  <function name="libcerror_system_set_error">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+    </arg>
+    <arg nr="4">
+      <not-uninit/>
+    </arg>
+    <formatstr/>
+    <arg nr="5">
+      <not-null/>
+      <not-uninit/>
+      <formatstr/>
+      <strz/>
+    </arg>
+  </function>
+</def>

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -231,6 +231,7 @@ def scanPackage(workPath, cppcheckPath, jobs, fast):
 
     libraryIncludes = {'boost': ['<boost/'],
                        'gtk': ['<gtk/gtk.h>', '<glib.h>', '<glib/'],
+                       # 'libcerror': ['<libcerror.h>'], <- Enable after release of 1.88
                        'motif': ['<X11/', '<Xm/'],
                        'python': ['<Python.h>'],
                        'qt': ['<QApplication>', '<QString>', '<QWidget>', '<QtWidgets>', '<QtGui'],


### PR DESCRIPTION
The function libcerror_error_set() is currently the function for which
daca@home most often reports a missing configuration (more than 80000
times).
Official repository of libcerror: https://github.com/libyal/libcerror
The library configuration has been tested with the library libvhdi:
ftp://ftp.se.debian.org/debian/pool/main/libv/libvhdi/libvhdi_20181227.orig.tar.gz