### PR TITLE
Handle 'arguments' sections in compile_commands.json

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -340,7 +340,7 @@ void ImportProject::importCompileCommands(std::istream &istr)
 
         const std::string directory = dirpath;
 
-        std::stringstream comm;
+        std::ostringstream comm;
         if( obj.find( "arguments" ) != obj.end() ) {
             if( obj[ "arguments" ].is< picojson::array >() ) {
                 for( const picojson::value& arg : obj[ "arguments" ].get< picojson::array >() ) {

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -353,7 +353,7 @@ void ImportProject::importCompileCommands(std::istream &istr)
                 return;
             }
         }
-        else if( obj.find( "arguments" ) != obj.end() ) {
+        else if( obj.find( "command" ) != obj.end() ) {
             if( obj[ "command" ].is< std::string >() ) {
                 comm << obj[ "command" ].get< std::string >();
             }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -30,7 +30,7 @@
 #include <cstring>
 #include <fstream>
 #include <utility>
-
+#include <sstream>
 
 void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
 {
@@ -339,7 +339,30 @@ void ImportProject::importCompileCommands(std::istream &istr)
             dirpath += '/';
 
         const std::string directory = dirpath;
-        const std::string command = obj["command"].get<std::string>();
+
+        std::stringstream comm;
+        if( obj.find( "arguments" ) != obj.end() ) {
+            if( obj[ "arguments" ].is< picojson::array >() ) {
+                for( const picojson::value& arg : obj[ "arguments" ].get< picojson::array >() ) {
+                    if( arg.is< std::string >() ) {
+                        comm << arg.get< std::string >() << " ";
+                    }
+                }
+            }
+            else {
+                return;
+            }
+        }
+        else if( obj.find( "arguments" ) != obj.end() ) {
+            if( obj[ "command" ].is< std::string >() ) {
+                comm << obj[ "command" ].get< std::string >();
+            }
+        }
+        else {
+            return;
+        }
+
+        const std::string command = comm.str();
         const std::string file = Path::fromNativeSeparators(obj["file"].get<std::string>());
 
         // Accept file?

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -47,6 +47,7 @@ private:
         TEST_CASE(importCompileCommands2); // #8563
         TEST_CASE(importCompileCommands3); // check with existing trailing / in directory
         TEST_CASE(importCompileCommands4); // only accept certain file types
+	TEST_CASE(importCompileCommandsArgumentsSection); // Handle arguments section
         TEST_CASE(importCompileCommandsNoCommandSection); // gracefully handles malformed json 
         TEST_CASE(importCppcheckGuiProject);
     }
@@ -137,6 +138,17 @@ private:
         TestImporter importer;
         importer.importCompileCommands(istr);
         ASSERT_EQUALS(0, importer.fileSettings.size());
+    }
+
+    void importCompileCommandsArgumentsSection() const {
+        const char json[] = "[ { \"directory\": \"/tmp/\","
+                            "\"arguments\": [\"gcc\", \"-c\", \"src.c\"],"
+                            "\"file\": \"src.c\" } ]";
+        std::istringstream istr(json);
+        TestImporter importer;
+        importer.importCompileCommands(istr);
+        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
     }
 
     void importCompileCommandsNoCommandSection() const {

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -47,6 +47,7 @@ private:
         TEST_CASE(importCompileCommands2); // #8563
         TEST_CASE(importCompileCommands3); // check with existing trailing / in directory
         TEST_CASE(importCompileCommands4); // only accept certain file types
+        TEST_CASE(importCompileCommandsNoCommandSection); // gracefully handles malformed json 
         TEST_CASE(importCppcheckGuiProject);
     }
 
@@ -131,6 +132,15 @@ private:
     void importCompileCommands4() const {
         const char json[] = "[ { \"directory\": \"/tmp/\","
                             "\"command\": \"gcc -c src.mm\","
+                            "\"file\": \"src.mm\" } ]";
+        std::istringstream istr(json);
+        TestImporter importer;
+        importer.importCompileCommands(istr);
+        ASSERT_EQUALS(0, importer.fileSettings.size());
+    }
+
+    void importCompileCommandsNoCommandSection() const {
+        const char json[] = "[ { \"directory\": \"/tmp/\","
                             "\"file\": \"src.mm\" } ]";
         std::istringstream istr(json);
         TestImporter importer;


### PR DESCRIPTION
Previous code assumes 'commands' exists and ill assert if t does not.