### PR TITLE
More Zero/Null as pointer constant corrections

### DIFF
--- a/gui/librarydialog.cpp
+++ b/gui/librarydialog.cpp
@@ -313,15 +313,13 @@ void LibraryDialog::editArg()
         return;
     CppcheckLibraryData::Function::Arg &arg = function->args[mUi->arguments->row(mUi->arguments->selectedItems().first())];
 
-    LibraryEditArgDialog *d = new LibraryEditArgDialog(0, arg);
-    if (d->exec() == QDialog::Accepted) {
+    LibraryEditArgDialog d(nullptr, arg);
+    if (d.exec() == QDialog::Accepted) {
         unsigned number = arg.nr;
-        arg = d->getArg();
+        arg = d.getArg();
         arg.nr = number;
         mUi->arguments->selectedItems().first()->setText(getArgText(arg));
     }
-
-    delete d;
     mUi->buttonSave->setEnabled(true);
 }
 

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -704,7 +704,7 @@ private:
             // s8
             {
                 const struct Library::PodType * const type = library.podtype("s8");
-                ASSERT_EQUALS(true, type != 0);
+                ASSERT_EQUALS(true, type != nullptr);
                 if (type) {
                     ASSERT_EQUALS(1U, type->size);
                     ASSERT_EQUALS('s', type->sign);
@@ -713,7 +713,7 @@ private:
             // u8
             {
                 const struct Library::PodType * const type = library.podtype("u8");
-                ASSERT_EQUALS(true, type != 0);
+                ASSERT_EQUALS(true, type != nullptr);
                 if (type) {
                     ASSERT_EQUALS(1U, type->size);
                     ASSERT_EQUALS('u', type->sign);
@@ -722,7 +722,7 @@ private:
             // u16
             {
                 const struct Library::PodType * const type = library.podtype("u16");
-                ASSERT_EQUALS(true, type != 0);
+                ASSERT_EQUALS(true, type != nullptr);
                 if (type) {
                     ASSERT_EQUALS(2U, type->size);
                     ASSERT_EQUALS('u', type->sign);
@@ -731,7 +731,7 @@ private:
             // s16
             {
                 const struct Library::PodType * const type = library.podtype("s16");
-                ASSERT_EQUALS(true, type != 0);
+                ASSERT_EQUALS(true, type != nullptr);
                 if (type) {
                     ASSERT_EQUALS(2U, type->size);
                     ASSERT_EQUALS('s', type->sign);
@@ -740,7 +740,7 @@ private:
             // robustness test: provide cfg without PodType
             {
                 const struct Library::PodType * const type = library.podtype("nonExistingPodType");
-                ASSERT_EQUALS(true, type == 0);
+                ASSERT_EQUALS(true, type == nullptr);
             }
         }
     }


### PR DESCRIPTION
Further to pull request #1938. Changes were missed in previous commit.

Resolve warnings `warning: zero as null pointer constant` in code by
using C++ 11 recommended `nullptr`.