### PR TITLE
Resolve Clang Compile warnings

### DIFF
--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -289,32 +289,9 @@ QStandardItem *ResultsTree::addBacktraceFiles(QStandardItem *parent,
 
 QString ResultsTree::severityToTranslatedString(Severity::SeverityType severity)
 {
-    switch (severity) {
-    case Severity::style:
-        return tr("style");
-
-    case Severity::error:
-        return tr("error");
-
-    case Severity::warning:
-        return tr("warning");
-
-    case Severity::performance:
-        return tr("performance");
-
-    case Severity::portability:
-        return tr("portability");
-
-    case Severity::information:
-        return tr("information");
-
-    case Severity::debug:
-        return tr("debug");
-
-    case Severity::none:
-    default:
+    if ((severity <= Severity::none) || severity > Severity::debug)
         return QString();
-    }
+    return tr(Severity::toString(severity).c_str());
 }
 
 QStandardItem *ResultsTree::findFileItem(const QString &name) const
@@ -1086,6 +1063,8 @@ QString ResultsTree::severityToIcon(Severity::SeverityType severity) const
         return ":images/utilities-system-monitor.png";
     case Severity::information:
         return ":images/dialog-information.png";
+    case Severity::none:
+    case Severity::debug:
     default:
         return QString();
     }

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -193,12 +193,21 @@ public:
                 : fileIndex(0), line(0), col(0) {
             }
 
-            FileLocation(const std::string &file, unsigned int aline)
-                : fileIndex(0), line(aline), col(0), mOrigFileName(file), mFileName(file) {
+            FileLocation(const std::string &file, unsigned int aline):
+                fileIndex(0),
+                line(static_cast<int>(aline)),
+                col(0),
+                mOrigFileName(file),
+                mFileName(file) {
             }
 
-            FileLocation(const std::string &file, const std::string &info, unsigned int aline)
-                : fileIndex(0), line(aline), col(0), mOrigFileName(file), mFileName(file), mInfo(info) {
+            FileLocation(const std::string &file, const std::string &info, unsigned int aline):
+                fileIndex(0),
+                line(static_cast<int>(aline)),
+                col(0),
+                mOrigFileName(file),
+                mFileName(file),
+                mInfo(info) {
             }
 
             FileLocation(const Token* tok, const TokenList* tokenList);

--- a/lib/platform.h
+++ b/lib/platform.h
@@ -43,24 +43,24 @@ namespace cppcheck {
         static long long min_value(int bit) {
             if (bit >= 64)
                 return LLONG_MIN;
-            return -(1LL << (bit-1));
+            return -(1LL << (static_cast<long long>(bit - 1)));
         }
 
         static long long max_value(int bit) {
             if (bit >= 64)
                 return (~0ULL) >> 1;
-            return (1LL << (bit-1)) - 1LL;
+            return (1LL << (static_cast<long long>(bit - 1))) - 1LL;
         }
     public:
         Platform();
         virtual ~Platform() {}
 
         bool isIntValue(long long value) const {
-            return value >= min_value(int_bit) && value <= max_value(int_bit);
+            return value >= min_value(static_cast<int>(int_bit)) && value <= max_value(static_cast<int>(int_bit));
         }
 
         bool isLongValue(long long value) const {
-            return value >= min_value(long_bit) && value <= max_value(long_bit);
+            return value >= min_value(static_cast<int>(long_bit)) && value <= max_value(static_cast<int>(long_bit));
         }
 
         unsigned int char_bit;       /// bits in char
@@ -127,6 +127,8 @@ namespace cppcheck {
         }
 
         static const char *platformString(PlatformType pt) {
+            if ((pt < Unspecified) || (pt > PlatformFile))
+                return "unknown";
             switch (pt) {
             case Unspecified:
                 return "Unspecified";
@@ -144,21 +146,19 @@ namespace cppcheck {
                 return "unix64";
             case PlatformFile:
                 return "platformFile";
-            default:
-                return "unknown";
             }
         }
 
         long long unsignedCharMax() const {
-            return max_value(char_bit + 1);
+            return max_value(static_cast<int>(char_bit + 1));
         }
 
         long long signedCharMax() const {
-            return max_value(char_bit);
+            return max_value(static_cast<int>(char_bit));
         }
 
         long long signedCharMin() const {
-            return min_value(char_bit);
+            return min_value(static_cast<int>(char_bit));
         }
     };
 


### PR DESCRIPTION
Commit resolves select warnings that fill the build log with repetition when using the flag -Weverything. Warnings highlighted areas where some improvements to code could be made. Changes resulted in a greatly reduced log file size.

lib/errorloger.h -Wsign-conversion,Value Conversion Issue - two occurrences
FileLocation constructor overloads have in their signatures unsigned int for line value. In context, line location is typed as int in the class. Line is intended to be -1 to indicate no line but enforce 0 or > with the unsigned value. Silence warning with static_cast<int> and refactor due to line length.

lib/platform.h -Wsign-conversion,Value Conversion Issue
Repeated warnings occur when using class(private and public) functions. Simple task of silencing the repetitive warnings with a static_cast to appropriate type.

lib/platform.h -Wcovered-switch-default
'default' case in usage of PlatformType was flagged as possibly covering conditions outside of defined PlatformType. Added check to handle out-of-bounds values, removed default, but left switch untouched.

gui/resultstree.cpp -Wcovered-switch-default
Numerous warnings encountered with usage of default with Severity enum. However, the code for the gui was improved by removing code that duplicates the actions of a Severity class function.