### PR TITLE
Fix FP with non-local variable referencing a non-local variable

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -630,7 +630,7 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
                 break;
             } else if (tok->variable() && tok->variable()->declarationId() == tok->varId() &&
                        !tok->variable()->isLocal() && !tok->variable()->isArgument() &&
-                       isInScope(val.tokvalue, tok->scope())) {
+                       isInScope(val.tokvalue->variable()->nameToken(), tok->scope())) {
                 errorDanglngLifetime(tok, &val);
                 break;
             }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1711,6 +1711,15 @@ private:
               "    std::map< S, B > m2;\n"
               "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("struct A {\n"
+              "    std::vector<int*> v;\n"
+              "    int x;\n"
+              "    void f() {\n"
+              "        v.push_back(&x);\n"
+              "    }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetime() {


### PR DESCRIPTION
This fixes the FP with:

```cpp
struct A {
    std::vector<int*> v;
    int x;
    void f() {
        v.push_back(&x);
    }
};

```