### PR TITLE
Fix FP with lifetime containers

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1827,6 +1827,12 @@ std::pair<const Token*, const Token*> Token::typeDecl(const Token * tok)
 }
 std::string Token::typeStr(const Token* tok)
 {
+    if (tok->valueType()) {
+        const ValueType * vt = tok->valueType();
+        std::string ret = vt->str();
+        if (!ret.empty())
+            return ret;   
+    }
     std::pair<const Token*, const Token*> r = Token::typeDecl(tok);
     if (!r.first || !r.second)
         return "";

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3161,7 +3161,7 @@ static void valueFlowLifetimeFunction(Token *tok, TokenList *tokenlist, ErrorLog
         Token *vartok = tok->tokAt(-2);
         std::vector<const Token *> args = getArguments(tok);
         std::size_t n = args.size();
-        if (n > 1 && astCanonicalType(args[n - 2]) == astCanonicalType(args[n - 1]) &&
+        if (n > 1 && Token::typeStr(args[n - 2]) == Token::typeStr(args[n - 1]) &&
             (((astIsIterator(args[n - 2]) && astIsIterator(args[n - 1])) ||
               (astIsPointer(args[n - 2]) && astIsPointer(args[n - 1]))))) {
             LifetimeStore{args.back(), "Added to container '" + vartok->str() + "'.", ValueFlow::Value::Object} .byDerefCopy(

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1701,6 +1701,16 @@ private:
               "};\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("void f(bool b) {\n"
+              "    std::vector<int> v = {1};\n"
+              "    if (b) {\n"
+              "        int a[] = {0};\n"
+              "        v.insert(a, a+1);\n"
+              "    }\n"
+              "    return v.back() == 0;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("class A {\n"
               "    int f( P p ) {\n"
               "        std::vector< S > maps;\n"


### PR DESCRIPTION
This fixes FP when inserting an array into a container:

```cpp
void f(bool b) {
    std::vector<int> v = {1};
    if (b) {
        int a[] = {0};
        v.insert(a, a+1);
    }
    return v.back() == 0;
}

```