### PR TITLE
Suppress Code semantic and syntax warnings

### DIFF
--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -59,7 +59,7 @@ public:
         const QColor& CmtFGColor, const QFont::Weight& CmtWeight,
         const QColor& SymbFGColor, const QColor& SymbBGColor,
         const QFont::Weight& SymbWeight);
-    ~CodeEditorStyle() {};
+    ~CodeEditorStyle() {}
 
     bool operator==(const CodeEditorStyle& rhs) const;
     bool operator!=(const CodeEditorStyle& rhs) const;

--- a/gui/codeeditstylecontrols.h
+++ b/gui/codeeditstylecontrols.h
@@ -31,7 +31,7 @@ class SelectColorButton : public QPushButton {
     Q_OBJECT
 public:
     explicit SelectColorButton(QWidget* parent);
-    virtual ~SelectColorButton() {};
+    virtual ~SelectColorButton() {}
 
     void setColor(const QColor& color);
     const QColor& getColor();
@@ -69,3 +69,4 @@ private:
 };
 
 #endif  //CODEEDITORSTYLECONTROLS_H
+

--- a/gui/codeeditstyledialog.h
+++ b/gui/codeeditstyledialog.h
@@ -30,7 +30,7 @@ class StyleEditDialog : public QDialog {
 public:
     explicit StyleEditDialog(const CodeEditorStyle& newStyle,
                              QWidget *parent = nullptr);
-    virtual ~StyleEditDialog() {};
+    virtual ~StyleEditDialog() {}
 
     CodeEditorStyle getStyle();
 
@@ -91,3 +91,4 @@ private:
 };
 
 #endif  //CODEEDITSTYLEDIALOG_H
+

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -366,3 +366,4 @@ void SettingsDialog::manageStyleControls()
     mUI.choiceCustom->setChecked(!isDefaultLight && !isDefaultDark);
     mUI.btnEditCustom->setEnabled(!isDefaultLight && !isDefaultDark);
 }
+

--- a/gui/translationhandler.cpp
+++ b/gui/translationhandler.cpp
@@ -29,6 +29,7 @@
 // Provide own translations for standard buttons. This (garbage) code is needed to enforce them to appear in .ts files even after "lupdate gui.pro"
 static void unused()
 {
+// NOTE: Keeping semi-colons at end of macro for style preference
 #if ((QT_VERSION >= 0x040000)&&(QT_VERSION < 0x050000))
     Q_UNUSED(QT_TRANSLATE_NOOP("QDialogButtonBox", "OK"));
     Q_UNUSED(QT_TRANSLATE_NOOP("QDialogButtonBox", "Cancel"));

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -138,7 +138,7 @@ public:
             return "information";
         case debug:
             return "debug";
-        };
+        }
         throw InternalError(nullptr, "Unknown severity");
     }
     static SeverityType fromString(const std::string &severity) {

--- a/lib/token.h
+++ b/lib/token.h
@@ -991,7 +991,7 @@ public:
         const auto it = std::find_if(mImpl->mValues->begin(), mImpl->mValues->end(), [=](const ValueFlow::Value &value) {
             return value.isContainerSizeValue() && value.intvalue == val;
         });
-        return it == mImpl->mValues->end() ? nullptr : &*it;;
+        return it == mImpl->mValues->end() ? nullptr : &*it;
     }
 
     const Token *getValueTokenMaxStrLength() const;

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -91,7 +91,7 @@ namespace ValueFlow {
             case LIFETIME:
                 if (tokvalue != rhs.tokvalue)
                     return false;
-            };
+            }
 
             return varvalue == rhs.varvalue &&
                    condition == rhs.condition &&

--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -103,7 +103,7 @@ void MainWindow::filter(QString filter)
 {
     QStringList allErrors;
 
-    for (const QString errorItem : mAllErrors) {
+    for (const QString &errorItem : mAllErrors) {
         if (filter.isEmpty()) {
             allErrors << errorItem;
             continue;


### PR DESCRIPTION
Sources were built with Clang but with increased verbosity of error detection.

A number of syntax and semantic warnings were encountered. Commit adds
changes to correct these warnings.

Some changes involve removing extra, and unncessary, semi-colons at EOL
(e.g. at end of Qt Macro).

Project astyle settings are not currently setup to detect if a file is to
have an extra carriage return after the last line of data. Two files were
altered to ensure an extra carriage return.

An advisory to enhance code was encountered in triage code. Clang advisory
on a for-loop interation value suggested that:
`use reference type 'const QString &' to prevent copying`