### PR TITLE
Fix #9197 (Template name cache: Assertion `tok && tok->str() == ">"' …

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -426,7 +426,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
 
         // Skip variadic types (Ticket #5774, #6059, #6172)
         if (Token::simpleMatch(tok, ". . .")) {
-            if ((tok->previous()->isName() && !Token::Match(tok->tokAt(-2), "<|,")) ||
+            if ((tok->previous()->isName() && !Token::Match(tok->tokAt(-2), "<|,|::")) ||
                 (!tok->previous()->isName() && tok->strAt(-1) != ">"))
                 return 0; // syntax error
             tok = tok->tokAt(3);
@@ -439,6 +439,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             } else if (tok->str() == ">>") {
                 if (level == 1)
                     return numberOfParameters;
+                level -= 2;
             } else if (tok->str() == "," && level == 0) {
                 ++numberOfParameters;
                 tok = tok->next();

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -161,6 +161,7 @@ private:
         TEST_CASE(template121); // #9193
         TEST_CASE(template122); // #9147
         TEST_CASE(template123); // #9183
+        TEST_CASE(template124); // #9197
         TEST_CASE(template_specialization_1);  // #7868 - template specialization template <typename T> struct S<C<T>> {..};
         TEST_CASE(template_specialization_2);  // #7868 - template specialization template <typename T> struct S<C<T>> {..};
         TEST_CASE(template_enum);  // #6299 Syntax error in complex enum declaration (including template)
@@ -2901,6 +2902,22 @@ private:
                            "} "
                            "void fn1 ( ) { "
                            "}";
+        ASSERT_EQUALS(exp, tok(code));
+    }
+
+    void template124() { // #9197
+        const char code[] = "template <bool> struct a;\n"
+                            "template <bool b> using c = typename a<b>::d;\n"
+                            "template <typename> struct e;\n"
+                            "template <typename> struct h {\n"
+                            "  template <typename... f, c<h<e<typename f::d...>>::g>> void i();\n"
+                            "};";
+        const char exp[] = "template < bool > struct a ; "
+                           "template < bool b > using c = typename a < b > :: d ; "
+                           "template < typename > struct e ; "
+                           "template < typename > struct h { "
+                           "template < typename . . . f , c < h < e < typename f :: d . . . > > :: g > > void i ( ) ; "
+                           "} ;";
         ASSERT_EQUALS(exp, tok(code));
     }
 


### PR DESCRIPTION
…failed.)