### PR TITLE
qt.cfg: Add support for further qtest macros & add definition Q_ASSERT, Q_ASSERT_X

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -1332,21 +1332,23 @@
   <define name="QT_TRANSLATE_NOOP_UTF8(scope, x)" value="x"/>
   <define name="QT_TRANSLATE_NOOP3(scope, x, comment)" value="{x, comment}"/>
   <define name="QT_TRANSLATE_NOOP3_UTF8(scope, x, comment)" value="{x, comment}"/>
-  <define name="QCOMPARE(a,b)" value="(void)((a)==(b))"/>
-  <define name="QVERIFY(expr)" value="(void)(expr)"/>
-  <define name="QVERIFY2(cond, msg)" value="(void)(cond)"/>
+  <define name="QCOMPARE(actual, expected)" value="(void)((actual)==(expected))"/>
+  <define name="QVERIFY(condition)" value="(void)(condition)"/>
+  <define name="QVERIFY2(condition, message)" value="(void)(condition)"/>
   <define name="QBENCHMARK_ONCE" value=""/>
   <define name="QBENCHMARK" value=""/>
-  <define name="QTRY_COMPARE(actual, expected)" value=""/>
-  <define name="QTRY_COMPARE_WITH_TIMEOUT(actual, expected, timeout)" value=""/>
-  <define name="QTRY_VERIFY2(condition, message)" value=""/>
-  <define name="QTRY_VERIFY(condition)" value=""/>
-  <define name="QTRY_VERIFY2_WITH_TIMEOUT(condition, message, timeout)" value=""/>
-  <define name="QTRY_VERIFY_WITH_TIMEOUT(condition, timeout)" value=""/>
+  <define name="QTRY_COMPARE(actual, expected)" value="(void)((actual)==(expected))"/>
+  <define name="QTRY_COMPARE_WITH_TIMEOUT(actual, expected, timeout)" value="(void)((actual)==(expected))"/>
+  <define name="QTRY_VERIFY2(condition, message)" value="(void)(condition)"/>
+  <define name="QTRY_VERIFY(condition)" value="(void)(condition)"/>
+  <define name="QTRY_VERIFY2_WITH_TIMEOUT(condition, message, timeout)" value="(void)(condition)"/>
+  <define name="QTRY_VERIFY_WITH_TIMEOUT(condition, timeout)" value="(void)(condition)"/>
   <define name="foreach(A,B)" value="for(A:B)"/>
   <define name="forever" value="for (;;)"/>
   <define name="emit(X)" value="(X)"/>
   <define name="Q_PLUGIN_METADATA(x)" value=""/>
+  <define name="Q_ASSERT(condition)" value="assert(condition)"/>
+  <define name="Q_ASSERT_X(condition, where, what)" value="assert(condition)"/>  
   <!-- https://doc.qt.io/qt-5/qtglobal.html#qreal-typedef -->
   <define name="qreal" value="double"/>
   <podtype name="qint8" sign="s" size="1"/>


### PR DESCRIPTION
Again additional qt test macro definition , this time according to danmar last fix.

Additional added Q_ASSERT, Q_ASSERT_X.