### PR TITLE
Fix crash in issue 9007

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -2955,6 +2955,9 @@ void TemplateSimplifier::replaceTemplateUsage(
                     }
                 }
             }
+            // Fix crash in #9007
+            if (Token::simpleMatch(nameTok->previous(), ">"))
+                mTemplateNamePos.erase(nameTok->previous());
             removeTokens.emplace_back(nameTok, tok2->next());
         }
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -460,6 +460,7 @@ private:
 
         // #9052
         TEST_CASE(noCrash1);
+        TEST_CASE(noCrash2);
 
         // --check-config
         TEST_CASE(checkConfiguration);
@@ -7806,6 +7807,23 @@ private:
                             "  A( const std::string &name = "" );\n"
                             "};\n"
                             "A::A( const std::string &name ) { return; }\n"))
+    }
+
+    // #9007
+    void noCrash2() {
+        ASSERT_NO_THROW(tokenizeAndStringify(
+                            "class a {\n"
+                            "public:\n"
+                            "  enum b {};\n"
+                            "};\n"
+                            "struct c;\n"
+                            "template <class> class d {\n"
+                            "  d(const int &, a::b, double, double);\n"
+                            "  d(const d &);\n"
+                            "};\n"
+                            "template <> d<int>::d(const int &, a::b, double, double);\n"
+                            "template <> d<int>::d(const d &) {}\n"
+                            "template <> d<c>::d(const d &) {}\n"))
     }
 
     void checkConfig(const char code[]) {


### PR DESCRIPTION
This fixes the crash in:

```cpp
class a {
public:
  enum b {};
};
struct c;
template <class> class d {
  d(const int &, a::b, double, double);
  d(const d &);
};
template <> d<int>::d(const int &, a::b, double, double);
template <> d<int>::d(const d &) {}
template <> d<c>::d(const d &) {}
```

When replacing a template `Foo < int >` with `Foo<int>` if the previous token is `>` then it will remove the cache entry for the name position.

I dont know if that fixes all cases of this. I would need to see an example where this would still be the case.