### PR TITLE
Fix #9047 (c-style casts before malloc)

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -65,12 +65,8 @@
   <define name="G_TYPE_INSTANCE_GET_PRIVATE(instance, g_type, c_type)" value="((c_type*) g_type_instance_get_private ((GTypeInstance*) (instance), (g_type)))"/>
   <define name="G_OBJECT(obj)" value="(GObject*)(obj)"/>
   <define name="G_OBJECT_CLASS(class)" value="(G_TYPE_CHECK_CLASS_CAST ((class), G_TYPE_OBJECT, GObjectClass))"/>
-  <!-- TODO #9047: use this define instead of the one without the cast as soon as memleaks are detected also with the cast
-  <define name="_G_NEW(struct_type, n_structs, func)" value="((struct_type *) g_##func##_n ((n_structs), sizeof (struct_type)))"/> -->
-  <define name="_G_NEW(struct_type, n_structs, func)" value="(g_##func##_n ((n_structs), sizeof (struct_type)))"/>
-  <!-- TODO #9047: use this define instead of the one without the cast as soon as memleaks are detected also with the cast
-  <define name="_G_RENEW(struct_type, mem, n_structs, func)" value="((struct_type *) g_##func##_n (mem, (n_structs), sizeof (struct_type)))"/> -->
-  <define name="_G_RENEW(struct_type, mem, n_structs, func)" value="(g_##func##_n (mem, (n_structs), sizeof (struct_type)))"/>
+  <define name="_G_NEW(struct_type, n_structs, func)" value="((struct_type *) g_##func##_n ((n_structs), sizeof (struct_type)))"/>
+  <define name="_G_RENEW(struct_type, mem, n_structs, func)" value="((struct_type *) g_##func##_n (mem, (n_structs), sizeof (struct_type)))"/>
   <define name="g_new(struct_type, n_structs)" value="_G_NEW (struct_type, n_structs, malloc)"/>
   <define name="g_new0(struct_type, n_structs)" value="_G_NEW (struct_type, n_structs, malloc0)"/>
   <define name="g_renew(struct_type, mem, n_structs)" value="_G_RENEW (struct_type, mem, n_structs, realloc)"/>

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -301,7 +301,9 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             }
 
             // right ast part (after `=` operator)
-            const Token* const tokRightAstOperand = tokAssignOp->astOperand2();
+            const Token* tokRightAstOperand = tokAssignOp->astOperand2();
+            while (tokRightAstOperand && tokRightAstOperand->isCast())
+                tokRightAstOperand = tokRightAstOperand->astOperand1();
 
             // is variable used in rhs?
             if (isVarUsedInTree(tokRightAstOperand, varTok->varId()))

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -374,7 +374,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     const Token* tokRightAstOperand = innerTok->next()->astOperand2();
                     while (tokRightAstOperand && tokRightAstOperand->isCast())
                         tokRightAstOperand = tokRightAstOperand->astOperand1();
