### PR TITLE
Fix use after free #9143

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1505,6 +1505,7 @@ void TemplateSimplifier::expandTemplate(
     const std::string &newName,
     bool copy)
 {
+    mDeletedTokens.clear();
     bool inTemplateDefinition = false;
     const Token *startOfTemplateDeclaration = nullptr;
     const Token *endOfTemplateDefinition = nullptr;

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -602,6 +602,7 @@ void TemplateSimplifier::eraseTokens(Token *begin, const Token *end)
         return;
 
     while (begin->next() && begin->next() != end) {
+        mDeletedTokens.insert(begin->next());
         begin->deleteNext();
     }
 }
@@ -2081,7 +2082,8 @@ void TemplateSimplifier::expandTemplate(
 
     // add new instantiations
     for (const auto & inst : newInstantiations)
-        addInstantiation(inst.token, inst.scope);
+        if (mDeletedTokens.find(inst.token) == mDeletedTokens.end())
+            addInstantiation(inst.token, inst.scope);
 }
 
 static bool isLowerThanLogicalAnd(const Token *lower)
@@ -2372,7 +2374,7 @@ void TemplateSimplifier::simplifyTemplateArgs(Token *start, Token *end)
                             else if (endTok->str() == ">" && !end)
                                 ;
                             else {
-                                Token::eraseTokens(colon->tokAt(-2), endTok);
+                                eraseTokens(colon->tokAt(-2), endTok);
                                 again = true;
                                 break;
                             }

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -430,7 +430,7 @@ private:
     /**
      * Remove a specific "template < ..." template class/function
      */
-    static bool removeTemplate(Token *tok);
+    bool removeTemplate(Token *tok);
 
     /** Syntax error */
     static void syntaxError(const Token *tok);
@@ -445,7 +445,7 @@ private:
      * @param begin Tokens after this will be erased.
      * @param end Tokens before this will be erased.
      */
-    static void eraseTokens(Token *begin, const Token *end);
+    void eraseTokens(Token *begin, const Token *end);
 
     /**
      * Delete specified token without invalidating pointer to following token.
@@ -486,6 +486,7 @@ private:
     std::vector<TokenAndName> mExplicitInstantiationsToDelete;
     std::vector<TokenAndName> mTypesUsedInTemplateInstantiation;
     std::unordered_map<const Token*, int> mTemplateNamePos;
+    std::set<Token *> mDeletedTokens;
 };
 
 /// @}


### PR DESCRIPTION
    In some cases, the tokens stored in newInstantiations can be simplified
    and deleted. This patch prevents those tokens from being used.
    It is a horrible workaround, with some big holes (some deleted tokens
    are not stored in mDeletedTokens).
    There might be a better fix for this.
