### PR TITLE
std.cfg: Fix wprintf(), add comment to swprintf().

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -5788,6 +5788,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="1" direction="in">
       <formatstr/>
       <not-null/>
+      <not-uninit/>
     </arg>
   </function>
   <!-- int sprintf(char *s, const char *format, ...); -->
@@ -5842,6 +5843,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:</valid>
     </arg>
     <arg nr="3" direction="in">
+      <!-- Due to different swprintf definitions "<formatstr/>" can not be used here. See https://trac.cppcheck.net/ticket/4790 -->
       <not-null/>
       <not-uninit/>
     </arg>


### PR DESCRIPTION
wprintf(): The format string must be initialized. So add `<not-uninit/>`
swprintf(): `<formatstr/>` should not be used because Microsoft uses the
same function with a different order of the arguments. Add comment to
document this in the library configuration also. See ticket
https://trac.cppcheck.net/ticket/4790