### PR TITLE
Add help to testrunner

### DIFF
--- a/test/options.cpp
+++ b/test/options.cpp
@@ -18,12 +18,15 @@
 
 #include <iterator>
 
-options::options(int argc, const char* argv[])
+options::options(int argc, const char* const argv[])
     :_options(argv + 1, argv + argc)
     ,_which_test("")
     ,_quiet(_options.count("-q") != 0)
+    ,_help(_options.count("-h") != 0 || _options.count("--help"))
 {
     _options.erase("-q");
+    _options.erase("-h");
+    _options.erase("--help");
     if (! _options.empty()) {
         _which_test = *_options.rbegin();
     }
@@ -32,6 +35,11 @@ options::options(int argc, const char* argv[])
 bool options::quiet() const
 {
     return _quiet;
+}
+
+bool options::help() const
+{
+    return _help;
 }
 
 const std::string& options::which_test() const

--- a/test/options.h
+++ b/test/options.h
@@ -28,9 +28,11 @@
 class options {
 public:
     /** Call from main() to populate object */
-    options(int argc, const char* argv[]);
+    options(int argc, const char* const argv[]);
     /** Don't print the name of each method being tested. */
     bool quiet() const;
+    /** Print help. */
+    bool help() const;
     /** Which test should be run. Empty string means 'all tests' */
     const std::string& which_test() const;
 
@@ -43,6 +45,7 @@ private:
     std::set<std::string> _options;
     std::string _which_test;
     const bool _quiet;
+    const bool _help;
 };
 
 #endif

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -32,6 +32,9 @@ private:
         TEST_CASE(no_test_method);
         TEST_CASE(not_quiet);
         TEST_CASE(quiet);
+        TEST_CASE(not_help);
+        TEST_CASE(help);
+        TEST_CASE(help_long);
         TEST_CASE(multiple_testcases);
         TEST_CASE(invalid_switches);
     }
@@ -71,8 +74,25 @@ private:
         ASSERT_EQUALS(true, args.quiet());
     }
 
+    void not_help() const {
+        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-v"};
+        options args(sizeof argv / sizeof argv[0], argv);
+        ASSERT_EQUALS(false, args.help());
+    }
 
 
+    void help() const {
+        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "-h"};
+        options args(sizeof argv / sizeof argv[0], argv);
+        ASSERT_EQUALS(true, args.help());
+    }
+
+
+    void help_long() const {
+        const char* argv[] = {"./test_runner", "TestClass::TestMethod", "--help"};
+        options args(sizeof argv / sizeof argv[0], argv);
+        ASSERT_EQUALS(true, args.help());
+    }
 
     void multiple_testcases() const {
         const char* argv[] = {"./test_runner", "TestClass::TestMethod", "Ignore::ThisOne"};

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -35,8 +35,12 @@ int main(int argc, char *argv[])
 #endif
         Preprocessor::macroChar = '$'; // While macroChar is char(1) per default outside test suite, we require it to be a human-readable character here.
 
-        options args(argc, const_cast<const char**>(argv));
+        options args(argc, argv);
 
+        if (args.help()) {
+            TestFixture::printHelp();
+            return EXIT_SUCCESS;
+        }
         const std::size_t failedTestsCount = TestFixture::runTests(args);
         return (failedTestsCount == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 #ifdef NDEBUG

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -275,6 +275,24 @@ void TestFixture::complainMissingLib(const char * const libname) const
     missingLibs.insert(libname);
 }
 
+void TestFixture::printHelp()
+{
+    std::cout << "Testrunner - run Cppcheck tests\n"
+              "\n"
+              "Syntax:\n"
+              "    testrunner [OPTIONS] [TestClass::TestCase]\n"
+              "    run all test cases:\n"
+              "        testrunner\n"
+              "    run all test cases in TestClass:\n"
+              "        testrunner TestClass\n"
+              "    run TestClass::TestCase:\n"
+              "        testrunner TestClass::TestCase\n"
+              "\n"
+              "Options:\n"
+              "    -q                   Do not print the test cases that have run.\n"
+              "    -h, --help           Print this help.\n";
+}
+
 void TestFixture::run(const std::string &str)
 {
     testToRun = str;
@@ -305,10 +323,10 @@ std::size_t TestFixture::runTests(const options& args)
 
     const TestSet &tests = TestRegistry::theInstance().tests();
 
-    for (TestSet::const_iterator it = tests.begin(); it != tests.end(); ++it) {
-        if (classname.empty() || (*it)->classname == classname) {
-            (*it)->processOptions(args);
-            (*it)->run(testname);
+    for (TestFixture * test : tests) {
+        if (classname.empty() || test->classname == classname) {
+            test->processOptions(args);
+            test->run(testname);
         }
     }
 

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -85,6 +85,7 @@ public:
     virtual void reportOut(const std::string &outmsg) OVERRIDE;
     virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
     void run(const std::string &str);
+    static void printHelp();
     const std::string classname;
 
     explicit TestFixture(const char * const _name);


### PR DESCRIPTION
For now, only print the ways of running testrunner and the few options
that are available.

Also, refactor to remove an unneeded const_cast and use a range for loop.

Partially fixes [#8514](https://trac.cppcheck.net/ticket/8514).