### PR TITLE
Parse lambdas as functions

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -667,7 +667,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
             } else if (const Token *lambdaEndToken = findLambdaEndToken(tok)) {
                 const Token *lambdaStartToken = lambdaEndToken->link();
                 const Token * argStart = lambdaStartToken->astParent();
-                const Token * funcStart = argStart->astParent();
+                const Token * funcStart = Token::simpleMatch(argStart, "[") ? argStart : argStart->astParent();
                 const Function* const function = addGlobalFunction(scope, tok, argStart, funcStart);
                 tok = lambdaStartToken;
             } else if (tok->str() == "{") {

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3045,6 +3045,8 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
 {
     // check for non-empty argument list "( ... )"
     const Token * start = arg ? arg : argDef;
+    if (!Token::simpleMatch(start, "("))
+        return;
     if (!(start && start->link() != start->next() && !Token::simpleMatch(start, "( void )")))
         return;
 

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -668,7 +668,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                 const Token *lambdaStartToken = lambdaEndToken->link();
                 const Token * argStart = lambdaStartToken->astParent();
                 const Token * funcStart = Token::simpleMatch(argStart, "[") ? argStart : argStart->astParent();
-                const Function* const function = addGlobalFunction(scope, tok, argStart, funcStart);
+                addGlobalFunction(scope, tok, argStart, funcStart);
                 tok = lambdaStartToken;
             } else if (tok->str() == "{") {
                 if (isExecutableScope(tok)) {

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -705,7 +705,7 @@ class CPPCHECKLIB Function {
     }
 
 public:
-    enum Type { eConstructor, eCopyConstructor, eMoveConstructor, eOperatorEqual, eDestructor, eFunction };
+    enum Type { eConstructor, eCopyConstructor, eMoveConstructor, eOperatorEqual, eDestructor, eFunction, eLambda };
 
     Function(const Tokenizer *mTokenizer, const Token *tok, const Scope *scope, const Token *tokDef, const Token *tokArgDef);
 
@@ -730,6 +730,10 @@ public:
 
     /** @brief get function in base class that is overridden */
     const Function *getOverriddenFunction(bool *foundAllBaseClasses = nullptr) const;
+
+    bool isLambda() const {
+        return type==eLambda;
+    }
 
     bool isConstructor() const {
         return type==eConstructor ||

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -955,6 +955,17 @@ const Token *Token::findmatch(const Token * const startTok, const char pattern[]
     return nullptr;
 }
 
+void Token::function(const Function *f) {
+    mImpl->mFunction = f;
+    if (f) {
+        if (f->isLambda())
+            tokType(eLambda);
+        else
+            tokType(eFunction);
+    } else if (mTokType == eFunction)
+        tokType(eName);
+}
+
 void Token::insertToken(const std::string &tokenStr, const std::string &originalNameStr, bool prepend)
 {
     Token *newToken;

--- a/lib/token.h
+++ b/lib/token.h
@@ -146,6 +146,7 @@ public:
         eNumber, eString, eChar, eBoolean, eLiteral, eEnumerator, // Literals: Number, String, Character, Boolean, User defined literal (C++11), Enumerator
         eArithmeticalOp, eComparisonOp, eAssignmentOp, eLogicalOp, eBitOp, eIncDecOp, eExtendedOp, // Operators: Arithmetical, Comparison, Assignment, Logical, Bitwise, ++/--, Extended
         eBracket, // {, }, <, >: < and > only if link() is set. Otherwise they are comparison operators.
+        eLambda, // A function without a name
         eOther,
         eNone
     };
@@ -765,19 +766,13 @@ public:
      * Associate this token with given function
      * @param f Function to be associated
      */
-    void function(const Function *f) {
-        mImpl->mFunction = f;
-        if (f)
-            tokType(eFunction);
-        else if (mTokType == eFunction)
-            tokType(eName);
-    }
+    void function(const Function *f); 
 
     /**
      * @return a pointer to the Function associated with this token.
      */
     const Function *function() const {
-        return mTokType == eFunction ? mImpl->mFunction : nullptr;
+        return mTokType == eFunction || mTokType == eLambda ? mImpl->mFunction : nullptr;
     }
 
     /**

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1438,14 +1438,13 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3] -> [test.cpp:4]: (error) Returning lambda that captures local variable 'a' that will be invalid when returning.\n", errout.str());
 
-        // TODO: Variable is not set correctly for this case
         check("auto f(int b) {\n"
               "    return [=](int a){\n"
               "        a += b;\n"
               "        return [&](){ return a; };\n"
               "    };\n"
               "}\n");
-        TODO_ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (error) Returning lambda that captures local variable 'a' that will be invalid when returning.\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (error) Returning lambda that captures local variable 'a' that will be invalid when returning.\n", errout.str());
 
         check("auto g(int& a) {\n"
               "    return [&](){ return a; };\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1444,7 +1444,7 @@ private:
               "        return [&](){ return a; };\n"
               "    };\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (error) Returning lambda that captures local variable 'a' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning lambda that captures local variable 'a' that will be invalid when returning.\n", errout.str());
 
         check("auto g(int& a) {\n"
               "    return [&](){ return a; };\n"


### PR DESCRIPTION
This will create a `Function` object for lambdas. A `eLambda` toktype is added so it can be treated as a function but `isName()` will be false.

This helps improve lifetime analysis with nested lambdas. We will now warn for case like this:

```cpp
auto f()
{
    auto g = [&](auto x) { return [&] { return x; }};
    return g;
}
```

Parsing the lambda as a `Function` allows the parameters to the lambda to be treated as argument variables.