### PR TITLE
std.cfg: Add missing argument directions as far as possible.

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -74,7 +74,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -86,7 +86,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -98,7 +98,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -255,7 +255,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -345,7 +345,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -393,7 +393,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -578,10 +578,10 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -598,7 +598,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -607,7 +607,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -626,11 +626,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -639,7 +639,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -648,7 +648,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -657,7 +657,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -703,7 +703,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -714,7 +714,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -725,7 +725,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -736,7 +736,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -814,7 +814,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -825,10 +825,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -839,10 +839,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -853,10 +853,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -866,7 +866,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
     </arg>
   </function>
@@ -877,7 +877,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -890,7 +890,7 @@
     <returnValue type="long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -903,7 +903,7 @@
     <returnValue type="long long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -916,7 +916,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -927,11 +927,11 @@
     <use-retval/>
     <noreturn>false</noreturn>
     <returnValue type="void *"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>1:</valid>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -943,7 +943,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -954,7 +954,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -965,7 +965,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -976,10 +976,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -990,10 +990,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1004,10 +1004,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1035,7 +1035,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1046,7 +1046,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1057,7 +1057,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1068,7 +1068,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1079,7 +1079,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1090,7 +1090,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1102,7 +1102,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1113,7 +1113,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1124,7 +1124,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1135,7 +1135,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1147,7 +1147,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1157,7 +1157,7 @@
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1168,10 +1168,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1181,10 +1181,10 @@
     <returnValue type="div_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>:-1,1:</valid>
     </arg>
@@ -1195,10 +1195,10 @@
     <returnValue type="imaxdiv_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>:-1,1:</valid>
     </arg>
@@ -1206,7 +1206,7 @@
   <!-- void exit(int status); -->
   <function name="exit,std::exit">
     <noreturn>true</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1217,7 +1217,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1228,7 +1228,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1239,7 +1239,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1250,7 +1250,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1261,7 +1261,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1272,7 +1272,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1283,7 +1283,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1294,7 +1294,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1305,7 +1305,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1316,7 +1316,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1327,7 +1327,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1338,7 +1338,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1350,7 +1350,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1362,7 +1362,7 @@
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1373,7 +1373,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1384,7 +1384,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1395,7 +1395,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1406,7 +1406,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1417,7 +1417,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1428,7 +1428,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1436,7 +1436,7 @@
   <!-- void quick_exit(int exit_code); -->
   <function name="_Exit,std::_Exit,quick_exit,std::quick_exit">
     <noreturn>true</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1447,7 +1447,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1458,7 +1458,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1469,7 +1469,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1480,10 +1480,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1494,10 +1494,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1508,10 +1508,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1519,7 +1519,7 @@
   <function name="fclose,std::fclose">
     <returnValue type="int"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1530,7 +1530,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1541,7 +1541,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1551,7 +1551,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-uninit/>
     </arg>
   </function>
@@ -1561,7 +1561,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1572,7 +1572,7 @@
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1582,11 +1582,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -1597,7 +1597,7 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1608,7 +1608,7 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1619,7 +1619,7 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1630,13 +1630,13 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1647,13 +1647,13 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1664,13 +1664,13 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1681,10 +1681,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1695,10 +1695,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1709,10 +1709,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1723,10 +1723,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1737,10 +1737,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1751,10 +1751,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1765,10 +1765,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1779,10 +1779,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1793,10 +1793,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -1805,12 +1805,12 @@
     <use-retval/>
     <returnValue type="FILE *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1824,12 +1824,12 @@
     <arg nr="1">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1839,12 +1839,12 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
     <formatstr/>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <formatstr/>
       <not-uninit/>
     </arg>
@@ -1854,11 +1854,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <formatstr/>
     </arg>
@@ -1869,11 +1869,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
     <arg nr="3"/>
@@ -1883,12 +1883,12 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1898,11 +1898,11 @@
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1912,12 +1912,12 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1927,11 +1927,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1941,19 +1941,19 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="mul" arg="2" arg2="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1971,15 +1971,15 @@
     <use-retval/>
     <returnValue type="FILE *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -1992,10 +1992,10 @@
     <arg nr="1">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2009,10 +2009,10 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -2021,10 +2021,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -2033,10 +2033,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -2048,13 +2048,13 @@
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3" default="0">
+    <arg nr="3" default="0" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2065,10 +2065,10 @@
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2079,10 +2079,10 @@
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2095,7 +2095,7 @@
       <not-uninit/>
     </arg>
     <formatstr scan="true"/>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <formatstr/>
       <not-uninit/>
     </arg>
