### PR TITLE
Fixed: FP return reference to thread_local variable

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9250,9 +9250,11 @@ void Tokenizer::simplifyKeyword()
                 Token::createMutualLinks(braceStart, braceEnd);
             }
 
-            // 3) thread_local
+            // 3) thread_local -> static
+            //    on single thread thread_local has the effect of static
             else if (tok->str() == "thread_local") {
-                tok->deleteThis();
+                tok->originalName(tok->str());
+                tok->str("static");
             }
         }
     }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -882,6 +882,13 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
+        check("std::vector<int> &foo()\n"
+              "{\n"
+              "    thread_local std::vector<int> v;\n"
+              "    return v;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
         check("std::string hello()\n"
               "{\n"
               "     return \"hello\";\n"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4132,7 +4132,7 @@ private:
             // Ticket #8679
             const char code[] = "thread_local void *thread_local_var; "
                                 "__thread void *thread_local_var_2;";
-            ASSERT_EQUALS("void * thread_local_var ; "
+            ASSERT_EQUALS("static void * thread_local_var ; "
                           "void * thread_local_var_2 ;", tokenizeAndStringify(code));
         }
     }


### PR DESCRIPTION
A function returning a reference to a `thread_local` variable is not a bug, as for example in the following function.
```C++
std::vector<int> &foo()
{
    thread_local std::vector<int> v;
    return v;
}
```
The returned reference can be used as long as the thread is alive.

The fix from this pull request solves this by handling `thread_local` as `static`. In fact, it replaces the token `thread_local` by `static`.