### PR TITLE
"col" are not always set in dump files

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -247,7 +247,10 @@ class Token:
         self.astOperand2 = None
         self.file = element.get('file')
         self.linenr = int(element.get('linenr'))
-        self.col = int(element.get('col'))
+        if element.get('col'):
+            self.col = int(element.get('col'))
+        else:
+            self.col = 0
 
     def setId(self, IdMap):
         self.scope = IdMap[self.scopeId]


### PR DESCRIPTION
It seems cppcheck 1.84 doesn't add col information to dump files

Not sure if the default value of 0 is correct, but it works for me...