### PR TITLE
template simplifier: fix another crash

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1448,21 +1448,23 @@ void TemplateSimplifier::expandTemplate(
                     if (start->strAt(1) == "<") {
                         // get the instantiated name
                         Token * closing = start->next()->findClosingBracket();
-                        std::string name;
-                        const Token * type = start;
-                        while (type && type != closing->next()) {
-                            if (!name.empty())
-                                name += " ";
-                            name += type->str();
-                            type = type->next();
-                        }
-                        // check if type is instantiated
-                        for (const auto & inst : mTemplateInstantiations) {
-                            if (Token::simpleMatch(inst.token, name.c_str())) {
-                                // use the instantiated name
-                                dst->insertToken(name, "", true);
-                                start = closing;
-                                break;
+                        if (closing) {
+                            std::string name;
+                            const Token * type = start;
+                            while (type && type != closing->next()) {
+                                if (!name.empty())
+                                    name += " ";
+                                name += type->str();
+                                type = type->next();
+                            }
+                            // check if type is instantiated
+                            for (const auto & inst : mTemplateInstantiations) {
+                                if (Token::simpleMatch(inst.token, name.c_str())) {
+                                    // use the instantiated name
+                                    dst->insertToken(name, "", true);
+                                    start = closing;
+                                    break;
+                                }
                             }
                         }
                         // just copy the token if it wasn't instantiated


### PR DESCRIPTION
This fixes a daca crash in Vc-1.3.3/tests/casts.cpp.