### PR TITLE
posix.cfg: Add `<use-retval/>` to pthread_mutex_trylock

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -3995,6 +3995,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
+    <use-retval/>
     <arg nr="1" direction="inout">
       <not-null/>
       <not-uninit/>

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -139,7 +139,7 @@ void nullPointer(char *p, int fd, pthread_mutex_t mutex)
     // cppcheck-suppress nullPointer
     pthread_mutex_lock(NULL);
     // cppcheck-suppress nullPointer
-    pthread_mutex_trylock(NULL);
+    (void)pthread_mutex_trylock(NULL);
     // cppcheck-suppress nullPointer
     pthread_mutex_unlock(NULL);
 }
@@ -344,13 +344,13 @@ void uninitvar(int fd)
     // cppcheck-suppress uninitvar
     pthread_mutex_lock(&mutex1);
     // cppcheck-suppress uninitvar
-    pthread_mutex_trylock(&mutex2);
+    (void)pthread_mutex_trylock(&mutex2);
     // cppcheck-suppress uninitvar
     pthread_mutex_unlock(&mutex3);
     // after initialization it must be OK to call lock, trylock and unlock for this mutex
     pthread_mutex_init(&mutex, NULL);
     pthread_mutex_lock(&mutex);
-    pthread_mutex_trylock(&mutex);
+    (void)pthread_mutex_trylock(&mutex);
     pthread_mutex_unlock(&mutex);
 }
 


### PR DESCRIPTION
Ignoring the return value of pthread_mutex_trylock is always a bug.
There is no other way to check if the mutex is locked or not after the
call.