### PR TITLE
 Fix issue 8890: AST broken calling member function from templated base class

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3847,7 +3847,7 @@ void Tokenizer::createLinks2()
 
             while (!type.empty() && type.top()->str() == "<")
                 type.pop();
-        } else if (token->str() == "<" && token->previous() && token->previous()->isName() && !token->previous()->varId()) {
+        } else if (token->str() == "<" && ((token->previous() && token->previous()->isName() && !token->previous()->varId()) || Token::simpleMatch(token->next(), ">"))) {
             type.push(token);
             if (!templateToken && (token->previous()->str() == "template"))
                 templateToken = token;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3847,7 +3847,9 @@ void Tokenizer::createLinks2()
 
             while (!type.empty() && type.top()->str() == "<")
                 type.pop();
-        } else if (token->str() == "<" && ((token->previous() && token->previous()->isName() && !token->previous()->varId()) || Token::simpleMatch(token->next(), ">"))) {
+        } else if (token->str() == "<" &&
+                   ((token->previous() && token->previous()->isName() && !token->previous()->varId()) ||
+                    Token::simpleMatch(token->next(), ">"))) {
             type.push(token);
             if (!templateToken && (token->previous()->str() == "template"))
                 templateToken = token;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3849,7 +3849,7 @@ void Tokenizer::createLinks2()
                 type.pop();
         } else if (token->str() == "<" &&
                    ((token->previous() && token->previous()->isName() && !token->previous()->varId()) ||
-                    Token::simpleMatch(token->next(), ">"))) {
+                    Token::Match(token->next(), ">|>>"))) {
             type.push(token);
             if (!templateToken && (token->previous()->str() == "template"))
                 templateToken = token;

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -455,7 +455,7 @@ private:
         // The TestGarbage ensures that there are true positives
         TEST_CASE(findGarbageCode);
         TEST_CASE(checkEnableIf);
-        TEST_CASE(emptyAngleBrackets);
+        TEST_CASE(templateAngleBrackets);
 
         // #9052
         TEST_CASE(noCrash1);
@@ -4796,6 +4796,21 @@ private:
             tokenizer.tokenize(istr, "test.cpp");
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "<")->link());
         }
+
+        {
+            // #8890
+            const char code[] = "template <typename = void> struct a {\n"
+                                "  void c();\n"
+                                "};\n"
+                                "void f() {\n"
+                                "  a<> b;\n"
+                                "  b.a<>::c();\n"
+                                "}\n";
+            Tokenizer tokenizer(&settings0, this);
+            std::istringstream istr(code);
+            tokenizer.tokenize(istr, "test.cpp");
+            ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> ::")->link());
+        }
     }
 
     void simplifyString() {
@@ -7584,7 +7599,7 @@ private:
 
     }
 
-    void emptyAngleBrackets()
+    void templateAngleBrackets()
     {
         ASSERT_NO_THROW(tokenizeAndStringify("template <typename = void> struct a {\n"
                                              "  void c();\n"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7584,15 +7584,15 @@ private:
 
     }
 
-    void emptyAngleBrackets() {
-        ASSERT_NO_THROW(tokenizeAndStringify(
-                            "template <typename = void> struct a {\n"
-                            "  void c();\n"
-                            "};\n"
-                            "void f() {\n"
-                            "  a<> b;\n"
-                            "  b.a<>::c();\n"
-                            "}\n"))
+    void emptyAngleBrackets()
+    {
+        ASSERT_NO_THROW(tokenizeAndStringify("template <typename = void> struct a {\n"
+                                             "  void c();\n"
+                                             "};\n"
+                                             "void f() {\n"
+                                             "  a<> b;\n"
+                                             "  b.a<>::c();\n"
+                                             "}\n"))
     }
 
     void noCrash1() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -455,6 +455,7 @@ private:
         // The TestGarbage ensures that there are true positives
         TEST_CASE(findGarbageCode);
         TEST_CASE(checkEnableIf);
+        TEST_CASE(emptyAngleBrackets);
 
         // #9052
         TEST_CASE(noCrash1);
@@ -7581,6 +7582,17 @@ private:
                             "    int x = a < b ? b : a;"
                             "};\n"))
 
+    }
+
+    void emptyAngleBrackets() {
+        ASSERT_NO_THROW(tokenizeAndStringify(
+                            "template <typename = void> struct a {\n"
+                            "  void c();\n"
+                            "};\n"
+                            "void f() {\n"
+                            "  a<> b;\n"
+                            "  b.a<>::c();\n"
+                            "}\n"))
     }
 
     void noCrash1() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -455,6 +455,7 @@ private:
         // The TestGarbage ensures that there are true positives
         TEST_CASE(findGarbageCode);
         TEST_CASE(checkEnableIf);
+        TEST_CASE(checkTemplates);
 
         // #9052
         TEST_CASE(noCrash1);
@@ -4798,10 +4799,7 @@ private:
 
         {
             // #8890
-            const char code[] = "template <typename = void> struct a {\n"
-                                "  void c();\n"
-                                "};\n"
-                                "void f() {\n"
+            const char code[] = "void f() {\n"
                                 "  a<> b;\n"
                                 "  b.a<>::c();\n"
                                 "}\n";
@@ -7596,6 +7594,17 @@ private:
                             "    int x = a < b ? b : a;"
                             "};\n"))
 
+    }
+
+    void checkTemplates() {
+        ASSERT_NO_THROW(tokenizeAndStringify(
+                            "template <typename = void> struct a {\n"
+                            "  void c();\n"
+                            "};\n"
+                            "void f() {\n"
+                            "  a<> b;\n"
+                            "  b.a<>::c();\n"
+                            "}\n"))
     }
 
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -455,7 +455,6 @@ private:
         // The TestGarbage ensures that there are true positives
         TEST_CASE(findGarbageCode);
         TEST_CASE(checkEnableIf);
-        TEST_CASE(templateAngleBrackets);
 
         // #9052
         TEST_CASE(noCrash1);
@@ -7599,16 +7598,6 @@ private:
 
     }
 
-    void templateAngleBrackets()
-    {
-        ASSERT_NO_THROW(tokenizeAndStringify("template <typename = void> struct a {\n"
-                                             "  void c();\n"
-                                             "};\n"
-                                             "void f() {\n"
-                                             "  a<> b;\n"
-                                             "  b.a<>::c();\n"
-                                             "}\n"))
-    }
 
     void noCrash1() {
         ASSERT_NO_THROW(tokenizeAndStringify(


### PR DESCRIPTION
Whenever there is a `<>`, we will always try to link them.