### PR TITLE
Fix issue 1777: Undefined Behavior: Comparing pointers to different objects

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2878,8 +2878,6 @@ void CheckOther::checkComparePointers()
                 continue;
             if (v1.tokvalue->varId() == v2.tokvalue->varId())
                 continue;
-            if (var1->isPointer() || var2->isPointer())
-                continue;
             if (var1->isReference() || var2->isReference())
                 continue;
             if (var1->isRValueReference() || var2->isRValueReference())

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2837,10 +2837,10 @@ void CheckOther::constArgumentError(const Token *tok, const Token *ftok, const V
     reportError(errorPath, Severity::style, "constArgument", errmsg, CWE570, false);
 }
 
-static ValueFlow::Value getLifetimeObjValue(const Token* tok)
+static ValueFlow::Value getLifetimeObjValue(const Token *tok)
 {
     ValueFlow::Value result;
-    auto pred = [](const ValueFlow::Value& v) {
+    auto pred = [](const ValueFlow::Value &v) {
         if (!v.isLocalLifetimeValue())
             return false;
         if (!v.tokvalue->variable())
@@ -2864,16 +2864,16 @@ void CheckOther::checkComparePointers()
         for (const Token *tok = functionScope->bodyStart; tok != functionScope->bodyEnd; tok = tok->next()) {
             if (!Token::Match(tok, "<|>|<=|>="))
                 continue;
-            const Token * tok1 = tok->astOperand1();
-            const Token * tok2 = tok->astOperand2();
+            const Token *tok1 = tok->astOperand1();
+            const Token *tok2 = tok->astOperand2();
             if (!astIsPointer(tok1) || !astIsPointer(tok2))
                 continue;
             ValueFlow::Value v1 = getLifetimeObjValue(tok1);
             ValueFlow::Value v2 = getLifetimeObjValue(tok2);
             if (!v1.isLocalLifetimeValue() || !v2.isLocalLifetimeValue())
                 continue;
-            const Variable * var1 = v1.tokvalue->variable();
-            const Variable * var2 = v2.tokvalue->variable();
+            const Variable *var1 = v1.tokvalue->variable();
+            const Variable *var2 = v2.tokvalue->variable();
             if (!var1 || !var2)
                 continue;
             if (v1.tokvalue->varId() == v2.tokvalue->varId())
@@ -2899,5 +2899,6 @@ void CheckOther::comparePointersError(const Token *tok, const ValueFlow::Value *
         errorPath.insert(errorPath.end(), v2->errorPath.begin(), v2->errorPath.end());
     }
     errorPath.emplace_back(tok, "");
-    reportError(errorPath, Severity::error, "comparePointers", "Comparing pointers that point to different objects", CWE570, false);
+    reportError(
+        errorPath, Severity::error, "comparePointers", "Comparing pointers that point to different objects", CWE570, false);
 }

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -83,6 +83,7 @@ public:
         checkOther.checkFuncArgNamesDifferent();
         checkOther.checkShadowVariables();
         checkOther.checkConstArgument();
+        checkOther.checkComparePointers();
         checkOther.checkIncompleteStatement();
     }
 
@@ -214,6 +215,8 @@ public:
 
     void checkConstArgument();
 
+    void checkComparePointers();
+
 private:
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &functionName, const std::string &varName, const bool result);
@@ -267,6 +270,7 @@ private:
     void funcArgOrderDifferent(const std::string & functionName, const Token * declaration, const Token * definition, const std::vector<const Token*> & declarations, const std::vector<const Token*> & definitions);
     void shadowError(const Token *var, const Token *shadowed, bool shadowVar);
     void constArgumentError(const Token *tok, const Token *ftok, const ValueFlow::Value *value);
+    void comparePointersError(const Token *tok, const ValueFlow::Value *v1, const ValueFlow::Value *v2);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckOther c(nullptr, settings, errorLogger);
@@ -331,6 +335,7 @@ private:
         c.shadowError(nullptr, nullptr, false);
         c.shadowError(nullptr, nullptr, true);
         c.constArgumentError(nullptr, nullptr, nullptr);
+        c.comparePointersError(nullptr, nullptr, nullptr);
 
         const std::vector<const Token *> nullvec;
         c.funcArgOrderDifferent("function", nullptr, nullptr, nullvec, nullvec);

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -217,7 +217,7 @@ public:
 
     void checkComparePointers();
 
-private:
+  private:
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &functionName, const std::string &varName, const bool result);
     void checkCastIntToCharAndBackError(const Token *tok, const std::string &strFunctionName);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3039,6 +3039,8 @@ static bool isDecayedPointer(const Token *tok, const Settings *settings)
         return false;
     if (astIsPointer(tok->astParent()) && !Token::simpleMatch(tok->astParent(), "return"))
         return true;
