### PR TITLE
Implement User Selectable Code Editor Style in cppcheck-gui

### DIFF
--- a/gui/codeeditor.h
+++ b/gui/codeeditor.h
@@ -24,14 +24,27 @@ public:
 
     void setSymbols(const QStringList &symbols);
 
+    void setStyle( const CodeEditorStyle &newStyle );
+
 protected:
     void highlightBlock(const QString &text) override;
 
 private:
+    enum RuleRole {
+        Keyword = 1,
+        Class   = 2,
+        Comment = 3,
+        Quote   = 4,
+        Symbol  = 5
+    };
     struct HighlightingRule {
         QRegularExpression pattern;
         QTextCharFormat format;
+        RuleRole ruleRole;
     };
+
+    void applyFormat( HighlightingRule &rule );
+
     QVector<HighlightingRule> mHighlightingRules;
     QVector<HighlightingRule> mHighlightingRulesWithSymbols;
 
@@ -52,13 +65,14 @@ class CodeEditor : public QPlainTextEdit {
     Q_OBJECT
 
 public:
-    explicit CodeEditor(QWidget *parent,
-                        CodeEditorStyle *widgetStyle = nullptr);
+    explicit CodeEditor(QWidget *parent);
     CodeEditor(const CodeEditor &) = delete;
     CodeEditor &operator=(const CodeEditor &) = delete;
+    ~CodeEditor();
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
+    void setStyle(const CodeEditorStyle& newStyle);
 
     /**
      * Set source code to show, goto error line and highlight that line.
@@ -75,6 +89,9 @@ private slots:
     void updateLineNumberAreaWidth(int newBlockCount);
     void highlightErrorLine();
     void updateLineNumberArea(const QRect &, int);
+
+private:
+    QString generateStyleString();
 
 private:
     QWidget *mLineNumberArea;

--- a/gui/codeeditorstyle.cpp
+++ b/gui/codeeditorstyle.cpp
@@ -1,0 +1,214 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "codeeditorstyle.h"
+#include <QSettings>
+
+CodeEditorStyle::CodeEditorStyle(
+        const QColor& CtrlFGColor, const QColor& CtrlBGColor,
+        const QColor& HiLiBGColor,
+        const QColor& LnNumFGColor, const QColor& LnNumBGColor,
+        const QColor& KeyWdFGColor, const QFont::Weight& KeyWdWeight,
+        const QColor& ClsFGColor, const QFont::Weight& ClsWeight,
+        const QColor& QteFGColor, const QFont::Weight& QteWeight,
+        const QColor& CmtFGColor, const QFont::Weight& CmtWeight,
+        const QColor& SymbFGColor, const QColor& SymbBGColor,
+        const QFont::Weight& SymbWeight) :
+    widgetFGColor(CtrlFGColor),
+    widgetBGColor(CtrlBGColor),
+    highlightBGColor(HiLiBGColor),
+    lineNumFGColor(LnNumFGColor),
+    lineNumBGColor(LnNumBGColor),
+    keywordColor(KeyWdFGColor),
+    keywordWeight(KeyWdWeight),
+    classColor(ClsFGColor),
+    classWeight(ClsWeight),
+    quoteColor(QteFGColor),
+    quoteWeight(QteWeight),
+    commentColor(CmtFGColor),
+    commentWeight(CmtWeight),
+    symbolFGColor(SymbFGColor),
+    symbolBGColor(SymbBGColor),
+    symbolWeight(SymbWeight)
+{}
+
+bool CodeEditorStyle::operator==( const CodeEditorStyle& rhs ) const
+{
+    if( widgetFGColor != rhs.widgetFGColor ) return false;
+    if( widgetBGColor != rhs.widgetBGColor ) return false;
+    if( highlightBGColor != rhs.highlightBGColor ) return false;
+    if( lineNumFGColor != rhs.lineNumFGColor ) return false;
+    if( lineNumBGColor != rhs.lineNumBGColor ) return false;
+    if( keywordColor != rhs.keywordColor ) return false;
+    if( keywordWeight != rhs.keywordWeight ) return false;
+    if( classColor != rhs.classColor ) return false;
+    if( classWeight != rhs.classWeight ) return false;
+    if( quoteColor != rhs.quoteColor ) return false;
+    if( quoteWeight != rhs.quoteWeight ) return false;
+    if( commentColor != rhs.commentColor ) return false;
+    if( commentWeight != rhs.commentWeight ) return false;
+    if( symbolFGColor != rhs.symbolFGColor ) return false;
+    if( symbolBGColor != rhs.symbolBGColor ) return false;
+    if( symbolWeight != rhs.symbolWeight ) return false;
+    return true;
+}
+
+bool CodeEditorStyle::operator!=( const CodeEditorStyle& rhs ) const
+{
+    return !(*this == rhs);
+}
+
+CodeEditorStyle CodeEditorStyle::loadSettings( QSettings *settings )
+{
+    CodeEditorStyle theStyle( defaultStyleLight );
+    if( !settings)  return theStyle;
+
+    if( !settings->childGroups().contains( SETTINGS_STYLE_GROUP ))
+        return theStyle;
+
+    // style section exists - load values
+    settings->beginGroup( SETTINGS_STYLE_GROUP );
+    QString type = settings->value(
+            SETTINGS_STYLE_TYPE,
+            QVariant( SETTINGS_STYLE_TYPE_LIGHT )
+        ).toString();
+    if( type == SETTINGS_STYLE_TYPE_LIGHT )
+    {
+        settings->endGroup();
+        return theStyle;
+    }
+    if( type == SETTINGS_STYLE_TYPE_DARK )
+    {
+        theStyle = defaultStyleDark;
+        settings->endGroup();
+        return theStyle;
+    }
+    if( type == SETTINGS_STYLE_TYPE_CUSTOM )
+    {
+        theStyle.widgetFGColor = settings->value(
+            SETTINGS_STYLE_WIDGETFG,
+            QVariant(defaultStyleLight.widgetFGColor)).value<QColor>();
+        theStyle.widgetBGColor = settings->value(
+            SETTINGS_STYLE_WIDGETBG,
+            QVariant(defaultStyleLight.widgetBGColor)).value<QColor>();
+        theStyle.highlightBGColor = settings->value(
+            SETTINGS_STYLE_HILIFG,
+            QVariant(defaultStyleLight.highlightBGColor)).value<QColor>();
+        theStyle.lineNumFGColor = settings->value(
+            SETTINGS_STYLE_LINENUMFG,
+            QVariant(defaultStyleLight.lineNumFGColor)).value<QColor>();
+        theStyle.lineNumBGColor = settings->value(
+            SETTINGS_STYLE_LINENUMBG,
+            QVariant(defaultStyleLight.lineNumBGColor)).value<QColor>();
+        theStyle.keywordColor = settings->value(
+            SETTINGS_STYLE_KEYWORDFG,
+            QVariant(defaultStyleLight.keywordColor)).value<QColor>();
+        QVariant defKeyWWt(static_cast<int>(defaultStyleLight.keywordWeight));
+        theStyle.keywordWeight = static_cast<QFont::Weight>(
+            settings->value( SETTINGS_STYLE_KEYWORDWT, defKeyWWt).toInt());
+        theStyle.classColor = settings->value(
+            SETTINGS_STYLE_CLASSFG,
+            QVariant(defaultStyleLight.classColor)).value<QColor>();
+        QVariant defClsWt(static_cast<int>(defaultStyleLight.classWeight));
+        theStyle.classWeight = static_cast<QFont::Weight>(
+            settings->value( SETTINGS_STYLE_CLASSWT, defClsWt).toInt());
+        theStyle.quoteColor = settings->value(
+            SETTINGS_STYLE_QUOTEFG,
+            QVariant(defaultStyleLight.quoteColor)).value<QColor>();
+        QVariant defQteWt(static_cast<int>(defaultStyleLight.quoteWeight));
+        theStyle.quoteWeight = static_cast<QFont::Weight>(
+            settings->value( SETTINGS_STYLE_QUOTEWT, defQteWt).toInt());
+        theStyle.commentColor = settings->value(
+            SETTINGS_STYLE_COMMENTFG,
+            QVariant(defaultStyleLight.commentColor)).value<QColor>();
+        QVariant defCmtWt(static_cast<int>(defaultStyleLight.commentWeight));
+        theStyle.commentWeight = static_cast<QFont::Weight>(
+            settings->value( SETTINGS_STYLE_COMMENTWT, defCmtWt).toInt());
+        theStyle.symbolFGColor = settings->value(
+            SETTINGS_STYLE_SYMBOLFG,
+            QVariant(defaultStyleLight.symbolFGColor)).value<QColor>();
+        theStyle.symbolBGColor = settings->value(
+            SETTINGS_STYLE_SYMBOLBG,
+            QVariant(defaultStyleLight.symbolBGColor)).value<QColor>();
+        QVariant defSymWt(static_cast<int>(defaultStyleLight.symbolWeight));
+        theStyle.symbolWeight = static_cast<QFont::Weight>(
+            settings->value( SETTINGS_STYLE_SYMBOLWT, defSymWt).toInt());
+    }
+    settings->endGroup();
+    return theStyle;
+}
+
+void CodeEditorStyle::saveSettings( QSettings *settings,
+                                    const CodeEditorStyle& theStyle )
+{
+    if( !settings ) return;
+
+    if( settings->childGroups().contains( SETTINGS_STYLE_GROUP ))
+    {
+        settings->remove( SETTINGS_STYLE_GROUP );
+    }
+
+    settings->beginGroup( SETTINGS_STYLE_GROUP );
+    bool isDefaultLight = ( defaultStyleLight == theStyle );
+    bool isDefaultDark = ( defaultStyleDark == theStyle );
+    if( isDefaultLight && !isDefaultDark ) {
+        settings->setValue( SETTINGS_STYLE_TYPE,
+                            SETTINGS_STYLE_TYPE_LIGHT );
+    }
+    else if( !isDefaultLight && isDefaultDark ) {
+        settings->setValue( SETTINGS_STYLE_TYPE,
+                            SETTINGS_STYLE_TYPE_DARK );
+    }
+    else {
+        settings->setValue( SETTINGS_STYLE_TYPE,
+                            SETTINGS_STYLE_TYPE_CUSTOM );
+        settings->setValue( SETTINGS_STYLE_WIDGETFG,
+                            QVariant( theStyle.widgetFGColor ));
+        settings->setValue( SETTINGS_STYLE_WIDGETBG,
+                            QVariant( theStyle.widgetBGColor ));
+        settings->setValue( SETTINGS_STYLE_HILIFG,
+                            QVariant( theStyle.highlightBGColor ));
+        settings->setValue( SETTINGS_STYLE_LINENUMFG,
+                            QVariant( theStyle.lineNumFGColor ));
+        settings->setValue( SETTINGS_STYLE_LINENUMBG,
+                            QVariant( theStyle.lineNumBGColor ));
+        settings->setValue( SETTINGS_STYLE_KEYWORDFG,
+                            QVariant( theStyle.keywordColor ));
+        settings->setValue( SETTINGS_STYLE_KEYWORDWT,
+                            QVariant( static_cast<int>( theStyle.keywordWeight )));
+        settings->setValue( SETTINGS_STYLE_CLASSFG,
+                            QVariant( theStyle.classColor ));
+        settings->setValue( SETTINGS_STYLE_CLASSWT,
+                            QVariant( static_cast<int>( theStyle.classWeight )));
+        settings->setValue( SETTINGS_STYLE_QUOTEFG,
+                            QVariant( theStyle.quoteColor ));
+        settings->setValue( SETTINGS_STYLE_QUOTEWT,
+                            QVariant( static_cast<int>( theStyle.quoteWeight )));
+        settings->setValue( SETTINGS_STYLE_COMMENTFG,
+                            QVariant( theStyle.commentColor ));
+        settings->setValue( SETTINGS_STYLE_COMMENTWT,
+                            QVariant( static_cast<int>( theStyle.commentWeight )));
+        settings->setValue( SETTINGS_STYLE_SYMBOLFG,
+                            QVariant( theStyle.symbolFGColor ));
+        settings->setValue( SETTINGS_STYLE_SYMBOLBG,
+                            QVariant( theStyle.symbolBGColor ));
+        settings->setValue( SETTINGS_STYLE_SYMBOLWT,
+                            QVariant( static_cast<int>( theStyle.symbolWeight )));
+    }
+    settings->endGroup();
+}

--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -1,3 +1,21 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #ifndef CODEEDITORSTYLE_H
 #define CODEEDITORSTYLE_H
 
@@ -5,11 +23,33 @@
 #include <QColor>
 #include <QFont>
 
+const QString SETTINGS_STYLE_GROUP( "EditorStyle" );
+const QString SETTINGS_STYLE_TYPE( "StyleType");
+const QString SETTINGS_STYLE_TYPE_LIGHT( "DefaultLight" );
+const QString SETTINGS_STYLE_TYPE_DARK( "DefaultDark" );
+const QString SETTINGS_STYLE_TYPE_CUSTOM( "Custom" );
+const QString SETTINGS_STYLE_WIDGETFG( "StyleWidgetFG" );
+const QString SETTINGS_STYLE_WIDGETBG( "StyleWidgetBG" );
+const QString SETTINGS_STYLE_HILIFG( "StyleHighlightFG" );
+const QString SETTINGS_STYLE_LINENUMFG( "StyleLineNumFG" );
+const QString SETTINGS_STYLE_LINENUMBG( "StyleLineNumBG" );
+const QString SETTINGS_STYLE_KEYWORDFG( "StyleKeywordFG" );
+const QString SETTINGS_STYLE_KEYWORDWT( "StyleKeywordWeight" );
+const QString SETTINGS_STYLE_CLASSFG( "StyleClassFG" );
+const QString SETTINGS_STYLE_CLASSWT( "StyleClassWeight" );
+const QString SETTINGS_STYLE_QUOTEFG( "StyleQuoteFG" );
+const QString SETTINGS_STYLE_QUOTEWT( "StyleQuoteWeight" );
+const QString SETTINGS_STYLE_COMMENTFG( "StyleCommentFG" );
+const QString SETTINGS_STYLE_COMMENTWT( "StyleCommentWeight" );
+const QString SETTINGS_STYLE_SYMBOLFG( "StyleSymbolFG" );
+const QString SETTINGS_STYLE_SYMBOLBG( "StyleSymbolBG" );
+const QString SETTINGS_STYLE_SYMBOLWT( "StyleSymbolWeight" );
+
+class QSettings;
+
 class CodeEditorStyle {
-private:
-    CodeEditorStyle() {};
 public:
-    CodeEditorStyle(
+    explicit CodeEditorStyle(
         const QColor& CtrlFGColor, const QColor& CtrlBGColor,
         const QColor& HiLiBGColor,
         const QColor& LnNumFGColor, const QColor& LnNumBGColor,
@@ -18,24 +58,14 @@ public:
         const QColor& QteFGColor, const QFont::Weight& QteWeight,
         const QColor& CmtFGColor, const QFont::Weight& CmtWeight,
         const QColor& SymbFGColor, const QColor& SymbBGColor,
-        const QFont::Weight& SymbWeight) :
-        widgetFGColor(CtrlFGColor),
-        widgetBGColor(CtrlBGColor),
-        highlightBGColor(HiLiBGColor),
-        lineNumFGColor(LnNumFGColor),
-        lineNumBGColor(LnNumBGColor),
-        keywordColor(KeyWdFGColor),
-        keywordWeight(KeyWdWeight),
-        classColor(ClsFGColor),
-        classWeight(ClsWeight),
-        quoteColor(QteFGColor),
-        quoteWeight(QteWeight),
-        commentColor(CmtFGColor),
-        commentWeight(CmtWeight),
-        symbolFGColor(SymbFGColor),
-        symbolBGColor(SymbBGColor),
-        symbolWeight(SymbWeight)
-    {}
+        const QFont::Weight& SymbWeight);
+    ~CodeEditorStyle() {};
+
+    bool operator==( const CodeEditorStyle& rhs ) const;
+    bool operator!=( const CodeEditorStyle& rhs ) const;
+
+    static CodeEditorStyle loadSettings( QSettings *settings );
+    static void saveSettings( QSettings *settings, const CodeEditorStyle& theStyle );
 
 public:
     QColor          widgetFGColor;
@@ -56,7 +86,7 @@ public:
     QFont::Weight   symbolWeight;
 };
 
-static const CodeEditorStyle defaultStyle({
+static const CodeEditorStyle defaultStyleLight(
     /* editor FG/BG */          Qt::black, QColor(240, 240, 240),
     /* highlight BG */          QColor(255, 220, 220),
     /* line number FG/BG */     Qt::black, QColor(240, 240, 240),
@@ -65,6 +95,19 @@ static const CodeEditorStyle defaultStyle({
     /* quote FG/Weight */       Qt::darkGreen, QFont::Normal,
     /* comment FG/Weight */     Qt::gray, QFont::Normal,
     /* Symbol FG/BG/Weight */   Qt::red, QColor(220, 220, 255), QFont::Normal
-});
+);
+
+// Styling derived from Eclipse Color Theme - 'RecognEyes'
+// http://www.eclipsecolorthemes.org/?view=theme&id=30
+static const CodeEditorStyle defaultStyleDark(
+    /* editor FG/BG */          QColor(218, 218, 218), QColor(16, 16, 32),
+    /* highlight BG */          QColor(64, 64, 64),
+    /* line number FG/BG */     QColor(43, 145, 175), QColor(16, 16, 32),
+    /* keyword FG/Weight */     QColor(0, 204, 204), QFont::Bold,
+    /* class FG/Weight */       QColor(218, 0, 218), QFont::Bold,
+    /* quote FG/Weight */       QColor(0, 204, 0), QFont::Normal,
+    /* comment FG/Weight */     QColor(180, 180, 180), QFont::Normal,
+    /* Symbol FG/BG/Weight */   QColor(218, 32, 32), QColor(32, 32, 108), QFont::Normal
+);
 
 #endif /* CODEEDITORSTYLE_H */

