### PR TITLE
Partial fix for #9191 (simplifyTypedef: Problem when namespace is used)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2037,14 +2037,13 @@ bool Tokenizer::simplifyUsing()
 
                     // remove the qualification
                     std::string fullScope = scope;
-                    std::string::size_type idx;
                     while (tok1->strAt(-1) == "::") {
                         if (fullScope == tok1->strAt(-2)) {
                             tok1->deletePrevious();
                             tok1->deletePrevious();
                             break;
                         } else {
-                            idx = fullScope.rfind(" ");
+                            std::string::size_type idx = fullScope.rfind(" ");
 
                             if (idx == std::string::npos)
                                 break;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2043,7 +2043,7 @@ bool Tokenizer::simplifyUsing()
                             tok1->deletePrevious();
                             break;
                         } else {
-                            std::string::size_type idx = fullScope.rfind(" ");
+                            const std::string::size_type idx = fullScope.rfind(" ");
 
                             if (idx == std::string::npos)
                                 break;

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -64,6 +64,7 @@ private:
         TEST_CASE(simplifyUsing8976);
         TEST_CASE(simplifyUsing9040);
         TEST_CASE(simplifyUsing9042);
+        TEST_CASE(simplifyUsing9191);
     }
 
     std::string tok(const char code[], bool simplify = true, Settings::PlatformType type = Settings::Native, bool debugwarnings = true) {
@@ -492,6 +493,35 @@ private:
                            "} ;";
 
         ASSERT_EQUALS(exp, tok(code, true, Settings::Win64));
+    }
+
+    void simplifyUsing9191() {
+        const char code[] = "namespace NS1 {\n"
+                            "  namespace NS2 {\n"
+                            "    using _LONG = signed long long;\n"
+                            "  }\n"
+                            "}\n"
+                            "void f1() {\n"
+                            "  using namespace NS1;\n"
+                            "  NS2::_LONG A;\n"
+                            "}\n"
+                            "void f2() {\n"
+                            "  using namespace NS1::NS2;\n"
+                            "  _LONG A;\n"
+                            "}";
+
+        const char exp[] = "namespace NS1 { "
+                           "} "
+                           "void f1 ( ) { "
+                           "using namespace NS1 ; "
+                           "signed long long A ; "
+                           "} "
+                           "void f2 ( ) { "
+                           "using namespace NS1 :: NS2 ; "
+                           "signed long long A ; "
+                           "}";
+
+        ASSERT_EQUALS(exp, tok(code, false));
     }
 
 };


### PR DESCRIPTION
This fixes simplifyUsing which has the same problem as simplifyTypedef.

simplifyUsing was designed to support using namespace but it was never
implemented. The changes are minor to add it.

simplifyTypedef requires much more work to support using namespace.