### PR TITLE
qt.cfg: define macro values to avoid unreadVariable

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1332,21 +1332,23 @@
   <define name="QT_TRANSLATE_NOOP_UTF8(scope, x)" value="x"/>
   <define name="QT_TRANSLATE_NOOP3(scope, x, comment)" value="{x, comment}"/>
   <define name="QT_TRANSLATE_NOOP3_UTF8(scope, x, comment)" value="{x, comment}"/>
-  <define name="QCOMPARE(a,b)" value=""/>
-  <define name="QVERIFY(expr)" value=""/>
-  <define name="QVERIFY2(cond, msg)" value=""/>
+  <define name="QCOMPARE(actual, expected)" value="(actual) == (expected)"/>
+  <define name="QVERIFY(condition)" value="condition"/>
+  <define name="QVERIFY2(condition, msg)" value="condition"/>
   <define name="QBENCHMARK_ONCE" value=""/>
   <define name="QBENCHMARK" value=""/>
-  <define name="QTRY_COMPARE(actual, expected)" value=""/>
-  <define name="QTRY_COMPARE_WITH_TIMEOUT(actual, expected, timeout)" value=""/>
-  <define name="QTRY_VERIFY2(condition, message)" value=""/>
-  <define name="QTRY_VERIFY(condition)" value=""/>
-  <define name="QTRY_VERIFY2_WITH_TIMEOUT(condition, message, timeout)" value=""/>
-  <define name="QTRY_VERIFY_WITH_TIMEOUT(condition, timeout)" value=""/>
+  <define name="QTRY_COMPARE(actual, expected)" value="(actual) == (expected)"/>
+  <define name="QTRY_COMPARE_WITH_TIMEOUT(actual, expected, timeout)" value="(actual) == (expected)"/>
+  <define name="QTRY_VERIFY2(condition, message)" value="condition"/>
+  <define name="QTRY_VERIFY(condition)" value="condition"/>
+  <define name="QTRY_VERIFY2_WITH_TIMEOUT(condition, message, timeout)" value="condition"/>
+  <define name="QTRY_VERIFY_WITH_TIMEOUT(condition, timeout)" value="condition"/>
   <define name="foreach(A,B)" value="for(A:B)"/>
   <define name="forever" value="for (;;)"/>
   <define name="emit(X)" value="(X)"/>
   <define name="Q_PLUGIN_METADATA(x)" value=""/>
+  <define name="Q_ASSERT(condition)" value="assert(condition)"/>
+  <define name="Q_ASSERT_X(condition, where, what)" value="assert(condition)"/>  
   <!-- https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef -->
   <define name="qreal" value="double"/>
   <podtype name="qint8" sign="s" size="1"/>


### PR DESCRIPTION
Thanks for the fast approval of my last pull request.
I found out that my change had some connected side effects.

The main side effect was, that i got a lot of new cppcheck warnings with unreadVariables. I adopted the value definition of the definition and now they are gone.  

I also added definitions for macros Q_ASSERT, Q_ASSERT_X