### PR TITLE
Fix 8840: Don't warn when returning a bitmask as bool

### DIFF
--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -474,7 +474,8 @@ void CheckBool::returnValueOfFunctionReturningBool(void)
             if (tok2)
                 tok = tok2;
             else if (Token::simpleMatch(tok, "return") && tok->astOperand1() &&
-                     (tok->astOperand1()->getValueGE(2, mSettings) || tok->astOperand1()->getValueLE(-1, mSettings)))
+                     (tok->astOperand1()->getValueGE(2, mSettings) || tok->astOperand1()->getValueLE(-1, mSettings)) &&
+                     !(tok->astOperand1()->astOperand1() && Token::Match(tok->astOperand1(), "&|%or%")))
                 returnValueBoolError(tok);
         }
     }

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -1104,6 +1104,21 @@ private:
               "return 2;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:3]: (style) Non-boolean value returned from function returning bool\n", errout.str());
+
+        check("bool f(int x) {\n"
+              "    return x & 0x4;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f(int x, int y) {\n"
+              "    return x | y;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool f(int x) {\n"
+              "    return (x & 0x2);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
A common pattern is to have a function like similar to this:

	bool isFlagSet(uint32_t f) {
		return f & 0x4;
	}

Warning that the function returns a non-boolean in this case is too
noisy, it would be better suited for a Misra check, so remove the
warnings in the most obvious cases.