### PR TITLE
Fix misra addon rule 4 1

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -631,7 +631,7 @@ class MisraChecker:
 
     def misra_4_1(self, rawTokens):
         for token in rawTokens:
-            if token.str[0] != '"':
+            if ((token.str[0] != '"') and (token.str[0] != '\'')):
                 continue
             pos = 1
             while pos < len(token.str) - 2:

--- a/addons/test/misra-test.c
+++ b/addons/test/misra-test.c
@@ -22,6 +22,12 @@ typedef unsigned long long u64;
 //   // 3.1
 ////
 
+void misra_4_1(void)
+{
+    const char *s1 = "\x41g";       // 4.1
+    int c1 = '\141t';               // 4.1
+}
+
 extern int misra_5_1_extern_var_hides_var_x;
 extern int misra_5_1_extern_var_hides_var_y; //5.1
 

--- a/addons/test/misra-test.c
+++ b/addons/test/misra-test.c
@@ -22,12 +22,6 @@ typedef unsigned long long u64;
 //   // 3.1
 ////
 
-void misra_4_1(void)
-{
-    const char *s1 = "\x41g";       // 4.1
-    int c1 = '\141t';               // 4.1
-}
-
 extern int misra_5_1_extern_var_hides_var_x;
 extern int misra_5_1_extern_var_hides_var_y; //5.1
 
@@ -69,6 +63,8 @@ int misra_5_2_field_hides_field1_31y;//5.2
 };
 const char *s41_1 = "\x41g"; // 4.1
 const char *s41_2 = "\x41\x42";
+int c41_3         = '\141t'; // 4.1
+int c41_4         = '\141\t';
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}


### PR DESCRIPTION
By this changes the check for MISRA rule 4.1 should catch constant character literals enclosed by single quotes too.
Additional test cases has been added to check non-compliant as well as compliant case defined by MISRA C 2012 document.