### PR TITLE
Load std.cfg before all other libraries

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -826,15 +826,13 @@
       <not-uninit/>
     </arg>
   </function>
-  <!-- boost containers that are similar to std containers, commented out due to dependency on std -->
-  <!--
-  <container id="boostArray" startPattern="boost :: array|scoped_array &lt;" inherits="stdArray" />
-  <container id="boostCircularBuffer" startPattern="boost :: circular_buffer &lt;" inherits="stdContainer" />
-  <container id="boostList" startPattern="boost :: list|slist &lt;" inherits="stdList" />
-  <container id="boostMap" startPattern="boost :: map|flat_map|flat_multimap|multimap|unordered_map|unordered_multimap &lt;" inherits="stdMap" />
-  <container id="boostSet" startPattern="boost :: set|flat_set|flat_multiset|multiset|unordered_set &lt;" inherits="stdSet" />
-  <container id="boostVectorDeque" startPattern="boost :: deque|vector|small_vector|stable_vector|static_vector &lt;" inherits="stdVectorDeque" />
-  -->
+  <!-- boost containers that are similar to std containers -->
+  <container id="boostArray" startPattern="boost :: array|scoped_array &lt;" inherits="stdArray"/>
+  <container id="boostCircularBuffer" startPattern="boost :: circular_buffer &lt;" inherits="stdContainer"/>
+  <container id="boostList" startPattern="boost :: list|slist &lt;" inherits="stdList"/>
+  <container id="boostMap" startPattern="boost :: map|flat_map|flat_multimap|multimap|unordered_map|unordered_multimap &lt;" inherits="stdMap"/>
+  <container id="boostSet" startPattern="boost :: set|flat_set|flat_multiset|multiset|unordered_set &lt;" inherits="stdSet"/>
+  <container id="boostVectorDeque" startPattern="boost :: deque|vector|small_vector|stable_vector|static_vector &lt;" inherits="stdVectorDeque"/>
   <!-- Tell cppcheck to interpret BOOST_AUTO_TEST_CASE as a function definition -->
   <define name="BOOST_AUTO_TEST_CASE(str)" value="void BOOST_AUTO_TEST_CASE_run(str)"/>
   <define name="BOOST_FIXTURE_TEST_CASE(str1, str2)" value="void BOOST_FIXTURE_TEST_CASE_run(str1,str2)"/>

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -532,8 +532,8 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // --library
             else if (std::strncmp(argv[i], "--library=", 10) == 0) {
-                if (!CppCheckExecutor::tryLoadLibrary(mSettings->library, argv[0], argv[i]+10))
-                    return false;
+                std::string lib(argv[i] + 10);
+                mSettings->libraries.push_back(lib);
             }
 
             // --project

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -811,6 +811,17 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck, int /*argc*/, const cha
     Settings& settings = cppcheck.settings();
     _settings = &settings;
     const bool std = tryLoadLibrary(settings.library, argv[0], "std.cfg");
+
+    for (const std::string &lib : settings.libraries) {
+        if (!tryLoadLibrary(settings.library, argv[0], lib.c_str())) {
+            const std::string msg("Failed to load the library " + lib);
+            const std::list<ErrorLogger::ErrorMessage::FileLocation> callstack;
+            ErrorLogger::ErrorMessage errmsg(callstack, emptyString, Severity::information, msg, "failedToLoadCfg", false);
+            reportErr(errmsg);
+            return EXIT_FAILURE;
+        }
+    }
+
     bool posix = true;
     if (settings.standards.posix)
         posix = tryLoadLibrary(settings.library, argv[0], "posix.cfg");

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -827,6 +827,17 @@ Settings MainWindow::getCppcheckSettings()
 
     Settings result;
 
+    const bool std = tryLoadLibrary(&result.library, "std.cfg");
+    bool posix = true;
+    if (result.standards.posix)
+        posix = tryLoadLibrary(&result.library, "posix.cfg");
+    bool windows = true;
+    if (result.isWindowsPlatform())
+        windows = tryLoadLibrary(&result.library, "windows.cfg");
+
+    if (!std || !posix || !windows)
+        QMessageBox::critical(this, tr("Error"), tr("Failed to load %1. Your Cppcheck installation is broken. You can use --data-dir=<directory> at the command line to specify where this file is located. Please note that --data-dir is supposed to be used by installation scripts and therefore the GUI does not start when it is used, all that happens is that the setting is configured.").arg(!std ? "std.cfg" : !posix ? "posix.cfg" : "windows.cfg"));
+
     // If project file loaded, read settings from it
     if (mProjectFile) {
         QStringList dirs = mProjectFile->getIncludeDirs();
@@ -919,17 +930,6 @@ Settings MainWindow::getCppcheckSettings()
     result.standards.c = mSettings->value(SETTINGS_STD_C99, true).toBool() ? Standards::C99 : (mSettings->value(SETTINGS_STD_C11, false).toBool() ? Standards::C11 : Standards::C89);
     result.standards.posix = mSettings->value(SETTINGS_STD_POSIX, false).toBool();
     result.enforcedLang = (Settings::Language)mSettings->value(SETTINGS_ENFORCED_LANGUAGE, 0).toInt();
-
-    const bool std = tryLoadLibrary(&result.library, "std.cfg");
-    bool posix = true;
-    if (result.standards.posix)
-        posix = tryLoadLibrary(&result.library, "posix.cfg");
-    bool windows = true;
-    if (result.isWindowsPlatform())
-        windows = tryLoadLibrary(&result.library, "windows.cfg");
-
-    if (!std || !posix || !windows)
-        QMessageBox::critical(this, tr("Error"), tr("Failed to load %1. Your Cppcheck installation is broken. You can use --data-dir=<directory> at the command line to specify where this file is located. Please note that --data-dir is supposed to be used by installation scripts and therefore the GUI does not start when it is used, all that happens is that the setting is configured.").arg(!std ? "std.cfg" : !posix ? "posix.cfg" : "windows.cfg"));
 
     if (result.jobs <= 1) {
         result.jobs = 1;

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -255,7 +255,10 @@ public:
     /** @brief --report-progress */
     bool reportProgress;
 
-    /** Library (--library) */
+    /** @brief --library= */
+    std::list<std::string> libraries;
+
+    /** Library */
     Library library;
 
     /** Rule */


### PR DESCRIPTION
- CLI: Save the libraries that should be loaded to a list and load them
after the std.cfg has been loaded.
- GUI: Load std.cfg (and windows.cfg / posix.cfg when applicable) before
setting other options and loading the other libraries.
In the project-file-dialog the std.cfg is searched first. If some
other library fails to load is is retried with first loading std.cfg.
- boost.cfg: Enable containers that depend on std containers.