### PR TITLE
Record C/CPP/Posix Standard used for cppcheck in dump file / use this for misra checking

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -569,6 +569,9 @@ class Configuration:
         arguments = []
 
         for element in confignode:
+            if element.tag == "standards":
+                self.standards = Standards(element)
+
             if element.tag == 'directivelist':
                 for directive in element:
                     self.directives.append(Directive(directive))
@@ -660,6 +663,21 @@ class Platform:
         self.long_long_bit = int(platformnode.get('long_long_bit'))
         self.pointer_bit = int(platformnode.get('pointer_bit'))
 
+class Standards:
+    """
+    Standards class
+    This class contains versions of standards that were used for the cppcheck
+
+    Attributes:
+        c            C Standard used
+        cpp          C++ Standard used
+        posix        If Posix was used
+    """
+
+    def __init__(self, standardsnode):
+        self.c = standardsnode.find("c").get("version")
+        self.cpp = standardsnode.find("cpp").get("version")
+        self.posix = standardsnode.find("posix") != None
 
 class CppcheckData:
     """

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -627,13 +627,11 @@ class MisraChecker:
 
         self.stdversion = stdversion
 
-    def get_num_significant_naming_chars(self):
-        if self.stdversion == "c90":
-            return 31
-        elif self.stdversion == "c99":
+    def get_num_significant_naming_chars(self, cfg):
+        if cfg.standards and cfg.standards.c == "c99":
             return 63
         else:
-            raise RuntimeException("Don't know the number of significant naming characters for C standard %s" % self.stdversion)
+            return 31
 
     def misra_3_1(self, rawTokens):
         for token in rawTokens:
@@ -743,7 +741,7 @@ class MisraChecker:
 
 
     def misra_5_3(self, data):
-        num_sign_chars = self.get_num_significant_naming_chars()
+        num_sign_chars = self.get_num_significant_naming_chars(data)
         enum = []
         scopeVars = {}
         for var in data.variables:
@@ -799,7 +797,7 @@ class MisraChecker:
 
 
     def misra_5_4(self, data):
-        num_sign_chars = self.get_num_significant_naming_chars()
+        num_sign_chars = self.get_num_significant_naming_chars(data)
         macro = {}
         compile_name = re.compile(r'#define ([a-zA-Z0-9_]+)')
         compile_param = re.compile(r'#define ([a-zA-Z0-9_]+)[(]([a-zA-Z0-9_, ]+)[)]')
@@ -838,7 +836,7 @@ class MisraChecker:
 
 
     def misra_5_5(self, data):
-        num_sign_chars = self.get_num_significant_naming_chars()
+        num_sign_chars = self.get_num_significant_naming_chars(data)
         macroNames = []
         compiled = re.compile(r'#define ([A-Za-z0-9_]+)')
         for dir in data.directives:
@@ -2290,12 +2288,11 @@ parser.add_argument("-verify", help=argparse.SUPPRESS, action="store_true")
 parser.add_argument("-generate-table", help=argparse.SUPPRESS, action="store_true")
 parser.add_argument("dumpfile", nargs='*', help="Path of dump file from cppcheck")
 parser.add_argument("--show-suppressed-rules", help="Print rule suppression list", action="store_true")
-parser.add_argument("--std", choices=("c90", "c99"), default="c90", help="Specify version of C language being used")
 parser.add_argument("-P", "--file-prefix", type=str, help="Prefix to strip when matching suppression file rules")
 parser.add_argument("--cli", help="Addon is executed from Cppcheck", action="store_true")
 args = parser.parse_args()
 
-checker = MisraChecker(args.std)
+checker = MisraChecker()
 
 if args.generate_table:
     generateTable()

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -591,7 +591,7 @@ class Rule:
 
 class MisraChecker:
 
-    def __init__(self):
+    def __init__(self, stdversion = "c90"):
 
         # Test validation rules lists
         self.verify_expected    = list()
@@ -624,6 +624,16 @@ class MisraChecker:
 
         # Statistics of all violations suppressed per rule
         self.suppressionStats   = dict()
+
+        self.stdversion = stdversion
+
+    def get_num_significant_naming_chars(self):
+        if self.stdversion == "c90":
+            return 31
+        elif self.stdversion == "c99":
+            return 63
+        else:
+            raise RuntimeException("Don't know the number of significant naming characters for C standard %s" % self.stdversion)
 
     def misra_3_1(self, rawTokens):
         for token in rawTokens:
@@ -733,6 +743,7 @@ class MisraChecker:
 
 
     def misra_5_3(self, data):
+        num_sign_chars = self.get_num_significant_naming_chars()
         enum = []
         scopeVars = {}
         for var in data.variables:
@@ -759,7 +770,7 @@ class MisraChecker:
                         outerScope = outerScope.nestedIn
                         continue
                     for outerVar in scopeVars[outerScope]:
-                        if innerVar.nameToken.str[:31] == outerVar.nameToken.str[:31]:
+                        if innerVar.nameToken.str[:num_sign_chars] == outerVar.nameToken.str[:num_sign_chars]:
                             if outerVar.isArgument and outerScope.type == "Global" and not innerVar.isArgument:
                                 continue
                             if int(innerVar.nameToken.linenr) > int(outerVar.nameToken.linenr):
@@ -768,7 +779,7 @@ class MisraChecker:
                                 self.reportError(outerVar.nameToken, 5, 3)
                     outerScope = outerScope.nestedIn
                 for scope in data.scopes:
-                    if scope.className and innerVar.nameToken.str[:31] == scope.className[:31]:
+                    if scope.className and innerVar.nameToken.str[:num_sign_chars] == scope.className[:num_sign_chars]:
                         if int(innerVar.nameToken.linenr) > int(scope.bodyStart.linenr):
                             self.reportError(innerVar.nameToken, 5, 3)
                         else:
@@ -776,18 +787,19 @@ class MisraChecker:
 
                 for e in enum:
                     for scope in data.scopes:
-                        if scope.className and innerVar.nameToken.str[:31] == e[:31]:
+                        if scope.className and innerVar.nameToken.str[:num_sign_chars] == e[:num_sign_chars]:
                             if int(innerVar.nameToken.linenr) > int(innerScope.bodyStart.linenr):
                                 self.reportError(innerVar.nameToken, 5, 3)
                             else:
                                 self.reportError(innerScope.bodyStart, 5, 3)
         for e in enum:
             for scope in data.scopes:
-                if scope.className and scope.className[:31] == e[:31]:
+                if scope.className and scope.className[:num_sign_chars] == e[:num_sign_chars]:
                     self.reportError(scope.bodyStart, 5, 3)
 
 
     def misra_5_4(self, data):
+        num_sign_chars = self.get_num_significant_naming_chars()
         macro = {}
         compile_name = re.compile(r'#define ([a-zA-Z0-9_]+)')
         compile_param = re.compile(r'#define ([a-zA-Z0-9_]+)[(]([a-zA-Z0-9_, ]+)[)]')
@@ -807,18 +819,18 @@ class MisraChecker:
             if len(macro[mvar]["params"]) > 0:
                 for i, macroparam1 in enumerate(macro[mvar]["params"]):
                     for j, macroparam2 in enumerate(macro[mvar]["params"]):
-                        if j > i and macroparam1[:31] == macroparam2[:31]:
+                        if j > i and macroparam1[:num_sign_chars] == macroparam2[:num_sign_chars]:
                             self.reportError(mvar, 5, 4)
 
         for x, m_var1 in enumerate(macro):
             for y, m_var2 in enumerate(macro):
-                if x < y and macro[m_var1]["name"][:31] == macro[m_var2]["name"][:31]:
+                if x < y and macro[m_var1]["name"][:num_sign_chars] == macro[m_var2]["name"][:num_sign_chars]:
                     if m_var1.linenr > m_var2.linenr:
                         self.reportError(m_var1, 5, 4)
                     else:
                         self.reportError(m_var2, 5, 4)
                 for param in macro[m_var2]["params"]:
-                    if macro[m_var1]["name"][:31] == param[:31]:
+                    if macro[m_var1]["name"][:num_sign_chars] == param[:num_sign_chars]:
                         if m_var1.linenr > m_var2.linenr:
                             self.reportError(m_var1, 5, 4)
                         else:
@@ -826,6 +838,7 @@ class MisraChecker:
 
 
     def misra_5_5(self, data):
+        num_sign_chars = self.get_num_significant_naming_chars()
         macroNames = []
         compiled = re.compile(r'#define ([A-Za-z0-9_]+)')
         for dir in data.directives:
@@ -835,11 +848,11 @@ class MisraChecker:
         for var in data.variables:
             for macro in macroNames:
                 if var.nameToken is not None:
-                    if var.nameToken.str[:31] == macro[:31]:
+                    if var.nameToken.str[:num_sign_chars] == macro[:num_sign_chars]:
                         self.reportError(var.nameToken, 5, 5)
         for scope in data.scopes:
             for macro in macroNames:
-                if scope.className and scope.className[:31] == macro[:31]:
+                if scope.className and scope.className[:num_sign_chars] == macro[:num_sign_chars]:
                     self.reportError(scope.bodyStart, 5, 5)
 
 
@@ -2277,11 +2290,12 @@ parser.add_argument("-verify", help=argparse.SUPPRESS, action="store_true")
 parser.add_argument("-generate-table", help=argparse.SUPPRESS, action="store_true")
 parser.add_argument("dumpfile", nargs='*', help="Path of dump file from cppcheck")
 parser.add_argument("--show-suppressed-rules", help="Print rule suppression list", action="store_true")
+parser.add_argument("--std", choices=("c90", "c99"), default="c90", help="Specify version of C language being used")
 parser.add_argument("-P", "--file-prefix", type=str, help="Prefix to strip when matching suppression file rules")
 parser.add_argument("--cli", help="Addon is executed from Cppcheck", action="store_true")
 args = parser.parse_args()
 
-checker = MisraChecker()
+checker = MisraChecker(args.std)
 
 if args.generate_table:
     generateTable()

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -476,9 +476,6 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                     fdump << "  <standards>" << std::endl;
                     fdump << "    <c version=\"" << mSettings.standards.getC() << "\"/>" << std::endl;
                     fdump << "    <cpp version=\"" << mSettings.standards.getCPP() << "\"/>" << std::endl;
-                    if (mSettings.standards.posix) {
-                        fdump << "    <posix/>" << std::endl;
-                    }
                     fdump << "  </standards>" << std::endl;
                     preprocessor.dump(fdump);
                     mTokenizer.dump(fdump);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -473,6 +473,13 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 // dump xml if --dump
                 if ((mSettings.dump || !mSettings.addons.empty()) && fdump.is_open()) {
                     fdump << "<dump cfg=\"" << ErrorLogger::toxml(mCurrentConfig) << "\">" << std::endl;
+                    fdump << "  <standards>" << std::endl;
+                    fdump << "    <c version=\"" << mSettings.standards.getC() << "\"/>" << std::endl;
+                    fdump << "    <cpp version=\"" << mSettings.standards.getCPP() << "\"/>" << std::endl;
+                    if (mSettings.standards.posix) {
+                        fdump << "    <posix/>" << std::endl;
+                    }
+                    fdump << "  </standards>" << std::endl;
                     preprocessor.dump(fdump);
                     mTokenizer.dump(fdump);
                     fdump << "</dump>" << std::endl;

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -57,10 +57,15 @@ struct Standards {
         return false;
     }
     const std::string getC(void) const {
-        if (c == C89) return "c89";
-        else if (c == C99) return "c99";
-        else if (c == C11) return "c11";
-        else return "";
+        switch (c) {
+            case C89:
+                return "c89";
+            case C99:
+                return "c99";
+            case C11:
+                return "c11";
+        }
+        return "";
     }
     bool setCPP(const std::string& str) {
         if (str == "c++03" || str == "C++03") {
@@ -86,10 +91,19 @@ struct Standards {
         return false;
     }
     const std::string getCPP(void) const {
-        if (cpp == CPP03) return "c++03";
-        else if (cpp == CPP11) return "c++11";
-        else if (cpp == CPP14) return "c++14";
-        else return "";
+        switch (cpp) {
+            case CPP03:
+                return "c++03";
+            case CPP11:
+                return "c++11";
+            case CPP14:
+                return "c++14";
+            case CPP17:
+                return "c++17";
+            case CPP20:
+                return "c++20";
+        }
+        return "";
     }
 };
 

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -56,6 +56,12 @@ struct Standards {
         }
         return false;
     }
+    const std::string getC(void) const {
+        if (c == C89) return "c89";
+        else if (c == C99) return "c99";
+        else if (c == C11) return "c11";
+        else return "";
+    }
     bool setCPP(const std::string& str) {
         if (str == "c++03" || str == "C++03") {
             cpp = CPP03;
@@ -78,6 +84,12 @@ struct Standards {
             return true;
         }
         return false;
+    }
+    const std::string getCPP(void) const {
+        if (cpp == CPP03) return "c++03";
+        else if (cpp == CPP11) return "c++11";
+        else if (cpp == CPP14) return "c++14";
+        else return "";
     }
 };
 


### PR DESCRIPTION
Misra rules defines different length criterias for identifiers depending on what version of the C language is being used.

This patch allows choosing C version on the command line, and fixes _some_ of these rules (there may be more).
