### PR TITLE
gtk.cfg: Add support for gtk_label_new(), enhance gtk_label_get().

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -11091,9 +11091,24 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- GtkWidget * gtk_label_new (const gchar *str); -->
+  <function name="gtk_label_new">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="GtkWidget *"/>
+    <arg nr="1">
+      <not-bool/>
+      <strz/>
+    </arg>
+  </function>
+  <!-- void gtk_label_get (GtkLabel *label, gchar **str); -->
   <function name="gtk_label_get">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <warn severity="style" reason="Obsolete">gtk_label_get is deprecated and should not be used in newly-written code.</warn>
+    <arg nr="1"/>
+    <arg nr="2"/>
   </function>
   <function name="gtk_label_get_angle">
     <leak-ignore/>


### PR DESCRIPTION
References:
https://developer.gnome.org/gtk3/stable/GtkLabel.html#gtk-label-new
https://developer.gnome.org/gtk2/stable/GtkLabel.html#gtk-label-get
Found by daca@home.