@@ -2105,10 +2105,10 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
     <arg nr="3"/>
@@ -2118,10 +2118,10 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2132,14 +2132,14 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2148,11 +2148,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2162,16 +2162,16 @@
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2181,16 +2181,16 @@
     <returnValue type="wchar_t*"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2201,7 +2201,7 @@
     <returnValue type="long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2211,11 +2211,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2224,20 +2224,20 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="mul" arg="2" arg2="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2247,10 +2247,10 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -2260,10 +2260,11 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -2273,15 +2274,15 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-uninit/>
     </arg>
   </function>
@@ -2292,7 +2293,7 @@
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:255</valid>
     </arg>
@@ -2302,7 +2303,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2317,11 +2318,12 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -2331,15 +2333,16 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-null/>
     </arg>
   </function>
@@ -2350,7 +2353,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2359,10 +2362,10 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2371,11 +2374,12 @@
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -2391,7 +2395,7 @@
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:255</valid>
     </arg>
@@ -2405,10 +2409,10 @@
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2430,7 +2434,7 @@
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
     <warn severity="warning">Obsolete function 'gets' called. It is recommended to use 'fgets' or 'gets_s' instead.
@@ -2441,11 +2445,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -2458,7 +2462,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="struct tm *"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2528,7 +2532,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int">arg1==' ' || arg1=='\t'</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2555,17 +2559,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
     </arg>
   </function>
-  <!-- int iswcntrl(wint_t c, wctype_t desc); -->
+  <!-- int iswctype( wint_t wc, wctype_t desc ); -->
   <function name="iswctype,std::iswctype">
     <use-retval/>
     <pure/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2760,10 +2764,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2774,7 +2778,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2785,7 +2789,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2796,7 +2800,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wctype_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2808,7 +2812,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wctype_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -2821,7 +2825,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2833,7 +2837,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2845,7 +2849,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2856,7 +2860,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long int">arg1&gt;0?arg1:-arg1</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2867,7 +2871,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long long int">arg1&gt;0?arg1:-arg1</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2878,10 +2882,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2892,10 +2896,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2906,10 +2910,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2920,7 +2924,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2931,7 +2935,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2942,7 +2946,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2953,7 +2957,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2964,7 +2968,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2975,7 +2979,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -2988,7 +2992,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3001,7 +3005,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3014,7 +3018,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3027,7 +3031,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3043,7 +3047,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3054,10 +3058,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="ldiv_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>:-1,1:</valid>
     </arg>
@@ -3068,10 +3072,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="lldiv_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>:-1,1:</valid>
     </arg>
@@ -3081,7 +3085,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="struct tm *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -3091,10 +3095,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="struct tm *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -3104,7 +3108,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3114,7 +3118,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3124,7 +3128,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3135,7 +3139,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3146,7 +3150,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3157,7 +3161,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3172,7 +3176,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -3184,10 +3188,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int">arg1&gt;arg2?1:0</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3198,10 +3202,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int">arg1 &gt;= arg2?1:0</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3216,7 +3220,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -3228,7 +3232,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3239,7 +3243,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3250,7 +3254,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3261,10 +3265,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int">arg1&lt;arg2?1:0</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3275,10 +3279,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int">arg1 &lt;= arg2?1:0</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3290,10 +3294,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <!-- true if x < y || x > y, false otherwise -->
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3304,7 +3308,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -3316,7 +3320,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -3328,7 +3332,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -3344,7 +3348,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -3360,7 +3364,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -3376,11 +3380,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
     </arg>
