### PR TITLE
 donate-cpu.py: improved error detection

### DIFF
--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -91,13 +91,13 @@ int ThreadExecutor::handleRead(int rpipe, unsigned int &result)
     }
 
     if (type != REPORT_OUT && type != REPORT_ERROR && type != REPORT_INFO && type != CHILD_END) {
-        std::cerr << "#### You found a bug from cppcheck.\nThreadExecutor::handleRead error, type was:" << type << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead error, type was:" << type << std::endl;
         std::exit(0);
     }
 
     unsigned int len = 0;
     if (read(rpipe, &len, sizeof(len)) <= 0) {
-        std::cerr << "#### You found a bug from cppcheck.\nThreadExecutor::handleRead error, type was:" << type << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead error, type was:" << type << std::endl;
         std::exit(0);
     }
 
@@ -106,7 +106,7 @@ int ThreadExecutor::handleRead(int rpipe, unsigned int &result)
     char *buf = new char[len + 1];
     const ssize_t readIntoBuf = read(rpipe, buf, len);
     if (readIntoBuf <= 0) {
-        std::cerr << "#### You found a bug from cppcheck.\nThreadExecutor::handleRead error, type was:" << type << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead error, type was:" << type << std::endl;
         std::exit(0);
     }
     buf[readIntoBuf] = 0;
