### PR TITLE
.travis.yml: Check python syntax (version 2 and 3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,14 @@ matrix:
 # check --dump
         - ${CPPCHECK} test/testpreprocessor.cpp --dump
         - xmllint --noout test/testpreprocessor.cpp.dump
+# check python syntax by compiling all addon scripts
+        - python -m compileall ./addons
+        - python3 -m compileall ./addons
+# check python syntax by compiling some selected scripts
+        - python -m py_compile ./tools/donate-cpu.py
+        - python3 -m py_compile ./tools/donate-cpu.py
+        - python -m py_compile ./tools/donate-cpu-server.py
+        # donate-cpu-server.py is currently not Python 3 compatible
 # check addons/misra.py
         - cd addons/test
         - ${CPPCHECK} --dump misc-test.cpp


### PR DESCRIPTION
As suggested by rikardfalkeborn here:
https://github.com/danmar/cppcheck/pull/1679#issuecomment-465927692
By compiling python scripts the syntax can be checked.
There are two compilations, one for Python 2 and one for Python 3 for
most scripts to make sure at least the syntax is valid for both
versions.