@@ -3392,7 +3396,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3403,7 +3407,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3414,7 +3418,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3425,7 +3429,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3436,7 +3440,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3447,7 +3451,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3458,7 +3462,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3469,7 +3473,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3480,7 +3484,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3491,7 +3495,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3502,7 +3506,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3513,7 +3517,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3524,7 +3528,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3535,7 +3539,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3546,7 +3550,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3557,10 +3561,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3571,10 +3575,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3585,10 +3589,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3599,10 +3603,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3613,10 +3617,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3627,10 +3631,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3642,7 +3646,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="1">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3651,7 +3655,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3661,7 +3665,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3671,10 +3675,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3684,7 +3688,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3697,17 +3701,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3720,17 +3724,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3743,17 +3747,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3766,17 +3770,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3787,16 +3791,16 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="memcpy,std::memcpy,wmemcpy,std::wmemcpy">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3808,19 +3812,19 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3831,16 +3835,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="memmove,std::memmove,wmemmove,std::wmemmove">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="2">
+      <!-- TODO: direction? memory could be overwritten -->
       <not-null/>
       <not-uninit/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3851,18 +3856,18 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -3872,14 +3877,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3890,14 +3895,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -3909,7 +3914,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="time_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -3919,10 +3924,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -3931,10 +3936,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -3943,10 +3948,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -3955,7 +3960,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3966,10 +3971,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3980,10 +3985,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -3994,10 +3999,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4009,10 +4014,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <pure/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4023,10 +4028,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4037,10 +4042,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4051,10 +4056,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4065,13 +4070,13 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -4082,13 +4087,13 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -4099,13 +4104,13 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="out">
       <not-null/>
     </arg>
   </function>
@@ -4125,7 +4130,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <formatstr/>
     </arg>
@@ -4136,7 +4141,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
     <arg nr="2"/>
@@ -4148,23 +4153,23 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="5">
+    <arg nr="5" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4174,19 +4179,19 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4196,12 +4201,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4211,10 +4216,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4224,7 +4229,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -4235,7 +4240,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wint_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4244,7 +4249,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <not-bool/>
@@ -4259,7 +4264,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="1">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -4272,11 +4277,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="1">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -4286,7 +4291,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -4297,12 +4302,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
@@ -4313,7 +4318,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4325,7 +4330,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4336,7 +4341,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="float"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4347,7 +4352,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long double"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4363,10 +4368,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long long int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4377,7 +4382,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4393,7 +4398,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="raise,std::raise">
     <returnValue type="int"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4403,7 +4408,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <formatstr scan="true"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <formatstr/>
       <not-null/>
       <not-uninit/>
@@ -4414,11 +4419,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4429,11 +4434,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4444,7 +4449,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4455,7 +4460,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
     </arg>
     <arg nr="2"/>
@@ -4465,7 +4470,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="void"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4478,17 +4483,17 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -4498,7 +4503,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1"/>
+    <arg nr="1" direction="out"/>
   </function>
   <!-- char * strcat(char *deststr, const char *srcstr); -->
   <function name="strcat,std::strcat">
@@ -4534,10 +4539,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3"/>
+    <arg nr="3" direction="inout"/>
   </function>
   <!-- char * strchr(const char *cs, int c); -->
   <function name="strchr,std::strchr">
@@ -4637,18 +4643,18 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4716,11 +4722,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4909,11 +4915,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <!-- In case the 3rd argument is 0, the 1st argument is permitted to be a null pointer. (#6306) -->
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -4924,11 +4931,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <!-- In case the 3rd argument is 0, the 1st argument is permitted to be a null pointer. (#6306) -->
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -4940,11 +4948,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -4961,7 +4969,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="struct std::locale"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4976,10 +4984,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -4989,7 +4997,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5000,11 +5008,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5016,11 +5024,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5031,11 +5039,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5048,11 +5056,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <minsize type="argvalue" arg="3"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -5064,11 +5072,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5079,11 +5087,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5095,12 +5103,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:255</valid>
     </arg>
@@ -5112,11 +5120,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5125,15 +5133,16 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-null/>
     </arg>
   </function>
@@ -5576,11 +5585,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="2" default=" ">
+    <arg nr="2" default=" " direction="in">
       <not-uninit/>
       <valid>0:255</valid>
     </arg>
@@ -5608,14 +5617,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-uninit/>
     </arg>
   </function>
@@ -5624,14 +5634,14 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="wchar_t *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-null/>
     </arg>
   </function>
@@ -5641,11 +5651,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="intmax_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5656,11 +5667,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="uintmax_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5671,11 +5683,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5686,11 +5699,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5701,11 +5715,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="unsigned long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5716,11 +5731,12 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="unsigned long long"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="2" direction="out"/>
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0,2:36</valid>
     </arg>
@@ -5731,7 +5747,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <formatstr/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <formatstr/>
       <not-null/>
     </arg>
@@ -5757,15 +5773,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-uninit/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5775,10 +5791,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
       <formatstr/>
@@ -5790,15 +5806,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -5809,11 +5825,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="int"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="inout">
       <not-null/>
     </arg>
     <formatstr/>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <formatstr/>
       <not-null/>
       <not-uninit/>
@@ -5927,7 +5943,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="setw,std::setw">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5937,10 +5953,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue>arg1&lt;arg2?arg1:arg2</returnValue>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5950,10 +5966,10 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue>arg1&gt;arg2?arg1:arg2</returnValue>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5961,7 +5977,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="setiosflags,std::setiosflags">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5969,7 +5985,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="resetiosflags,std::resetiosflags">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5977,7 +5993,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="setfill,std::setfill">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5989,7 +6005,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="std::ios_base::fmtflags"/>
     <leak-ignore/>
-    <arg nr="any">
+    <arg nr="any" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -5997,7 +6013,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="setprecision,std::setprecision">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6007,7 +6023,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="std::streamsize"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6017,7 +6033,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6025,7 +6041,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="setbase,std::setbase">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6035,11 +6051,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="struct tmx *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6049,11 +6065,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1"/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -6064,15 +6080,15 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <returnValue type="size_t"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1"/>
-    <arg nr="2">
+    <arg nr="1" direction="out"/>
+    <arg nr="2" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>
@@ -6267,7 +6283,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::vector::reserve">
     <noreturn>false</noreturn>
     <returnValue type="void"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -6277,7 +6293,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::list::remove">
     <noreturn>false</noreturn>
     <returnValue type="void"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6287,7 +6303,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::vector::resize">
     <noreturn>false</noreturn>
     <returnValue type="void"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
       <valid>0:</valid>
@@ -6329,7 +6345,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="char &amp;"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6340,7 +6356,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="wchar_t &amp;"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6351,7 +6367,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="char16_t &amp;"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6362,7 +6378,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <use-retval/>
     <returnValue type="char32_t &amp;"/>
     <noreturn>false</noreturn>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6371,7 +6387,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::string::push_back">
     <noreturn>false</noreturn>
     <returnValue type="void"/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6472,11 +6488,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::string::substr,std::wstring::substr,std::basic_string::substr">
     <use-retval/>
     <noreturn>false</noreturn>
-    <arg nr="1" default="0">
+    <arg nr="1" default="0" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="2" default="0">
+    <arg nr="2" default="0" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6493,11 +6509,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="std::istream&amp;"/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6507,11 +6523,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="std::ifstream&amp;"/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6521,11 +6537,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="std::wifstream&amp;"/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6534,11 +6550,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::istream::readsome,std::ifstream::readsome">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
@@ -6548,16 +6564,16 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::istream::getline,std::ifstream::getline">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <strz/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3" default="'\n'">
+    <arg nr="3" default="'\n'" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6566,16 +6582,16 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::istream::get,std::ifstream::get">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="out">
       <not-null/>
       <strz/>
       <minsize type="argvalue" arg="2"/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="3" default="'\n'">
+    <arg nr="3" default="'\n'" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -6584,13 +6600,13 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="itoa">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <arg nr="1">
+    <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <arg nr="2">
+    <arg nr="2" direction="out">
       <not-null/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>2:36</valid>
     </arg>
@@ -6851,7 +6867,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
       <iterator container="1" type="last"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>
@@ -7001,11 +7017,11 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
       <iterator container="1" type="last"/>
     </arg>
-    <arg nr="3">
+    <arg nr="3" direction="in">
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4">
+    <arg nr="4" direction="in">
       <not-uninit/>
     </arg>
     <arg nr="5" default=""/>


### PR DESCRIPTION
I added all argument directions i know or where i was able to find
information without too much effort. When in doubt i looked at the
Microsoft SAL annotations and used similar configurations when this
made sense.