### PR TITLE
Fix issue 9156: Analysis failed because square brackets arent linked correctly

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1578,9 +1578,7 @@ void TemplateSimplifier::expandTemplate(
                     previous->isSigned(typetok->isSigned());
                     previous->isUnsigned(typetok->isUnsigned());
                     previous->isLong(typetok->isLong());
-                    if (previous->str() == "{") {
-                        brackets1.push(previous);
-                    } else if (previous->str() == "(") {
+                    if (Token::Match(previous, "{|(|[")) {
                         brackets1.push(previous);
                     } else if (previous->str() == "}") {
                         assert(brackets1.empty() == false);
@@ -1590,6 +1588,11 @@ void TemplateSimplifier::expandTemplate(
                     } else if (previous->str() == ")") {
                         assert(brackets1.empty() == false);
                         assert(brackets1.top()->str() == "(");
+                        Token::createMutualLinks(brackets1.top(), previous);
+                        brackets1.pop();
+                    } else if (previous->str() == "]") {
+                        assert(brackets1.empty() == false);
+                        assert(brackets1.top()->str() == "[");
                         Token::createMutualLinks(brackets1.top(), previous);
                         brackets1.pop();
                     }
@@ -1785,9 +1788,7 @@ void TemplateSimplifier::expandTemplate(
                                         --typeindentlevel;
                                     mTokenList.addtoken(typetok, tok5->linenr(), tok5->fileIndex());
                                     Token *back = mTokenList.back();
-                                    if (back->str() == "{") {
-                                        brackets1.push(back);
-                                    } else if (back->str() == "(") {
+                                    if (Token::Match(back, "{|(|[")) {
                                         brackets1.push(back);
                                     } else if (back->str() == "}") {
                                         assert(brackets1.empty() == false);
@@ -1797,6 +1798,11 @@ void TemplateSimplifier::expandTemplate(
                                     } else if (back->str() == ")") {
                                         assert(brackets1.empty() == false);
                                         assert(brackets1.top()->str() == "(");
+                                        Token::createMutualLinks(brackets1.top(), back);
+                                        brackets1.pop();
+                                    } else if (back->str() == "]") {
+                                        assert(brackets1.empty() == false);
+                                        assert(brackets1.top()->str() == "[");
                                         Token::createMutualLinks(brackets1.top(), back);
                                         brackets1.pop();
                                     }
@@ -1864,7 +1870,7 @@ void TemplateSimplifier::expandTemplate(
                         if (copy) {
                             mTokenList.addtoken(typetok, tok3->linenr(), tok3->fileIndex());
                             Token *back = mTokenList.back();
-                            if (back->str() == "{") {
+                            if (Token::Match(back, "{|(|[")) {
                                 brackets1.push(back);
                             } else if (back->str() == "(") {
                                 brackets1.push(back);
@@ -1876,6 +1882,11 @@ void TemplateSimplifier::expandTemplate(
                             } else if (back->str() == ")") {
                                 assert(brackets1.empty() == false);
                                 assert(brackets1.top()->str() == "(");
+                                Token::createMutualLinks(brackets1.top(), back);
+                                brackets1.pop();
+                            } else if (back->str() == "]") {
+                                assert(brackets1.empty() == false);
+                                assert(brackets1.top()->str() == "[");
                                 Token::createMutualLinks(brackets1.top(), back);
                                 brackets1.pop();
                             }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7770,6 +7770,20 @@ private:
                             "template <template <class> class t, class... w, template <class> class x,\n"
                             "          class... u>\n"
                             "struct s<t<w...>, x<u...>>;\n"))
+
+        // #9156
+        ASSERT_NO_THROW(tokenizeAndStringify(
+                            "template <typename> struct a;\n"
+                            "template <bool> struct b;\n"
+                            "template <class k, class> using d = typename b<k::c>::e;\n"
+                            "template <class> struct f;\n"
+                            "template <template <class> class, class... g> using i = typename f<g...>::e;\n"
+                            "template <template <class> class h, class... g> using ab = d<i<h, g...>, int>;\n"
+                            "template <template <class> class h, class... g> struct j {\n"
+                            "  template <class... ag> using ah = typename ab<h, ag..., g...>::e;\n"
+                            "};\n"
+                            "template <class> struct F;\n"
+                            "int main() { using T = void (*)(a<j<F, char[]>>); }\n"))
     }
 
     void noCrash1() {


### PR DESCRIPTION
The fixes the analysis error, however, the template expansion is not entirely correct yet because of the varidiac templates. So this:

```cpp
template <typename> struct a;
template <bool> struct b;
template <class k, class> using d = typename b<k::c>::e;
template <class> struct f;
template <template <class> class, class... g> using i = typename f<g...>::e;
template <template <class> class h, class... g> using ab = d<i<h, g...>, int>;
template <template <class> class h, class... g> struct j {
  template <class... ag> using ah = typename ab<h, ag..., g...>::e;
};
template <class> struct F;
int main() { using T = void (*)(a<j<F, char[]>>); }
```

Will now expand to this:

```
1: template < typename > struct a ;
2: template < bool > struct b ;
3: template < class k , class > using d = typename b < k :: c > :: e ;
4: template < class > struct f ;
5: template < template < class > class , class . . . g > using i = typename f < g . . . > :: e ;
6: template < template < class > class h , class . . . g > using ab = d < i < h , g . . . > , int > ;
7: struct j<> ;
8:
9:
10: template < class > struct F ;
11: int main ( ) { using T = void ( * ) ( a < j < F , char [ ] > > ) ; } struct j<> {
8: template < class . . . ag > using ah = typename ab < F , ag . . . , char [ ] . . . > :: e ;
9: } ;
```