### PR TITLE
Correct Zero/Null as pointer constant

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -227,7 +227,7 @@ static void print_stacktrace(FILE* output, bool demangling, int maxdepth, bool l
 // 32 vs. 64bit
 #define ADDRESSDISPLAYLENGTH ((sizeof(long)==8)?12:8)
     const int fd = fileno(output);
-    void *callstackArray[32]= {0}; // the less resources the better...
+    void *callstackArray[32]= {nullptr}; // the less resources the better...
     const int currentdepth = backtrace(callstackArray, (int)GetArrayLength(callstackArray));
     const int offset=2; // some entries on top are within our own exception handling code or libc
     if (maxdepth<0)

--- a/gui/aboutdialog.h
+++ b/gui/aboutdialog.h
@@ -35,8 +35,9 @@ class QWidget;
 class AboutDialog : public QDialog {
     Q_OBJECT
 public:
-    AboutDialog(const QString &version, const QString &extraVersion,
-                QWidget *parent = 0);
+    AboutDialog(const QString &version,
+                const QString &extraVersion,
+                QWidget *parent = nullptr);
 
 private:
     Ui::About mUI;

--- a/gui/applicationdialog.h
+++ b/gui/applicationdialog.h
@@ -45,8 +45,9 @@ public:
     * @param app Application definition.
     * @param parent Parent widget.
     */
-    ApplicationDialog(const QString &title, Application &app,
-                      QWidget *parent = 0);
+    ApplicationDialog(const QString &title,
+                      Application &app,
+                      QWidget *parent = nullptr);
     virtual ~ApplicationDialog();
 
 protected slots:

--- a/gui/applicationlist.h
+++ b/gui/applicationlist.h
@@ -33,7 +33,7 @@ class ApplicationList : public QObject {
     Q_OBJECT
 public:
 
-    explicit ApplicationList(QObject *parent = 0);
+    explicit ApplicationList(QObject *parent = nullptr);
     virtual ~ApplicationList();
 
     /**

--- a/gui/checkstatistics.h
+++ b/gui/checkstatistics.h
@@ -30,7 +30,7 @@
  */
 class CheckStatistics : public QObject {
 public:
-    explicit CheckStatistics(QObject *parent = NULL);
+    explicit CheckStatistics(QObject *parent = nullptr);
 
     /**
     * @brief Add new checked item to statistics.

--- a/gui/fileviewdialog.h
+++ b/gui/fileviewdialog.h
@@ -41,7 +41,7 @@ class FileViewDialog : public QDialog {
 public:
     FileViewDialog(const QString &file,
                    const QString &title,
-                   QWidget *parent = 0);
+                   QWidget *parent = nullptr);
 
 
 protected:

--- a/gui/libraryaddfunctiondialog.h
+++ b/gui/libraryaddfunctiondialog.h
@@ -15,7 +15,7 @@ class LibraryAddFunctionDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit LibraryAddFunctionDialog(QWidget *parent = 0);
+    explicit LibraryAddFunctionDialog(QWidget *parent = nullptr);
     LibraryAddFunctionDialog(const LibraryAddFunctionDialog &) = delete;
     ~LibraryAddFunctionDialog();
     LibraryAddFunctionDialog &operator=(const LibraryAddFunctionDialog &) = delete;

--- a/gui/librarydialog.h
+++ b/gui/librarydialog.h
@@ -34,7 +34,7 @@ class LibraryDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit LibraryDialog(QWidget *parent = 0);
+    explicit LibraryDialog(QWidget *parent = nullptr);
     LibraryDialog(const LibraryDialog &) = delete;
     ~LibraryDialog();
     LibraryDialog &operator=(const LibraryDialog &) = delete;

--- a/gui/newsuppressiondialog.h
+++ b/gui/newsuppressiondialog.h
@@ -12,7 +12,7 @@ class NewSuppressionDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit NewSuppressionDialog(QWidget *parent = 0);
+    explicit NewSuppressionDialog(QWidget *parent = nullptr);
     NewSuppressionDialog(const NewSuppressionDialog &) = delete;
     ~NewSuppressionDialog();
     NewSuppressionDialog &operator=(const NewSuppressionDialog &) = delete;

--- a/gui/platforms.h
+++ b/gui/platforms.h
@@ -44,7 +44,7 @@ class Platforms : public QObject {
     Q_OBJECT
 
 public:
-    explicit Platforms(QObject *parent = NULL);
+    explicit Platforms(QObject *parent = nullptr);
     void add(const QString &title, Settings::PlatformType platform);
     int getCount() const;
     void init();

--- a/gui/projectfile.h
+++ b/gui/projectfile.h
@@ -39,8 +39,8 @@ class ProjectFile : public QObject {
     Q_OBJECT
 
 public:
-    explicit ProjectFile(QObject *parent = 0);
-    explicit ProjectFile(const QString &filename, QObject *parent = 0);
+    explicit ProjectFile(QObject *parent = nullptr);
+    explicit ProjectFile(const QString &filename, QObject *parent = nullptr);
 
     /**
      * @brief Read the project file.

--- a/gui/projectfiledialog.h
+++ b/gui/projectfiledialog.h
@@ -42,7 +42,7 @@ class ProjectFile;
 class ProjectFileDialog : public QDialog {
     Q_OBJECT
 public:
-    explicit ProjectFileDialog(ProjectFile *projectFile, QWidget *parent = 0);
+    explicit ProjectFileDialog(ProjectFile *projectFile, QWidget *parent = nullptr);
     virtual ~ProjectFileDialog();
 
 private:

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -56,13 +56,13 @@ ResultsTree::ResultsTree(QWidget * parent) :
     QTreeView(parent),
     mSettings(nullptr),
     mApplications(nullptr),
-    mContextItem(0),
+    mContextItem(nullptr),
     mShowFullPath(false),
     mSaveFullPath(false),
     mSaveAllErrors(true),
     mShowErrorId(false),
     mVisibleErrors(false),
-    mSelectionModel(0),
+    mSelectionModel(nullptr),
     mThread(nullptr),
     mShowCppcheck(true),
     mShowClang(true)
@@ -330,7 +330,7 @@ QStandardItem *ResultsTree::findFileItem(const QString &name) const
 #endif
             return mModel.item(i, 0);
     }
-    return 0;
+    return nullptr;
 }
 
 void ResultsTree::clear()

--- a/gui/resultstree.h
+++ b/gui/resultstree.h
@@ -48,7 +48,7 @@ class ThreadHandler;
 class ResultsTree : public QTreeView {
     Q_OBJECT
 public:
-    explicit ResultsTree(QWidget * parent = 0);
+    explicit ResultsTree(QWidget * parent = nullptr);
     virtual ~ResultsTree();
     void initialize(QSettings *settings, ApplicationList *list, ThreadHandler *checkThreadHandler);
 

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -161,7 +161,7 @@ void ResultsView::save(const QString &filename, Report::Type type) const
         msgBox.exec();
     }
 
-    Report *report = NULL;
+    Report *report = nullptr;
 
     switch (type) {
     case Report::CSV:
@@ -185,7 +185,7 @@ void ResultsView::save(const QString &filename, Report::Type type) const
             msgBox.exec();
         }
         delete report;
-        report = NULL;
+        report = nullptr;
     } else {
         QMessageBox msgBox;
         msgBox.setText(tr("Failed to save the report."));

--- a/gui/resultsview.h
+++ b/gui/resultsview.h
@@ -44,7 +44,7 @@ class ResultsView : public QWidget {
     Q_OBJECT
 public:
 
-    explicit ResultsView(QWidget * parent = 0);
+    explicit ResultsView(QWidget * parent = nullptr);
     void initialize(QSettings *settings, ApplicationList *list, ThreadHandler *checkThreadHandler);
     ResultsView(const ResultsView &) = delete;
     virtual ~ResultsView();

--- a/gui/settingsdialog.cpp
+++ b/gui/settingsdialog.cpp
@@ -226,7 +226,7 @@ void SettingsDialog::removeApplication()
 void SettingsDialog::editApplication()
 {
     QList<QListWidgetItem *> selected = mUI.mListWidget->selectedItems();
-    QListWidgetItem *item = 0;
+    QListWidgetItem *item = nullptr;
     foreach (item, selected) {
         int row = mUI.mListWidget->row(item);
         Application& app = mTempApplications->getApplication(row);

--- a/gui/settingsdialog.h
+++ b/gui/settingsdialog.h
@@ -41,7 +41,7 @@ class SettingsDialog : public QDialog {
 public:
     SettingsDialog(ApplicationList *list,
                    TranslationHandler *translator,
-                   QWidget *parent = 0);
+                   QWidget *parent = nullptr);
     SettingsDialog(const SettingsDialog &) = delete;
     virtual ~SettingsDialog();
     SettingsDialog &operator=(const SettingsDialog &) = delete;

--- a/gui/statsdialog.cpp
+++ b/gui/statsdialog.cpp
@@ -149,7 +149,7 @@ void StatsDialog::pdfExport()
                          .arg(tr("Information messages"))
                          .arg(mStatistics->getCount(CPPCHECK,ShowTypes::ShowInformation));
 
-    QString fileName = QFileDialog::getSaveFileName((QWidget*)0, tr("Export PDF"), QString(), "*.pdf");
+    QString fileName = QFileDialog::getSaveFileName((QWidget*)nullptr, tr("Export PDF"), QString(), "*.pdf");
     if (QFileInfo(fileName).suffix().isEmpty()) {
         fileName.append(".pdf");
     }

--- a/gui/statsdialog.h
+++ b/gui/statsdialog.h
@@ -38,7 +38,7 @@ class CheckStatistics;
 class StatsDialog : public QDialog {
     Q_OBJECT
 public:
-    explicit StatsDialog(QWidget *parent = 0);
+    explicit StatsDialog(QWidget *parent = nullptr);
 
     /**
     * @brief Sets the project to extract statistics from

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -44,7 +44,7 @@ class Settings;
 class ThreadHandler : public QObject {
     Q_OBJECT
 public:
-    explicit ThreadHandler(QObject *parent = 0);
+    explicit ThreadHandler(QObject *parent = nullptr);
     virtual ~ThreadHandler();
 
     /**

--- a/gui/translationhandler.cpp
+++ b/gui/translationhandler.cpp
@@ -47,7 +47,7 @@ static void unused()
 TranslationHandler::TranslationHandler(QObject *parent) :
     QObject(parent),
     mCurrentLanguage("en"),
-    mTranslator(NULL)
+    mTranslator(nullptr)
 {
     // Add our available languages
     // Keep this list sorted
@@ -90,7 +90,7 @@ bool TranslationHandler::setLanguage(const QString &code)
         if (mTranslator) {
             qApp->removeTranslator(mTranslator);
             delete mTranslator;
-            mTranslator = NULL;
+            mTranslator = nullptr;
         }
 
         mCurrentLanguage = code;

--- a/gui/translationhandler.h
+++ b/gui/translationhandler.h
@@ -61,7 +61,7 @@ struct TranslationInfo {
 class TranslationHandler : QObject {
     Q_OBJECT
 public:
-    explicit TranslationHandler(QObject *parent = 0);
+    explicit TranslationHandler(QObject *parent = nullptr);
     virtual ~TranslationHandler();
 
     /**

--- a/gui/xmlreportv2.cpp
+++ b/gui/xmlreportv2.cpp
@@ -50,8 +50,8 @@ static const QString VerboseAttribute = "verbose";
 
 XmlReportV2::XmlReportV2(const QString &filename) :
     XmlReport(filename),
-    mXmlReader(NULL),
-    mXmlWriter(NULL)
+    mXmlReader(nullptr),
+    mXmlWriter(nullptr)
 {
 }
 

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -522,7 +522,7 @@ std::list<ErrorLogger::ErrorMessage::FileLocation> CTU::FileInfo::getErrorPath(I
 {
     std::list<ErrorLogger::ErrorMessage::FileLocation> locationList;
 
-    const CTU::FileInfo::CallBase *path[10] = {0};
+    const CTU::FileInfo::CallBase *path[10] = {nullptr};
 
     if (!findPath(unsafeUsage.myId, unsafeUsage.myArgNr, unsafeUsage.value, invalidValue, callsMap, path, 0, warning))
         return locationList;

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -370,7 +370,7 @@ MathLib::bigint MathLib::characterLiteralToLongNumber(const std::string& str)
 
     // '\123'
     if (str.size() == 4 && str[0] == '\\' && isoctal(str[1]) && isoctal(str[2]) && isoctal(str[3])) {
-        return (char)std::strtoul(str.substr(1).c_str(), NULL, 8);
+        return (char)std::strtoul(str.substr(1).c_str(), nullptr, 8);
     }
 
     // C99 6.4.4.4

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -967,7 +967,7 @@ void SymbolDatabase::createSymbolDatabaseVariableSymbolTable()
                 (tok->next()->str() == "." ||
                  (tok->next()->str() == "[" && tok->linkAt(1)->strAt(1) == "."))) {
                 const Token *tok1 = tok->next()->str() == "." ? tok->tokAt(2) : tok->linkAt(1)->tokAt(2);
-                if (tok1 && tok1->varId() && mVariableList[tok1->varId()] == 0) {
+                if (tok1 && tok1->varId() && mVariableList[tok1->varId()] == nullptr) {
                     const Variable *var = mVariableList[tok->varId()];
                     if (var && var->typeScope()) {
                         // find the member variable of this variable

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3579,7 +3579,7 @@ static void valueFlowForwardAssign(Token * const               tok,
             if (it->isIntValue())
                 it->intvalue = (it->intvalue != 0);
             if (it->isTokValue())
-                it ->intvalue = (it->tokvalue != 0);
+                it ->intvalue = (it->tokvalue != nullptr);
         }
     }
 
@@ -5432,9 +5432,9 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
     valueFlowFwdAnalysis(tokenlist, settings);
 
     // Temporary hack.. run valueflow until there is nothing to update or timeout expires
-    const std::time_t timeout = std::time(0) + TIMEOUT;
+    const std::time_t timeout = std::time(nullptr) + TIMEOUT;
     std::size_t values = 0;
-    while (std::time(0) < timeout && values < getTotalValues(tokenlist)) {
+    while (std::time(nullptr) < timeout && values < getTotalValues(tokenlist)) {
         values = getTotalValues(tokenlist);
         valueFlowArrayBool(tokenlist);
         valueFlowRightShift(tokenlist, settings);

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3918,7 +3918,7 @@ private:
     void getErrorMessages() {
         // Ticket #2292: segmentation fault when using --errorlist
         CheckBufferOverrun c;
-        c.getErrorMessages(this, 0);
+        c.getErrorMessages(this, nullptr);
     }
 
     void arrayIndexThenCheck() {

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -3320,7 +3320,7 @@ private:
                       "[test.cpp:3]: (warning) Suspicious pointer subtraction. Did you intend to write '->'?\n", errout.str());
     }
 
-    void checkConst(const char code[], Settings *s = 0, bool inconclusive = true) {
+    void checkConst(const char code[], Settings *s = nullptr, bool inconclusive = true) {
         // Clear the error log
         errout.str("");
 
@@ -5552,7 +5552,7 @@ private:
                    "  void set(const Key& key) {\n"
                    "      inherited::set(inherited::Key(key));\n"
                    "  }\n"
-                   "};\n", 0, false);
+                   "};\n", nullptr, false);
         ASSERT_EQUALS("", errout.str());
     }
 
@@ -6774,7 +6774,7 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void checkVirtualFunctionCall(const char code[], Settings *s = 0, bool inconclusive = true) {
+    void checkVirtualFunctionCall(const char code[], Settings *s = nullptr, bool inconclusive = true) {
         // Clear the error log
         errout.str("");
 

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -281,7 +281,7 @@ private:
 
         tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(false, false, false, true, false, 0, 0);
+        return tokenizer.tokens()->stringifyList(false, false, false, true, false, nullptr, nullptr);
     }
 
     std::string getSyntaxError(const char code[]) {

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -110,7 +110,7 @@ private:
 
         // there is no allocation
         const Token *tok = Token::findsimplematch(tokenizer.tokens(), "ret =");
-        const CheckMemoryLeak check(&tokenizer, 0, &settings);
+        const CheckMemoryLeak check(&tokenizer, nullptr, &settings);
         ASSERT_EQUALS(CheckMemoryLeak::No, check.getAllocationType(tok->tokAt(2), 1));
     }
 };

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1875,7 +1875,7 @@ private:
               "    case 3:\n"
               "      strcpy(str, \"b'\");\n"
               "    }\n"
-              "}", 0, false, false, false);
+              "}", nullptr, false, false, false);
         // TODO ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:8]: (warning) Buffer 'str' is being written before its old content has been used. 'break;' missing?\n", errout.str());
 
         check("void foo(int a) {\n"
@@ -3346,7 +3346,7 @@ private:
 
         check("void f(char c) {\n"
               "    printf(\"%i\", 1 + 1 ? 1 : 2);\n" // "1+1" is simplified away
-              "}",0,false,false,false);
+              "}",nullptr,false,false,false);
         ASSERT_EQUALS("[test.cpp:2]: (style) Clarify calculation precedence for '+' and '?'.\n", errout.str());
 
         check("void f() {\n"

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -46,7 +46,7 @@ public:
     class OurPreprocessor : public Preprocessor {
     public:
 
-        static std::string expandMacros(const char code[], ErrorLogger *errorLogger = 0) {
+        static std::string expandMacros(const char code[], ErrorLogger *errorLogger = nullptr) {
             std::istringstream istr(code);
             simplecpp::OutputList outputList;
             std::vector<std::string> files;
@@ -269,7 +269,7 @@ private:
         }
     }
 
-    std::string getConfigsStr(const char filedata[], const char *arg=NULL) {
+    std::string getConfigsStr(const char filedata[], const char *arg = nullptr) {
         Settings settings;
         if (arg && std::strncmp(arg,"-D",2)==0)
             settings.userDefines = arg + 2;

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -223,7 +223,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
 
-        return tokenizer.tokens()->stringifyList(0, true);
+        return tokenizer.tokens()->stringifyList(nullptr, true);
     }
 
     void template1() {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -274,7 +274,7 @@ private:
         if (simplify)
             tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, !simplify);
+        return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
 
     std::string tokWithWindows(const char code[], bool simplify = true, Settings::PlatformType type = Settings::Native) {
@@ -289,7 +289,7 @@ private:
         if (simplify)
             tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, !simplify);
+        return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
 
     std::string tok(const char code[], const char filename[], bool simplify = true) {
@@ -302,7 +302,7 @@ private:
         if (simplify)
             tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, false);
+        return tokenizer.tokens()->stringifyList(nullptr, false);
     }
 
     std::string tokWithNewlines(const char code[]) {
@@ -326,7 +326,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");
         tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, false);
+        return tokenizer.tokens()->stringifyList(nullptr, false);
     }
 
     std::string tokenizeDebugListing(const char code[], bool simplify = false, const char filename[] = "test.cpp") {
@@ -1810,7 +1810,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
 
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
         ASSERT_EQUALS(true, tokenizer.tokens()->tokAt(2)->isLong());
     }
 
@@ -1823,7 +1823,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
 
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
         ASSERT_EQUALS(true, tokenizer.tokens()->tokAt(2)->isLong());
     }
 
@@ -1836,7 +1836,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
 
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
         ASSERT_EQUALS(true, tokenizer.tokens()->tokAt(2)->isLong());
     }
 
@@ -1850,7 +1850,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
 
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
         ASSERT_EQUALS(false, tokenizer.tokens()->tokAt(2)->isLong());
     }
 
@@ -2910,7 +2910,7 @@ private:
 
         tokenizer.simplifyIfAndWhileAssign();
 
-        return tokenizer.tokens()->stringifyList(0, false);
+        return tokenizer.tokens()->stringifyList(nullptr, false);
     }
 
     void ifassign1() {
@@ -2994,7 +2994,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");
         tokenizer.simplifyTokenList2();
 
-        ASSERT_EQUALS("; m = q . push < Message > ( x ) ; while ( ! m ) { m = q . push < Message > ( x ) ; }", tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS("; m = q . push < Message > ( x ) ; while ( ! m ) { m = q . push < Message > ( x ) ; }", tokenizer.tokens()->stringifyList(nullptr, false));
         ASSERT(tokenizer.tokens()->tokAt(26) != nullptr);
         if (tokenizer.tokens()->tokAt(26)) {
             ASSERT(tokenizer.tokens()->linkAt(6) == tokenizer.tokens()->tokAt(8));

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -193,7 +193,7 @@ private:
         if (simplify)
             tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, !simplify);
+        return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
 
     std::string simplifyTypedef(const char code[]) {
@@ -206,7 +206,7 @@ private:
         tokenizer.createLinks();
         tokenizer.simplifyTypedef();
 
-        return tokenizer.tokens()->stringifyList(0, false);
+        return tokenizer.tokens()->stringifyList(nullptr, false);
     }
 
     void checkSimplifyTypedef(const char code[]) {

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -80,7 +80,7 @@ private:
         if (simplify)
             tokenizer.simplifyTokenList2();
 
-        return tokenizer.tokens()->stringifyList(0, !simplify);
+        return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
 
     void simplifyUsing1() {

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -83,7 +83,7 @@ private:
                     return &(*scope);
             }
         }
-        return 0;
+        return nullptr;
     }
 
     static const Function *findFunctionByName(const char str[], const Scope* startScope) {
@@ -101,7 +101,7 @@ private:
             }
             currScope = currScope->nestedIn;
         }
-        return 0;
+        return nullptr;
     }
 
     void run() OVERRIDE {
@@ -428,7 +428,7 @@ private:
         ASSERT_EQUALS(false, result);
         ASSERT(nullptr == vartok);
         ASSERT(nullptr == typetok);
-        Variable v(nullptr, nullptr, nullptr, 0, Public, 0, 0, &settings1);
+        Variable v(nullptr, nullptr, nullptr, 0, Public, nullptr, nullptr, &settings1);
     }
 
     void test_isVariableDeclarationIdentifiesSimpleDeclaration() {
@@ -438,7 +438,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -451,7 +451,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -464,7 +464,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -477,7 +477,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -490,7 +490,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("string", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -503,7 +503,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("string", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -516,7 +516,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("x", vartok->str());
         ASSERT_EQUALS("EE", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -529,14 +529,14 @@ private:
         ASSERT_EQUALS(true, result1);
         ASSERT_EQUALS("p", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v1(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v1(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v1.isArray());
         ASSERT(true == v1.isPointer());
         ASSERT(false == v1.isReference());
 
         reset();
         givenACodeSampleToTokenize constpointer("const int* p;");
-        Variable v2(constpointer.tokens()->tokAt(3), constpointer.tokens()->next(), constpointer.tokens()->tokAt(2), 0, Public, 0, 0, &settings1);
+        Variable v2(constpointer.tokens()->tokAt(3), constpointer.tokens()->next(), constpointer.tokens()->tokAt(2), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v2.isArray());
         ASSERT(true == v2.isPointer());
         ASSERT(false == v2.isConst());
@@ -548,7 +548,7 @@ private:
         ASSERT_EQUALS(true, result2);
         ASSERT_EQUALS("p", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v3(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v3(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v3.isArray());
         ASSERT(true == v3.isPointer());
         ASSERT(true == v3.isConst());
@@ -571,7 +571,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("first", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -584,7 +584,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("p", vartok->str());
         ASSERT_EQUALS("EE", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -597,7 +597,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("pp", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -610,7 +610,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("p", vartok->str());
         ASSERT_EQUALS("int", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -623,7 +623,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("v", vartok->str());
         ASSERT_EQUALS("string", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(true == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isPointerArray());
@@ -637,7 +637,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("a", vartok->str());
         ASSERT_EQUALS("A", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isPointer());
         ASSERT(true == v.isArray());
         ASSERT(false == v.isPointerToArray());
@@ -652,7 +652,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("a", vartok->str());
         ASSERT_EQUALS("A", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointerToArray());
@@ -667,7 +667,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("chars", vartok->str());
         ASSERT_EQUALS("set", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -680,7 +680,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("ints", vartok->str());
         ASSERT_EQUALS("deque", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -693,7 +693,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("ints", vartok->str());
         ASSERT_EQUALS("deque", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(true == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -706,7 +706,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("ints", vartok->str());
         ASSERT_EQUALS("vector", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -719,7 +719,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("floats", vartok->str());
         ASSERT_EQUALS("const_iterator", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -732,7 +732,7 @@ private:
         ASSERT_EQUALS(true, result);
         ASSERT_EQUALS("intsets", vartok->str());
         ASSERT_EQUALS("deque", typetok->str());
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(false == v.isReference());
@@ -743,7 +743,7 @@ private:
         givenACodeSampleToTokenize var1("int& foo;");
         const bool result1 = nullScope.isVariableDeclaration(var1.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result1);
-        Variable v1(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v1(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v1.isArray());
         ASSERT(false == v1.isPointer());
         ASSERT(true == v1.isReference());
@@ -752,7 +752,7 @@ private:
         givenACodeSampleToTokenize var2("foo*& bar;");
         const bool result2 = nullScope.isVariableDeclaration(var2.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result2);
-        Variable v2(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v2(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v2.isArray());
         ASSERT(true == v2.isPointer());
         ASSERT(true == v2.isReference());
@@ -761,7 +761,7 @@ private:
         givenACodeSampleToTokenize var3("std::vector<int>& foo;");
         const bool result3 = nullScope.isVariableDeclaration(var3.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result3);
-        Variable v3(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v3(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v3.isArray());
         ASSERT(false == v3.isPointer());
         ASSERT(true == v3.isReference());
@@ -786,7 +786,7 @@ private:
         givenACodeSampleToTokenize var("std::string const* s;");
         const bool result = nullScope.isVariableDeclaration(var.tokens()->next(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -797,12 +797,12 @@ private:
         givenACodeSampleToTokenize var("int&& i;");
         const bool result = nullScope.isVariableDeclaration(var.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(false == v.isPointer());
         ASSERT(true == v.isReference());
         ASSERT(true == v.isRValueReference());
-        ASSERT(var.tokens()->tokAt(2)->scope() != 0);
+        ASSERT(var.tokens()->tokAt(2)->scope() != nullptr);
     }
 
     void isVariableDeclarationDoesNotIdentifyCase() {
@@ -962,7 +962,7 @@ private:
             list.createTokens(code, "test.cpp");
             const bool result = nullScope.isVariableDeclaration(list.front(), vartok, typetok);
             ASSERT_EQUALS(true, result);
-            Variable v(vartok, list.front(), list.back(), 0, Public, 0, 0, &settings1);
+            Variable v(vartok, list.front(), list.back(), 0, Public, nullptr, nullptr, &settings1);
             static const std::set<std::string> types = { "string", "wstring" };
             static const std::set<std::string> no_types = { "set" };
             ASSERT_EQUALS(true, v.isStlType());
@@ -978,7 +978,7 @@ private:
             list.front()->tokAt(3)->link(list.front()->tokAt(5));
             const bool result = nullScope.isVariableDeclaration(list.front(), vartok, typetok);
             ASSERT_EQUALS(true, result);
-            Variable v(vartok, list.front(), list.back(), 0, Public, 0, 0, &settings1);
+            Variable v(vartok, list.front(), list.back(), 0, Public, nullptr, nullptr, &settings1);
             static const std::set<std::string> types = { "bitset", "set", "vector", "wstring" };
             static const std::set<std::string> no_types = { "bitset", "map", "set" };
             ASSERT_EQUALS(true, v.isStlType());
@@ -993,7 +993,7 @@ private:
             list.createTokens(code, "test.cpp");
             const bool result = nullScope.isVariableDeclaration(list.front(), vartok, typetok);
             ASSERT_EQUALS(true, result);
-            Variable v(vartok, list.front(), list.back(), 0, Public, 0, 0, &settings1);
+            Variable v(vartok, list.front(), list.back(), 0, Public, nullptr, nullptr, &settings1);
             static const std::set<std::string> types = { "bitset", "set", "vector" };
             ASSERT_EQUALS(false, v.isStlType());
             ASSERT_EQUALS(false, v.isStlType(types));
@@ -1006,7 +1006,7 @@ private:
         givenACodeSampleToTokenize var("char* const * s;");
         bool result = nullScope.isVariableDeclaration(var.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -1017,7 +1017,7 @@ private:
         givenACodeSampleToTokenize var("char* volatile * s;");
         bool result = nullScope.isVariableDeclaration(var.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -1028,7 +1028,7 @@ private:
         givenACodeSampleToTokenize var("char* const volatile * s;");
         bool result = nullScope.isVariableDeclaration(var.tokens(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -1039,7 +1039,7 @@ private:
         givenACodeSampleToTokenize var("const char* const volatile * const volatile * const volatile * const volatile s;");
         bool result = nullScope.isVariableDeclaration(var.tokens()->next(), vartok, typetok);
         ASSERT_EQUALS(true, result);
-        Variable v(vartok, typetok, vartok->previous(), 0, Public, 0, 0, &settings1);
+        Variable v(vartok, typetok, vartok->previous(), 0, Public, nullptr, nullptr, &settings1);
         ASSERT(false == v.isArray());
         ASSERT(true == v.isPointer());
         ASSERT(false == v.isReference());
@@ -1127,7 +1127,7 @@ private:
             ASSERT(scope && scope->className == "func");
             if (!scope)
                 return;
-            ASSERT(scope->functionOf == 0);
+            ASSERT(scope->functionOf == nullptr);
 
             const Function *function = findFunctionByName("func", &db->scopeList.front());
 
@@ -1151,7 +1151,7 @@ private:
             ASSERT(scope && scope->className == "func");
             if (!scope)
                 return;
-            ASSERT(scope->functionOf == 0);
+            ASSERT(scope->functionOf == nullptr);
 
             const Function *function = findFunctionByName("func", &db->scopeList.front());
 
@@ -1491,67 +1491,67 @@ private:
             GET_SYMBOL_DB("class Foo { Foo(); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor && !ctor->isExplicit());
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { explicit Foo(Foo f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(4)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor && ctor->isExplicit());
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Bar& f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo& f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(const Foo &f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("template <T> class Foo { Foo(Foo<T>& f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(7)->function();
             ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo& f, int default = 0); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eCopyConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo& f, char noDefault); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo&& f); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eMoveConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
             GET_SYMBOL_DB("class Foo { Foo(Foo & & f, int default = 1, bool defaultToo = true); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eMoveConstructor);
-            ASSERT(ctor && ctor->retDef == 0);
+            ASSERT(ctor && ctor->retDef == nullptr);
         }
     }
 

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -363,7 +363,7 @@ private:
 
 
     void deleteLast() const {
-        TokensFrontBack listEnds{ 0 };
+        TokensFrontBack listEnds{ nullptr };
         Token ** const tokensBack = &(listEnds.back);
         Token tok(&listEnds);
         tok.insertToken("aba");
@@ -373,7 +373,7 @@ private:
     }
 
     void deleteFirst() const {
-        TokensFrontBack listEnds{ 0 };
+        TokensFrontBack listEnds{ nullptr };
         Token ** const tokensFront = &(listEnds.front);
         Token tok(&listEnds);
 
@@ -390,7 +390,7 @@ private:
         ASSERT_EQUALS(true, Token::simpleMatch(example1.tokens()->tokAt(4)->nextArgument(), "3 , 4"));
 
         givenACodeSampleToTokenize example2("foo();");
-        ASSERT_EQUALS(true, example2.tokens()->tokAt(2)->nextArgument() == 0);
+        ASSERT_EQUALS(true, example2.tokens()->tokAt(2)->nextArgument() == nullptr);
 
         givenACodeSampleToTokenize example3("foo(bar(a, b), 2, 3);");
         ASSERT_EQUALS(true, Token::simpleMatch(example3.tokens()->tokAt(2)->nextArgument(), "2 , 3"));
@@ -402,7 +402,7 @@ private:
     void eraseTokens() const {
         givenACodeSampleToTokenize code("begin ; { this code will be removed } end", true);
         Token::eraseTokens(code.tokens()->next(), code.tokens()->tokAt(9));
-        ASSERT_EQUALS("begin ; end", code.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS("begin ; end", code.tokens()->stringifyList(nullptr, false));
     }
 
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -495,7 +495,7 @@ private:
         }
 
         if (tokenizer.tokens())
-            return tokenizer.tokens()->stringifyList(false, expand, false, true, false, 0, 0);
+            return tokenizer.tokens()->stringifyList(false, expand, false, true, false, nullptr, nullptr);
         else
             return "";
     }
@@ -525,7 +525,7 @@ private:
         }
 
         if (tokenizer.tokens())
-            return tokenizer.tokens()->stringifyList(false, expand, false, true, false, 0, 0);
+            return tokenizer.tokens()->stringifyList(false, expand, false, true, false, nullptr, nullptr);
         else
             return "";
     }
@@ -539,7 +539,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");
         if (!tokenizer.tokens())
             return "";
-        return tokenizer.tokens()->stringifyList(false, true, false, true, false, 0, 0);
+        return tokenizer.tokens()->stringifyList(false, true, false, true, false, nullptr, nullptr);
     }
 
     std::string tokenizeDebugListing(const char code[], bool simplify = false, const char filename[] = "test.cpp") {
@@ -1499,7 +1499,7 @@ private:
 
         tokenizer.simplifyKnownVariables();
 
-        return tokenizer.tokens()->stringifyList(0, false);
+        return tokenizer.tokens()->stringifyList(nullptr, false);
     }
 
     void simplifyKnownVariables1() {
@@ -4481,8 +4481,8 @@ private:
             ASSERT_EQUALS(true, tok->tokAt(14) == tok->linkAt(16));
 
             // a<b && b>f
-            ASSERT_EQUALS(true, 0 == tok->linkAt(28));
-            ASSERT_EQUALS(true, 0 == tok->linkAt(32));
+            ASSERT_EQUALS(true, nullptr == tok->linkAt(28));
+            ASSERT_EQUALS(true, nullptr == tok->linkAt(32));
 
             ASSERT_EQUALS("", errout.str());
         }
@@ -5141,7 +5141,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");
 
         // Expected result..
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
 
         const Token * func1 = Token::findsimplematch(tokenizer.tokens(), "func1");
         const Token * func2 = Token::findsimplematch(tokenizer.tokens(), "func2");
@@ -5172,7 +5172,7 @@ private:
         tokenizer.tokenize(istr, "test.cpp");
 
         // Expected result..
-        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(0, false));
+        ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
 
         const Token * func1 = Token::findsimplematch(tokenizer.tokens(), "func1");
         const Token * func2 = Token::findsimplematch(tokenizer.tokens(), "func2");

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -41,7 +41,7 @@ private:
         TEST_CASE(checkFloatToIntegerOverflow);
     }
 
-    void check(const char code[], Settings* settings = 0, const char filename[] = "test.cpp") {
+    void check(const char code[], Settings* settings = nullptr, const char filename[] = "test.cpp") {
         // Clear the error buffer..
         errout.str("");
 

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -31,7 +31,7 @@ private:
 
 public:
     explicit givenACodeSampleToTokenize(const char sample[], bool createOnly = false, bool cpp = true)
-        : _tokenizer(&_settings, 0) {
+        : _tokenizer(&_settings, nullptr) {
         std::istringstream iss(sample);
         if (createOnly)
             _tokenizer.list.createTokens(iss, cpp ? "test.cpp" : "test.c");


### PR DESCRIPTION
Building with enhanced clang warnings indicated a large number of
instances with the warning:

`warning: zero as null pointer constant`

Recommended practice in C++11 is to use `nullptr` as value for
a NULL or empty pointer value. All instances where this warning
was encountered were corrected in this commit.

Where warning was encountered in dependency code (i.e. external library)
no chnages were made. Patching will be offered upstream.