### PR TITLE
Fix syntax error in issue 9155

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -523,12 +523,15 @@ bool TemplateSimplifier::removeTemplate(Token *tok)
         }
 
         else if (tok2->str() == "{") {
-            tok2 = tok2->link()->next();
-            if (tok2 && tok2->str() == ";" && tok2->next())
+            tok2 = tok2->link();
+            if (indentlevel < 2) {
                 tok2 = tok2->next();
-            eraseTokens(tok, tok2);
-            deleteToken(tok);
-            return true;
+                if (tok2 && tok2->str() == ";" && tok2->next())
+                    tok2 = tok2->next();
+                eraseTokens(tok, tok2);
+                deleteToken(tok);
+                return true;
+            }
         } else if (tok2->str() == "}") {  // garbage code! (#3449)
             eraseTokens(tok,tok2);
             deleteToken(tok);
@@ -1971,7 +1974,7 @@ void TemplateSimplifier::expandTemplate(
                         mTokenList.addtoken(tokSemicolon, tokSemicolon->linenr(), tokSemicolon->fileIndex());
                     }
                     brackets.pop();
-                    if (brackets.empty()) {
+                    if (brackets.empty() && !Token::Match(tok3, "} >|,|%cop%")) {
                         inTemplateDefinition = false;
                         break;
                     }

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -2683,17 +2683,30 @@ private:
     }
 
     void template114() { // #9155
-        const char code[] = "template <typename a, a> struct b {};\n"
-                            "template <typename> struct c;\n"
-                            "template <typename> struct d : b<bool, std::is_polymorphic<int>{}> {};\n"
-                            "template <bool> struct e;\n"
-                            "template <typename a> using f = typename e<c<d<a>>::g>::h;";
-        const char exp[] = "template < typename a , a > struct b { } ; "
-                           "template < typename > struct c ; "
-                           "template < typename > struct d : b < bool , std :: is_polymorphic < int > { } > { } ; "
-                           "template < bool > struct e ; "
-                           "template < typename a > using f = typename e < c < d < a > > :: g > :: h ;";
-        ASSERT_EQUALS(exp, tok(code));
+        {
+            const char code[] = "template <typename a, a> struct b {};\n"
+                                "template <typename> struct c;\n"
+                                "template <typename> struct d : b<bool, std::is_polymorphic<int>{}> {};\n"
+                                "template <bool> struct e;\n"
+                                "template <typename a> using f = typename e<c<d<a>>::g>::h;";
+            const char exp[] =  "template < typename a , a > struct b { } ; "
+                                "template < typename > struct c ; "
+                                "template < typename > struct d : b < bool , std :: is_polymorphic < int > { } > { } ; "
+                                "template < bool > struct e ; "
+                                "template < typename a > using f = typename e < c < d < a > > :: g > :: h ;";
+            ASSERT_EQUALS(exp, tok(code));
+        }
+        {
+            const char code[] = "template <typename a, a> struct b;\n"
+                                "template <bool, typename> struct c;\n"
+                                "template <typename a> struct d : b<bool, std::is_empty<a>{}> {};\n"
+                                "template <typename a> using e = typename c<std::is_final<a>{}, d<a>>::f;\n";
+            const char exp[] =  "template < typename a , a > struct b ; "
+                                "template < bool , typename > struct c ; "
+                                "struct d<a> ; "
+                                "template < typename a > using e = typename c < std :: is_final < a > { } , d<a> > :: f ; struct d<a> : b < bool , std :: is_empty < a > { } > { } ;";
+            ASSERT_EQUALS(exp, tok(code));
+        }
     }
 
     void template_specialization_1() {  // #7868 - template specialization template <typename T> struct S<C<T>> {..};


### PR DESCRIPTION
This fixes the template simplification in issue 9155 and the syntax error for this case:

```cpp
template <typename a, a> struct b;
template <bool, typename> struct c;
template <typename a> struct d : b<bool, std::is_empty<a>{}> {};
template <typename a> using e = typename c<std::is_final<a>{}, d<a>>::f;
```