### PR TITLE
donate-cpu.py: Fix crash during decoding under Python 3.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -37,7 +37,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.8"
+CLIENT_VERSION = "1.1.9"
 
 
 def checkRequirements():
@@ -208,7 +208,10 @@ def hasInclude(path, includes):
         for name in files:
             filename = os.path.join(root, name)
             try:
-                f = open(filename, 'rt')
+                if sys.version_info.major < 3:
+                    f = open(filename, 'rt')
+                else:
+                    f = open(filename, 'rt', errors='ignore')
                 filedata = f.read()
                 try:
                     # Python2 needs to decode the data first

--- a/tools/test/run_donate_cpu_client_tests.sh
+++ b/tools/test/run_donate_cpu_client_tests.sh
@@ -18,16 +18,22 @@ trap error_occurred ERR
 
 # Run tests
 client_script=../donate-cpu.py
-test_package=ftp://ftp.se.debian.org/debian/pool/main/0/0xffff/0xffff_0.8.orig.tar.gz
+test_packages=(
+ftp://ftp.se.debian.org/debian/pool/main/0/0xffff/0xffff_0.8.orig.tar.gz
+ftp://ftp.se.debian.org/debian/pool/main/a/actionaz/actionaz_3.8.0.orig.tar.gz
+)
 
 for python_exec in "python" "python3"
 do
-    echo "Testing with ${python_exec} ..."
-    ${python_exec} ${client_script} --package=${test_package}
-    ${python_exec} ${client_script} --package=${test_package} -j1
-    ${python_exec} ${client_script} --package=${test_package} -j2
-    ${python_exec} ${client_script} --package=${test_package} --bandwidth-limit=250k
-    ${python_exec} ${client_script} --package=${test_package} -j2 --bandwidth-limit=0.5M
+    for test_package in "${test_packages[@]}"
+    do
+        echo "Testing package ${test_package} with ${python_exec} ..."
+        ${python_exec} ${client_script} --package=${test_package}
+        ${python_exec} ${client_script} --package=${test_package} -j1
+        ${python_exec} ${client_script} --package=${test_package} -j2
+        ${python_exec} ${client_script} --package=${test_package} --bandwidth-limit=250k
+        ${python_exec} ${client_script} --package=${test_package} -j2 --bandwidth-limit=0.5M
+    done
 done
 
 # Report result and exit accordingly


### PR DESCRIPTION
Python 3 directly decodes the text when it is read(). If there is any
invalid UTF-8 character in the text an exception is thrown (IIRC it is
UnicodeDecodeError). Opening the file with `error='ignore'` avoids
throwing an exception and just ignores the invalid character. Since
this is only possible since Python version 3 there must be extra code
for older versions.
The test script has been enhanced. It now also uses a package which
contains a file with at least one invalid UTF-8 character.