### PR TITLE
Fix crash in TemplateSimplifier::TokenAndName::TokenAndName 

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -83,8 +83,13 @@ TemplateSimplifier::TokenAndName::TokenAndName(Token *tok, const std::string &s,
         isAlias(paramEnd->strAt(1) == "using");
         isClass(Token::Match(paramEnd->next(), "class|struct|union %name% <|{|:|;"));
         const Token *tok1 = nameToken->next();
-        if (tok1->str() == "<")
-            tok1 = tok1->findClosingBracket()->next();
+        if (tok1->str() == "<") {
+            const Token *closing = tok1->findClosingBracket();
+            if (closing)
+                tok1 = closing->next();
+            else
+                throw InternalError(tok, "unsupported syntax", InternalError::SYNTAX);
+        }
         isFunction(tok1->str() == "(");
         isVariable(!isClass() && Token::Match(tok1, "=|;"));
         if (isVariable())


### PR DESCRIPTION
in case of template constexpr like
```
namespace a {
template <typename T, typename enable = void>
struct promote {
    using type = T;
};

template <typename T>
struct promote <T, typename std::enable_if< std::is_integral<T>::value && sizeof(T) < sizeof(int) >::type>{   
};
}
```
This is not proper solution. This change just eliminates crash and logs error.
Error is better than crash.

https://trac.cppcheck.net/ticket/9046