### PR TITLE
7772 Add uninitMemberVarPrivate to errorlist (really) #1557

### DIFF
--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -208,7 +208,7 @@ private:
         c.noOperatorEqError(nullptr, false, nullptr, false);
         c.noDestructorError(nullptr, false, nullptr);
         c.uninitVarError(nullptr, false, "classname", "varname", false);
-        c.uninitVarError(nullptr, true, "classname", "varname", false);
+        c.uninitVarError(nullptr, true, "classname", "varnamepriv", false);
         c.operatorEqVarError(nullptr, "classname", emptyString, false);
         c.unusedPrivateFunctionError(nullptr, "classname", "funcname");
         c.memsetError(nullptr, "memfunc", "classname", "class");


### PR DESCRIPTION
Previous attempt 70527a78f70aa35df141cea3fadf08ca6468cf1c
doesn't work because equal error messages are filtered.