### PR TITLE
SimplifyTokens: Handle more c++ string literals

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1928,7 +1928,7 @@ void Tokenizer::combineStringAndCharLiterals()
 {
     // Combine wide strings and wide characters
     for (Token *tok = list.front(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "[Lu] %char%|%str%")) {
+        if (Token::Match(tok, "L|u|U|u8 %char%|%str%")) {
             // Combine 'L "string"' and 'L 'c''
             tok->str(tok->next()->str());
             tok->deleteNext();

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -115,6 +115,8 @@ private:
 
         TEST_CASE(combine_wstrings);
         TEST_CASE(combine_ustrings);
+        TEST_CASE(combine_Ustrings);
+        TEST_CASE(combine_u8strings);
 
         // Simplify "not" to "!" (#345)
         TEST_CASE(not1);
@@ -507,9 +509,36 @@ private:
     }
 
     void combine_ustrings() {
-        const char code[] =  "abc = u\"abc\";";
+        const char code[] =  "abcd = u\"ab\" u\"cd\";";
 
-        const char expected[] =  "abc = \"abc\" ;";
+        const char expected[] =  "abcd = \"abcd\" ;";
+
+        Tokenizer tokenizer(&settings0, this);
+        std::istringstream istr(code);
+        tokenizer.tokenize(istr, "test.cpp");
+
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(true, tokenizer.tokens()->tokAt(2)->isLong());
+    }
+
+    void combine_Ustrings() {
+        const char code[] =  "abcd = U\"ab\" U\"cd\";";
+
+        const char expected[] =  "abcd = \"abcd\" ;";
+
+        Tokenizer tokenizer(&settings0, this);
+        std::istringstream istr(code);
+        tokenizer.tokenize(istr, "test.cpp");
+
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(true, tokenizer.tokens()->tokAt(2)->isLong());
+    }
+
+    void combine_u8strings() {
+        const char code[] =  "abcd = u8\"ab\" u8\"cd\";";
+
+        const char expected[] =  "abcd = \"abcd\" ;";
+
 
         Tokenizer tokenizer(&settings0, this);
         std::istringstream istr(code);


### PR DESCRIPTION
Fixes [#8583](https://trac.cppcheck.net/ticket/8583).

This is the same fix as in [#8226](https://trac.cppcheck.net/ticket/8226) but for the `U` and `u8` prefixes. It is  however the wrong fix since this should be done already in the preprocessor (that is what gcc and clang does), but the existing code that handles `L` and `u` is equally wrong.

The "wrongness" is seen when the tokenizer can not distinghuish between `U"abc"` and `U "abc"` (note the space) and will therefore combine both (only the first one should be combined).

Should I try fixing this in simplecpp instead?