--- a/gui/codeeditstylecontrols.cpp
+++ b/gui/codeeditstylecontrols.cpp
@@ -1,0 +1,114 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "codeeditstylecontrols.h"
+#include <QColorDialog>
+
+SelectColorButton::SelectColorButton( QWidget* parent ) :
+    QPushButton( parent ),
+    mColor( QColor( 255, 255, 255 ))
+{
+    updateColor();
+    connect( this, SIGNAL( clicked() ), this, SLOT( changeColor() ));
+}
+
+void SelectColorButton::updateColor() {
+    QString btnColorStyle = QString(
+                                "background-color:rgb(%1,%2,%3);"
+                                "border-style:outset;"
+                                "border-width: 1px;")
+                            .arg( mColor.red() )
+                            .arg( mColor.green() )
+                            .arg( mColor.blue() );
+    setObjectName("SelectColorButton");
+    setStyleSheet( btnColorStyle );
+}
+
+void SelectColorButton::changeColor() {
+    QColorDialog pDlg( mColor );
+    pDlg.setModal( true );
+    int nResult = pDlg.exec();
+    if (nResult == QDialog::Accepted )
+    {
+        setColor( pDlg.selectedColor() );
+        emit colorChanged( mColor );
+    }
+}
+
+void SelectColorButton::setColor( const QColor& color ) {
+    mColor = color;
+    updateColor();
+}
+
+const QColor& SelectColorButton::getColor() {
+    return mColor;
+}
+
+SelectFontWeightCombo::SelectFontWeightCombo( QWidget* parent ) :
+    QComboBox( parent ),
+    mWeight( QFont::Normal )
+{
+    addItem( QObject::tr( "Thin" ),
+             QVariant( static_cast<int>( QFont::Thin )));
+    addItem( QObject::tr( "ExtraLight" ),
+             QVariant( static_cast<int>( QFont::ExtraLight )));
+    addItem( QObject::tr( "Light" ),
+             QVariant( static_cast<int>( QFont::Light )));
+    addItem( QObject::tr( "Normal" ),
+             QVariant( static_cast<int>( QFont::Normal )));
+    addItem( QObject::tr( "Medium" ),
+             QVariant( static_cast<int>( QFont::Medium )));
+    addItem( QObject::tr( "DemiBold" ),
+             QVariant( static_cast<int>( QFont::DemiBold )));
+    addItem( QObject::tr( "Bold" ),
+             QVariant( static_cast<int>( QFont::Bold )));
+    addItem( QObject::tr( "ExtraBold" ),
+             QVariant( static_cast<int>( QFont::ExtraBold )));
+    addItem( QObject::tr( "Black" ),
+             QVariant( static_cast<int>( QFont::Black )));
+    updateWeight();
+    connect( this, SIGNAL( currentIndexChanged( int )),
+             this, SLOT( changeWeight( int )));
+}
+
+void SelectFontWeightCombo::updateWeight() {
+    int nResult = findData( QVariant( static_cast<int>( mWeight )));
+
+    if( nResult != -1 ) {
+        setCurrentIndex( nResult );
+    }
+    else {
+        setCurrentIndex( findData( static_cast<int>( QFont::Normal )));
+    }
+}
+
+void SelectFontWeightCombo::changeWeight( int index ) {
+    if( index != -1 ) {
+        setWeight( static_cast<QFont::Weight>( itemData( index ).toInt() ));
+        emit weightChanged( mWeight );
+    }
+}
+
+void SelectFontWeightCombo::setWeight( const QFont::Weight& weight ) {
+    mWeight = weight;
+    updateWeight();
+}
+
+const QFont::Weight& SelectFontWeightCombo::getWeight() {
+    return mWeight;
+}

