### PR TITLE
Misra xml output

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -808,6 +808,8 @@ def reportError(template, callstack=(), severity='', message='', errorId='', sup
         template = '{file}({line}): {severity}: {message}'
     elif template == 'edit':
         template = '{file} +{line}: {severity}: {message}'
+    elif template == 'xml':
+        return reportErrorXML(callstack, severity, message, errorId, suppressions, outputFunc)
     # compute 'callstack}, {file} and {line} replacements
     stack = ' -> '.join('[' + f + ':' + str(l) + ']' for (f, l) in callstack)
     file = callstack[-1][0]
@@ -822,3 +824,30 @@ def reportError(template, callstack=(), severity='', message='', errorId='', sup
         outputFunc(outputLine)
     # format message
     return outputLine
+
+def reportErrorXML(callstack, severity, message, errorId, suppressions, outputFunc):
+    """
+        Format an error message according to cppcheck's xml format.
+
+        :param callstack: e.g. [['file1.cpp',10],['file2.h','20'], ... ]
+        :param severity: e.g. 'error', 'warning' ...
+        :param id: message ID.
+        :param message: message text.
+    """
+    node = ET.Element("error")
+    if errorId:
+        node.set("id", errorId)
+    if severity:
+        node.set("severity", severity)
+    node.set("msg", message)
+
+    file = callstack[-1][0]
+    line = str(callstack[-1][1])
+    if suppressions is not None and any(suppression.isMatch(file, line, message, errorId) for suppression in suppressions):
+        return None
+
+    for filename, lineno in callstack:
+        location = ET.Element("location", { 'file': filename, 'line': str(lineno) } )
+        node.append(location)
+
+    return ET.tostring(node, encoding="unicode")

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2220,12 +2220,6 @@ else:
     if args.no_summary:
         SHOW_SUMMARY = False
     if args.dumpfile:
-        if args.template == 'xml':
-            sys.stderr.write("""<?xml version="1.0" encoding="UTF-8"?>
-<results version="2">
-    <cppcheck version="1.84"/>
-    <errors>
-""")
         exitCode = 0
         for item in args.dumpfile:
             checker.parseDump(item)
@@ -2263,8 +2257,4 @@ else:
         if args.show_suppressed_rules:
             checker.showSuppressedRules()
 
-        if args.template == 'xml':
-            sys.stderr.write("""    </errors>
-</results>
-""")
         sys.exit(exitCode)

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2220,6 +2220,12 @@ else:
     if args.no_summary:
         SHOW_SUMMARY = False
     if args.dumpfile:
+        if args.template == 'xml':
+            sys.stderr.write("""<?xml version="1.0" encoding="UTF-8"?>
+<results version="2">
+    <cppcheck version="1.84"/>
+    <errors>
+""")
         exitCode = 0
         for item in args.dumpfile:
             checker.parseDump(item)
@@ -2257,4 +2263,8 @@ else:
         if args.show_suppressed_rules:
             checker.showSuppressedRules()
 
+        if args.template == 'xml':
+            sys.stderr.write("""    </errors>
+</results>
+""")
         sys.exit(exitCode)


### PR DESCRIPTION
I'm not sure if you want this, it isn't really a complete solution, but it adds 'xml' as output format, producing cppcheck compatible output.  It does **not** create a complete xml though, the header and footer is missing, and I could not come up with a good solution to add it.

I use this to process each dump file into an xml stub file, then concatenate all stubs and xml header+footer into a complete xml file, then feed this to the cppcheck plugin for Jenkins. 