### PR TITLE
library.cpp: optimized Library::detectContainer()

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -381,8 +381,10 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
             }
 
             const char* const startPattern = node->Attribute("startPattern");
-            if (startPattern)
+            if (startPattern) {
                 container.startPattern = startPattern;
+                container.startPattern2 = container.startPattern + " !!::";
+            }
             const char* const endPattern = node->Attribute("endPattern");
             if (endPattern)
                 container.endPattern = endPattern;
@@ -1012,10 +1014,7 @@ const Library::Container* Library::detectContainer(const Token* typeStart, bool 
         if (container.startPattern.empty())
             continue;
 
-        if (!endsWith(container.startPattern, '<')) {
-            if (!Token::Match(typeStart, (container.startPattern + " !!::").c_str()))
-                continue;
-        } else if (!Token::Match(typeStart, (container.startPattern + " !!::").c_str()))
+        if (!Token::Match(typeStart, container.startPattern2.c_str()))
             continue;
 
         if (!iterator && container.endPattern.empty()) // If endPattern is undefined, it will always match, but itEndPattern has to be defined.

--- a/lib/library.h
+++ b/lib/library.h
@@ -196,7 +196,7 @@ public:
             Action action;
             Yield yield;
         };
-        std::string startPattern, endPattern, itEndPattern;
+        std::string startPattern, startPattern2, endPattern, itEndPattern;
         std::map<std::string, Function> functions;
         int type_templateArgNo;
         int size_templateArgNo;

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -6113,6 +6113,7 @@ private:
             Settings sC;
             Library::Container c;
             c.startPattern = "C";
+            c.startPattern2 = "C !!::";
             sC.library.containers["C"] = c;
             ASSERT_EQUALS("container(C) *", typeOf("C*c=new C;","new","test.cpp",&sC));
             ASSERT_EQUALS("container(C) *", typeOf("x=(C*)c;","(","test.cpp",&sC));
@@ -6122,6 +6123,7 @@ private:
             Settings set;
             Library::Container vector;
             vector.startPattern = "Vector";
+            vector.startPattern2 = "Vector !!::";
             vector.type_templateArgNo = 0;
             vector.arrayLike_indexOp = true;
             set.library.containers["Vector"] = vector;


### PR DESCRIPTION
reduces Ir from 5882 to 1149 according to callgrind

I chose the random package `nn` for profiling.