### PR TITLE
append summary message with clang-tidy check information.

### DIFF
--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -413,7 +413,7 @@ void CheckThread::parseClangErrors(const QString &tool, const QString &file0, QS
 
         QString message,id;
         if (r2.exactMatch(r1.cap(5))) {
-            message = r2.cap(1);
+            message = "[clang] " + r2.cap(1) + "["+r2.cap(2)+"]";
             const QString id1(r2.cap(2));
             if (id1.startsWith("clang"))
                 id = id1;


### PR DESCRIPTION
Example summary before: 
"'atoi' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead"

summary after:
"[clang] 'atoi' used to convert a string to an integer value, but function will not report conversion errors; consider using 'strtol' instead [cert-err34-c]"