### PR TITLE
donate-cpu-server.py: Replace syntax that is deprecated in Python 3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
         - python -m py_compile ./tools/donate-cpu.py
         - python3 -m py_compile ./tools/donate-cpu.py
         - python -m py_compile ./tools/donate-cpu-server.py
-        # donate-cpu-server.py is currently not Python 3 compatible
+        - python3 -m py_compile ./tools/donate-cpu-server.py
 # check addons/misra.py
         - cd addons/test
         - ${CPPCHECK} --dump misc-test.cpp

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -12,6 +12,7 @@ import sys
 import urllib
 import logging
 import logging.handlers
+import operator
 
 OLD_VERSION = '1.87'
 
@@ -522,7 +523,7 @@ def check_library_report(result_path, message_id):
                 function_counts[function_name] = function_counts.setdefault(function_name, 0) + 1
 
     function_details_list = []
-    for function_name, count in sorted(function_counts.iteritems(), key=lambda (k, v): (v, k), reverse=True):
+    for function_name, count in sorted(function_counts.items(), key=operator.itemgetter(1), reverse=True):
         if len(function_details_list) >= functions_shown_max:
             break
         function_details_list.append(str(count).rjust(column_widths[0]) + ' ' +


### PR DESCRIPTION
The function `iteritems()` of `dict`s is deprecated. The recommended
alternative is to use `items()`, this function also works with Python 2.

The next issue is that lambdas can no longer unpack tuple parameters
in Python 3. It would be possible to use some workaround and still use
a lambda, but using `operator.itemgetter(1)` instead is faster and the
recommended method in such a case.

The syntax is now compatible with Python 2 and 3 but the server script
still does not work with Python 3. For example `socket.recv()` returns
`bytes` in Python 3 and `str` in Python 2. Currently `str` is expected
so it does not work with Python 3.