### PR TITLE
Fix getStrSize for wchar_t

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -229,10 +229,10 @@ void CheckBufferOverrun::arrayIndex()
                     return ChildrenToVisit::op1_and_op2;
                 });
             }
-        } else if (const Token *stringLiteral = array->getValueTokenMinStrSize()) {
+        } else if (const Token *stringLiteral = array->getValueTokenMinStrSize(mSettings)) {
             Dimension dim;
             dim.tok = nullptr;
-            dim.num = Token::getStrSize(stringLiteral);
+            dim.num = Token::getStrSize(stringLiteral, mSettings);
             dim.known = array->hasKnownValue();
             dimensions.emplace_back(dim);
         } else if (array->valueType() && array->valueType()->pointer >= 1 && array->valueType()->isIntegral()) {

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -60,7 +60,7 @@ void CheckString::stringLiteralWrite()
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!tok->variable() || !tok->variable()->isPointer())
                 continue;
-            const Token *str = tok->getValueTokenMinStrSize();
+            const Token *str = tok->getValueTokenMinStrSize(mSettings);
             if (!str)
                 continue;
             if (Token::Match(tok, "%var% [") && Token::simpleMatch(tok->linkAt(1), "] ="))

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -741,16 +741,27 @@ std::size_t Token::getStrLength(const Token *tok)
     return len;
 }
 
-std::size_t Token::getStrSize(const Token *tok)
+std::size_t Token::getStrArraySize(const Token *tok)
 {
     assert(tok != nullptr && tok->tokType() == eString);
     const std::string &str = tok->str();
-    unsigned int sizeofstring = 1U;
+    std::size_t sizeofstring = 1U;
     for (unsigned int i = 1U; i < str.size() - 1U; i++) {
         if (str[i] == '\\')
             ++i;
         ++sizeofstring;
     }
+
+    return sizeofstring;
+}
+
+std::size_t Token::getStrSize(const Token *tok, const Settings *settings)
+{
+    assert(tok != nullptr && tok->tokType() == eString);
+    std::size_t sizeofstring = getStrArraySize(tok);
+
+    if (settings && tok->isLong())
+        sizeofstring *= settings->sizeof_wchar_t;
     return sizeofstring;
 }
 
@@ -1584,7 +1595,7 @@ const ValueFlow::Value * Token::getInvalidValue(const Token *ftok, unsigned int 
     return ret;
 }
 
