### PR TITLE
Update symbol database such that the override keyword implies that the function is also virtual

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1220,7 +1220,7 @@ void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Sco
 
     // Warn if type is a class that contains any virtual functions
     for (const Function &func : type->functionList) {
-        if (func.isVirtual()) {
+        if (func.hasVirtualSpecifier()) {
             if (allocation)
                 mallocOnClassError(tok, tok->str(), type->classDef, "virtual function");
             else
@@ -1643,9 +1643,9 @@ void CheckClass::virtualDestructor()
         if (scope->definedType->derivedFrom.empty()) {
             if (printInconclusive) {
                 const Function *destructor = scope->getDestructor();
-                if (destructor && !destructor->isVirtual()) {
+                if (destructor && !destructor->hasVirtualSpecifier()) {
                     for (const Function &func : scope->functionList) {
-                        if (func.isVirtual()) {
+                        if (func.hasVirtualSpecifier()) {
                             inconclusiveErrors.push_back(destructor);
                             break;
                         }
@@ -1728,7 +1728,7 @@ void CheckClass::virtualDestructor()
                     if (derivedFrom->derivedFrom.empty()) {
                         virtualDestructorError(derivedFrom->classDef, derivedFrom->name(), derivedClass->str(), false);
                     }
-                } else if (!baseDestructor->isVirtual()) {
+                } else if (!baseDestructor->hasVirtualSpecifier()) {
                     // TODO: This is just a temporary fix, better solution is needed.
                     // Skip situations where base class has base classes of its own, because
                     // some of the base classes might have virtual destructor.
@@ -1819,7 +1819,7 @@ void CheckClass::checkConst()
             if (func.type != Function::eFunction || !func.hasBody())
                 continue;
             // don't warn for friend/static/virtual functions
-            if (func.isFriend() || func.isStatic() || func.isVirtual())
+            if (func.isFriend() || func.isStatic() || func.hasVirtualSpecifier())
                 continue;
             // get last token of return type
             const Token *previous = func.tokenDef->previous();

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2361,7 +2361,7 @@ const std::list<const Token *> & CheckClass::getVirtualFunctionCalls(const Funct
                 continue;
         }
 
-        if (callFunction->isVirtual()) {
+        if (callFunction->isImplicitlyVirtual()) {
             if (!callFunction->isPure() && Token::simpleMatch(tok->previous(), "::"))
                 continue;
             virtualFunctionCalls.push_back(tok);
@@ -2381,7 +2381,7 @@ void CheckClass::getFirstVirtualFunctionCallStack(
     std::list<const Token *> & pureFuncStack)
 {
     const Function *callFunction = callToken->function();
-    if (callFunction->isVirtual() && (!callFunction->isPure() || !callFunction->hasBody())) {
+    if (callFunction->isImplicitlyVirtual() && (!callFunction->isPure() || !callFunction->hasBody())) {
         pureFuncStack.push_back(callFunction->tokenDef);
         return;
     }

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -317,7 +317,7 @@ private:
     void initializeVarList(const Function &func, std::list<const Function *> &callstack, const Scope *scope, std::vector<Usage> &usage);
 
     /**
-     * @brief gives a list of tokens where pure virtual functions are called directly or indirectly
+     * @brief gives a list of tokens where virtual functions are called directly or indirectly
      * @param function function to be checked
      * @param virtualFunctionCallsMap map of results for already checked functions
      * @return list of tokens where pure virtual functions are called
@@ -327,7 +327,7 @@ private:
         std::map<const Function *, std::list<const Token *> > & virtualFunctionCallsMap);
 
     /**
-     * @brief looks for the first pure virtual function call stack
+     * @brief looks for the first virtual function call stack
      * @param virtualFunctionCallsMap map of results obtained from getVirtualFunctionCalls
      * @param callToken token where pure virtual function is called directly or indirectly
      * @param[in,out] pureFuncStack list to append the stack

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1239,7 +1239,7 @@ void CheckOther::checkPassByReference()
         }
 
         // Check if variable could be const
-        if (!var->scope() || var->scope()->function->isVirtual())
+        if (!var->scope() || var->scope()->function->hasVirtualSpecifier())
             continue;
 
         if (canBeConst(var)) {

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1809,9 +1809,10 @@ Function::Function(const Tokenizer *mTokenizer, const Token *tok, const Scope *s
             hasLvalRefQualifier(true);
         else if (tok->str() == "&&")
             hasRvalRefQualifier(true);
-        else if (tok->str() == "override")
+        else if (tok->str() == "override") {
             setFlag(fHasOverrideSpecifier, true);
-        else if (tok->str() == "final")
+            isVirtual(true);
+        } else if (tok->str() == "final")
             setFlag(fHasFinalSpecifier, true);
         else if (tok->str() == "volatile")
             isVolatile(true);

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1757,7 +1757,7 @@ Function::Function(const Tokenizer *mTokenizer, const Token *tok, const Scope *s
 
         // virtual function
         else if (tok1->str() == "virtual") {
-            isVirtual(true);
+            hasVirtualSpecifier(true);
         }
 
         // static function
@@ -1809,10 +1809,9 @@ Function::Function(const Tokenizer *mTokenizer, const Token *tok, const Scope *s
             hasLvalRefQualifier(true);
         else if (tok->str() == "&&")
             hasRvalRefQualifier(true);
-        else if (tok->str() == "override") {
+        else if (tok->str() == "override")
             setFlag(fHasOverrideSpecifier, true);
-            isVirtual(true);
-        } else if (tok->str() == "final")
+        else if (tok->str() == "final")
             setFlag(fHasFinalSpecifier, true);
         else if (tok->str() == "volatile")
             isVolatile(true);
@@ -2696,7 +2695,7 @@ void SymbolDatabase::printOut(const char *title) const
             std::cout << "        hasBody: " << func->hasBody() << std::endl;
             std::cout << "        isInline: " << func->isInline() << std::endl;
             std::cout << "        isConst: " << func->isConst() << std::endl;
-            std::cout << "        isVirtual: " << func->isVirtual() << std::endl;
+            std::cout << "        hasVirtualSpecifier: " << func->hasVirtualSpecifier() << std::endl;
             std::cout << "        isPure: " << func->isPure() << std::endl;
             std::cout << "        isStatic: " << func->isStatic() << std::endl;
             std::cout << "        isStaticLocal: " << func->isStaticLocal() << std::endl;
@@ -2952,8 +2951,8 @@ void SymbolDatabase::printXml(std::ostream &out) const
                                           function->type == Function::eFunction ? "Function" :
                                           "Unknown") << '\"';
                     if (function->nestedIn->definedType) {
-                        if (function->isVirtual())
-                            out << " isVirtual=\"true\"";
+                        if (function->hasVirtualSpecifier())
+                            out << " hasVirtualSpecifier=\"true\"";
                         else if (function->isImplicitlyVirtual())
                             out << " isImplicitlyVirtual=\"true\"";
                     }
@@ -3145,7 +3144,7 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
 
 bool Function::isImplicitlyVirtual(bool defaultVal) const
 {
-    if (isVirtual())
+    if (hasVirtualSpecifier()) //If it has the virtual specifier it's definitely virtual
         return true;
     bool foundAllBaseClasses = true;
     if (getOverriddenFunction(&foundAllBaseClasses))
@@ -3181,7 +3180,7 @@ const Function * Function::getOverriddenFunctionRecursive(const ::Type* baseType
         // check if function defined in base class
         for (std::multimap<std::string, const Function *>::const_iterator it = parent->functionMap.find(tokenDef->str()); it != parent->functionMap.end() && it->first == tokenDef->str(); ++it) {
             const Function * func = it->second;
-            if (func->isVirtual()) { // Base is virtual and of same name
+            if (func->hasVirtualSpecifier()) { // Base is virtual and of same name
                 const Token *temp1 = func->tokenDef->previous();
                 const Token *temp2 = tokenDef->previous();
                 bool match = true;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3146,12 +3146,14 @@ bool Function::isImplicitlyVirtual(bool defaultVal) const
 {
     if (hasVirtualSpecifier()) //If it has the virtual specifier it's definitely virtual
         return true;
-    bool foundAllBaseClasses = true;
-    if (getOverriddenFunction(&foundAllBaseClasses))
+    if (hasOverrideSpecifier()) //If it has the override specifier then it's either virtual or not going to compile
         return true;
-    if (foundAllBaseClasses)
+    bool foundAllBaseClasses = true;
+    if (getOverriddenFunction(&foundAllBaseClasses)) //If it overrides a base class's method then it's virtual
+        return true;
+    if (foundAllBaseClasses) //If we've seen all the base classes and none of the above were true then it must not be virtual
         return false;
-    return defaultVal;
+    return defaultVal; //If we can't see all the bases classes then we can't say conclusively
 }
 
 const Function *Function::getOverriddenFunction(bool *foundAllBaseClasses) const

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -665,7 +665,7 @@ class CPPCHECKLIB Function {
         fHasBody               = (1 << 0),  ///< @brief has implementation
         fIsInline              = (1 << 1),  ///< @brief implementation in class definition
         fIsConst               = (1 << 2),  ///< @brief is const
-        fIsVirtual             = (1 << 3),  ///< @brief is virtual
+        fHasVirtualSpecifier   = (1 << 3),  ///< @brief does declaration contain 'virtual' specifier
         fIsPure                = (1 << 4),  ///< @brief is pure virtual
         fIsStatic              = (1 << 5),  ///< @brief is static
         fIsStaticLocal         = (1 << 6),  ///< @brief is static local
@@ -771,8 +771,8 @@ public:
     bool isConst() const {
         return getFlag(fIsConst);
     }
-    bool isVirtual() const {
-        return getFlag(fIsVirtual);
+    bool hasVirtualSpecifier() const {
+        return getFlag(fHasVirtualSpecifier);
     }
     bool isPure() const {
         return getFlag(fIsPure);
@@ -878,8 +878,8 @@ private:
     void isConst(bool state) {
         setFlag(fIsConst, state);
     }
-    void isVirtual(bool state) {
-        setFlag(fIsVirtual, state);
+    void hasVirtualSpecifier(bool state) {
+        setFlag(fHasVirtualSpecifier, state);
     }
     void isPure(bool state) {
         setFlag(fIsPure, state);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4830,7 +4830,7 @@ static void valueFlowFunctionReturn(TokenList *tokenlist, ErrorLogger *errorLogg
                 &error);
         if (!error) {
             ValueFlow::Value v(result);
-            if (function->isVirtual())
+            if (function->hasVirtualSpecifier())
                 v.setPossible();
             else
                 v.setKnown();

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6820,6 +6820,16 @@ private:
                                  "int A::f() { return 1; }\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Virtual function 'f' is called from constructor 'A()' at line 3. Dynamic binding is not used.\n", errout.str());
 
+        checkVirtualFunctionCall("class B {\n"
+                                 "    virtual int f() = 0;\n"
+                                 "};\n"
+                                 "class A : B {\n"
+                                 "    int f();\n"
+                                 "    A() {f();}\n"
+                                 "};\n"
+                                 "int A::f() { return 1; }\n");
+        ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:5]: (warning) Virtual function 'f' is called from constructor 'A()' at line 6. Dynamic binding is not used.\n", errout.str());
+
         checkVirtualFunctionCall("class A\n"
                                  "{\n"
                                  "    A() { A::f(); }\n"

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6813,6 +6813,13 @@ private:
                                  "int A::f() { return 1; }\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Virtual function 'f' is called from constructor 'A()' at line 3. Dynamic binding is not used.\n", errout.str());
 
+        checkVirtualFunctionCall("class A : B {\n"
+                                 "    int f() override;\n"
+                                 "    A() {f();}\n"
+                                 "};\n"
+                                 "int A::f() { return 1; }\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (warning) Virtual function 'f' is called from constructor 'A()' at line 3. Dynamic binding is not used.\n", errout.str());
+
         checkVirtualFunctionCall("class A\n"
                                  "{\n"
                                  "    A() { A::f(); }\n"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -4075,7 +4075,7 @@ private:
         const Token *f = db ? Token::findsimplematch(tokenizer.tokens(), "get_endpoint_url ( ) const noexcept ;") : nullptr;
         ASSERT(f != nullptr);
         ASSERT(f && f->function() && f->function()->token->linenr() == 2);
-        ASSERT(f && f->function() && f->function()->isVirtual());
+        ASSERT(f && f->function() && f->function()->hasVirtualSpecifier());
         ASSERT(f && f->function() && !f->function()->hasOverrideSpecifier());
         ASSERT(f && f->function() && !f->function()->hasFinalSpecifier());
         ASSERT(f && f->function() && f->function()->isConst());
@@ -4083,7 +4083,7 @@ private:
         f = db ? Token::findsimplematch(tokenizer.tokens(), "get_endpoint_url ( ) const noexcept override final ;") : nullptr;
         ASSERT(f != nullptr);
         ASSERT(f && f->function() && f->function()->token->linenr() == 5);
-        ASSERT(f && f->function() && f->function()->isVirtual());
+        ASSERT(f && f->function() && f->function()->hasVirtualSpecifier());
         ASSERT(f && f->function() && f->function()->hasOverrideSpecifier());
         ASSERT(f && f->function() && f->function()->hasFinalSpecifier());
         ASSERT(f && f->function() && f->function()->isConst());


### PR DESCRIPTION
I raised this on the  IRC but haven't seen the response so apologies if this contradicts something said there.

See for example the following code
```
struct A
{
    virtual char x() { return 'A'; }
};

struct B : A
{
    char x() override { return 'B'; }
    B() { std::cout << x(); }
};

struct B2 : A
{
    virtual char x() override { return 'X'; }
    B2() { std::cout << x(); }
};
```

cppcheck 1.87 will correctly warn that "Virtual function 'x' is called from constructor 'B2()' at line 21. Dynamic binding is not used. [virtualCallInConstructor]" however it will not detect the same for struct B which is structurally identical but lacks the virtual keyword.

Note that B::x is already virtual by virtue of A::x being virtual and matching the method signature. The virtual keyword isn't actually doing anything in this case. It may not be obvious (I haven't checked) to cppcheck that A::x is virtual when analyzing B::x. Note that even if the code is or could be made to be smart enough to recognise this relationship, sometimes the header containing A may not be available to cppcheck at all.

It should at least recognize that B::x is virtual because it has the override keyword applied to it. Either the method is virtual or the code will not compile (which I presume would qualify as "garbage" in adhering to the cppcheck philosophy document).

This change adds a test case for the case where the override keyword is supplied and the virtual keyword is not and then modifies the implementation so this test passes by treating all methods with the override keyword as virtual.

A complete solution would require checking for the override keyword and for corresponding virtual methods in ancestors. I have done only the former here. Note however that if the override keyword is not specified and cppcheck knows that the method is overriding a parent method then there is a separate warning for not specifying the override keyword so fixing this warning would just be a time saver rather than improving coverage.

My motivation for this change is that http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-one-of-virtual-override-or-final recommends specifying exactly one of virtual and override which would mean hiding warnings like this. I'd like to be able to follow the cpp core guidelines but not if it means reducing cppcheck's effectiveness.
