### PR TITLE
Minor Corrections to Doxygen data

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -94,7 +94,7 @@ bool isDifferentKnownValues(const Token * const tok1, const Token * const tok2);
  * @param cond1  condition1
  * @param cond2  condition2
  * @param library files data
- * @param pure
+ * @param pure boolean
  */
 bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -73,7 +73,7 @@ public:
         /**
          * Constructor used for instantiations.
          * \param tok template instantiation name token "name<...>"
-         * \param scope full qualification of template
+         * \param s full qualification of template(scope)
          */
         TokenAndName(Token *tok, const std::string &s);
         /**
@@ -330,7 +330,7 @@ private:
 
     /**
      * simplify template instantiations (use default argument values)
-     * @param template1 template declaration or forward declaration
+     * @param declaration template declaration or forward declaration
      */
     void useDefaultArgumentValues(TokenAndName &declaration);
 
@@ -449,7 +449,7 @@ private:
     /**
      * Get the new token name.
      * @param tok2 name token
-     * @param &typeStringsUsedInTemplateInstantiation type strings use in template instantiation
+     * @param typeStringsUsedInTemplateInstantiation type strings use in template instantiation
      * @return new token name
      */
     std::string getNewName(


### PR DESCRIPTION
Increasing the verbosity in Clang, warnings were produced that identified
differences in code and doxygen-formatted comments.

Corrections applied to silence warnings yet still convey intent of original comments.