@@ -183,25 +183,25 @@ unsigned int ThreadExecutor::check()
         if ((iFile != _files.end() || iFileSettings != _settings.project.fileSettings.end()) && nchildren < _settings.jobs && checkLoadAverage(nchildren)) {
             int pipes[2];
             if (pipe(pipes) == -1) {
-                std::cerr << "pipe() failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, pipe() failed: "<< std::strerror(errno) << std::endl;
                 std::exit(EXIT_FAILURE);
             }
 
             int flags = 0;
             if ((flags = fcntl(pipes[0], F_GETFL, 0)) < 0) {
-                std::cerr << "fcntl(F_GETFL) failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, fcntl(F_GETFL) failed: "<< std::strerror(errno) << std::endl;
                 std::exit(EXIT_FAILURE);
             }
 
             if (fcntl(pipes[0], F_SETFL, flags | O_NONBLOCK) < 0) {
-                std::cerr << "fcntl(F_SETFL) failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, fcntl(F_SETFL) failed: "<< std::strerror(errno) << std::endl;
                 std::exit(EXIT_FAILURE);
             }
 
             pid_t pid = fork();
             if (pid < 0) {
                 // Error
-                std::cerr << "Failed to create child process: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, Failed to create child process: "<< std::strerror(errno) << std::endl;
                 std::exit(EXIT_FAILURE);
             } else if (pid == 0) {
                 close(pipes[0]);
@@ -377,7 +377,7 @@ unsigned int ThreadExecutor::check()
     for (unsigned int i = 0; i < _settings.jobs; ++i) {
         threadHandles[i] = (HANDLE)_beginthreadex(nullptr, 0, threadProc, this, 0, nullptr);
         if (!threadHandles[i]) {
-            std::cerr << "#### .\nThreadExecutor::check error, errno :" << errno << std::endl;
+            std::cerr << "#### ThreadExecutor::check error, errno :" << errno << std::endl;
             exit(EXIT_FAILURE);
         }
     }
@@ -385,10 +385,10 @@ unsigned int ThreadExecutor::check()
     const DWORD waitResult = WaitForMultipleObjects(_settings.jobs, threadHandles, TRUE, INFINITE);
     if (waitResult != WAIT_OBJECT_0) {
         if (waitResult == WAIT_FAILED) {
-            std::cerr << "#### .\nThreadExecutor::check wait failed, result: " << waitResult << " error: " << GetLastError() << std::endl;
+            std::cerr << "#### ThreadExecutor::check wait failed, result: " << waitResult << " error: " << GetLastError() << std::endl;
             exit(EXIT_FAILURE);
         } else {
-            std::cerr << "#### .\nThreadExecutor::check wait failed, result: " << waitResult << std::endl;
+            std::cerr << "#### ThreadExecutor::check wait failed, result: " << waitResult << std::endl;
             exit(EXIT_FAILURE);
         }
     }
@@ -398,14 +398,14 @@ unsigned int ThreadExecutor::check()
         DWORD exitCode;
 
         if (!GetExitCodeThread(threadHandles[i], &exitCode)) {
-            std::cerr << "#### .\nThreadExecutor::check get exit code failed, error:" << GetLastError() << std::endl;
+            std::cerr << "#### ThreadExecutor::check get exit code failed, error:" << GetLastError() << std::endl;
             exit(EXIT_FAILURE);
         }
 
         result += exitCode;
 
         if (!CloseHandle(threadHandles[i])) {
-            std::cerr << "#### .\nThreadExecutor::check close handle failed, error:" << GetLastError() << std::endl;
+            std::cerr << "#### ThreadExecutor::check close handle failed, error:" << GetLastError() << std::endl;
             exit(EXIT_FAILURE);
         }
     }

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -39,7 +39,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.17"
+CLIENT_VERSION = "1.1.18"
 
 
 def checkRequirements():

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -300,7 +300,7 @@ def scanPackage(workPath, cppcheckPath, jobs):
         pos2 = stderr.find(' [cppcheckError]', pos1)
         signr = int(stderr[pos1+len(s):pos2])
         return -signr, '', '', -signr, options
-    if stderr.find('#### ThreadExecutor'):
+    if stderr.find('#### ThreadExecutor') > 0:
         print('Thread!')
         return -111, '', '', -111, options
     information_messages_list = []

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -274,8 +274,8 @@ def scanPackage(workPath, cppcheckPath, jobs):
     cppcheck_cmd = cppcheckPath + '/cppcheck' + ' ' + options
     cmd = 'nice ' + cppcheck_cmd
     returncode, stdout, stderr, elapsedTime = runCommand(cmd)
+    print('cppcheck finished with ' + str(returncode))
     if returncode == -11 or stderr.find('Internal error: Child process crashed with signal 11 [cppcheckError]') > 0:
-        # Crash!
         print('Crash!')
         stacktrace = ''
         if cppcheckPath == 'cppcheck':
@@ -289,7 +289,20 @@ def scanPackage(workPath, cppcheckPath, jobs):
                     stacktrace = stdout[gdb_pos:]
                 else:
                     stacktrace = stdout[last_check_pos:]
-        return -1, stacktrace, '', -1, options
+        return -11, stacktrace, '', -11, options
+    if returncode != 0:
+        print('Error!')
+        return returncode, '', '', returncode, options
+    if stderr.find('Internal error: Child process crashed with signal ') > 0:
+        print('Error!')
+        s = 'Internal error: Child process crashed with signal '
+        pos1 = stderr.find(s)
+        pos2 = stderr.find(' [cppcheckError]', pos1)
+        signr = int(stderr[pos1+len(s):pos2])
+        return -signr, '', '', -signr, options
+    if stderr.find('#### ThreadExecutor'):
+        print('Thread!')
+        return -111, '', '', -111, options
     information_messages_list = []
     issue_messages_list = []
     count = 0


### PR DESCRIPTION
Currently only signal 11 (aka `SIGSEGV` aka Segmentation fault) is being handled as a crash. This adds handling for all signals and exitcodes which are not 0 as well as ThreadExecutor errors.

I have seen reproducible ThreadExecutor errors with `fork()` failing for `php5` and another package I cannot remember. I haven't look into these, but these are obviously causing incomplete results.

Other signal should also be handled like signal 11 and produce stack trace. The most obvious would be `SIGABRT`. As the actual signal will be reflected in the negative `elapsedTime` value we can add this handling step by step.