--- a/gui/codeeditstylecontrols.h
+++ b/gui/codeeditstylecontrols.h
@@ -1,0 +1,73 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// widget subclass methodology derived from here:
+// https://stackoverflow.com/questions/18257281/qt-color-picker-widget/43871405#43871405
+
+#ifndef CODEEDITORSTYLECONTROLS_H
+#define CODEEDITORSTYLECONTROLS_H
+
+#include <QPushButton>
+#include <QComboBox>
+#include <QColor>
+#include <QFont>
+
+class SelectColorButton : public QPushButton
+{
+    Q_OBJECT
+public:
+    explicit SelectColorButton( QWidget* parent );
+    virtual ~SelectColorButton(){};
+
+    void setColor( const QColor& color );
+    const QColor& getColor();
+
+signals:
+    void colorChanged( QColor& newColor );
+
+public slots:
+    void updateColor();
+    void changeColor();
+
+private:
+    QColor mColor;
+};
+
+
+class SelectFontWeightCombo : public QComboBox
+{
+    Q_OBJECT
+public:
+    explicit SelectFontWeightCombo( QWidget* parent );
+    virtual ~SelectFontWeightCombo() {}
+
+    void setWeight( const QFont::Weight& weight );
+    const QFont::Weight& getWeight();
+
+signals:
+    void weightChanged( QFont::Weight& newWeight );
+
+public slots:
+    void updateWeight();
+    void changeWeight( int index );
+
+private:
+    QFont::Weight mWeight;
+};
+
+#endif  //CODEEDITORSTYLECONTROLS_H

