### PR TITLE
Fix FP with cast pointer to free()

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -778,6 +778,9 @@ void CheckLeakAutoVar::functionCall(const Token *tokName, const Token *tokOpenin
                 arg = arg->tokAt(5);
         }
 
+        // Skip casts
+        while (arg && arg->isCast())
+            arg = arg->astOperand2() ? arg->astOperand2() : arg->astOperand1();
         const Token * const argTypeStartTok = arg;
 
         while (Token::Match(arg, "%name% .|:: %name%"))

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -64,6 +64,7 @@ private:
         TEST_CASE(assign16);
         TEST_CASE(assign17); // #9047
         TEST_CASE(assign18);
+        TEST_CASE(assign19);
 
         TEST_CASE(realloc1);
         TEST_CASE(realloc2);
@@ -356,6 +357,14 @@ private:
               "    if (x && (p = (char*)(int*)malloc(10))) { }"
               "}");
         ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p\n", errout.str());
+    }
+
+    void assign19() {
+        check("void f() {\n"
+              "    char *p = malloc(10);\n"
+              "    free((void*)p);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void realloc1() {
@@ -1342,6 +1351,12 @@ private:
         check("void f() {\n"
               "    FILE*f=fopen(fname,a);\n"
               "    free(f);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Mismatching allocation and deallocation: f\n", errout.str());
+
+        check("void f() {\n"
+              "    FILE*f=fopen(fname,a);\n"
+              "    free((void*)f);\n"
               "}");
         ASSERT_EQUALS("[test.c:3]: (error) Mismatching allocation and deallocation: f\n", errout.str());
 


### PR DESCRIPTION
This fixes false positives when the pointer passed to free() (or similar
deallocation functions) is cast using a c-style cast.

Related to Trac ticket [#9047](https://trac.cppcheck.net/ticket/9047) but for dealloction instead of allocation..