### PR TITLE
Misra explicitly allows spaces between # and the preprocessing tokens

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1608,13 +1608,14 @@ class MisraChecker:
 
 
     def misra_20_13(self, data):
+        dir_pattern = re.compile(r'#[ ]*([^ (<]*)')
         for directive in data.directives:
             dir = directive.str
-            for sep in ' (<':
-                if dir.find(sep) > 0:
-                    dir = dir[:dir.find(sep)]
-            if dir not in ['#define', '#elif', '#else', '#endif', '#error', '#if', '#ifdef', '#ifndef', '#include',
-                        '#pragma', '#undef', '#warning']:
+            mo = dir_pattern.match(dir)
+            if mo:
+                dir = mo.group(1)
+            if dir not in ['define', 'elif', 'else', 'endif', 'error', 'if', 'ifdef', 'ifndef', 'include',
+                        'pragma', 'undef', 'warning']:
                 self.reportError(directive, 20, 13)
 
 

--- a/addons/test/misra-test.c
+++ b/addons/test/misra-test.c
@@ -500,6 +500,14 @@ union misra_19_2 { }; // 19.2
 
 #else1 // 20.13
 
+#ifdef A>1
+# define somethingis 5 // no warning
+# define func_20_13(v) (v) // no warning
+#else
+# definesomethingis 6 // 20.13
+# def fun_2013(v) () // 20.13
+#endif
+
 void misra_21_3() {
   p1=malloc(10); // 21.3
   p2=calloc(10); // 21.3


### PR DESCRIPTION
This patch uses a regexp for handling preprocessor directives, which allows constructs like e.g:
   
```
#ifdef BLABLA
# define MY_MACRO 1
#else 
# define MY_MACRO 2
#endif 
```

