### PR TITLE
Supress or Resolve compile-time warnings

### DIFF
--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -197,7 +197,7 @@ void CheckThread::runAddonsAndTools(const ImportProject::FileSettings *fileSetti
                 QFile f1(analyzerInfoFile + '.' + addon + "-E");
                 if (f1.open(QIODevice::ReadOnly | QIODevice::Text)) {
                     QTextStream in1(&f1);
-                    const quint16 oldchksum = in1.readAll().toInt();
+                    const quint16 oldchksum = static_cast<quint16>(in1.readAll().toUInt());
                     if (oldchksum == chksum) {
                         QFile f2(analyzerInfoFile + '.' + addon + "-results");
                         if (f2.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/gui/common.h
+++ b/gui/common.h
@@ -91,7 +91,7 @@
 #define SETTINGS_OPEN_PROJECT           "Open Project"
 
 // The maximum value for the progress bar
-#define PROGRESS_MAX                    1024.0
+#define PROGRESS_MAX                    1024
 
 #define SETTINGS_CHECKED_PLATFORM       "Checked platform"
 

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -182,7 +182,7 @@ bool ResultsTree::addErrorItem(const ErrorItem &item)
     //Add user data to that item
     QMap<QString, QVariant> data;
     data["hide"] = false;
-    data["severity"]  = ShowTypes::SeverityToShowType(item.severity);
+    data["severity"]  = static_cast<unsigned int>(ShowTypes::SeverityToShowType(item.severity));
     data["summary"] = item.summary;
     data["message"]  = item.message;
     data["file"]  = loc.file;
@@ -214,7 +214,7 @@ bool ResultsTree::addErrorItem(const ErrorItem &item)
 
             //Add user data to that item
             QMap<QString, QVariant> child_data;
-            child_data["severity"]  = ShowTypes::SeverityToShowType(line.severity);
+            child_data["severity"]  = static_cast<unsigned int>(ShowTypes::SeverityToShowType(line.severity));
             child_data["summary"] = line.summary;
             child_data["message"]  = line.message;
             child_data["file"]  = e.file;

--- a/gui/statsdialog.cpp
+++ b/gui/statsdialog.cpp
@@ -99,7 +99,7 @@ void StatsDialog::setNumberOfFilesScanned(int num)
 void StatsDialog::setScanDuration(double seconds)
 {
     // Factor the duration into units (days/hours/minutes/seconds)
-    int secs = seconds;
+    int secs = static_cast<int>(seconds);
     int days = secs / (24 * 60 * 60);
     secs -= days * (24 * 60 * 60);
     int hours = secs / (60 * 60);

--- a/gui/threadresult.cpp
+++ b/gui/threadresult.cpp
@@ -135,5 +135,5 @@ void ThreadResult::clearFiles()
 int ThreadResult::getFileCount() const
 {
     QMutexLocker locker(&mutex);
-    return mFiles.size() + mFileSettings.size();
+    return static_cast<int>(mFiles.size() + mFileSettings.size());
 }

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -68,7 +68,7 @@ public:
     /**
      * Message severities.
      */
-    enum SeverityType {
+    enum SeverityType : unsigned int {
         /**
          * No severity (default value).
          */


### PR DESCRIPTION
During build with full warnings, several items were flagged by the
compiler. Most warning indicators involved conversion to/from QVariant
and a locally defined enumerated type. Issues of this type were resovled
with explicit type casting to as required by called function.

There was also needed a few explicit casting conversions to integer type
required in code to supress type conversion warnings( size_t to int).

Defined value PROGRESS_MAX was changed to an integer type (remove '.0').
This resolved warnings where PROGRESS_MAX was apart of arithmetic operations
involving other integer typed values and warnings of their conversion
to float/double.