### PR TITLE
Cache template name position to improve performance

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1304,7 +1304,7 @@ bool TemplateSimplifier::getTemplateNamePositionTemplateVariable(const Token *to
 int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
 {
     auto it = mTemplateNamePos.find(tok);
-    if (it != mTemplateNamePos.end()) {
+    if (!mSettings->debugtemplate && it != mTemplateNamePos.end()) {
         return it->second;
     }
     // get the position of the template name
@@ -1318,6 +1318,9 @@ int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
     else if (!getTemplateNamePositionTemplateFunction(tok, namepos))
         namepos = -1; // Name not found
     mTemplateNamePos[tok] = namepos;
+    if (mSettings->debugtemplate && it != mTemplateNamePos.end() && it->second != namepos) {
+        printOut("### Error: Invalid namepos cache: " + std::to_string(it->second) + " != " + std::to_string(namepos) + " ###");
+    }
     return namepos;
 }
 
@@ -3094,6 +3097,7 @@ void TemplateSimplifier::simplifyTemplates(
             mInstantiatedTemplates.clear();
             mExplicitInstantiationsToDelete.clear();
         }
+        mTemplateNamePos.clear();
 
         bool hasTemplates = getTemplateDeclarations();
 

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1303,6 +1303,10 @@ bool TemplateSimplifier::getTemplateNamePositionTemplateVariable(const Token *to
 
 int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
 {
+    auto it = mTemplateNamePos.find(tok);
+    if (it != mTemplateNamePos.end()) {
+        return it->second;
+    }
     // get the position of the template name
     int namepos = 0;
     if (Token::Match(tok, "> class|struct|union %type% :|<|;|{"))
@@ -1312,8 +1316,8 @@ int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
     else if (getTemplateNamePositionTemplateVariable(tok, namepos))
         ;
     else if (!getTemplateNamePositionTemplateFunction(tok, namepos))
-        return -1; // Name not found
-
+        namepos = -1; // Name not found
+    mTemplateNamePos[tok] = namepos;
     return namepos;
 }
 

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1318,9 +1318,6 @@ int TemplateSimplifier::getTemplateNamePosition(const Token *tok)
     else if (!getTemplateNamePositionTemplateFunction(tok, namepos))
         namepos = -1; // Name not found
     mTemplateNamePos[tok] = namepos;
-    if (mSettings->debugtemplate && it != mTemplateNamePos.end() && it->second != namepos) {
-        printOut("### Error: Invalid namepos cache: " + std::to_string(it->second) + " != " + std::to_string(namepos) + " ###");
-    }
     return namepos;
 }
 
@@ -3096,8 +3093,8 @@ void TemplateSimplifier::simplifyTemplates(
             mTemplateInstantiations.clear();
             mInstantiatedTemplates.clear();
             mExplicitInstantiationsToDelete.clear();
+            mTemplateNamePos.clear();
         }
-        mTemplateNamePos.clear();
 
         bool hasTemplates = getTemplateDeclarations();
 

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -29,6 +29,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class ErrorLogger;
@@ -197,7 +198,7 @@ public:
      * @return -1 to bail out or positive integer to identity the position
      * of the template name.
      */
-    static int getTemplateNamePosition(const Token *tok);
+    int getTemplateNamePosition(const Token *tok);
 
     /**
      * Get function template name position
@@ -417,6 +418,7 @@ private:
     std::list<TokenAndName> mMemberFunctionsToDelete;
     std::vector<TokenAndName> mExplicitInstantiationsToDelete;
     std::vector<TokenAndName> mTypesUsedInTemplateInstantiation;
+    std::unordered_map<const Token*, int> mTemplateNamePos;
 };
 
 /// @}


### PR DESCRIPTION
This improves the performance of the templatesimplefier by caching the template name position. I am not sure if the works entirely correctly but all the tests do pass with this change. Running this with gtest headers without removing unused template headers the time went from 48s to 5s, almost a 10x improvement.