### PR TITLE
FP on assignment through pointer

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1429,7 +1429,7 @@ FwdAnalysis::Result FwdAnalysis::check(const Token *expr, const Token *startToke
     Result result = checkRecursive(expr, startToken, endToken, exprVarIds, local);
 
     // Break => continue checking in outer scope
-    while (result.type == FwdAnalysis::Result::Type::BREAK) {
+    while (mWhat!=What::ValueFlow && result.type == FwdAnalysis::Result::Type::BREAK) {
         const Scope *s = result.token->scope();
         while (s->type == Scope::eIf)
             s = s->nestedIn;

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -2552,6 +2552,22 @@ private:
                "}";
         values = tokenValues(code, "+");
         TODO_ASSERT_EQUALS(2U, 0U, values.size()); // should be 2
+
+        // FP: Condition '*b>0' is always true
+        code = "bool dostuff(const char *x, const char *y);\n"
+               "void fun(char *s, int *b) {\n"
+               "  for (int i = 0; i < 42; ++i) {\n"
+               "    if (dostuff(s, \"1\")) {\n"
+               "      *b = 1;\n"
+               "      break;\n"
+               "    }\n"
+               "  }\n"
+               "  if (*b > 0) {\n" // *b does not have known value
+               "  }\n"
+               "}";
+        values = tokenValues(code, ">");
+        ASSERT_EQUALS(true, values.empty());
+
     }
 
     void valueFlowSwitchVariable() {


### PR DESCRIPTION
On the following code

    void f(char const *const s, bool *b) {
        for (int i = 0; i < 42; ++i) {
            if (strcmp(s, "1")) {
                *b = true;
                break;
            }
        }

        if (*b) {
        }
    }

cppcheck would wrongly warn
"Condition '*b>0' is always true"