### PR TITLE
donate-cpu.py: Enable sqlite3 library for local includes.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -40,7 +40,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.23"
+CLIENT_VERSION = "1.1.24"
 
 
 def check_requirements():
@@ -267,7 +267,7 @@ def scan_package(work_path, cppcheck_path, jobs):
                        'qt': ['<QApplication>', '<QString>', '<QWidget>', '<QtWidgets>', '<QtGui'],
                        'ruby': ['<ruby.h>', '<ruby/'],
                        'sdl': ['<SDL.h>'],
-                       'sqlite3': ['<sqlite3.h>'],
+                       'sqlite3': ['<sqlite3.h>', '"sqlite3.h"'],
                        'tinyxml2': ['<tinyxml2', '"tinyxml2'],
                        'wxwidgets': ['<wx/', '"wx/'],
                        'zlib': ['<zlib.h>'],


### PR DESCRIPTION
Many projects use a local copy of the sqlite3 library and several of
them use local includes.