### PR TITLE
Fix FP with unused variable

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -483,7 +483,7 @@ static bool iscpp11init(const Token * const tok)
         endtok = nameToken->linkAt(1)->linkAt(1);
     else
         return false;
-    if (Token::Match(nameToken, "else|try|do"))
+    if (Token::Match(nameToken, "else|try|do|const|override|volatile|&|&&"))
         return false;
     // There is no initialisation for example here: 'class Fred {};'
     if (!Token::simpleMatch(endtok, "} ;"))

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -86,6 +86,7 @@ private:
         TEST_CASE(redundantstmts);
         TEST_CASE(vardecl);
         TEST_CASE(archive);             // ar & x
+        TEST_CASE(ast);
     }
 
     void test1() {
@@ -378,6 +379,11 @@ private:
               "  ar & x;\n"
               "}", true);
         ASSERT_EQUALS("[test.cpp:2]: (warning, inconclusive) Found suspicious operator '&'\n", errout.str());
+    }
+
+    void ast() {
+        check("struct c { void a() const { for (int x=0; x;); } };", true);
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7091,6 +7091,12 @@ private:
 
         // C++17: if (expr1; expr2)
         ASSERT_EQUALS("ifx3=y;(", testAst("if (int x=3; y)"));
+
+        ASSERT_EQUALS("a( forx0=x;;(", testAst("struct c { void a() const { for (int x=0; x;); } };"));
+        // TODO: We dont correctly parse ref qualifiers
+        TODO_ASSERT_EQUALS("a( forx0=x;;(", "a({&", testAst("struct c { void a() & { for (int x=0; x;); } };"));
+        TODO_ASSERT_EQUALS("a( forx0=x;;(", "a({&&", testAst("struct c { void a() && { for (int x=0; x;); } };"));
+
     }
 
     void astexpr2() { // limit for large expressions


### PR DESCRIPTION
So this fixes the AST when using member function qualifiers. It doesn't work with ref qualifiers, but neither does the previous commit. So you may want to run another bisect to figure out which commit broke the ref qualifiers. For now I added TODO test cases for ref qualifiers.