+    if (Token::Match(tok->astParent(), "%cop%"))
+        return true;
     if (!Token::simpleMatch(tok->astParent(), "return"))
         return false;
     if (!tok->scope())

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2727,8 +2727,7 @@ const Token *getLifetimeToken(const Token *tok, ValueFlow::Value::ErrorPath &err
         if (!vartok)
             return tok;
         const Variable *tokvar = vartok->variable();
-        if (!astIsContainer(vartok) && !(tokvar && tokvar->isArray()) && Token::Match(vartok->astParent(), "[|*|.") &&
-            vartok->astParent()->originalName() != ".") {
+        if (!astIsContainer(vartok) && !(tokvar && tokvar->isArray()) && (Token::Match(vartok->astParent(), "[|*") || vartok->astParent()->originalName() == "->")) {
             for (const ValueFlow::Value &v : vartok->values()) {
                 if (!v.isLocalLifetimeValue())
                     continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2727,7 +2727,8 @@ const Token *getLifetimeToken(const Token *tok, ValueFlow::Value::ErrorPath &err
         if (!vartok)
             return tok;
         const Variable *tokvar = vartok->variable();
-        if (!astIsContainer(vartok) && !(tokvar && tokvar->isArray()) && (Token::Match(vartok->astParent(), "[|*") || vartok->astParent()->originalName() == "->")) {
+        if (!astIsContainer(vartok) && !(tokvar && tokvar->isArray()) &&
+            (Token::Match(vartok->astParent(), "[|*") || vartok->astParent()->originalName() == "->")) {
             for (const ValueFlow::Value &v : vartok->values()) {
                 if (!v.isLocalLifetimeValue())
                     continue;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7592,7 +7592,8 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void checkComparePointers() {
+    void checkComparePointers()
+    {
         check("int f() {\n"
               "    int foo[1] = {0};\n"
               "    int bar[1] = {0};\n"
@@ -7602,7 +7603,9 @@ private:
               "    }\n"
               "    return diff;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:5]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:5]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("bool f() {\n"
               "    int x = 0;\n"
@@ -7611,14 +7614,18 @@ private:
               "    int* yp = &y;\n"
               "    return xp > yp;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:6]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:6]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("bool f() {\n"
               "    int x = 0;\n"
               "    int y = 1;\n"
               "    return &x > &y;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:4] -> [test.cpp:4]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:4] -> [test.cpp:4]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("struct A {int data;};\n"
               "bool f() {\n"
@@ -7628,7 +7635,9 @@ private:
               "    int* yp = &y.data;\n"
               "    return xp > yp;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:5] -> [test.cpp:1] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:1] -> [test.cpp:5] -> [test.cpp:1] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("struct A {int data;};\n"
               "bool f(A ix, A iy) {\n"
@@ -7638,12 +7647,16 @@ private:
               "    int* yp = &y->data;\n"
               "    return xp > yp;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:2] -> [test.cpp:4] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:2] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:2] -> [test.cpp:4] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("bool f(int * xp, int* yp) {\n"
               "    return &xp > &yp;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:2]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:1] -> [test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:2]: (error) Comparing pointers that point to different objects\n",
+            errout.str());
 
         check("bool f() {\n"
               "    int x[2] = {1, 2}m;\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7613,6 +7613,13 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:6]: (error) Comparing pointers that point to different objects\n", errout.str());
 
+        check("bool f() {\n"
+              "    int x = 0;\n"
+              "    int y = 1;\n"
+              "    return &x > &y;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:4] -> [test.cpp:4]: (error) Comparing pointers that point to different objects\n", errout.str());
+
         check("struct A {int data;};\n"
               "bool f() {\n"
               "    A x;\n"
@@ -7621,7 +7628,60 @@ private:
               "    int* yp = &y.data;\n"
               "    return xp > yp;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:5]: (error) Comparing pointers that point to different objects\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:5] -> [test.cpp:1] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n", errout.str());
+
+        check("struct A {int data;};\n"
+              "bool f(A ix, A iy) {\n"
+              "    A* x = &ix;\n"
+              "    A* y = &iy;\n"
+              "    int* xp = &x->data;\n"
+              "    int* yp = &y->data;\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:2] -> [test.cpp:4] -> [test.cpp:6] -> [test.cpp:7]: (error) Comparing pointers that point to different objects\n", errout.str());
+
+        check("bool f(int * xp, int* yp) {\n"
+              "    return &xp > &yp;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:1] -> [test.cpp:2] -> [test.cpp:2]: (error) Comparing pointers that point to different objects\n", errout.str());
+
+        check("bool f() {\n"
+              "    int x[2] = {1, 2}m;\n"
+              "    int* xp = &x[0];\n"
+              "    int* yp = &x[1];\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f(int * xp, int* yp) {\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f(int & x, int& y) {\n"
+              "    return &x > &y;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int& g();\n"
+              "bool f() {\n"
+              "    int& x = g();\n"
+              "    int& y = g();\n"
+              "    int* xp = &x;\n"
+              "    int* yp = &y;\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct A {int data;};\n"
+              "bool f(A ix) {\n"
+              "    A* x = &ix;\n"
+              "    A* y = x;\n"
+              "    int* xp = &x->data;\n"
+              "    int* yp = &y->data;\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -223,6 +223,7 @@ private:
 
         TEST_CASE(shadowVariables);
         TEST_CASE(constArgument);
+        TEST_CASE(checkComparePointers);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool runSimpleChecks=true, bool verbose=false, Settings* settings = 0) {
@@ -7574,6 +7575,38 @@ private:
               "    g(static_cast<int>(i));\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkComparePointers() {
+        check("int f() {\n"
+              "    int foo[1] = {0};\n"
+              "    int bar[1] = {0};\n"
+              "    int diff = 0;\n"
+              "    if(foo > bar) {\n"
+              "       diff = 1;\n"
+              "    }\n"
+              "    return diff;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:5]: (error) Comparing pointers that point to different objects\n", errout.str());
+
+        check("bool f() {\n"
+              "    int x = 0;\n"
+              "    int y = 0;\n"
+              "    int* xp = &x;\n"
+              "    int* yp = &y;\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:4] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:6]: (error) Comparing pointers that point to different objects\n", errout.str());
+
+        check("struct A {int data;};\n"
+              "bool f() {\n"
+              "    A x;\n"
+              "    A y;\n"
+              "    int* xp = &x.data;\n"
+              "    int* yp = &y.data;\n"
+              "    return xp > yp;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:5] -> [test.cpp:5]: (error) Comparing pointers that point to different objects\n", errout.str());
     }
 };
 


### PR DESCRIPTION
This uses the lifetime analysis to check when comparing pointer that point to different objects:

```cpp
int main(void)
{
    int foo[10];
    int bar[10];
    int diff;

    if(foo > bar)   // Undefined Behavior
    {
       diff = 1;
    }

    return 0;
}
```