### PR TITLE
lib: reorders settings to match definition (-Wreorder)

### DIFF
--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -49,11 +49,11 @@ Settings::Settings()
       maxConfigs(12),
       enforcedLang(None),
       reportProgress(false),
-      checkHeaders(true),
-      removeUnusedIncludedTemplates(false),
-      removeUnusedTemplates(false),
       checkConfiguration(false),
-      checkLibrary(false)
+      checkLibrary(false),
+      checkHeaders(true),
+      removeUnusedTemplates(false),
+      removeUnusedIncludedTemplates(false)
 {
 }
 


### PR DESCRIPTION
lib/settings.cpp:53:7: warning: field 'removeUnusedIncludedTemplates' will be
      initialized after field 'removeUnusedTemplates' [-Wreorder]
      removeUnusedIncludedTemplates(false),
      ^
lib/settings.cpp:54:7: warning: field 'removeUnusedTemplates' will be
      initialized after field 'checkConfiguration' [-Wreorder]
      removeUnusedTemplates(false),
      ^