-const Token *Token::getValueTokenMinStrSize() const
+const Token *Token::getValueTokenMinStrSize(const Settings *settings) const
 {
     if (!mImpl->mValues)
         return nullptr;
@@ -1593,7 +1604,7 @@ const Token *Token::getValueTokenMinStrSize() const
     std::list<ValueFlow::Value>::const_iterator it;
     for (it = mImpl->mValues->begin(); it != mImpl->mValues->end(); ++it) {
         if (it->isTokValue() && it->tokvalue && it->tokvalue->tokType() == Token::eString) {
-            const std::size_t size = getStrSize(it->tokvalue);
+            const std::size_t size = getStrSize(it->tokvalue, settings);
             if (!ret || size < minsize) {
                 minsize = size;
                 ret = it->tokvalue;

--- a/lib/token.h
+++ b/lib/token.h
@@ -281,13 +281,23 @@ public:
     static std::size_t getStrLength(const Token *tok);
 
     /**
-     * @return sizeof of C-string.
+     * @return array length of C-string.
      *
      * Should be called for %%str%% tokens only.
      *
      * @param tok token with C-string
      **/
-    static std::size_t getStrSize(const Token *tok);
+    static std::size_t getStrArraySize(const Token *tok);
+
+    /**
+     * @return sizeof of C-string.
+     *
+     * Should be called for %%str%% tokens only.
+     *
+     * @param tok token with C-string
+     * @param settings Settings
+     **/
+    static std::size_t getStrSize(const Token *tok, const Settings *const);
 
     /**
      * @return char of C-string at index (possible escaped "\\n")
@@ -971,7 +981,7 @@ public:
     }
 
     const Token *getValueTokenMaxStrLength() const;
-    const Token *getValueTokenMinStrSize() const;
+    const Token *getValueTokenMinStrSize(const Settings *settings) const;
 
     const Token *getValueTokenDeadPointer() const;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2119,7 +2119,7 @@ void Tokenizer::arraySize()
 
         if (addlength || Token::Match(tok, "%var% [ ] = %str% ;")) {
             tok = tok->next();
-            const std::size_t sz = Token::getStrSize(tok->tokAt(3));
+            const std::size_t sz = Token::getStrArraySize(tok->tokAt(3));
             tok->insertToken(MathLib::toString(sz));
             tok = tok->tokAt(5);
         }

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -2059,6 +2059,26 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
+        check("void f() {\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[10]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Array 'str[4]' accessed at index 10, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[4]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'str[4]' accessed at index 4, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[3]);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f()\n"
               "{\n"
               "    const char *str = \"a\tc\";\n"
@@ -3292,9 +3312,27 @@ private:
         // Ticket #909
         check("void f(void) {\n"
               "    char str[] = \"abcd\";\n"
-              "    mymemset(str, 0, 10);\n"
+              "    mymemset(str, 0, 6);\n"
               "}", settings);
         ASSERT_EQUALS("[test.cpp:3]: (error) Buffer is accessed out of bounds: str\n", errout.str());
+
+        check("void f(void) {\n"
+              "    char str[] = \"abcd\";\n"
+              "    mymemset(str, 0, 5);\n"
+              "}", settings);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(void) {\n"
+              "    wchar_t str[] = L\"abcd\";\n"
+              "    mymemset(str, 0, 10081);\n"
+              "}", settings);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Buffer is accessed out of bounds: str\n", errout.str());
+
+        check("void f(void) {\n"
+              "    wchar_t str[] = L\"abcd\";\n"
+              "    mymemset(str, 0, 49);\n"
+              "}", settings);
+        ASSERT_EQUALS("", errout.str());
 
         // ticket #1659 - overflowing variable when using memcpy
         check("void f(void) { \n"

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -293,15 +293,52 @@ private:
 
     void getStrSize() const {
         Token tok;
+        Settings settings;
 
         tok.str("\"abc\"");
-        ASSERT_EQUALS(sizeof("abc"), Token::getStrSize(&tok));
+        ASSERT_EQUALS(sizeof("abc"), Token::getStrSize(&tok, &settings));
 
         tok.str("\"\\0abc\"");
-        ASSERT_EQUALS(sizeof("\0abc"), Token::getStrSize(&tok));
+        ASSERT_EQUALS(sizeof("\0abc"), Token::getStrSize(&tok, &settings));
 
         tok.str("\"\\\\\"");
-        ASSERT_EQUALS(sizeof("\\"), Token::getStrSize(&tok));
+        ASSERT_EQUALS(sizeof("\\"), Token::getStrSize(&tok, &settings));
+
+        tok.str("L\"abc\"");
+        ASSERT_EQUALS(sizeof(L"abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("L\"\\0abc\"");
+        ASSERT_EQUALS(sizeof(L"\0abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("L\"\\\\\"");
+        ASSERT_EQUALS(sizeof(L"\\"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u8\"abc\"");
+        ASSERT_EQUALS(sizeof(u8"abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u8\"\\0abc\"");
+        ASSERT_EQUALS(sizeof(u8"\0abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u8\"\\\\\"");
+        ASSERT_EQUALS(sizeof(u8"\\"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u\"abc\"");
+        ASSERT_EQUALS(sizeof(u"abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u\"\\0abc\"");
+        ASSERT_EQUALS(sizeof(u"\0abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("u\"\\\\\"");
+        ASSERT_EQUALS(sizeof(u"\\"), Token::getStrSize(&tok, &settings));
+
+        tok.str("U\"abc\"");
+        ASSERT_EQUALS(sizeof(U"abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("U\"\\0abc\"");
+        ASSERT_EQUALS(sizeof(U"\0abc"), Token::getStrSize(&tok, &settings));
+
+        tok.str("U\"\\\\\"");
+        ASSERT_EQUALS(sizeof(U"\\"), Token::getStrSize(&tok, &settings));
     }
 
     void strValue() const {


### PR DESCRIPTION
Work in progress I need some input on. There are two issues I don't know how to solve.

There are basically five different types of strings. Plain chars, wide chars, utf-8, utf-16 and utf-32. chars and utf-8 chars are both encoded the same way (until c++20 at least), but currently the only way we separate them is to set the `isLong()` property, which is not enough to separate four different sizes. I'm a little reluctant to add another flag just to separate these, but couldn't see any better way to do it. Would it be ok to add a flag for isUtfString that can be used for utf16 and utf32 (and setting utf32 as long to be able to separate them). Or are these corner cases that we shouldn't worry too much about (I don't know how much these are used).

Ignoring the above, there is still an issue to make it work for wchar_t. In order for it to work, [`ValueType::typeFromString()`](https://github.com/danmar/cppcheck/blob/7995b2fb8672790871dcb2b7fb29efe89b084727/lib/symboldatabase.cpp#L5495) needs to know about `wchar_t`. None of the existing types are a perfect match (since wchar_t is two bytes on windows, and four everewhere else). Do I just pick a type that's somewhat appropriate (at another place in [symboldatabase.cpp](https://github.com/danmar/cppcheck/blob/7995b2fb8672790871dcb2b7fb29efe89b084727/lib/symboldatabase.cpp#L5334), SHORT is picked), or do I add a new type to ValueType::Type?