### PR TITLE
Fix #6115 (Add support to realloc to cfg files)

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -37,6 +37,18 @@
               </optional>
               <ref name="DATA-NAME"/>
             </element>
+            <element name="realloc">
+              <optional>
+                <attribute name="init"><ref name="DATA-BOOL"/></attribute>
+              </optional>
+              <optional>
+                <attribute name="arg"><ref name="ARGNO"/></attribute>
+              </optional>
+              <optional>
+                <attribute name="buffer-size"><ref name="DATA-BUFFER-SIZE"/></attribute>
+              </optional>
+              <ref name="DATA-NAME"/>
+            </element>
             <element name="use"><ref name="DATA-EXTNAME"/></element>
           </choice>
         </zeroOrMore>
@@ -54,6 +66,15 @@
               <ref name="DATA-EXTNAME"/>
             </element>
             <element name="alloc">
+              <optional>
+                <attribute name="init"><ref name="DATA-BOOL"/></attribute>
+              </optional>
+              <optional>
+                <attribute name="arg"><ref name="ARGNO"/></attribute>
+              </optional>
+              <ref name="DATA-NAME"/>
+            </element>
+            <element name="realloc">
               <optional>
                 <attribute name="init"><ref name="DATA-BOOL"/></attribute>
               </optional>

--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -47,6 +47,9 @@
               <optional>
                 <attribute name="buffer-size"><ref name="DATA-BUFFER-SIZE"/></attribute>
               </optional>
+              <optional>
+                <attribute name="realloc-arg"><ref name="ARGNO"/></attribute>
+              </optional>
               <ref name="DATA-NAME"/>
             </element>
             <element name="use"><ref name="DATA-EXTNAME"/></element>
@@ -80,6 +83,9 @@
               </optional>
               <optional>
                 <attribute name="arg"><ref name="ARGNO"/></attribute>
+              </optional>
+              <optional>
+                <attribute name="realloc-arg"><ref name="ARGNO"/></attribute>
               </optional>
               <ref name="DATA-NAME"/>
             </element>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7506,6 +7506,8 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
     <alloc init="false" buffer-size="malloc">malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc</alloc>
     <alloc init="false" buffer-size="malloc:2">aligned_alloc</alloc>
+    <realloc init="false" buffer-size="malloc:2">realloc</realloc>
+    <realloc init="false" buffer-size="calloc:2,3">reallocarray</realloc>
     <dealloc>free</dealloc>
   </memory>
   <resource>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7513,6 +7513,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
   <resource>
     <alloc init="true">fopen</alloc>
     <alloc init="true">tmpfile</alloc>
+    <realloc init="true" realloc-arg="3">freopen</realloc>
     <dealloc>fclose</dealloc>
   </resource>
   <container id="stdContainer" endPattern="&gt; !!::" opLessAllowed="false" itEndPattern="&gt; :: iterator|const_iterator|reverse_iterator|const_reverse_iterator">

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -296,7 +296,7 @@ void CheckAutoVariables::autoVariables()
                 errorAutoVariableAssignment(tok->next(), false);
             }
             // Invalid pointer deallocation
-            else if ((Token::Match(tok, "%name% ( %var% ) ;") && mSettings->library.dealloc(tok)) ||
+            else if ((Token::Match(tok, "%name% ( %var% ) ;") && mSettings->library.getDeallocFuncInfo(tok)) ||
                      (mTokenizer->isCPP() && Token::Match(tok, "delete [| ]| (| %var% !!["))) {
                 tok = Token::findmatch(tok->next(), "%var%");
                 if (isArrayVar(tok))
@@ -309,7 +309,7 @@ void CheckAutoVariables::autoVariables()
                         }
                     }
                 }
