### PR TITLE
Fix adding unescaped slash token when splitting gcc case range.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2821,7 +2821,11 @@ void Tokenizer::simplifyCaseRange()
                 tok->next()->str("case");
                 for (char i = end - 1; i > start; i--) {
                     tok->insertToken(":");
-                    tok->insertToken(std::string(1, '\'') + i + '\'');
+                    if (i == '\\') {
+                      tok->insertToken(std::string("\'\\") + i + '\'');
+                    } else {
+                      tok->insertToken(std::string(1, '\'') + i + '\'');
+                    }
                     tok->insertToken("case");
                 }
             }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7114,6 +7114,8 @@ private:
 
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'a' : case 'b' : case 'c' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'a' ... 'c': } }"));
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'c' . . . 'a' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'c' ... 'a': } }"));
+        
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '[' : case '\\\\' : case ']' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '[' ... ']': } }"));
     }
 
     void prepareTernaryOpForAST() {


### PR DESCRIPTION
Constructions like **case '1'...'9'** (gcc extension) converted to a list of separate case tokens. When slash \ symbol appears as a part of this list, it is added "as is", but it should be escaped like '\\' to be valid c++ code.

Next code causes internal error,:
**cppcheckError: Internal Error. MathLib::normalizeCharacterLiteral: Unhandled char constant '\'.**

```
switch( x ) {
	case ' ' ... '~': // <--- error here
		break;
}
```
Here is my solution of this problem. Please review it, taking in account that I'm new to this project and not sure if my solution good enough for Cppcheck architecture. But at least it works for me.