### PR TITLE
Handle prefixed string in Token

### DIFF
--- a/lib/token.h
+++ b/lib/token.h
@@ -1069,6 +1069,9 @@ private:
     /** Update internal property cache about isStandardType() */
     void update_property_isStandardType();
 
+    /** Update internal property cache about string and char literals */
+    void update_property_char_string_literal();
+
 public:
     void astOperand1(Token *tok);
     void astOperand2(Token *tok);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1928,18 +1928,6 @@ void Tokenizer::combineOperators()
 
 void Tokenizer::combineStringAndCharLiterals()
 {
-    for (Token *tok = list.front(); tok; tok = tok->next()) {
-        const std::string prefix[4] = {"u8", "L", "U", "u"};
-        for (const std::string & p : prefix) {
-            if (((tok->tokType() == Token::eString) && (tok->str().find(p + "\"") == 0)) ||
-                ((tok->tokType() == Token::eChar) && (tok->str().find(p + "\'") == 0))) {
-                tok->str(tok->str().substr(p.size()));
-                tok->isLong(p != "u8");
-                break;
-            }
-        }
-    }
-
     // Combine strings
     for (Token *tok = list.front();
          tok;

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -267,16 +267,28 @@ private:
         Token tok;
 
         tok.str("\"\"");
-        ASSERT_EQUALS(0, (int)Token::getStrLength(&tok));
+        ASSERT_EQUALS(0, Token::getStrLength(&tok));
 
         tok.str("\"test\"");
-        ASSERT_EQUALS(4, (int)Token::getStrLength(&tok));
+        ASSERT_EQUALS(4, Token::getStrLength(&tok));
 
         tok.str("\"test \\\\test\"");
-        ASSERT_EQUALS(10, (int)Token::getStrLength(&tok));
+        ASSERT_EQUALS(10, Token::getStrLength(&tok));
 
         tok.str("\"a\\0\"");
-        ASSERT_EQUALS(1, (int)Token::getStrLength(&tok));
+        ASSERT_EQUALS(1, Token::getStrLength(&tok));
+
+        tok.str("L\"\"");
+        ASSERT_EQUALS(0, Token::getStrLength(&tok));
+
+        tok.str("u8\"test\"");
+        ASSERT_EQUALS(4, Token::getStrLength(&tok));
+
+        tok.str("U\"test \\\\test\"");
+        ASSERT_EQUALS(10, Token::getStrLength(&tok));
+
+        tok.str("u\"a\\0\"");
+        ASSERT_EQUALS(1, Token::getStrLength(&tok));
     }
 
     void getStrSize() const {


### PR DESCRIPTION
This makes it possible to call getStrLength() and similar functions
before the tokenizer is called.

Following up the discussion in #1734, I believe this is better than tweaking `getStrSize()`, `getStrLength()`, etc to handle a possible prefix.