### PR TITLE
Add tests of std.cfg buffer size

### DIFF
--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -102,6 +102,35 @@ void arrayIndexOutOfBounds()
     // cppcheck-suppress arrayIndexOutOfBounds
     pAlloc1[16] = '1';
     free(pAlloc1);
+
+    char * pAlloc2 = malloc(9);
+    pAlloc2[8] = 'a';
+    // cppcheck-suppress arrayIndexOutOfBounds
+    pAlloc2[9] = 'a';
+
+    // #1379
+    // cppcheck-suppress memleakOnRealloc
+    pAlloc2 = realloc(pAlloc2, 8);
+    pAlloc2[7] = 'b';
+    // cppcheck-suppress arrayIndexOutOfBounds
+    pAlloc2[8] = 0;
+    // cppcheck-suppress memleakOnRealloc
+    pAlloc2 = realloc(pAlloc2, 20);
+    pAlloc2[19] = 'b';
+    // cppcheck-suppress arrayIndexOutOfBounds
+    pAlloc2[20] = 0;
+    free(pAlloc2);
+
+    char * pAlloc3 = calloc(2,3);
+    pAlloc3[5] = 'a';
+    // cppcheck-suppress arrayIndexOutOfBounds
+    pAlloc3[6] = 1;
+    // TODO cppcheck-suppress memleakOnRealloc
+    pAlloc3 = reallocarray(pAlloc3, 3,3);
+    pAlloc3[8] = 'a';
+    // cppcheck-suppress arrayIndexOutOfBounds
+    pAlloc3[9] = 1;
+    free(pAlloc3);
 }
 
 void resourceLeak_tmpfile(void)


### PR DESCRIPTION
Includes a testcase for trac ticket [#1379](https://trac.cppcheck.net/ticket/1379) which was fixed in
839fcddd8a1bd21960c8cfc42b5ea16aaea6b395.