### PR TITLE
Fixed #9155 (Syntax error on valid C++ code)

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4858,7 +4858,6 @@ private:
             Tokenizer tokenizer(&settings0, this);
             std::istringstream istr(code);
             tokenizer.tokenize(istr, "test.cpp");
-            ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> > ;")->link());
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> ;")->link());
         }
 


### PR DESCRIPTION
Refactored simplifyTemplateAliases to iterate over template type aliases
rather than instantiations. This fixed template type aliases that were
not templates.

Don't instantiate templates in template type aliases. They will get
instantiated once the type alias is instantiated. This required
increasing the template simplifier pass count to 3 so one of the
existing tests continued to work.