### PR TITLE
donate-cpu.py: Add new argument `--max-packages=N`.

### DIFF
--- a/tools/test/run_donate_cpu_client_tests.sh
+++ b/tools/test/run_donate_cpu_client_tests.sh
@@ -33,6 +33,7 @@ do
         ${python_exec} ${client_script} --package=${test_package} -j2
         ${python_exec} ${client_script} --package=${test_package} --bandwidth-limit=250k
         ${python_exec} ${client_script} --package=${test_package} -j2 --bandwidth-limit=0.5M
+        ${python_exec} ${client_script} --package=${test_package} --max-packages=1
     done
 done
 


### PR DESCRIPTION
The client script will exit after the specified number of packages
have been processed. 0 means infinitely.
Useful for example to regularly quit the script, check for updates to
the client and start it again. Or as an alternative to the `--stop-time`
argument.