### PR TITLE
Add defines set by compiler options when using compilation database

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -297,7 +297,6 @@ void ImportProject::FileSettings::parseCommand(const std::string &command)
                 defs += stddef;
                 defs += ";";
             }
-        }
         } else if (F == 'i' && fval == "system") {
             ++pos;
             const std::string isystem = readUntil(command, &pos, " ");


### PR DESCRIPTION
sets __cplusplus and __STDC_VERSION__ based on -std and the defines for -municode, -fpie, -fPIE, -fpic and -fPIC