### PR TITLE
Add missing line feed to the generated plist output

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -732,7 +732,7 @@ std::string ErrorLogger::plistData(const ErrorLogger::ErrorMessage &msg)
               << "     <key>depth</key><integer>0</integer>\r\n"
               << "     <key>extended_message</key>\r\n"
               << "     <string>" << ErrorLogger::toxml(message) << "</string>\r\n"
-              << "     <key>message</key>\r"
+              << "     <key>message</key>\r\n"
               << "     <string>" << ErrorLogger::toxml(message) << "</string>\r\n"
               << "    </dict>\r\n";
     }


### PR DESCRIPTION
Add missing line feed to the generated plist output because DOS uses carriage return and line feed as a line ending.