### PR TITLE
itions of QCOMPARE, QVERIFY & QVERIFY2, this are qtest macros not asserts

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1335,6 +1335,14 @@
   <define name="QCOMPARE(a,b)" value=""/>
   <define name="QVERIFY(expr)" value=""/>
   <define name="QVERIFY2(cond, msg)" value=""/>
+  <define name="QBENCHMARK_ONCE" value=""/>
+  <define name="QBENCHMARK" value=""/>
+  <define name="QTRY_COMPARE(actual, expected)" value=""/>
+  <define name="QTRY_COMPARE_WITH_TIMEOUT(actual, expected, timeout)" value=""/>
+  <define name="QTRY_VERIFY2(condition, message)" value=""/>
+  <define name="QTRY_VERIFY(condition)" value=""/>
+  <define name="QTRY_VERIFY2_WITH_TIMEOUT(condition, message, timeout)" value=""/>
+  <define name="QTRY_VERIFY_WITH_TIMEOUT(condition, timeout)" value=""/>
   <define name="foreach(A,B)" value="for(A:B)"/>
   <define name="forever" value="for (;;)"/>
   <define name="emit(X)" value="(X)"/>

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1332,9 +1332,9 @@
   <define name="QT_TRANSLATE_NOOP_UTF8(scope, x)" value="x"/>
   <define name="QT_TRANSLATE_NOOP3(scope, x, comment)" value="{x, comment}"/>
   <define name="QT_TRANSLATE_NOOP3_UTF8(scope, x, comment)" value="{x, comment}"/>
-  <define name="QCOMPARE(a,b)" value="assert( (a) == (b) )"/>
-  <define name="QVERIFY(expr)" value="assert( expr )"/>
-  <define name="QVERIFY2(cond, msg)" value="assert( cond )"/>
+  <define name="QCOMPARE(a,b)" value=""/>
+  <define name="QVERIFY(expr)" value=""/>
+  <define name="QVERIFY2(cond, msg)" value=""/>
   <define name="foreach(A,B)" value="for(A:B)"/>
   <define name="forever" value="for (;;)"/>
   <define name="emit(X)" value="(X)"/>


### PR DESCRIPTION
I would like t change the definition of the qt test macros for the qt library config. Defining this qt test macros as asserts lead to false positive assertWithSideEffect.

Second I added the definition of futher test macros.