### PR TITLE
Fixed #9056 ("using namespace" inside namespace causes "SymbolDatabas…

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -99,7 +99,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                                          tok->progressValue());
         // Locate next class
         if ((mTokenizer->isCPP() && ((Token::Match(tok, "class|struct|union|namespace ::| %name% {|:|::|<") &&
-                                      !Token::Match(tok->previous(), "new|friend|const|enum|typedef|mutable|volatile|)|(|<")) ||
+                                      !Token::Match(tok->previous(), "new|friend|const|enum|typedef|mutable|volatile|using|)|(|<")) ||
                                      (Token::Match(tok, "enum class| %name% {") ||
                                       Token::Match(tok, "enum class| %name% : %name% {"))))
             || (mTokenizer->isC() && Token::Match(tok, "struct|union|enum %name% {"))) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3018,11 +3018,13 @@ void Tokenizer::setVarIdPass2()
         for (Token *tok = list.front(); tok; tok = tok->next()) {
             if (!tok->previous() || Token::Match(tok->previous(), "[;{}]")) {
                 if (Token::Match(tok, "using namespace %name% ::|;")) {
-                    const Token *endtok = tok->tokAt(2);
+                    Token *endtok = tok->tokAt(2);
                     while (Token::Match(endtok, "%name% ::"))
                         endtok = endtok->tokAt(2);
                     if (Token::Match(endtok, "%name% ;"))
                         usingnamespaces.push_back(tok->tokAt(2));
+                    tok = endtok;
+                    continue;
                 } else if (Token::Match(tok, "namespace %name% {")) {
                     scope.push_back(tok->strAt(1));
                     endOfScope[tok->linkAt(2)] = tok->strAt(1);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -296,6 +296,7 @@ private:
         TEST_CASE(symboldatabase73); // #8603
         TEST_CASE(symboldatabase74); // #8838 - final
         TEST_CASE(symboldatabase75);
+        TEST_CASE(symboldatabase76); // #9056
 
         TEST_CASE(createSymbolDatabaseFindAllScopes1);
 
@@ -4216,6 +4217,15 @@ private:
         ASSERT(f->function->isConst());
         ASSERT(f->function->hasTrailingReturnType());
         ASSERT(f->function->hasLvalRefQualifier());
+    }
+
+    void symboldatabase76() { // #9056
+        GET_SYMBOL_DB("namespace foo {\n"
+                      "  using namespace bar::baz;\n"
+                      "  auto func(int arg) -> bar::quux {}\n"
+                      "}");
+        // bar on line 3 should not have a varid
+        TODO_ASSERT_EQUALS(2, 3, db->mVariableList.size());
     }
 
     void createSymbolDatabaseFindAllScopes1() {


### PR DESCRIPTION
…e bailout;)

Fixed the bailout warning and one of the varid bugs.

The trailing return type still has a varid.