### PR TITLE
gnu.cfg: Add support for non-GNU _(string) macro.

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -839,7 +839,7 @@
   </function>
   <!-- _(string) is often defined as gettext(string) or string somewhere in projects. -->
   <!-- See https://www.gnu.org/software/gettext//manual/html_node/Mark-Keywords.html -->
-  <define name="_(string)" value="gettext(string)"/>
+  <define name="_(string)" value="string"/>
   <!-- char * dgettext (const char *domainname, const char *msgid); -->
   <function name="dgettext">
     <noreturn>false</noreturn>

--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -837,6 +837,9 @@
       <not-bool/>
     </arg>
   </function>
+  <!-- _(string) is often defined as gettext(string) or string somewhere in projects. -->
+  <!-- See https://www.gnu.org/software/gettext//manual/html_node/Mark-Keywords.html -->
+  <define name="_(string)" value="gettext(string)"/>
   <!-- char * dgettext (const char *domainname, const char *msgid); -->
   <function name="dgettext">
     <noreturn>false</noreturn>


### PR DESCRIPTION
As can be read here:
https://www.gnu.org/software/gettext//manual/html_node/Mark-Keywords.html
The _(str) macro is typically defined for a project to abbreviate the
gettext(str) call. Although this is not part of GNU it would enhance the
analysis. Cppcheck often does not know what _() is. In daca@home it is
reported thousands of times as a function without configuration.