### PR TITLE
Add check for duplicate condition and assignment

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1575,8 +1575,15 @@ void CheckCondition::checkDuplicateConditionalAssign()
 void CheckCondition::duplicateConditionalAssignError(const Token *condTok, const Token* assignTok)
 {
     ErrorPath errors;
-    errors.emplace_back(assignTok, "Assignment to same expression in condition.");
-    errors.emplace_back(condTok, "");
+    if (condTok && assignTok) {
+        if (condTok->str() == "==") {
+            errors.emplace_back(condTok, "Condition '" + condTok->expressionString() + "'");
+            errors.emplace_back(assignTok, "Assignment '" + assignTok->expressionString() + "' is redundant");
+        } else {
+            errors.emplace_back(assignTok, "Assignment '" + assignTok->expressionString() + "'");
+            errors.emplace_back(condTok, "Condition '" + condTok->expressionString() + "' is redundant");
+        }
+    }
     reportError(
         errors, Severity::style, "duplicateConditionalAssign", "Duplicate expression for the condition and assignment.", CWE398, false);
 }

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1567,13 +1567,16 @@ void CheckCondition::checkDuplicateConditionalAssign()
             if (!isSameExpression(
                     mTokenizer->isCPP(), true, condTok->astOperand2(), assignTok->astOperand2(), mSettings->library, true, true))
                 continue;
-            duplicateConditionalAssignError(condTok);
+            duplicateConditionalAssignError(condTok, assignTok);
         }
     }
 }
 
