### PR TITLE
Variable Shadow Warnings, Reformatting, and type resolution

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -508,8 +508,8 @@ ValueFlow::Value CheckBufferOverrun::getBufferSize(const Token *bufTok) const
     if (!var)
         return ValueFlow::Value(-1);
 
-    MathLib::bigint dim = std::accumulate(var->dimensions().begin(), var->dimensions().end(), 1LL, [](MathLib::bigint i1, const Dimension &dim) {
-        return i1 * dim.num;
+    MathLib::bigint dim = std::accumulate(var->dimensions().begin(),var->dimensions().end(),1LL,[](MathLib::bigint i1, const Dimension &paramDim) {
+        return i1 * paramDim.num;
     });
 
     ValueFlow::Value v;
@@ -529,7 +529,11 @@ ValueFlow::Value CheckBufferOverrun::getBufferSize(const Token *bufTok) const
 }
 //---------------------------------------------------------------------------
 
-static bool checkBufferSize(const Token *ftok, const Library::ArgumentChecks::MinSize &minsize, const std::vector<const Token *> &args, const MathLib::bigint bufferSize, const Settings *settings)
+static bool checkBufferSize(const Token *ftok,
+                            const Library::ArgumentChecks::MinSize &minsize,
+                            const std::vector<const Token *> &args,
+                            const MathLib::bigint bufferSize,
+                            const Settings *settings)
 {
     const Token * const arg = (minsize.arg > 0 && minsize.arg - 1 < args.size()) ? args[minsize.arg - 1] : nullptr;
     const Token * const arg2 = (minsize.arg2 > 0 && minsize.arg2 - 1 < args.size()) ? args[minsize.arg2 - 1] : nullptr;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -634,13 +634,13 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
 
                     picojson::object obj = res.get<picojson::object>();
 
-                    const std::string filename = obj["file"].get<std::string>();
+                    const std::string localFilename = obj["file"].get<std::string>();
                     const int64_t lineNumber = obj["linenr"].get<int64_t>();
                     const int64_t column = obj["col"].get<int64_t>();
 
                     ErrorLogger::ErrorMessage errmsg;
 
-                    errmsg._callStack.emplace_back(ErrorLogger::ErrorMessage::FileLocation(filename, lineNumber));
+                    errmsg._callStack.emplace_back(ErrorLogger::ErrorMessage::FileLocation(localFilename, lineNumber));
                     errmsg._callStack.back().col = column;
 
                     errmsg._id = obj["errorId"].get<std::string>();
@@ -650,7 +650,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                     errmsg._severity = Severity::fromString(severity);
                     if (errmsg._severity == Severity::SeverityType::none)
                         continue;
-                    errmsg.file0 = filename;
+                    errmsg.file0 = localFilename;
 
                     reportErr(errmsg);
                 }

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -47,7 +47,17 @@ namespace CTU {
 
         struct UnsafeUsage {
             UnsafeUsage() = default;
-            UnsafeUsage(const std::string &myId, unsigned int myArgNr, const std::string &myArgumentName, const Location &location, MathLib::bigint value) : myId(myId), myArgNr(myArgNr), myArgumentName(myArgumentName), location(location), value(value) {}
+            UnsafeUsage(const std::string &myId,
+                        unsigned int myArgNr,
+                        const std::string &myArgumentName,
+                        const Location &location,
+                        MathLib::bigint value) :
+                myId(myId),
+                myArgNr(myArgNr),
+                myArgumentName(myArgumentName),
+                location(location),
+                value(value)
+            {}
             std::string myId;
             unsigned int myArgNr;
             std::string myArgumentName;
@@ -59,8 +69,14 @@ namespace CTU {
         class CallBase {
         public:
             CallBase() = default;
-            CallBase(const std::string &callId, int callArgNr, const std::string &callFunctionName, const Location &loc)
-                : callId(callId), callArgNr(callArgNr), callFunctionName(callFunctionName), location(loc)
+            CallBase(const std::string &callId,
+                     int callArgNr,
+                     const std::string &callFunctionName,
+                     const Location &location) :
+                callId(callId),
+                callArgNr(callArgNr),
+                callFunctionName(callFunctionName),
+                location(location)
             {}
             CallBase(const Tokenizer *tokenizer, const Token *callToken);
             virtual ~CallBase() {}
@@ -89,10 +105,15 @@ namespace CTU {
         public:
             NestedCall() = default;
 
-            NestedCall(const std::string &myId, unsigned int myArgNr, const std::string &callId, unsigned int callArgnr, const std::string &callFunctionName, const Location &location)
-                : CallBase(callId, callArgnr, callFunctionName, location),
-                  myId(myId),
-                  myArgNr(myArgNr) {
+            NestedCall(const std::string &myId,
+                       unsigned int myArgNr,
+                       const std::string &paramCallId,
+                       int paramCallArgnr,
+                       const std::string &paramCallFunctionName,
+                       const Location &paramLocation) :
+                CallBase(paramCallId, paramCallArgnr, paramCallFunctionName, paramLocation),
+                myId(myId),
+                myArgNr(myArgNr) {
             }
 
             NestedCall(const Tokenizer *tokenizer, const Function *myFunction, const Token *callToken);
@@ -127,7 +148,10 @@ namespace CTU {
     /** @brief Parse current TU and extract file info */
     CPPCHECKLIB FileInfo *getFileInfo(const Tokenizer *tokenizer);
 
-    CPPCHECKLIB std::list<FileInfo::UnsafeUsage> getUnsafeUsage(const Tokenizer *tokenizer, const Settings *settings, const Check *check, bool (*isUnsafeUsage)(const Check *check, const Token *argtok, MathLib::bigint *value));
+    CPPCHECKLIB std::list<FileInfo::UnsafeUsage> getUnsafeUsage(const Tokenizer *tokenizer,
+            const Settings *settings,
+            const Check *check,
+            bool (*isUnsafeUsage)(const Check *check, const Token *argtok, MathLib::bigint *value));
 
     CPPCHECKLIB std::list<FileInfo::UnsafeUsage> loadUnsafeUsageListFromXml(const tinyxml2::XMLElement *xmlElement);
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3028,8 +3028,11 @@ struct LifetimeStore {
 
     LifetimeStore(const Token *argtok,
                   const std::string &message,
-                  ValueFlow::Value::LifetimeKind type = ValueFlow::Value::Object)
-        : argtok(argtok), message(message), type(type), errorPath()
+                  ValueFlow::Value::LifetimeKind type = ValueFlow::Value::Object) :
+        argtok(argtok),
+        message(message),
+        type(type),
+        errorPath()
     {}
 
     template <class Predicate>


### PR DESCRIPTION
Increased warning level with clang build produced warnings about parameters
or local variables shadowing members. Initial changes attempted to resolve
all instances of shadowing. Some warnings are discarded with the compiler
flag `-Wno-shadow-field-in-constructor`. Remaining shadow warnings
resolved in commit.

While resolving shadow warnings, a warning message was found indicating
that the derived class `NestedCall` had a changed sign for a parameter
being passed to the base class `CallBase`. Parameter type corrected.

Also, minor reformatting of code was done to improve readability.