### PR TITLE
Libraries: Move valloc() from std.cfg to posix.cfg.

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -4359,6 +4359,22 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <valid>0:</valid>
     </arg>
   </function>
+  <!-- https://pubs.opengroup.org/onlinepubs/7908799/xsh/valloc.html -->
+  <!-- void *valloc(size_t size); -->
+  <function name="valloc">
+    <use-retval/>
+    <returnValue type="void *"/>
+    <noreturn>false</noreturn>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+    <warn severity="style" alternatives="malloc,mmap" reason="Obsolete"/>
+  </function>
+  <memory>
+    <alloc init="false" buffer-size="malloc">valloc</alloc>
+    <dealloc>free</dealloc>
+  </memory>
   <memory>
     <alloc init="false" arg="1">posix_memalign</alloc>
     <dealloc>free</dealloc>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -3702,16 +3702,6 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <valid>0:</valid>
     </arg>
   </function>
-  <!-- void *valloc(size_t size); -->
-  <function name="valloc,std::valloc">
-    <use-retval/>
-    <returnValue type="void *"/>
-    <noreturn>false</noreturn>
-    <arg nr="1" direction="in">
-      <not-uninit/>
-      <valid>0:</valid>
-    </arg>
-  </function>
   <!-- const void * memchr ( const void * ptr, int value, size_t num );-->
   <!-- void * memchr (       void * ptr, int value, size_t num );-->
   <function name="memchr,std::memchr">
@@ -7323,7 +7313,6 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <alloc init="false" buffer-size="malloc">malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc</alloc>
     <alloc init="false">aligned_alloc</alloc>
-    <alloc init="false" buffer-size="malloc">valloc</alloc>
     <dealloc>free</dealloc>
   </memory>
   <resource>


### PR DESCRIPTION
Add buffer-size attribute for aligned_alloc() and add test in std.c.
Move valloc() to posix.cfg since it is a legacy POSIX function and not
part of the standard (not even commonly used).