### PR TITLE
CodeEditor Widget Styling

### DIFF
--- a/gui/codeeditor.h
+++ b/gui/codeeditor.h
@@ -5,6 +5,7 @@
 #include <QPlainTextEdit>
 #include <QObject>
 #include <QRegularExpression>
+#include "codeeditorstyle.h"
 
 class QPaintEvent;
 class QResizeEvent;
@@ -18,7 +19,8 @@ class Highlighter : public QSyntaxHighlighter {
     Q_OBJECT
 
 public:
-    explicit Highlighter(QTextDocument *parent);
+    explicit Highlighter( QTextDocument *parent,
+                          CodeEditorStyle *widgetStyle );
 
     void setSymbols(const QStringList &symbols);
 
@@ -42,13 +44,16 @@ private:
     QTextCharFormat mMultiLineCommentFormat;
     QTextCharFormat mQuotationFormat;
     QTextCharFormat mSymbolFormat;
+
+    CodeEditorStyle *mWidgetStyle;
 };
 
 class CodeEditor : public QPlainTextEdit {
     Q_OBJECT
 
 public:
-    explicit CodeEditor(QWidget *parent);
+    explicit CodeEditor( QWidget *parent,
+                         CodeEditorStyle *widgetStyle = nullptr );
     CodeEditor(const CodeEditor &) = delete;
     CodeEditor &operator=(const CodeEditor &) = delete;
 
@@ -74,6 +79,7 @@ private slots:
 private:
     QWidget *mLineNumberArea;
     Highlighter *mHighlighter;
+    CodeEditorStyle *mWidgetStyle;
     int mErrorPosition;
 };
 

--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -1,0 +1,78 @@
+#ifndef CODEEDITORSTYLE_H
+#define CODEEDITORSTYLE_H
+
+#include <QString>
+#include <QColor>
+#include <QFont>
+
+class CodeEditorStyle {
+public:
+    CodeEditorStyle(
+        const QColor& CtrlFGColor, const QColor& CtrlBGColor,
+        const QColor& HiLiBGColor,
+        const QColor& LnNumFGColor, const QColor& LnNumBGColor,
+        const QColor& KeyWdFGColor, const QFont::Weight& KeyWdWeight,
+        const QColor& ClsFGColor, const QFont::Weight& ClsWeight,
+        const QColor& QteFGColor, const QFont::Weight& QteWeight,
+        const QColor& CmtFGColor, const QFont::Weight& CmtWeight,
+        const QColor& SymbFGColor, const QColor& SymbBGColor,
+        const QFont::Weight& SymbWeight ) :
+    widgetFGColor( CtrlFGColor ),
+    widgetBGColor( CtrlBGColor ),
+    highlightBGColor( HiLiBGColor ),
+    lineNumFGColor( LnNumFGColor ),
+    lineNumBGColor( LnNumBGColor ),
+    keywordColor( KeyWdFGColor ),
+    keywordWeight( KeyWdWeight ),
+    classColor( ClsFGColor ),
+    classWeight( ClsWeight ),
+    quoteColor( QteFGColor ),
+    quoteWeight( QteWeight ),
+    commentColor( CmtFGColor ),
+    commentWeight( CmtWeight ),
+    symbolFGColor( SymbFGColor ),
+    symbolBGColor( SymbBGColor ),
+    symbolWeight( SymbWeight )
+    {}
+
+    // delete empty constructor
+    CodeEditorStyle() = delete;
+    // default copy constructor and copy operator=
+    CodeEditorStyle( const CodeEditorStyle& rhs ) = default;
+    CodeEditorStyle& operator=( const CodeEditorStyle& rhs ) = default;
+    // default move constructor and move operator=
+    CodeEditorStyle( CodeEditorStyle&& rhs ) = default;
+    CodeEditorStyle& operator=( CodeEditorStyle&& rhs ) = default;
+    // default destructor
+    ~CodeEditorStyle() = default;
+
+public:
+    QColor          widgetFGColor;
+    QColor          widgetBGColor;
+    QColor          highlightBGColor;
+    QColor          lineNumFGColor;
+    QColor          lineNumBGColor;
+    QColor          keywordColor;
+    QFont::Weight   keywordWeight;
+    QColor          classColor;
+    QFont::Weight   classWeight;
+    QColor          quoteColor;
+    QFont::Weight   quoteWeight;
+    QColor          commentColor;
+    QFont::Weight   commentWeight;
+    QColor          symbolFGColor;
+    QColor          symbolBGColor;
+    QFont::Weight   symbolWeight;
+};
+
+static const CodeEditorStyle defaultStyle({
+/* editor FG/BG */          Qt::black, QColor( 240, 240, 240 ),
+/* highlight BG */          QColor( 255, 220, 220 ),
+/* line number FG/BG */     Qt::black, QColor( 240, 240, 240 ),
+/* keyword FG/Weight */     Qt::darkBlue, QFont::Bold,
+/* class FG/Weight */       Qt::darkMagenta, QFont::Bold,
+/* quote FG/Weight */       Qt::darkGreen, QFont::Normal,
+/* comment FG/Weight */     Qt::gray, QFont::Normal,
+/* Symbol FG/BG/Weight */   Qt::red, QColor( 220, 220, 255 ), QFont::Normal });
+
+#endif /* CODEEDITORSTYLE_H */

--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -6,6 +6,8 @@
 #include <QFont>
 
 class CodeEditorStyle {
+private:
+    CodeEditorStyle(){};
 public:
     CodeEditorStyle(
         const QColor& CtrlFGColor, const QColor& CtrlBGColor,
@@ -34,17 +36,6 @@ public:
     symbolBGColor( SymbBGColor ),
     symbolWeight( SymbWeight )
     {}
-
-    // delete empty constructor
-    CodeEditorStyle() = delete;
-    // default copy constructor and copy operator=
-    CodeEditorStyle( const CodeEditorStyle& rhs ) = default;
-    CodeEditorStyle& operator=( const CodeEditorStyle& rhs ) = default;
-    // default move constructor and move operator=
-    CodeEditorStyle( CodeEditorStyle&& rhs ) = default;
-    CodeEditorStyle& operator=( CodeEditorStyle&& rhs ) = default;
-    // default destructor
-    ~CodeEditorStyle() = default;
 
 public:
     QColor          widgetFGColor;

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -90,6 +90,7 @@ HEADERS += aboutdialog.h \
            applicationlist.h \
            checkstatistics.h \
            checkthread.h \
+           codeeditorstyle.h \
            codeeditor.h \
            common.h \
            csvreport.h \


### PR DESCRIPTION
With profileration of Qt5 styling methods, problems with presentation
can occur when using cppcheck-gui and user choosen themes. With a dark
theme, a highlighted line in the CodeEditor appears with white text on
a light background or dark colors on a dark background.

Commit makes changes to enforce a default style on the Code Editor widget.
Mechanism is provided, if desired, where a user defined styling can
be provided to CodeEditor widget.