### PR TITLE
Fix false positive in constArgument when passing struct member

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2820,6 +2820,16 @@ void CheckOther::shadowError(const Token *var, const Token *shadowed, bool shado
     reportError(errorPath, Severity::style, id, message, CWE398, false);
 }
 
+static bool isVariableExpression(const Token* tok)
+{
+    if (Token::Match(tok, "%var%"))
+        return true;
+    if (Token::simpleMatch(tok, "."))
+        return isVariableExpression(tok->astOperand1()) && 
+               isVariableExpression(tok->astOperand2());
+    return false;
+}
+
 void CheckOther::checkConstArgument()
 {
     if (!mSettings->isEnabled(Settings::STYLE))
@@ -2844,7 +2854,7 @@ void CheckOther::checkConstArgument()
             const Token * tok2 = tok;
             if (isCPPCast(tok2))
                 tok2 = tok2->astOperand2();
-            if (Token::Match(tok2, "%var%"))
+            if (isVariableExpression(tok2))
                 continue;
             constArgumentError(tok, tok->astParent()->previous(), &tok->values().front());
         }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7637,6 +7637,15 @@ private:
               "    f(x[0]);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("struct A { int x; };"
+              "void g(int);\n"
+              "void f(int x) {\n"
+              "    A y;\n"
+              "    y.x = 1;\n"
+              "    g(y.x);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkComparePointers() {


### PR DESCRIPTION
This fixes FP in cases like this:

```cpp
struct A { int x; };
void g(int);
void f(int x) {
    A y;
    y.x = 1;
    g(y.x);
}
```