### PR TITLE
.travis.yml: Add retries to the `apt-get` commands.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 
 before_install:
 # install needed deps
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet
+ - travis_retry sudo apt-get update -qq
+ - travis_retry sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet
 
 matrix:
 # do notify immediately about it when a job of a build fails.
@@ -166,8 +166,8 @@ matrix:
       compiler: gcc
       dist: precise
       before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install libxml2-utils libpcre3
+        - travis_retry sudo apt-get update -qq
+        - travis_retry sudo apt-get install libxml2-utils libpcre3
       script:
         - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2
         - make clean
@@ -177,8 +177,8 @@ matrix:
       compiler: gcc
       dist: trusty
       before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install libxml2-utils libpcre3
+        - travis_retry sudo apt-get update -qq
+        - travis_retry sudo apt-get install libxml2-utils libpcre3
       script:
         - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2
         - make clean


### PR DESCRIPTION
Travis often fails to update / install the packages via apt-get and
jobs must be restarted manually. This should fix the problem or at least
reduce the frequency at which these failures occur.
Details about the problem and the `travis_retry` command can be found
here:
https://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries