### PR TITLE
Fix bug in lifetime constructors

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3189,6 +3189,7 @@ static void valueFlowLifetimeConstructor(Token *tok, TokenList *tokenlist, Error
                 } else {
                     ls.byVal(tok, tokenlist, errorLogger, settings);
                 }
+                i++;
             }
         }
     } else if (Token::simpleMatch(tok, "{") && (astIsContainer(tok->astParent()) || astIsPointer(tok->astParent()))) {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1966,6 +1966,13 @@ private:
               "    return A{x, x};\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("struct A { int i; const int& j; };\n"
+              "A f(int& x) {\n"
+              "    int y = 0;\n"
+              "    return A{y, x};\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeInitList() {


### PR DESCRIPTION
This fixes the `unsignedLessThanZero` warnings from cppcheck.