-                    if (Token::Match(tokRightAstOperand->previous(), "%type% (")) {
+                    if (tokRightAstOperand && Token::Match(tokRightAstOperand->previous(), "%type% (")) {
                         const Library::AllocFunc* f = mSettings->library.alloc(tokRightAstOperand->previous());
                         if (f && f->arg == -1) {
                             VarInfo::AllocInfo& varAlloc = alloctype[innerTok->varId()];

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -303,7 +303,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             // right ast part (after `=` operator)
             const Token* tokRightAstOperand = tokAssignOp->astOperand2();
             while (tokRightAstOperand && tokRightAstOperand->isCast())
-                tokRightAstOperand = tokRightAstOperand->astOperand1();
+                tokRightAstOperand = tokRightAstOperand->astOperand2() ? tokRightAstOperand->astOperand2() : tokRightAstOperand->astOperand1();
 
             // is variable used in rhs?
             if (isVarUsedInTree(tokRightAstOperand, varTok->varId()))
@@ -373,7 +373,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     // right ast part (after `=` operator)
                     const Token* tokRightAstOperand = innerTok->next()->astOperand2();
                     while (tokRightAstOperand && tokRightAstOperand->isCast())
-                        tokRightAstOperand = tokRightAstOperand->astOperand1();
+                        tokRightAstOperand = tokRightAstOperand->astOperand2() ? tokRightAstOperand->astOperand2() : tokRightAstOperand->astOperand1();
                     if (tokRightAstOperand && Token::Match(tokRightAstOperand->previous(), "%type% (")) {
                         const Library::AllocFunc* f = mSettings->library.alloc(tokRightAstOperand->previous());
                         if (f && f->arg == -1) {

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -370,8 +370,12 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
 
                 if (Token::Match(innerTok, "%var% =") && innerTok->astParent() == innerTok->next()) {
                     // allocation?
-                    if (Token::Match(innerTok->tokAt(2), "%type% (")) {
-                        const Library::AllocFunc* f = mSettings->library.alloc(innerTok->tokAt(2));
+                    // right ast part (after `=` operator)
+                    const Token* tokRightAstOperand = innerTok->next()->astOperand2();
+                    while (tokRightAstOperand && tokRightAstOperand->isCast())
+                        tokRightAstOperand = tokRightAstOperand->astOperand1();
+                    if (Token::Match(tokRightAstOperand->previous(), "%type% (")) {
+                        const Library::AllocFunc* f = mSettings->library.alloc(tokRightAstOperand->previous());
                         if (f && f->arg == -1) {
                             VarInfo::AllocInfo& varAlloc = alloctype[innerTok->varId()];
                             varAlloc.type = f->groupId;

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -79,7 +79,7 @@ void ignoreleak(void)
 {
     char *p = (char *)malloc(10);
     __builtin_memset(&(p[0]), 0, 10);
-    // TODO // cppcheck-suppress memleak
+    // cppcheck-suppress memleak
 }
 
 void memleak_asprintf(char **ptr, const char *fmt, const int arg)

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -107,6 +107,19 @@ void g_new_test()
     // cppcheck-suppress memleak
 }
 
+void g_new_if_test()
+{
+    struct a {
+        int b;
+    };
+
+    struct a * pNew3;
+    if (pNew3 = g_new(struct a, 6)) {
+        printf("%p", pNew3);
+    }
+    // cppcheck-suppress memleak
+}
+
 void g_try_new0_test()
 {
     struct a {

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -117,7 +117,7 @@ void ignoreleak(void)
 {
     char *p = (char *)malloc(10);
     memset(&(p[0]), 0, 10);
-    // TODO cppcheck-suppress memleak
+    // cppcheck-suppress memleak
 }
 
 // null pointer

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -379,7 +379,7 @@ void memleak_LocalAlloc()
     (void)LocalFlags(pszBuf);
     LocalLock(pszBuf);
     LocalUnlock(pszBuf);
-    // TODO cppcheck-suppress memleak
+    // cppcheck-suppress memleak
 }
 
 void resourceLeak_CreateSemaphoreA()

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -61,6 +61,7 @@ private:
         TEST_CASE(assign15);
         TEST_CASE(assign16);
         TEST_CASE(assign17); // #9047
+        TEST_CASE(assign18);
 
         TEST_CASE(deallocuse1);
         TEST_CASE(deallocuse2);
@@ -331,6 +332,20 @@ private:
 
         check("void f() {\n"
               "    char *p = (char*)(int*)malloc(10);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
+    }
+
+    void assign18() {
+        check("void f(int x) {\n"
+              "    char *p;\n"
+              "    if (x && (p = (char*)malloc(10))) { }"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
+
+        check("void f(int x) {\n"
+              "    char *p;\n"
+              "    if (x && (p = (char*)(int*)malloc(10))) { }"
               "}");
         ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
     }

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -60,6 +60,7 @@ private:
         TEST_CASE(assign14);
         TEST_CASE(assign15);
         TEST_CASE(assign16);
+        TEST_CASE(assign17); // #9047
 
         TEST_CASE(deallocuse1);
         TEST_CASE(deallocuse2);
@@ -320,6 +321,18 @@ private:
               "   if (p=dostuff()) *p = 0;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void assign17() { // #9047
+        check("void f() {\n"
+              "    char *p = (char*)malloc(10);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
+
+        check("void f() {\n"
+              "    char *p = (char*)(int*)malloc(10);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
     }
 
     void deallocuse1() {


### PR DESCRIPTION
Note that there are still no warnings for c++-style casts