-            } else if ((Token::Match(tok, "%name% ( & %var% ) ;") && mSettings->library.dealloc(tok)) ||
+            } else if ((Token::Match(tok, "%name% ( & %var% ) ;") && mSettings->library.getDeallocFuncInfo(tok)) ||
                        (mTokenizer->isCPP() && Token::Match(tok, "delete [| ]| (| & %var% !!["))) {
                 tok = Token::findmatch(tok->next(), "%var%");
                 if (isAutoVar(tok))

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -331,7 +331,7 @@ void CheckClass::copyconstructors()
             const Token* tok = func.token->linkAt(1);
             for (const Token* const end = func.functionScope->bodyStart; tok != end; tok = tok->next()) {
                 if (Token::Match(tok, "%var% ( new") ||
-                    (Token::Match(tok, "%var% ( %name% (") && mSettings->library.alloc(tok->tokAt(2)))) {
+                    (Token::Match(tok, "%var% ( %name% (") && mSettings->library.getAllocFuncInfo(tok->tokAt(2)))) {
                     const Variable* var = tok->variable();
                     if (var && var->isPointer() && var->scope() == scope)
                         allocatedVars[tok->varId()] = tok;
@@ -339,7 +339,7 @@ void CheckClass::copyconstructors()
             }
             for (const Token* const end = func.functionScope->bodyEnd; tok != end; tok = tok->next()) {
                 if (Token::Match(tok, "%var% = new") ||
-                    (Token::Match(tok, "%var% = %name% (") && mSettings->library.alloc(tok->tokAt(2)))) {
+                    (Token::Match(tok, "%var% = %name% (") && mSettings->library.getAllocFuncInfo(tok->tokAt(2)))) {
                     const Variable* var = tok->variable();
                     if (var && var->isPointer() && var->scope() == scope && !var->isStatic())
                         allocatedVars[tok->varId()] = tok;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -763,8 +763,7 @@ void CheckLeakAutoVar::functionCall(const Token *tokName, const Token *tokOpenin
     // Ignore function call?
     if (mSettings->library.isLeakIgnore(tokName->str()))
         return;
-    const Library::AllocFunc* g = mSettings->library.getReallocFuncInfo(tokName);
-    if (g)
+    if (mSettings->library.getReallocFuncInfo(tokName))
         return;
 
     const Token * const tokFirstArg = tokOpeningPar->next();

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -347,9 +347,11 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
                     varAlloc.type = g->groupId;
                     varAlloc.status = VarInfo::ALLOC;
-                    const Token* argTok = tokRightAstOperand->next();
-                    VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
-                    argAlloc.status = VarInfo::DEALLOC;
+                    if (0 < g->reallocArg && g->reallocArg <= numberOfArguments(tokRightAstOperand->previous())) {
+                        const Token* argTok = getArguments(tokRightAstOperand->previous()).at(g->reallocArg - 1);
+                        VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
+                        argAlloc.status = VarInfo::DEALLOC;
+                    }
 
                 }
             } else if (mTokenizer->isCPP() && Token::Match(varTok->tokAt(2), "new !!(")) {
@@ -399,9 +401,11 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                             VarInfo::AllocInfo& varAlloc = alloctype[innerTok->varId()];
                             varAlloc.type = g->groupId;
                             varAlloc.status = VarInfo::ALLOC;
-                            const Token* argTok = innerTok->tokAt(4);
-                            VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
-                            argAlloc.status = VarInfo::DEALLOC;
+                            if (0 < g->reallocArg && g->reallocArg <= numberOfArguments(innerTok->tokAt(2))) {
+                                const Token* argTok = getArguments(innerTok->tokAt(2)).at(g->reallocArg - 1);
+                                VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
+                                argAlloc.status = VarInfo::DEALLOC;
+                            }
                         }
                     } else if (mTokenizer->isCPP() && Token::Match(innerTok->tokAt(2), "new !!(")) {
                         const Token* tok2 = innerTok->tokAt(2)->astOperand1();

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -344,15 +344,15 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     varAlloc.status = VarInfo::ALLOC;
                 }
                 const Library::AllocFunc* g = mSettings->library.getReallocFuncInfo(fTok);
-                if (g && g->arg == -1) {
+                if (g && g->arg == -1 && g->reallocArg > 0 && g->reallocArg <= numberOfArguments(fTok)) {
+                    const Token* argTok = getArguments(fTok).at(g->reallocArg - 1);
+                    VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
+                    argAlloc.status = VarInfo::DEALLOC;
+                    if (argAlloc.type != 0 && argAlloc.type != g->groupId)
+                        mismatchError(fTok, argTok->str());
                     varAlloc.type = g->groupId;
                     varAlloc.status = VarInfo::ALLOC;
-                    if (g->reallocArg > 0 && g->reallocArg <= numberOfArguments(fTok)) {
-                        const Token* argTok = getArguments(fTok).at(g->reallocArg - 1);
-                        VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
-                        argAlloc.status = VarInfo::DEALLOC;
-                    }
                 }
             } else if (mTokenizer->isCPP() && Token::Match(varTok->tokAt(2), "new !!(")) {
                 const Token* tok2 = varTok->tokAt(2)->astOperand1();

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -335,8 +335,8 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             }
 
             // allocation?
-            const Token *const fTok = tokRightAstOperand->previous();
-            if (tokRightAstOperand && Token::Match(fTok, "%type% (")) {
+            const Token *const fTok = tokRightAstOperand ? tokRightAstOperand->previous() : nullptr;
+            if (Token::Match(fTok, "%type% (")) {
                 const Library::AllocFunc* f = mSettings->library.getAllocFuncInfo(fTok);
                 if (f && f->arg == -1) {
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -347,7 +347,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
                     varAlloc.type = g->groupId;
                     varAlloc.status = VarInfo::ALLOC;
-                    if (0 < g->reallocArg && g->reallocArg <= numberOfArguments(tokRightAstOperand->previous())) {
+                    if (g->reallocArg > 0 && g->reallocArg <= numberOfArguments(tokRightAstOperand->previous())) {
                         const Token* argTok = getArguments(tokRightAstOperand->previous()).at(g->reallocArg - 1);
                         VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
                         argAlloc.status = VarInfo::DEALLOC;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -335,24 +335,24 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             }
 
             // allocation?
-            if (tokRightAstOperand && Token::Match(tokRightAstOperand->previous(), "%type% (")) {
-                const Library::AllocFunc* f = mSettings->library.getAllocFuncInfo(tokRightAstOperand->previous());
+            const Token *const fTok = tokRightAstOperand->previous();
+            if (tokRightAstOperand && Token::Match(fTok, "%type% (")) {
+                const Library::AllocFunc* f = mSettings->library.getAllocFuncInfo(fTok);
                 if (f && f->arg == -1) {
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
                     varAlloc.type = f->groupId;
                     varAlloc.status = VarInfo::ALLOC;
                 }
-                const Library::AllocFunc* g = mSettings->library.getReallocFuncInfo(tokRightAstOperand->previous());
+                const Library::AllocFunc* g = mSettings->library.getReallocFuncInfo(fTok);
                 if (g && g->arg == -1) {
                     VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
                     varAlloc.type = g->groupId;
                     varAlloc.status = VarInfo::ALLOC;
-                    if (g->reallocArg > 0 && g->reallocArg <= numberOfArguments(tokRightAstOperand->previous())) {
-                        const Token* argTok = getArguments(tokRightAstOperand->previous()).at(g->reallocArg - 1);
+                    if (g->reallocArg > 0 && g->reallocArg <= numberOfArguments(fTok)) {
+                        const Token* argTok = getArguments(fTok).at(g->reallocArg - 1);
                         VarInfo::AllocInfo& argAlloc = alloctype[argTok->varId()];
                         argAlloc.status = VarInfo::DEALLOC;
                     }
-
                 }
             } else if (mTokenizer->isCPP() && Token::Match(varTok->tokAt(2), "new !!(")) {
                 const Token* tok2 = varTok->tokAt(2)->astOperand1();

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -131,6 +131,9 @@ private:
     /** parse changes in allocation status */
     void changeAllocStatus(VarInfo *varInfo, const VarInfo::AllocInfo& allocation, const Token* tok, const Token* arg);
 
+    /** update allocation status if reallocation function */
+    void changeAllocStatusIfRealloc(std::map<unsigned int, VarInfo::AllocInfo> &alloctype, const Token *fTok, const Token *retTok);
+
     /** return. either "return" or end of variable scope is seen */
     void ret(const Token *tok, const VarInfo &varInfo);
 

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -172,7 +172,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::getAllocationType(const Token *tok2,
         }
 
         // Does tok2 point on a Library allocation function?
-        const int alloctype = mSettings_->library.alloc(tok2, -1);
+        const int alloctype = mSettings_->library.getAllocId(tok2, -1);
         if (alloctype > 0) {
             if (alloctype == mSettings_->library.deallocId("free"))
                 return Malloc;
@@ -263,7 +263,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::getDeallocationType(const Token *tok
                 }
 
                 // Does tok point on a Library deallocation function?
-                const int dealloctype = mSettings_->library.dealloc(tok, argNr);
+                const int dealloctype = mSettings_->library.getDeallocId(tok, argNr);
                 if (dealloctype > 0) {
                     if (dealloctype == mSettings_->library.deallocId("free"))
                         return Malloc;

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -225,6 +225,14 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
                             return Error(BAD_ATTRIBUTE_VALUE, bufferSize);
                     }
 
+                    if (memorynodename == "realloc") {
+                        const char *reallocArg =  memorynode->Attribute("realloc-arg");
+                        if (reallocArg)
+                            temp.reallocArg = atoi(reallocArg);
+                        else
+                            temp.reallocArg = 1;
+                    }
+
                     if (memorynodename != "realloc")
                         mAlloc[memorynode->GetText()] = temp;
                     else

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -945,44 +945,44 @@ bool Library::isuninitargbad(const Token *ftok, int argnr) const
 
 
 /** get allocation info for function */
-const Library::AllocFunc* Library::alloc(const Token *tok) const
+const Library::AllocFunc* Library::getAllocFuncInfo(const Token *tok) const
 {
     const std::string funcname = getFunctionName(tok);
     return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mAlloc, funcname);
 }
 
 /** get deallocation info for function */
-const Library::AllocFunc* Library::dealloc(const Token *tok) const
+const Library::AllocFunc* Library::getDeallocFuncInfo(const Token *tok) const
 {
     const std::string funcname = getFunctionName(tok);
     return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mDealloc, funcname);
 }
 
 /** get reallocation info for function */
-const Library::AllocFunc* Library::realloc(const Token *tok) const
+const Library::AllocFunc* Library::getReallocFuncInfo(const Token *tok) const
 {
     const std::string funcname = getFunctionName(tok);
     return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mRealloc, funcname);
 }
 
 /** get allocation id for function */
-int Library::alloc(const Token *tok, int arg) const
+int Library::getAllocId(const Token *tok, int arg) const
 {
-    const Library::AllocFunc* af = alloc(tok);
+    const Library::AllocFunc* af = getAllocFuncInfo(tok);
     return (af && af->arg == arg) ? af->groupId : 0;
 }
 
 /** get deallocation id for function */
-int Library::dealloc(const Token *tok, int arg) const
+int Library::getDeallocId(const Token *tok, int arg) const
 {
-    const Library::AllocFunc* af = dealloc(tok);
+    const Library::AllocFunc* af = getDeallocFuncInfo(tok);
     return (af && af->arg == arg) ? af->groupId : 0;
 }
 
 /** get reallocation id for function */
-int Library::realloc(const Token *tok, int arg) const
+int Library::getReallocId(const Token *tok, int arg) const
 {
-    const Library::AllocFunc* af = realloc(tok);
+    const Library::AllocFunc* af = getReallocFuncInfo(tok);
     return (af && af->arg == arg) ? af->groupId : 0;
 }
 

--- a/lib/library.h
+++ b/lib/library.h
@@ -77,6 +77,7 @@ public:
         BufferSize bufferSize;
         int bufferSizeArg1;
         int bufferSizeArg2;
+        int reallocArg;
     };
 
     /** get allocation info for function */

--- a/lib/library.h
+++ b/lib/library.h
@@ -131,9 +131,10 @@ public:
         mDealloc[functionname].arg = arg;
     }
 
-    void setrealloc(const std::string &functionname, int id, int arg) {
+    void setrealloc(const std::string &functionname, int id, int arg, int reallocArg = 1) {
         mRealloc[functionname].groupId = id;
         mRealloc[functionname].arg = arg;
+        mRealloc[functionname].reallocArg = reallocArg;
     }
 
     /** add noreturn function setting */

--- a/lib/library.h
+++ b/lib/library.h
@@ -85,11 +85,17 @@ public:
     /** get deallocation info for function */
     const AllocFunc* dealloc(const Token *tok) const;
 
+    /** get reallocation info for function */
+    const AllocFunc* realloc(const Token *tok) const;
+
     /** get allocation id for function */
     int alloc(const Token *tok, int arg) const;
 
     /** get deallocation id for function */
     int dealloc(const Token *tok, int arg) const;
+
+    /** get reallocation id for function */
+    int realloc(const Token *tok, int arg) const;
 
     /** get allocation info for function by name (deprecated, use other alloc) */
     const AllocFunc* alloc(const char name[]) const {
@@ -122,6 +128,11 @@ public:
     void setdealloc(const std::string &functionname, int id, int arg) {
         mDealloc[functionname].groupId = id;
         mDealloc[functionname].arg = arg;
+    }
+
+    void setrealloc(const std::string &functionname, int id, int arg) {
+        mRealloc[functionname].groupId = id;
+        mRealloc[functionname].arg = arg;
     }
 
     /** add noreturn function setting */
@@ -523,6 +534,7 @@ private:
     std::set<std::string> mFiles;
     std::map<std::string, AllocFunc> mAlloc; // allocation functions
     std::map<std::string, AllocFunc> mDealloc; // deallocation functions
+    std::map<std::string, AllocFunc> mRealloc; // reallocation functions
     std::map<std::string, bool> mNoReturn; // is function noreturn?
     std::map<std::string, std::string> mReturnValue;
     std::map<std::string, std::string> mReturnValueType;

--- a/lib/library.h
+++ b/lib/library.h
@@ -81,30 +81,30 @@ public:
     };
 
     /** get allocation info for function */
-    const AllocFunc* alloc(const Token *tok) const;
+    const AllocFunc* getAllocFuncInfo(const Token *tok) const;
 
     /** get deallocation info for function */
-    const AllocFunc* dealloc(const Token *tok) const;
+    const AllocFunc* getDeallocFuncInfo(const Token *tok) const;
 
     /** get reallocation info for function */
-    const AllocFunc* realloc(const Token *tok) const;
+    const AllocFunc* getReallocFuncInfo(const Token *tok) const;
 
     /** get allocation id for function */
-    int alloc(const Token *tok, int arg) const;
+    int getAllocId(const Token *tok, int arg) const;
 
     /** get deallocation id for function */
-    int dealloc(const Token *tok, int arg) const;
+    int getDeallocId(const Token *tok, int arg) const;
 
     /** get reallocation id for function */
-    int realloc(const Token *tok, int arg) const;
+    int getReallocId(const Token *tok, int arg) const;
 
     /** get allocation info for function by name (deprecated, use other alloc) */
-    const AllocFunc* alloc(const char name[]) const {
+    const AllocFunc* getAllocFuncInfo(const char name[]) const {
         return getAllocDealloc(mAlloc, name);
     }
 
     /** get deallocation info for function by name (deprecated, use other alloc) */
-    const AllocFunc* dealloc(const char name[]) const {
+    const AllocFunc* getDeallocFuncInfo(const char name[]) const {
         return getAllocDealloc(mDealloc, name);
     }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5311,6 +5311,8 @@ static void valueFlowDynamicBufferSize(TokenList *tokenlist, SymbolDatabase *sym
                 continue;
 
             const Library::AllocFunc *allocFunc = settings->library.alloc(rhs->previous());
+            if (!allocFunc)
+                allocFunc = settings->library.realloc(rhs->previous());
             if (!allocFunc || allocFunc->bufferSize == Library::AllocFunc::BufferSize::none)
                 continue;
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5310,9 +5310,9 @@ static void valueFlowDynamicBufferSize(TokenList *tokenlist, SymbolDatabase *sym
             if (!Token::Match(rhs->previous(), "%name% ("))
                 continue;
 
-            const Library::AllocFunc *allocFunc = settings->library.alloc(rhs->previous());
+            const Library::AllocFunc *allocFunc = settings->library.getAllocFuncInfo(rhs->previous());
             if (!allocFunc)
-                allocFunc = settings->library.realloc(rhs->previous());
+                allocFunc = settings->library.getReallocFuncInfo(rhs->previous());
             if (!allocFunc || allocFunc->bufferSize == Library::AllocFunc::BufferSize::none)
                 continue;
 

--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -1217,7 +1217,7 @@ Checking pen1.c...
   &lt;/resource&gt;
 &lt;/def&gt;</programlisting>
 
-        <para>Functions that reallocate memory can be configured using a realloc tag. The input argument which points to the memory the be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
+        <para>Functions that reallocate memory can be configured using a realloc tag. The input argument which points to the memory that shall be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
 
         <programlisting>&lt;?xml version="1.0"?&gt;
 &lt;def&gt;

--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -1183,7 +1183,7 @@ Checking test.c...
       functions do not affect the allocation at all.</para>
 
       <section>
-        <title>alloc and dealloc</title>
+        <title>alloc, realloc and dealloc</title>
 
         <para>Here is an example program:</para>
 
@@ -1214,6 +1214,17 @@ Checking pen1.c...
   &lt;resource&gt;
     &lt;alloc&gt;CreatePen&lt;/alloc&gt;
     &lt;dealloc&gt;DeleteObject&lt;/dealloc&gt;
+  &lt;/resource&gt;
+&lt;/def&gt;</programlisting>
+
+        <para>Functions that reallocate memory can be configured using a realloc tag. The input argument which points to the memory the be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
+
+        <programlisting>&lt;?xml version="1.0"?&gt;
+&lt;def&gt;
+  &lt;resource&gt;
+    &lt;alloc&gt;fopen&lt;/alloc&gt;
+    &lt;realloc realloc-arg="3"&gt;freopen&lt;/realloc&gt;
+    &lt;dealloc&gt;fclose&lt;/dealloc&gt;
   &lt;/resource&gt;
 &lt;/def&gt;</programlisting>
 

--- a/man/reference-cfg-format.md
+++ b/man/reference-cfg-format.md
@@ -15,7 +15,7 @@ This is a reference for the .cfg file format that Cppcheck uses.
 
 Cppcheck has configurable checking for leaks, e.g. you can specify which functions allocate and free memory or resources and which functions do not affect the allocation at all.
 
-## `<alloc>` and `<dealloc>`
+## `<alloc>`, `<realloc>` and `<dealloc>`
 
 Here is an example program:
 
@@ -42,6 +42,17 @@ Here is a minimal windows.cfg file:
       <resource>
         <alloc>CreatePen</alloc>
         <dealloc>DeleteObject</dealloc>
+      </resource>
+    </def>
+
+Functions that reallocate memory can be configured using a `<realloc>` tag. The input argument which points to the memory the be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
+
+    <?xml version="1.0"?>
+    <def>
+      <resource>
+        <alloc>fopen</alloc>
+        <realloc realloc-arg="3">freopen</realloc>
+        <dealloc>fclose</dealloc>
       </resource>
     </def>
 

--- a/man/reference-cfg-format.md
+++ b/man/reference-cfg-format.md
@@ -45,7 +45,7 @@ Here is a minimal windows.cfg file:
       </resource>
     </def>
 
-Functions that reallocate memory can be configured using a `<realloc>` tag. The input argument which points to the memory the be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
+Functions that reallocate memory can be configured using a `<realloc>` tag. The input argument which points to the memory that shall be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
 
     <?xml version="1.0"?>
     <def>

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -1434,7 +1434,7 @@ void uninitvar_freopen(void)
     FILE *stream;
     // cppcheck-suppress uninitvar
     FILE * p = freopen(filename,mode,stream);
-    free(p);
+    fclose(p);
 }
 
 void uninitvar_frexp(void)

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1377,6 +1377,29 @@ private:
               "    std::unique_ptr<int[]> x(i);\n"
               "}\n", true);
         ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: i\n", errout.str());
+
+        check("void f() {\n"
+              "   void* a = malloc(1);\n"
+              "   void* b = freopen(f, p, a);\n"
+              "   free(b);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Mismatching allocation and deallocation: a\n"
+                      "[test.c:4]: (error) Mismatching allocation and deallocation: b\n", errout.str());
+
+        check("void f() {\n"
+              "   void* a;\n"
+              "   void* b = realloc(a, 10);\n"
+              "   free(b);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "   int * i = new int;\n"
+              "   int * j = realloc(i, 2 * sizeof(int));\n"
+              "   delete[] j;\n"
+              "}", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Mismatching allocation and deallocation: i\n"
+                      "[test.cpp:4]: (error) Mismatching allocation and deallocation: j\n", errout.str());
     }
 
     void smartPointerDeleter() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -40,7 +40,7 @@ private:
         settings.library.setdealloc("free", id, 1);
         while (!settings.library.isresource(++id));
         settings.library.setalloc("fopen", id, -1);
-        settings.library.setrealloc("freopen", id, -1);
+        settings.library.setrealloc("freopen", id, -1, 3);
         settings.library.setdealloc("fclose", id, 1);
         settings.library.smartPointers.insert("std::shared_ptr");
         settings.library.smartPointers.insert("std::unique_ptr");
@@ -68,6 +68,8 @@ private:
         TEST_CASE(realloc1);
         TEST_CASE(realloc2);
         TEST_CASE(realloc3);
+        TEST_CASE(freopen1);
+        TEST_CASE(freopen2);
 
         TEST_CASE(deallocuse1);
         TEST_CASE(deallocuse2);
@@ -379,6 +381,23 @@ private:
               "    char *q = (char*) realloc(p, 20);\n"
               "}");
         ASSERT_EQUALS("[test.c:4]: (error) Memory leak: q\n", errout.str());
+    }
+
+    void freopen1() {
+        check("void f() {\n"
+              "    void *p = fopen(name,a);\n"
+              "    void *q = freopen(name, b, p);\n"
+              "    fclose(q)\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void freopen2() {
+        check("void f() {\n"
+              "    void *p = fopen(name,a);\n"
+              "    void *q = freopen(name, b, p);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:4]: (error) Resource leak: q\n", errout.str());
     }
 
     void deallocuse1() {

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -622,11 +622,11 @@ private:
         ASSERT_EQUALS(true, Library::OK == (readLibrary(library, xmldata)).errorcode);
         ASSERT(library.functions.empty());
 
-        ASSERT(Library::ismemory(library.alloc("CreateX")));
+        ASSERT(Library::ismemory(library.getAllocFuncInfo("CreateX")));
         ASSERT_EQUALS(library.allocId("CreateX"), library.deallocId("DeleteX"));
-        const Library::AllocFunc* af = library.alloc("CreateX");
+        const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
         ASSERT(af && af->arg == -1);
-        const Library::AllocFunc* df = library.dealloc("DeleteX");
+        const Library::AllocFunc* df = library.getDeallocFuncInfo("DeleteX");
         ASSERT(df && df->arg == 1);
     }
     void memory2() const {
@@ -665,9 +665,9 @@ private:
         ASSERT_EQUALS(true, Library::OK == (readLibrary(library, xmldata)).errorcode);
         ASSERT(library.functions.empty());
 
-        const Library::AllocFunc* af = library.alloc("CreateX");
+        const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
         ASSERT(af && af->arg == 5);
-        const Library::AllocFunc* df = library.dealloc("DeleteX");
+        const Library::AllocFunc* df = library.getDeallocFuncInfo("DeleteX");
         ASSERT(df && df->arg == 2);
 
         ASSERT(library.returnuninitdata.find("CreateX") != library.returnuninitdata.cend());

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -3887,6 +3887,20 @@ private:
                "  return x;\n"
                "}";
         ASSERT_EQUALS(true, testValueOfX(code, 4U, 5,  ValueFlow::Value::BUFFER_SIZE));
+
+        code = "void* f() {\n"
+               "  void* y = malloc(10);\n"
+               "  void* x = realloc(y, 20);\n"
+               "  return x;\n"
+               "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 20,  ValueFlow::Value::BUFFER_SIZE));
+
+        code = "void* f() {\n"
+               "  void* y = calloc(10, 4);\n"
+               "  void* x = reallocarray(y, 20, 5);\n"
+               "  return x;\n"
+               "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 100,  ValueFlow::Value::BUFFER_SIZE));
     }
 };
 


### PR DESCRIPTION
This PR adds support to configure realloc like functions in cfg files. It also makes use of the library configurations in some of the memleak checkers. It also makes it possible to configure the buffer size for these functions. Finally, configure functions in std.cfg (specifically `realloc`, `reallocarray` and `freopen`).

Possible improvements are:
* Usage of the function in the `memleakOnRealloc` check (I have a somewhat working prototype that needs some polishing)
* Configuration of other libraries than `std.cfg`. At least `gnu.cfg` (`xrealloc()`), `gtk.cfg` (`g_realloc`, `g_try_realloc()`, and more) and probably `windows.cfg` (`HeapRealloc()`, `LocalRealloc()`) can have their memory configuration improved. (I have tested that it works for the gtk functions, but have some other improvements I want to make to memory functions in gtk.cfg and figured it'd be better as a separate PR).  
 * ~~Mismatching allocation/deallocation support for realloc like functions. (I have not looked at this at all)~~ This should work now