### PR TITLE
checkuninitvar.cpp: Use argument direction "out" info from library cfg

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1205,6 +1205,8 @@ bool CheckUninitVar::isMemberVariableAssignment(const Token *tok, const std::str
                     const Library::ArgumentChecks::Direction argDirection = mSettings->library.getArgDirection(ftok, 1 + argumentNumber);
                     if (argDirection == Library::ArgumentChecks::Direction::DIR_IN)
                         return false;
+                    else if (argDirection == Library::ArgumentChecks::Direction::DIR_OUT)
+                        return true;
                 }
 
                 const Variable *arg      = function ? function->getArgumentVar(argumentNumber) : nullptr;

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3175,6 +3175,21 @@ private:
                        "}\n", "test.c");
         ASSERT_EQUALS("", errout.str());
 
+        checkUninitVar("struct AB { int a; int b; };\n"  // pass struct members to memcmp by address
+                       "void f(void) {\n"
+                       "    struct AB ab;\n"
+                       "    (void)memcmp(&ab.a, &ab.b, sizeof(int));\n"
+                       "}\n", "test.c");
+        ASSERT_EQUALS("[test.c:4]: (error) Uninitialized variable: ab\n", errout.str());
+
+        checkUninitVar("struct AB { int a; int b; };\n"  // pass struct members to memset and memcmp by address
+                       "void f(void) {\n"
+                       "    struct AB ab;\n"
+                       "    memset(&ab, 0, sizeof(struct AB));\n"
+                       "    (void)memcmp(&ab.a, &ab.b, sizeof(int));\n"
+                       "}\n", "test.c");
+        ASSERT_EQUALS("", errout.str());
+
         checkUninitVar("struct AB { int a; int b; };\n"
                        "void do_something(const struct AB ab);\n"
                        "void f(void) {\n"


### PR DESCRIPTION
CheckUninitVar::isMemberVariableAssignment uses argument direction "out"
now also to check for assignment when the member variable is handed over
to a function by reference.