### PR TITLE
library.cpp: WarnInfo: Fix crash

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -726,8 +726,7 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
             } else {
                 const char * const message = functionnode->GetText();
                 if (!message) {
-                    printf("Error in library configuration. Warning for function '%s' is missing arguments 'reason' and 'alternatives' or some text.\n", name.c_str());
-                    return Error(MISSING_ATTRIBUTE);
+                    return Error(MISSING_ATTRIBUTE, "\"reason\" and \"alternatives\" or some text.");
                 } else
                     wi.message = message;
             }

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -723,8 +723,14 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
                     else
                         wi.message += ", ";
                 }
-            } else
-                wi.message = functionnode->GetText();
+            } else {
+                const char * const message = functionnode->GetText();
+                if (!message) {
+                    printf("Error in library configuration. Warning for function '%s' is missing arguments 'reason' and 'alternatives' or some text.\n", name.c_str());
+                    return Error(MISSING_ATTRIBUTE);
+                } else
+                    wi.message = message;
+            }
 
             functionwarn[name] = wi;
         } else


### PR DESCRIPTION
If no 'alternatives' argument was specified and the `<warn/>` element
did not contain any text Cppcheck crashed because of a null pointer
access.
If there is no 'reason' and no text an error message is printed now and
loadFunction() returns with an error.

And it is now allowed to only specify a 'reason' because it is hard
sometimes to suggest 'alternatives' and an additional text also does
not help much.