-void CheckCondition::duplicateConditionalAssignError(const Token *tok)
+void CheckCondition::duplicateConditionalAssignError(const Token *condTok, const Token* assignTok)
 {
+    ErrorPath errors;
+    errors.emplace_back(assignTok, "Assignment to same expression in condition.");
+    errors.emplace_back(condTok, "");
     reportError(
-        tok, Severity::style, "duplicateConditionalAssign", "Duplicate expression for the condition and assignment.");
+        errors, Severity::style, "duplicateConditionalAssign", "Duplicate expression for the condition and assignment.", CWE398, false);
 }

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1544,26 +1544,28 @@ void CheckCondition::checkDuplicateConditionalAssign()
         return;
 
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (const Scope * scope : symbolDatabase->functionScopes) {
-        for (const Token* tok = scope->bodyStart; tok != scope->bodyEnd; tok = tok->next()) {
+    for (const Scope *scope : symbolDatabase->functionScopes) {
+        for (const Token *tok = scope->bodyStart; tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "if ("))
                 continue;
             if (!Token::simpleMatch(tok->next()->link(), ") {"))
                 continue;
-            const Token * blockTok = tok->next()->link()->next();
-            const Token * condTok = tok->next()->astOperand2();
+            const Token *blockTok = tok->next()->link()->next();
+            const Token *condTok = tok->next()->astOperand2();
             if (!Token::Match(condTok, "==|!="))
                 continue;
             if (condTok->str() == "!=" && Token::simpleMatch(blockTok->link(), "} else {"))
                 continue;
             if (!blockTok->next())
                 continue;
-            const Token * assignTok = blockTok->next()->astTop();
+            const Token *assignTok = blockTok->next()->astTop();
             if (!Token::simpleMatch(assignTok, "="))
                 continue;
-            if (!isSameExpression(mTokenizer->isCPP(), true, condTok->astOperand1(), assignTok->astOperand1(), mSettings->library, true, true))
+            if (!isSameExpression(
+                    mTokenizer->isCPP(), true, condTok->astOperand1(), assignTok->astOperand1(), mSettings->library, true, true))
                 continue;
-            if (!isSameExpression(mTokenizer->isCPP(), true, condTok->astOperand2(), assignTok->astOperand2(), mSettings->library, true, true))
+            if (!isSameExpression(
+                    mTokenizer->isCPP(), true, condTok->astOperand2(), assignTok->astOperand2(), mSettings->library, true, true))
                 continue;
             duplicateConditionalAssignError(condTok);
         }
@@ -1572,6 +1574,6 @@ void CheckCondition::checkDuplicateConditionalAssign()
 
 void CheckCondition::duplicateConditionalAssignError(const Token *tok)
 {
-    reportError(tok, Severity::style, "duplicateConditionalAssign", "Duplicate expression for the condition and assignment.");
+    reportError(
+        tok, Severity::style, "duplicateConditionalAssign", "Duplicate expression for the condition and assignment.");
 }
-

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -189,6 +189,7 @@ public:
                "- Mismatching assignment and comparison => comparison is always true/false\n"
                "- Mismatching lhs and rhs in comparison => comparison is always true/false\n"
                "- Detect usage of | where & should be used\n"
+               "- Duplicate condition and assignment\n"
                "- Detect matching 'if' and 'else if' conditions\n"
                "- Mismatching bitand (a &= 0xf0; a &= 1; => a = 0)\n"
                "- Opposite inner condition is always false\n"

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -154,7 +154,7 @@ public:
     void invalidTestForOverflow(const Token* tok, bool result);
     void pointerAdditionResultNotNullError(const Token *tok, const Token *calc);
 
-    void duplicateConditionalAssignError(const Token *tok);
+    void duplicateConditionalAssignError(const Token *condTok, const Token* assignTok);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckCondition c(nullptr, settings, errorLogger);
@@ -177,7 +177,7 @@ public:
         c.alwaysTrueFalseError(nullptr, nullptr);
         c.invalidTestForOverflow(nullptr, false);
         c.pointerAdditionResultNotNullError(nullptr, nullptr);
-        c.duplicateConditionalAssignError(nullptr);
+        c.duplicateConditionalAssignError(nullptr, nullptr);
     }
 
     static std::string myName() {

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -61,6 +61,7 @@ public:
         checkCondition.alwaysTrueFalse();
         checkCondition.duplicateCondition();
         checkCondition.checkPointerAdditionResultNotNull();
+        checkCondition.checkDuplicateConditionalAssign();
         checkCondition.assignIf();
         checkCondition.checkBadBitmaskCheck();
         checkCondition.comparison();
@@ -115,6 +116,8 @@ public:
     /** @brief Check if pointer addition result is NULL '(ptr + 1) == NULL' */
     void checkPointerAdditionResultNotNull();
 
+    void checkDuplicateConditionalAssign();
+
 private:
     // The conditions that have been diagnosed
     std::set<const Token*> mCondDiags;
@@ -151,6 +154,8 @@ private:
     void invalidTestForOverflow(const Token* tok, bool result);
     void pointerAdditionResultNotNullError(const Token *tok, const Token *calc);
 
+    void duplicateConditionalAssignError(const Token *tok);
+
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckCondition c(nullptr, settings, errorLogger);
 
@@ -172,6 +177,7 @@ private:
         c.alwaysTrueFalseError(nullptr, nullptr);
         c.invalidTestForOverflow(nullptr, false);
         c.pointerAdditionResultNotNullError(nullptr, nullptr);
+        c.duplicateConditionalAssignError(nullptr);
     }
 
     static std::string myName() {

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -118,7 +118,7 @@ public:
 
     void checkDuplicateConditionalAssign();
 
-private:
+  private:
     // The conditions that have been diagnosed
     std::set<const Token*> mCondDiags;
     bool diag(const Token* tok, bool insert=true);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3076,13 +3076,13 @@ private:
               "    if (x == y)\n"
               "        x = y;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
 
         check("void f(int& x, int y) {\n"
               "    if (x != y)\n"
               "        x = y;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
 
         check("void f(int& x, int y) {\n"
               "    if (x == y)\n"
@@ -3090,7 +3090,7 @@ private:
               "    else\n"
               "        x = 1;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
 
         check("void f(int& x, int y) {\n"
               "    if (x != y)\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3070,7 +3070,8 @@ private:
         ASSERT_EQUALS("[test.cpp:2]: (warning) Comparison is wrong. Result of 'ptr+1' can't be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour.\n", errout.str());
     }
 
-    void duplicateConditionalAssign() {
+    void duplicateConditionalAssign()
+    {
         check("void f(int& x, int y) {\n"
               "    if (x == y)\n"
               "        x = y;\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -114,6 +114,7 @@ private:
         TEST_CASE(checkConditionIsAlwaysTrueOrFalseInsideIfWhile);
         TEST_CASE(alwaysTrueFalseInLogicalOperators);
         TEST_CASE(pointerAdditionResultNotNull);
+        TEST_CASE(duplicateConditionalAssign);
     }
 
     void check(const char code[], const char* filename = "test.cpp", bool inconclusive = false) {
@@ -3067,6 +3068,42 @@ private:
               "  if (ptr + 1 != 0);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Comparison is wrong. Result of 'ptr+1' can't be 0 unless there is pointer overflow, and pointer overflow is undefined behaviour.\n", errout.str());
+    }
+
+    void duplicateConditionalAssign() {
+        check("void f(int& x, int y) {\n"
+              "    if (x == y)\n"
+              "        x = y;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+
+        check("void f(int& x, int y) {\n"
+              "    if (x != y)\n"
+              "        x = y;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+
+        check("void f(int& x, int y) {\n"
+              "    if (x == y)\n"
+              "        x = y;\n"
+              "    else\n"
+              "        x = 1;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+
+        check("void f(int& x, int y) {\n"
+              "    if (x != y)\n"
+              "        x = y;\n"
+              "    else\n"
+              "        x = 1;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int& x, int y) {\n"
+              "    if (x == y)\n"
+              "        x = y + 1;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3076,7 +3076,7 @@ private:
               "    if (x == y)\n"
               "        x = y;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
 
         check("void f(int& x, int y) {\n"
               "    if (x != y)\n"
@@ -3090,7 +3090,7 @@ private:
               "    else\n"
               "        x = 1;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Duplicate expression for the condition and assignment.\n", errout.str());
 
         check("void f(int& x, int y) {\n"
               "    if (x != y)\n"


### PR DESCRIPTION
This will warn when writing expressions like this:

```cpp
void f(int& x, int y) {
    if (x == y)
        x = y;
}
```

This is rather suspicious. If `x == y` then there is no need to reassign the same value. It most likely a copy-paste error.

The same applies for `x != y`. It is faster and more readable to write `x = y` instead of checking the condition first. This most likely copy-paste error.