### PR TITLE
Fix link to cppcheck wiki in man page

### DIFF
--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -622,6 +622,6 @@ There are false positives with this option. Each result must be carefully invest
   <refsect1 id="see_also">
     <title>SEE ALSO</title>
     <!-- In alphabetical order. -->
-    <para>Full list of features: http://cppcheck.wiki.sourceforge.net/</para>
+    <para>Full list of features: https://sourceforge.net/p/cppcheck/wiki/Home/</para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
As the title - I am not sure if the cppcheck.wiki.sourceforge.net link is down just temporarily, but the wiki link on the homepage is to the one I have linked in my patch.