### PR TITLE
Add keyboard shortcuts for CodeEditor Widget

### DIFF
--- a/gui/codeeditor.cpp
+++ b/gui/codeeditor.cpp
@@ -1,5 +1,5 @@
 #include <QtWidgets>
-
+#include <QShortcut>
 #include "codeeditor.h"
 
 
@@ -200,8 +200,13 @@ CodeEditor::CodeEditor(QWidget *parent) :
     setObjectName("CodeEditor");
     setStyleSheet(generateStyleString());
 
+    QShortcut *copyText = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_C),this);
+    QShortcut *allText = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_A),this);
+
     connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
     connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
+    connect(copyText, SIGNAL(activated()), this, SLOT(copy()));
+    connect(allText, SIGNAL(activated()), this, SLOT(selectAll()));
 
     updateLineNumberAreaWidth(0);
 }


### PR DESCRIPTION
Functionality for `copy` and `select all` text already exists as part
of widget construction. Commit adds connection of those existing
functions to execution with keyboard shortcuts user would normally expect.
(e.g. CTRL+C for copy text)

Qt does translation of keyboard shortcuts for platform
(i.e. Mac OS uses command key rather than control).