--- a/gui/codeeditstyledialog.cpp
+++ b/gui/codeeditstyledialog.cpp
@@ -1,0 +1,342 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "codeeditstyledialog.h"
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QFormLayout>
+#include <QDialogButtonBox>
+
+const QString StyleEditDialog::mSampleDocument(
+"/*****\n"
+"* Multiline Comment\n"
+"*****/\n"
+"#include <QApplication>\n"
+"#include <iostream>\n"
+"\n"
+"class fwdClass;\n"
+"\n"
+"int main(int argc, char *argv[])\n"
+"{\n"
+"    QApplication a(argc, argv);\n"
+"    int nLife = 42;\n"
+"    w.show();\n"
+"    // single line comment\n"
+"    // line below is highlighted\n"
+"    fwdClass( nLife );\n"
+"    return a.exec();\n"
+"}\n"
+"\n"
+"void class fwdClass( double dValue ) {\n"
+"    std::cout << \"Ipsum Lorem: \"\n"
+"              << nValue\n"
+"              << std::endl;\n"
+"}\n");
+
+const QStringList StyleEditDialog::mErrSymbolsList = (
+    QStringList( QStringList()
+                 << "nLife"
+                 << "dValue"
+                 << "nValue"));
+const int StyleEditDialog::mErrLineNum = 16;
+
+StyleEditDialog::StyleEditDialog( const CodeEditorStyle& newStyle,
+                                  QWidget *parent /*= nullptr*/ ) :
+    QDialog( parent ),
+    mStyleIncoming( newStyle ),
+    mStyleOutgoing( newStyle )
+{
+    QVBoxLayout *vboxMain = new QVBoxLayout(this);
+    QHBoxLayout *hboxEdit = new QHBoxLayout();
+    // Color/Weight controls
+    QFormLayout *flEditControls = new QFormLayout();
+    mBtnWidgetColorFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Editor Foreground Color"),
+                            mBtnWidgetColorFG );
+    mBtnWidgetColorBG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Editor Background Color"),
+                            mBtnWidgetColorBG );
+    mBtnHighlightBG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Highlight Background Color"),
+                            mBtnHighlightBG );
+    mBtnLineNumFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Line Number Foreground Color"),
+                            mBtnLineNumFG );
+    mBtnLineNumBG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Line Number Background Color"),
+                            mBtnLineNumBG );
+    mBtnKeywordFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Keyword Foreground Color"),
+                            mBtnKeywordFG );
+    mCBKeywordWeight = new SelectFontWeightCombo( this );
+    flEditControls->addRow( QObject::tr("Keyword Font Weight"),
+                            mCBKeywordWeight );
+    mBtnClassFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Class ForegroundColor"),
+                            mBtnClassFG );
+    mCBClassWeight = new SelectFontWeightCombo( this );
+    flEditControls->addRow( QObject::tr("Class Font Weight"),
+                            mCBClassWeight );
+    mBtnQuoteFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Quote Foreground Color"),
+                            mBtnQuoteFG );
+    mCBQuoteWeight = new SelectFontWeightCombo( this );
+    flEditControls->addRow( QObject::tr("Quote Font Weight"),
+                            mCBQuoteWeight );
+    mBtnCommentFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Comment Foreground Color"),
+                            mBtnCommentFG );
+    mCBCommentWeight = new SelectFontWeightCombo( this );
+    flEditControls->addRow( QObject::tr("Comment Font Weight"),
+                            mCBCommentWeight );
+    mBtnSymbolFG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Symbol Foreground Color"),
+                            mBtnSymbolFG );
+    mBtnSymbolBG = new SelectColorButton( this );
+    flEditControls->addRow( QObject::tr("Symbol Background Color"),
+                            mBtnSymbolBG );
+    mCBSymbolWeight = new SelectFontWeightCombo( this );
+    flEditControls->addRow( QObject::tr("Symbol Font Weight"),
+                            mCBSymbolWeight );
+    hboxEdit->addLayout( flEditControls );
+    // CodeEditor to display Style
+    mSampleEditor = new CodeEditor( this );
+    QFont sampleFont( "Monospace" );
+    QFontMetrics fm(sampleFont);
+    mSampleEditor->setMinimumWidth( fm.width(QString( 40, 'W' )));
+    // designate highlight, errors, and symbols
+    mSampleEditor->setError( mSampleDocument, mErrLineNum, mErrSymbolsList);
+    // End Controls
+    hboxEdit->addWidget( mSampleEditor );
+    vboxMain->addLayout( hboxEdit );
+
+    // Default Controls
+    QHBoxLayout *hboxDefaultControls = new QHBoxLayout();
+    mBtnDefaultLight = new QPushButton( QObject::tr("Set to Default Light"),
+                                       this );
+    mBtnDefaultDark  = new QPushButton( QObject::tr("Set to Default Dark"),
+                                       this );
+    hboxDefaultControls->addStretch( 1 );
+    hboxDefaultControls->addWidget( mBtnDefaultLight );
+    hboxDefaultControls->addWidget( mBtnDefaultDark );
+    hboxDefaultControls->addStretch( 1 );
+    vboxMain->addLayout( hboxDefaultControls );
+    vboxMain->addStretch( 2 );
+    // dialog controls
+    QDialogButtonBox *dBtnBox = new QDialogButtonBox(
+        QDialogButtonBox::Cancel |
+        QDialogButtonBox::Ok |
+        QDialogButtonBox::Reset );
+    vboxMain->addStretch( 1 );
+    vboxMain->addWidget( dBtnBox );
+
+    // setup values for style controls
+    updateControls();
+    updateStyle();
+
+    connect( dBtnBox, SIGNAL( accepted() ), this, SLOT( accept() ));
+    connect( dBtnBox, SIGNAL( rejected() ), this, SLOT( reject() ));
+    connect( dBtnBox->button( QDialogButtonBox::Reset ), SIGNAL(clicked()),
+             this, SLOT( resetStyle() ));
+    connect( mBtnDefaultLight, SIGNAL( clicked() ),
+             this, SLOT( setStyleDefaultLight() ));
+    connect( mBtnDefaultDark, SIGNAL( clicked() ),
+             this, SLOT( setStyleDefaultDark() ));
+    connect( mBtnWidgetColorFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedWidgetFG( QColor& )));
+    connect( mBtnWidgetColorBG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedWidgetBG( QColor& )));
+    connect( mBtnHighlightBG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedHighlightBG( QColor& )));
+    connect( mBtnLineNumFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedLineNumFG( QColor& )));
+    connect( mBtnLineNumBG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedLineNumBG( QColor& )));
+    connect( mBtnKeywordFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedKeywordFG( QColor& )));
+    connect( mCBKeywordWeight, SIGNAL( weightChanged( QFont::Weight& )),
+             this, SLOT( weightChangedKeyword( QFont::Weight& )));
+    connect( mBtnClassFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedClassFG( QColor& )));
+    connect( mCBClassWeight, SIGNAL( weightChanged( QFont::Weight& )),
+             this, SLOT( weightChangedClass( QFont::Weight& )));
+    connect( mBtnQuoteFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedQuoteFG( QColor& )));
+    connect( mCBQuoteWeight, SIGNAL( weightChanged( QFont::Weight& )),
+             this, SLOT( weightChangedQuote( QFont::Weight& )));
+    connect( mBtnCommentFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedCommentFG( QColor& )));
+    connect( mCBCommentWeight, SIGNAL( weightChanged( QFont::Weight& )),
+             this, SLOT( weightChangedComment( QFont::Weight& )));
+    connect( mBtnSymbolFG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedSymbolFG( QColor& )));
+    connect( mBtnSymbolBG, SIGNAL( colorChanged( QColor& )),
+             this, SLOT( colorChangedSymbolBG( QColor& )));
+    connect( mCBSymbolWeight, SIGNAL( weightChanged( QFont::Weight& )),
+             this, SLOT( weightChangedSymbol( QFont::Weight& )));
+}
+
+void StyleEditDialog::updateControls()
+{
+    mBtnWidgetColorFG->setColor( mStyleOutgoing.widgetFGColor );
+    mBtnWidgetColorBG->setColor( mStyleOutgoing.widgetBGColor );
+    mBtnHighlightBG->setColor( mStyleOutgoing.highlightBGColor );
+    mBtnLineNumFG->setColor( mStyleOutgoing.lineNumFGColor );
+    mBtnLineNumBG->setColor( mStyleOutgoing.lineNumBGColor );
+    mBtnKeywordFG->setColor( mStyleOutgoing.keywordColor );
+    mCBKeywordWeight->setWeight( mStyleOutgoing.keywordWeight );
+    mBtnClassFG->setColor( mStyleOutgoing.classColor );
+    mCBClassWeight->setWeight( mStyleOutgoing.classWeight );
+    mBtnQuoteFG->setColor( mStyleOutgoing.quoteColor );
+    mCBQuoteWeight->setWeight( mStyleOutgoing.quoteWeight );
+    mBtnCommentFG->setColor( mStyleOutgoing.commentColor );
+    mCBCommentWeight->setWeight( mStyleOutgoing.commentWeight );
+    mBtnSymbolFG->setColor( mStyleOutgoing.symbolFGColor );
+    mBtnSymbolBG->setColor( mStyleOutgoing.symbolBGColor );
+    mCBSymbolWeight->setWeight( mStyleOutgoing.symbolWeight );
+}
+
+void StyleEditDialog::updateStyle()
+{
+    mBtnDefaultLight->setEnabled( mStyleOutgoing != defaultStyleLight );
+    mBtnDefaultDark->setEnabled( mStyleOutgoing != defaultStyleDark );
+    // set Editor Styling
+    mSampleEditor->setStyle( mStyleOutgoing );
+}
+
+CodeEditorStyle StyleEditDialog::getStyle()
+{
+    return mStyleOutgoing;
+}
+
+void StyleEditDialog::resetStyle()
+{
+    mStyleOutgoing = mStyleIncoming;
+    updateControls();
+    updateStyle();
+}
+
+void StyleEditDialog::setStyleDefaultLight()
+{
+    mStyleOutgoing = defaultStyleLight;
+    updateControls();
+    updateStyle();
+}
+
+void StyleEditDialog::setStyleDefaultDark()
+{
+    mStyleOutgoing = defaultStyleDark;
+    updateControls();
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedWidgetFG( QColor& newColor )
+{
+    mStyleOutgoing.widgetFGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedWidgetBG( QColor& newColor )
+{
+    mStyleOutgoing.widgetBGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedHighlightBG( QColor& newColor )
+{
+    mStyleOutgoing.highlightBGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedLineNumFG( QColor& newColor )
+{
+    mStyleOutgoing.lineNumFGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedLineNumBG( QColor& newColor )
+{
+    mStyleOutgoing.lineNumBGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedKeywordFG( QColor& newColor )
+{
+    mStyleOutgoing.keywordColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::weightChangedKeyword( QFont::Weight& newWeight )
+{
+    mStyleOutgoing.keywordWeight = newWeight;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedClassFG( QColor& newColor )
+{
+    mStyleOutgoing.classColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::weightChangedClass( QFont::Weight& newWeight )
+{
+    mStyleOutgoing.classWeight = newWeight;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedQuoteFG( QColor& newColor )
+{
+    mStyleOutgoing.quoteColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::weightChangedQuote( QFont::Weight& newWeight )
+{
+    mStyleOutgoing.quoteWeight = newWeight;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedCommentFG( QColor& newColor )
+{
+    mStyleOutgoing.commentColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::weightChangedComment( QFont::Weight& newWeight )
+{
+    mStyleOutgoing.commentWeight = newWeight;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedSymbolFG( QColor& newColor )
+{
+    mStyleOutgoing.symbolFGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::colorChangedSymbolBG( QColor& newColor )
+{
+    mStyleOutgoing.symbolBGColor = newColor;
+    updateStyle();
+}
+
+void StyleEditDialog::weightChangedSymbol( QFont::Weight& newWeight )
+{
+    mStyleOutgoing.symbolWeight = newWeight;
+    updateStyle();
+}

--- a/gui/codeeditstyledialog.h
+++ b/gui/codeeditstyledialog.h
@@ -1,0 +1,94 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CODEEDITSTYLEDIALOG_H
+#define CODEEDITSTYLEDIALOG_H
+
+#include <QDialog>
+#include <QPushButton>
+#include "codeeditstylecontrols.h"
+#include "codeeditor.h"
+#include "codeeditorstyle.h"
+
+class StyleEditDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit StyleEditDialog( const CodeEditorStyle& newStyle,
+                              QWidget *parent = nullptr);
+    virtual ~StyleEditDialog() {};
+
+    CodeEditorStyle getStyle();
+
+private:
+    void updateControls();
+    void updateStyle();
+
+public slots:
+    void resetStyle();
+    void setStyleDefaultLight();
+    void setStyleDefaultDark();
+    void colorChangedWidgetFG( QColor& newColor );
+    void colorChangedWidgetBG( QColor& newColor );
+    void colorChangedHighlightBG( QColor& newColor );
+    void colorChangedLineNumFG( QColor& newColor );
+    void colorChangedLineNumBG( QColor& newColor );
+    void colorChangedKeywordFG( QColor& newColor );
+    void weightChangedKeyword( QFont::Weight& newWeight );
+    void colorChangedClassFG( QColor& newColor );
+    void weightChangedClass( QFont::Weight& newWeight );
+    void colorChangedQuoteFG( QColor& newColor );
+    void weightChangedQuote( QFont::Weight& newWeight );
+    void colorChangedCommentFG( QColor& newColor );
+    void weightChangedComment( QFont::Weight& newWeight );
+    void colorChangedSymbolFG( QColor& newColor );
+    void colorChangedSymbolBG( QColor& newColor );
+    void weightChangedSymbol( QFont::Weight& newWeight );
+
+private:
+    CodeEditorStyle         mStyleIncoming;
+    CodeEditorStyle         mStyleOutgoing;
+
+    CodeEditor              *mSampleEditor;
+
+    SelectColorButton       *mBtnWidgetColorFG;
+    SelectColorButton       *mBtnWidgetColorBG;
+    SelectColorButton       *mBtnHighlightBG;
+    SelectColorButton       *mBtnLineNumFG;
+    SelectColorButton       *mBtnLineNumBG;
+    SelectColorButton       *mBtnKeywordFG;
+    SelectFontWeightCombo   *mCBKeywordWeight;
+    SelectColorButton       *mBtnClassFG;
+    SelectFontWeightCombo   *mCBClassWeight;
+    SelectColorButton       *mBtnQuoteFG;
+    SelectFontWeightCombo   *mCBQuoteWeight;
+    SelectColorButton       *mBtnCommentFG;
+    SelectFontWeightCombo   *mCBCommentWeight;
+    SelectColorButton       *mBtnSymbolFG;
+    SelectColorButton       *mBtnSymbolBG;
+    SelectFontWeightCombo   *mCBSymbolWeight;
+
+    QPushButton             *mBtnDefaultLight;
+    QPushButton             *mBtnDefaultDark;
+
+    static const QString     mSampleDocument;
+    static const QStringList mErrSymbolsList;
+    static const int         mErrLineNum;
+};
+
+#endif  //CODEEDITSTYLEDIALOG_H

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -90,7 +90,9 @@ HEADERS += aboutdialog.h \
            applicationlist.h \
            checkstatistics.h \
            checkthread.h \
+           codeeditstylecontrols.h \
            codeeditorstyle.h \
+           codeeditstyledialog.h \
            codeeditor.h \
            common.h \
            csvreport.h \
@@ -127,6 +129,9 @@ SOURCES += aboutdialog.cpp \
            applicationlist.cpp \
            checkstatistics.cpp \
            checkthread.cpp \
+           codeeditorstyle.cpp \
+           codeeditstylecontrols.cpp \
+           codeeditstyledialog.cpp \
            codeeditor.cpp \
            common.cpp \
            csvreport.cpp \
@@ -168,7 +173,7 @@ win32 {
 }
 
 contains(QMAKE_CC, gcc) {
-    QMAKE_CXXFLAGS += -std=c++0x -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare
+    QMAKE_CXXFLAGS += -std=c++11 -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare
 }
 
 contains(QMAKE_CXX, clang++) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1000,12 +1000,14 @@ void MainWindow::programSettings()
     SettingsDialog dialog(mApplications, mTranslation, this);
     if (dialog.exec() == QDialog::Accepted) {
         dialog.saveSettingValues();
+        mSettings->sync();
         mUI.mResults->updateSettings(dialog.showFullPath(),
                                      dialog.saveFullPath(),
                                      dialog.saveAllErrors(),
                                      dialog.showNoErrorsMessage(),
                                      dialog.showErrorId(),
                                      dialog.showInconclusive());
+        mUI.mResults->updateStyleSetting( mSettings );
         const QString newLang = mSettings->value(SETTINGS_LANGUAGE, "en").toString();
         setLanguage(newLang);
     }

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -41,6 +41,7 @@
 #include "applicationlist.h"
 #include "checkstatistics.h"
 #include "path.h"
+#include "codeeditorstyle.h"
 
 ResultsView::ResultsView(QWidget * parent) :
     QWidget(parent),
@@ -68,6 +69,9 @@ void ResultsView::initialize(QSettings *settings, ApplicationList *list, ThreadH
 {
     mUI.mProgress->setMinimum(0);
     mUI.mProgress->setVisible(false);
+
+    CodeEditorStyle theStyle( CodeEditorStyle::loadSettings( settings ));
+    mUI.mCode->setStyle( theStyle );
 
     QByteArray state = settings->value(SETTINGS_MAINWND_SPLITTER_STATE).toByteArray();
     mUI.mVerticalSplitter->restoreState(state);
@@ -234,6 +238,12 @@ void ResultsView::updateSettings(bool showFullPath,
 {
     mUI.mTree->updateSettings(showFullPath, saveFullPath, saveAllErrors, showErrorId, showInconclusive);
     mShowNoErrorsMessage = showNoErrorsMessage;
+}
+
+void ResultsView::updateStyleSetting( QSettings *settings )
+{
+    CodeEditorStyle theStyle( CodeEditorStyle::loadSettings( settings ));
+    mUI.mCode->setStyle( theStyle );
 }
 
 void ResultsView::setCheckDirectory(const QString &dir)

--- a/gui/resultsview.h
+++ b/gui/resultsview.h
@@ -108,6 +108,16 @@ public:
                         bool showInconclusive);
 
     /**
+     * @brief Update Code Editor Style
+     *
+     * Function will read updated Code Editor styling from
+     * stored program settings.
+     *
+     * @param settings Pointer to QSettings Object
+     */
+    void updateStyleSetting( QSettings *settings );
+
+    /**
     * @brief Set the directory we are checking
     *
     * This is used to split error file path to relative if necessary

--- a/gui/settings.ui
+++ b/gui/settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>589</width>
-    <height>319</height>
+    <height>346</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -420,6 +420,80 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="mTabEditorStyle">
+      <attribute name="title">
+       <string>Code Editor</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_11">
+       <item>
+        <widget class="QGroupBox" name="gboxEditorStyle">
+         <property name="title">
+          <string>Code Editor Style</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <widget class="QRadioButton" name="choiceLight">
+            <property name="text">
+             <string>Default Light Style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="choiceDark">
+            <property name="text">
+             <string>Default Dark Style</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="hlEditCustom">
+            <item>
+             <widget class="QRadioButton" name="choiceCustom">
+              <property name="text">
+               <string>Custom</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnEditCustom">
+              <property name="text">
+               <string>Edit...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="hspaceCustom">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="vspaceEditorStyle">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -463,8 +537,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>336</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -479,8 +553,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>325</x>
+     <y>336</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -28,6 +28,8 @@
 #include "applicationdialog.h"
 #include "applicationlist.h"
 #include "translationhandler.h"
+#include "codeeditorstyle.h"
+#include "codeeditstyledialog.h"
 #include "common.h"
 
 SettingsDialog::SettingsDialog(ApplicationList *list,
@@ -64,6 +66,9 @@ SettingsDialog::SettingsDialog(ApplicationList *list,
 #else
     mUI.mTabClang->setVisible(false);
 #endif
+    mCurrentStyle = new CodeEditorStyle( CodeEditorStyle::loadSettings( &settings ));
+    manageStyleControls();
+
     connect(mUI.mButtons, &QDialogButtonBox::accepted, this, &SettingsDialog::ok);
     connect(mUI.mButtons, &QDialogButtonBox::rejected, this, &SettingsDialog::reject);
     connect(mUI.mBtnAddApplication, SIGNAL(clicked()),
@@ -79,6 +84,10 @@ SettingsDialog::SettingsDialog(ApplicationList *list,
 
     connect(mUI.mBtnBrowsePythonPath, &QPushButton::clicked, this, &SettingsDialog::browsePythonPath);
     connect(mUI.mBtnBrowseMisraFile, &QPushButton::clicked, this, &SettingsDialog::browseMisraFile);
+    connect(mUI.btnEditCustom, SIGNAL( clicked() ), this, SLOT( editCodeEditorStyle() ));
+    connect(mUI.choiceLight, SIGNAL( released() ), this, SLOT( setCodeEditorStyleDefault() ));
+    connect(mUI.choiceDark, SIGNAL( released() ), this, SLOT( setCodeEditorStyleDefault() ));
+    connect(mUI.choiceCustom, SIGNAL( toggled( bool )), mUI.btnEditCustom, SLOT( setEnabled( bool )));
 
     mUI.mListWidget->setSortingEnabled(false);
     populateApplicationList();
@@ -175,6 +184,8 @@ void SettingsDialog::saveSettingValues() const
         const QString langcode = currentLang->data(mLangCodeRole).toString();
         settings.setValue(SETTINGS_LANGUAGE, langcode);
     }
+    CodeEditorStyle::saveSettings(&settings, *mCurrentStyle );
+
 }
 
 void SettingsDialog::saveCheckboxValue(QSettings *settings, QCheckBox *box,
@@ -316,6 +327,26 @@ void SettingsDialog::browseMisraFile()
         mUI.mEditMisraFile->setText(fileName);
 }
 
+// Slot to set default light style
+void SettingsDialog::setCodeEditorStyleDefault()
+{
+    if( mUI.choiceLight->isChecked() ) *mCurrentStyle = defaultStyleLight;
+    if( mUI.choiceDark->isChecked() ) *mCurrentStyle = defaultStyleDark;
+    manageStyleControls();
+}
+
+// Slot to edit custom style
+void SettingsDialog::editCodeEditorStyle()
+{
+    StyleEditDialog pDlg( *mCurrentStyle, this );
+    int nResult = pDlg.exec();
+    if( nResult == QDialog::Accepted )
+    {
+        *mCurrentStyle = pDlg.getStyle();
+        manageStyleControls();
+    }
+}
+
 void SettingsDialog::browseClangPath()
 {
     QString selectedDir = QFileDialog::getExistingDirectory(this,
@@ -325,4 +356,14 @@ void SettingsDialog::browseClangPath()
     if (!selectedDir.isEmpty()) {
         mUI.mEditClangPath->setText(selectedDir);
     }
+}
+
+void SettingsDialog::manageStyleControls()
+{
+    bool isDefaultLight = *mCurrentStyle == defaultStyleLight;
+    bool isDefaultDark =  *mCurrentStyle == defaultStyleDark;
+    mUI.choiceLight->setChecked( isDefaultLight && !isDefaultDark );
+    mUI.choiceDark->setChecked( !isDefaultLight && isDefaultDark );
+    mUI.choiceCustom->setChecked( !isDefaultLight && !isDefaultDark );
+    mUI.btnEditCustom->setEnabled( !isDefaultLight && !isDefaultDark );
 }

--- a/gui/settingsdialog.h
+++ b/gui/settingsdialog.h
@@ -27,6 +27,7 @@ class QSettings;
 class QWidget;
 class ApplicationList;
 class TranslationHandler;
+class CodeEditorStyle;
 
 /// @addtogroup GUI
 /// @{
@@ -136,6 +137,17 @@ protected slots:
      * @brief Browse for MISRA file
      */
     void browseMisraFile();
+
+    /**
+     * @brief Set Code Editor Style to Default
+     */
+    void setCodeEditorStyleDefault();
+
+    /**
+     * @brief Edit Custom Code Editor Style
+     */
+    void editCodeEditorStyle();
+
 protected:
     /**
     * @brief Clear all applications from the list and re insert them from mTempApplications
@@ -187,6 +199,11 @@ protected:
     void initTranslationsList();
 
     /**
+     * @brief Current Code Editor Style
+     */
+    CodeEditorStyle *mCurrentStyle;
+
+    /**
     * @brief List of applications user has specified
     *
     */
@@ -211,6 +228,8 @@ protected:
     */
     Ui::Settings mUI;
 private:
+    void manageStyleControls();
+
     static const int mLangCodeRole = Qt::UserRole;
 };
 /// @}

--- a/tools/triage/CMakeLists.txt
+++ b/tools/triage/CMakeLists.txt
@@ -13,7 +13,13 @@ if (BUILD_GUI AND BUILD_TESTS)
     file(GLOB uis  "*.ui")
     qt5_wrap_ui(uis_hdrs ${uis})
 
-    add_executable(triage ${hdrs} ${srcs} ${uis_hdrs} ${PROJECT_SOURCE_DIR}/gui/codeeditor.cpp)
+    add_executable(
+        triage
+        ${hdrs}
+        ${srcs}
+        ${uis_hdrs}
+        ${PROJECT_SOURCE_DIR}/gui/codeeditorstyle.cpp
+        ${PROJECT_SOURCE_DIR}/gui/codeeditor.cpp)
     target_include_directories(triage PUBLIC ${PROJECT_SOURCE_DIR}/gui/)
     target_link_libraries(triage Qt5::Core Qt5::Gui Qt5::Widgets)
 

--- a/tools/triage/triage.pro
+++ b/tools/triage/triage.pro
@@ -28,9 +28,11 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 SOURCES += main.cpp\
         mainwindow.cpp \
+        ../../gui/codeeditorstyle.cpp \
         ../../gui/codeeditor.cpp
 
 HEADERS  += mainwindow.h \
+        ../../gui/codeeditorstyle.h \
         ../../gui/codeeditor.h
 
 FORMS    += mainwindow.ui


### PR DESCRIPTION
Building on #1874, commit adds user controls to choose
or edit style in cppcheck-gui ONLY. Commit does not
address CodeEditor style usage in triage app at this time.

Code Editor style can be altered from the added "Code Editor"
tab in the user preferences. The user has the option to select
default light, default dark, or to customize.

If user leaves the style set to light or dark defaults, this
will be reflected in the choices shown in the preferences
dialog.

User choice for Code Editor Style is saved in the cppcheck-gui
preferences under the heading "EditorStyle".