### PR TITLE
Bugfix buffer size for strdup like functions

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5329,7 +5329,7 @@ static void valueFlowDynamicBufferSize(TokenList *tokenlist, SymbolDatabase *sym
                 if (arg1 && arg1->hasKnownValue()) {
                     const ValueFlow::Value &value = arg1->values().back();
                     if (value.isTokValue() && value.tokvalue->tokType() == Token::eString)
-                        sizeValue = Token::getStrLength(value.tokvalue);
+                        sizeValue = Token::getStrLength(value.tokvalue) + 1; // Add one for the null terminator
                 }
                 break;
             };


### PR DESCRIPTION
strdup() allocates the string length plus one for a terminating null
character. Add one to compensate for this.

Fixes false positive buffer out of bounds on code like this:

	void f() {
		const char *a = "abcd";
		char * b = strdup(a);
		printf("%c", b[4]); // prints the terminating null character
		free(b);
	}

Also, add a testcase for valueFlowDynamicBufferSize() and add tests for
strdup(), malloc() and calloc().