### PR TITLE
Minor changes to gui code to silence repeated build warnings

### DIFF
--- a/gui/erroritem.h
+++ b/gui/erroritem.h
@@ -101,7 +101,7 @@ public:
     static bool sameCID(const ErrorItem &errorItem1, const ErrorItem &errorItem2);
 };
 
-Q_DECLARE_METATYPE(ErrorItem);
+Q_DECLARE_METATYPE(ErrorItem)
 
 /**
 * @brief A class containing error data for one shown error line.

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -1363,5 +1363,5 @@ void ResultsTree::showInconclusiveColumn(bool show)
 void ResultsTree::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     QTreeView::currentChanged(current, previous);
-    emit selectionChanged(current);
+    emit treeSelectionChanged(current);
 }

--- a/gui/resultstree.h
+++ b/gui/resultstree.h
@@ -198,7 +198,7 @@ signals:
     *
     * @param current Model index to specify new selected item.
     */
-    void selectionChanged(const QModelIndex &current);
+    void treeSelectionChanged(const QModelIndex &current);
 
     /**
      * Selected item(s) has been tagged

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -51,7 +51,7 @@ ResultsView::ResultsView(QWidget * parent) :
 
     connect(mUI.mTree, &ResultsTree::resultsHidden, this, &ResultsView::resultsHidden);
     connect(mUI.mTree, &ResultsTree::checkSelected, this, &ResultsView::checkSelected);
-    connect(mUI.mTree, &ResultsTree::selectionChanged, this, &ResultsView::updateDetails);
+    connect(mUI.mTree, &ResultsTree::treeSelectionChanged, this, &ResultsView::updateDetails);
     connect(mUI.mTree, &ResultsTree::tagged, this, &ResultsView::tagged);
     connect(mUI.mTree, &ResultsTree::suppressIds, this, &ResultsView::suppressIds);
     connect(this, &ResultsView::showResults, mUI.mTree, &ResultsTree::showResults);


### PR DESCRIPTION
Compile of gui would result in repeated warnings from two conditions:

1) gui/erroritem.h:104:30: warning: extra ‘;’ [-Wpedantic]
Message points to Qt Macro Q_DECLARE_METATYPE usage.
Semi Colon at EOL removed.

2) gui/resultstree.h:201:10: warning [-Woverloaded-virtual]
Message is indicating that function ResultsTree::selectionChanged
is being iterpreted as overloading function of the same name
in base clase (QTreeView::selectionChanged).
Refactored - function renamed to ResultsTree::treeSelectionChanged