### PR TITLE
Remove <noreturn> from g_malloc and friends

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -2844,7 +2844,6 @@
   </function>
   <!-- gpointer g_realloc (gpointer mem, gsize n_bytes); -->
   <function name="g_realloc">
-    <noreturn>false</noreturn>
     <returnValue type="gpointer"/>
     <use-retval/>
     <arg nr="1"/>
@@ -2856,7 +2855,6 @@
   </function>
   <!-- gpointer g_realloc_n (gpointer mem, gsize n_blocks, gsize n_block_bytes); -->
   <function name="g_realloc_n">
-    <noreturn>false</noreturn>
     <returnValue type="gpointer"/>
     <use-retval/>
     <arg nr="1"/>
@@ -4679,7 +4677,6 @@
   <!-- gpointer g_malloc(gsize n_bytes); -->
   <!-- gpointer g_malloc0(gsize n_bytes); -->
   <function name="g_malloc,g_malloc0">
-    <noreturn>false</noreturn>
     <returnValue type="gpointer"/>
     <arg nr="1" direction="in">
       <not-uninit/>
@@ -4691,7 +4688,6 @@
   <!-- gpointer g_malloc_n (gsize n_blocks, gsize n_block_bytes); -->
   <!-- gpointer g_malloc0_n (gsize n_blocks, gsize n_block_bytes); -->
   <function name="g_malloc_n,g_malloc0_n">
-    <noreturn>false</noreturn>
     <returnValue type="gpointer"/>
     <arg nr="1" direction="in">
       <not-uninit/>


### PR DESCRIPTION
From the Gnome Developer documentation
(https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html):

    If any call to allocate memory using functions g_new(), g_new0(),
    g_renew(), g_malloc(), g_malloc0(), g_malloc0_n(), g_realloc(), and
    g_realloc_n() fails, the application is terminated. This also means
    that there is no need to check if the call succeeded. On the other
    hand, g_try_...() family of functions returns NULL on failure that
    can be used as a check for unsuccessful memory allocation. The
    application is not terminated in this case.

`g_new()`, `g_new0()` and `g_renew()` are defines using `g_malloc()`,
`g_malloc0()` and `g_realloc()` respectively, so there is no need to change
those.