### PR TITLE
reduce: Reset cppcheck terminate setting between test runs

### DIFF
--- a/tools/reduce.cpp
+++ b/tools/reduce.cpp
@@ -97,6 +97,7 @@ static bool test(const ReduceSettings &settings, const std::vector<std::string> 
     fout.close();
 
     CppcheckExecutor cppcheck(settings);
+    settings.terminate(false);
     return cppcheck.run(tempfilename.c_str(), settings.maxtime);
 }
 


### PR DESCRIPTION
Without this, reduction fails at the second invocation of cppcheck since
the it is in terminated state.

This was broken in a94628d8fc5f3df15f44ec0589a944ec3a8b6e32 (August 2016!)
where the terminate state was made static.

Since this has been broken for two and a half years, is it worth keeping the file at all?