### PR TITLE
Donate CPU: Also use and accept .tar.bz2 package files.

### DIFF
--- a/tools/daca2-getpackages.py
+++ b/tools/daca2-getpackages.py
@@ -88,7 +88,7 @@ def getpackages():
             filename = None
         elif line.startswith('./pool/main/'):
             path = line[2:-1]
-        elif path and line.endswith('.orig.tar.gz'):
+        elif path and line.endswith(('.orig.tar.gz', '.orig.tar.bz2')):
             filename = line[1 + line.rfind(' '):]
 
     return archives

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -743,7 +743,7 @@ def server(server_address_port, packages, packageIndex, resultPath):
             print('[' + strDateTime() + '] write:' + url)
 
             # save data
-            res = re.match(r'ftp://.*pool/main/[^/]+/([^/]+)/[^/]*tar.gz', url)
+            res = re.match(r'ftp://.*pool/main/[^/]+/([^/]+)/[^/]*tar.(gz|bz2)', url)
             if res is None:
                 print('results not written. res is None.')
                 continue
@@ -809,7 +809,7 @@ def server(server_address_port, packages, packageIndex, resultPath):
             print('[' + strDateTime() + '] write_info:' + url)
 
             # save data
-            res = re.match(r'ftp://.*pool/main/[^/]+/([^/]+)/[^/]*tar.gz', url)
+            res = re.match(r'ftp://.*pool/main/[^/]+/([^/]+)/[^/]*tar.(gz|bz2)', url)
             if res is None:
                 print('info output not written. res is None.')
                 continue


### PR DESCRIPTION
In my tests there were about 1500 additional packages
available as bz2 on the server.
For some packages a newer version is now used if it is
only available as .tar.bz2 archive.
The donate-cpu.py client is tested to work with .tar.bz2
files under Python 2.7.15 and 3.6.8.