### PR TITLE
Cleanup some const_cast of Token*

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1243,7 +1243,7 @@ void SymbolDatabase::createSymbolDatabaseEnums()
 
                 // look for possible constant folding expressions
                 // rhs of operator:
-                const Token *rhs = enumerator.start->previous()->astOperand2();
+                Token *rhs = enumerator.start->previous()->astOperand2();
 
                 // constant folding of expression:
                 ValueFlow::valueFlowConstantFoldAST(rhs, mSettings);
@@ -2469,7 +2469,7 @@ bool Variable::arrayDimensions(const Settings* settings)
                 while (tok->astParent() && !Token::Match(tok->astParent(), "[,<>]"))
                     tok = tok->astParent();
                 dimension_.tok = tok;
-                ValueFlow::valueFlowConstantFoldAST(dimension_.tok, settings);
+                ValueFlow::valueFlowConstantFoldAST(const_cast<Token *>(dimension_.tok), settings);
                 if (tok->hasKnownIntValue()) {
                     dimension_.num = tok->getKnownIntValue();
                     dimension_.known = true;
@@ -2500,7 +2500,7 @@ bool Variable::arrayDimensions(const Settings* settings)
         // check for empty array dimension []
         if (dim->next()->str() != "]") {
             dimension_.tok = dim->astOperand2();
-            ValueFlow::valueFlowConstantFoldAST(dimension_.tok, settings);
+            ValueFlow::valueFlowConstantFoldAST(const_cast<Token *>(dimension_.tok), settings);
             if (dimension_.tok && dimension_.tok->hasKnownIntValue()) {
                 dimension_.num = dimension_.tok->getKnownIntValue();
                 dimension_.known = true;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4889,7 +4889,7 @@ static void setAutoTokenProperties(Token * const autoTok)
 void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
 {
     tok->setValueType(new ValueType(valuetype));
-    Token *parent = const_cast<Token *>(tok->astParent());
+    Token *parent = tok->astParent();
     if (!parent || parent->valueType())
         return;
     if (!parent->astOperand1())
@@ -5019,7 +5019,7 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
         !parent->previous()->valueType() &&
         Token::simpleMatch(parent->astParent()->astOperand1(), "for")) {
         const bool isconst = Token::simpleMatch(parent->astParent()->next(), "const");
-        Token * const autoToken = const_cast<Token *>(parent->astParent()->tokAt(isconst ? 2 : 1));
+        Token * const autoToken = parent->astParent()->tokAt(isconst ? 2 : 1);
         if (vt2->pointer) {
             ValueType autovt(*vt2);
             autovt.pointer--;
@@ -5091,7 +5091,7 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
     if (ternary) {
         if (vt2 && vt1->pointer == vt2->pointer && vt1->type == vt2->type && vt1->sign == vt2->sign)
             setValueType(parent, *vt2);
-        parent = const_cast<Token*>(parent->astParent());
+        parent = parent->astParent();
     }
 
     if (ternary || parent->isArithmeticalOp() || parent->tokType() == Token::eIncDecOp) {

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -757,9 +757,9 @@ void TemplateSimplifier::getTemplateInstantiations()
             const bool isUsing = tok->strAt(1) == "using";
             if (isUsing && Token::Match(tok->tokAt(2), "%name% <")) {
                 // Cant have specialized type alias so ignore it
-                const Token *tok2 = Token::findsimplematch(tok->tokAt(3), ";");
+                Token *tok2 = Token::findsimplematch(tok->tokAt(3), ";");
                 if (tok2)
-                    tok = const_cast<Token *>(tok2);
+                    tok = tok2;
             } else if (tok->strAt(-1) == "<") {
                 // Don't ignore user specialization but don't consider it an instantiation.
                 // Instantiations in return type, function parameters, and executable code
@@ -771,22 +771,22 @@ void TemplateSimplifier::getTemplateInstantiations()
                 // #7914
                 // Ignore template instantiations within template definitions: they will only be
                 // handled if the definition is actually instantiated
-                const Token *tok2 = Token::findmatch(tok, "{|;");
+                Token *tok2 = Token::findmatch(tok, "{|;");
                 if (tok2 && tok2->str() == "{")
                     tok = tok2->link();
                 else if (tok2 && tok2->str() == ";")
-                    tok = const_cast<Token *>(tok2);
+                    tok = tok2;
             }
         } else if (Token::Match(tok, "template using %name% <")) {
             // Cant have specialized type alias so ignore it
-            const Token *tok2 = Token::findsimplematch(tok->tokAt(3), ";");
+            Token *tok2 = Token::findsimplematch(tok->tokAt(3), ";");
             if (tok2)
-                tok = const_cast<Token *>(tok2);
+                tok = tok2;
         } else if (Token::Match(tok, "using %name% <")) {
             // Cant have specialized type alias so ignore it
-            const Token *tok2 = Token::findsimplematch(tok->tokAt(2), ";");
+            Token *tok2 = Token::findsimplematch(tok->tokAt(2), ";");
             if (tok2)
-                tok = const_cast<Token *>(tok2);
+                tok = tok2;
         } else if (Token::Match(tok->previous(), "(|{|}|;|=|>|<<|:|.|*|&|return|<|, %name% ::|<|(") ||
                    Token::Match(tok->previous(), "%type% %name% ::|<") ||
                    Token::Match(tok->tokAt(-2), "[,:] private|protected|public %name% ::|<")) {
@@ -879,7 +879,7 @@ void TemplateSimplifier::getTemplateInstantiations()
 
             // Add inner template instantiations first => go to the ">"
             // and then parse backwards, adding all seen instantiations
-            const Token *tok2 = tok->next()->findClosingBracket();
+            Token *tok2 = tok->next()->findClosingBracket();
 
             // parse backwards and add template instantiations
             // TODO
@@ -888,7 +888,7 @@ void TemplateSimplifier::getTemplateInstantiations()
                     templateParameters(tok2->tokAt(2))) {
                     addInstantiation(tok2->next(), getScopeName(scopeList));
                 } else if (Token::Match(tok2->next(), "class|struct"))
-                    const_cast<Token *>(tok2)->deleteNext();
+                    tok2->deleteNext();
             }
 
             // Add outer template..

--- a/lib/token.h
+++ b/lib/token.h
@@ -1088,15 +1088,31 @@ public:
     void astOperand1(Token *tok);
     void astOperand2(Token *tok);
 
+    Token * astOperand1() {
+        return mImpl->mAstOperand1;
+    }
     const Token * astOperand1() const {
         return mImpl->mAstOperand1;
+    }
+    Token * astOperand2() {
+        return mImpl->mAstOperand2;
     }
     const Token * astOperand2() const {
         return mImpl->mAstOperand2;
     }
+    Token * astParent() {
+        return mImpl->mAstParent;
+    }
     const Token * astParent() const {
         return mImpl->mAstParent;
     }
+    Token *astTop() {
+        Token *ret = this;
+        while (ret->mImpl->mAstParent)
+            ret = ret->mImpl->mAstParent;
+        return ret;
+    }
+
     const Token *astTop() const {
         const Token *ret = this;
         while (ret->mImpl->mAstParent)

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1071,9 +1071,9 @@ static void createAstAtTokenInner(Token * const tok1, const Token *endToken, boo
                 tok = createAstAtToken(tok, cpp);
         } else if (tok->str() == "[") {
             if (isLambdaCaptureList(tok)) {
-                tok = const_cast<Token *>(tok->astOperand1());
+                tok = tok->astOperand1();
                 if (tok->str() == "(")
-                    tok = const_cast<Token *>(tok->astOperand1());
+                    tok = tok->astOperand1();
                 const Token * const endToken2 = tok->link();
                 for (; tok && tok != endToken && tok != endToken2; tok = tok ? tok->next() : nullptr)
                     tok = createAstAtToken(tok, cpp);
@@ -1086,7 +1086,7 @@ static Token * findAstTop(Token *tok1, Token *tok2)
 {
     for (Token *tok = tok1; tok && (tok != tok2); tok = tok->next()) {
         if (tok->astParent() || tok->astOperand1() || tok->astOperand2())
-            return const_cast<Token *>(tok->astTop());
+            return tok->astTop();
         if (Token::simpleMatch(tok, "( {"))
             tok = tok->link();
     }
@@ -1149,7 +1149,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
         compileExpression(tok2, state3);
 
         if (init != semicolon1)
-            semicolon1->astOperand1(const_cast<Token*>(init->astTop()));
+            semicolon1->astOperand1(init->astTop());
         tok2 = findAstTop(semicolon1->next(), semicolon2);
         if (tok2)
             semicolon2->astOperand1(tok2);
@@ -1157,7 +1157,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
         if (tok2)
             semicolon2->astOperand2(tok2);
         else if (!state3.op.empty())
-            semicolon2->astOperand2(const_cast<Token*>(state3.op.top()));
+            semicolon2->astOperand2(state3.op.top());
 
         semicolon1->astOperand2(semicolon2);
         tok->next()->astOperand1(tok);

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -228,7 +228,7 @@ namespace ValueFlow {
     };
 
     /// Constant folding of expression. This can be used before the full ValueFlow has been executed (ValueFlow::setValues).
-    const ValueFlow::Value * valueFlowConstantFoldAST(const Token *expr, const Settings *settings);
+    const ValueFlow::Value * valueFlowConstantFoldAST(Token *expr, const Settings *settings);
 
     /// Perform valueflow analysis.
     void setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, ErrorLogger *errorLogger, const Settings *settings);

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -936,7 +936,7 @@ private:
     void canFindMatchingBracketsInnerPair() const {
         givenACodeSampleToTokenize var("std::deque<std::set<int> > intsets;");
 
-        const Token * const t = const_cast<Token*>(var.tokens()->tokAt(7))->findClosingBracket();
+        const Token * const t = var.tokens()->tokAt(7)->findClosingBracket();
         ASSERT_EQUALS(">", t->str());
         ASSERT(var.tokens()->tokAt(9) == t);
     }


### PR DESCRIPTION
This patches replace some usage of const_cast with the addition of non-const methods.
Also, it fixes some functions (valueFlowSetConstantValue for instance) which were lying about some of their arguments, claiming not to modify them while they did it.

There are obviously more similar things to clean later.