### PR TITLE
lib: Separate "assert(a && b)" statements into "assert(a)" and "assert(b)" for more precise diagnostics

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -993,7 +993,8 @@ void SymbolDatabase::createSymbolDatabaseSetScopePointers()
             start = const_cast<Token*>(mTokenizer->list.front());
             end = const_cast<Token*>(mTokenizer->list.back());
         }
-        assert(start && end);
+        assert(start);
+        assert(end);
 
         end->scope(&*it);
 

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1782,7 +1782,8 @@ void TemplateSimplifier::expandTemplate(
                 } else if (tok3->str() == "[") {
                     brackets.push(mTokenList.back());
                 } else if (tok3->str() == "}") {
-                    assert(brackets.empty() == false && brackets.top()->str() == "{");
+                    assert(brackets.empty() == false);
+                    assert(brackets.top()->str() == "{");
                     Token::createMutualLinks(brackets.top(), mTokenList.back());
                     if (tok3->strAt(1) == ";") {
                         const Token * tokSemicolon = tok3->next();
@@ -1794,11 +1795,13 @@ void TemplateSimplifier::expandTemplate(
                         break;
                     }
                 } else if (tok3->str() == ")") {
-                    assert(brackets.empty() == false && brackets.top()->str() == "(");
+                    assert(brackets.empty() == false);
+                    assert(brackets.top()->str() == "(");
                     Token::createMutualLinks(brackets.top(), mTokenList.back());
                     brackets.pop();
                 } else if (tok3->str() == "]") {
-                    assert(brackets.empty() == false && brackets.top()->str() == "[");
+                    assert(brackets.empty() == false);
+                    assert(brackets.top()->str() == "[");
                     Token::createMutualLinks(brackets.top(), mTokenList.back());
                     brackets.pop();
                 }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -743,7 +743,8 @@ std::size_t Token::getStrLength(const Token *tok)
 
 std::size_t Token::getStrSize(const Token *tok)
 {
-    assert(tok != nullptr && tok->tokType() == eString);
+    assert(tok != nullptr);
+    assert(tok->tokType() == eString);
     const std::string &str = tok->str();
     unsigned int sizeofstring = 1U;
     for (unsigned int i = 1U; i < str.size() - 1U; i++) {


### PR DESCRIPTION
[Hello, Daniel.  Thank you for writing such an amazingly useful program as "cppcheck".  Being able to run it without setting up a build (that is, letting it just try all #ifdef combinations even if I have to wade through a lot of false alarms) has made it so easy for me to try, that I am now in the habit of running it any just about every C or C++ source tree that I visit.  Amazingly, it usually finds something, even in longstanding well maintained open source projects.  So, thank you so much for it!   --Adam]

This tiny patch converts a few statements of the form "assert(a && b);" into "assert(a); assert(b);" in the lib subdirectory.

The following discussion about why I think this is useful is only in this pull request, not the commit message, which is more concise.

Assertion failure messages can sometimes  be difficult to reproduce in practice, even with a perhaps fully deterministic program like cppcheck.  For example, you may receive a bug report from a user who cannot easily rerun cppcheck on the same input, because the input program has evolved by the time the user got permission to release the bug report.  

Perhaps more practically, it makes more efficient use of developer time and may potentially attract more analysis if is not necessary to invest incremental human effort in the step of figuring out which side of the "and" statement was the one that actually failed.

Anyhow, I encourage you to merge this change.  Please feel free to let me know if you have any questions or want to discuss this further (for example, if you want discussion on the sourceforge forum or a bug report in trac, although I am hoping that you will accept this minor patch from just this pull request).

In the future, I hope to make cppcheck warn about input programs that contain "assert(a && b)" and "assert(!(a || b))", but that would be a bigger change, and I would want to avoid warning in the cases where that conjunction is the result of a macro expansion or either a or b is a string literal, (assert (condtition && "helpful string to include in assertion failure message")), as is already checked for in at least one existing cppcheck rule.
