### PR TITLE
Resolve -Winconsistent-missing-destructor-override warnings.

### DIFF
--- a/gui/codeeditor.h
+++ b/gui/codeeditor.h
@@ -68,7 +68,7 @@ public:
     explicit CodeEditor(QWidget *parent);
     CodeEditor(const CodeEditor &) = delete;
     CodeEditor &operator=(const CodeEditor &) = delete;
-    ~CodeEditor();
+    virtual ~CodeEditor() override;
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();

--- a/gui/codeeditorstyle.cpp
+++ b/gui/codeeditorstyle.cpp
@@ -68,6 +68,10 @@ bool CodeEditorStyle::operator==(const CodeEditorStyle& rhs) const
     return true;
 }
 
+CodeEditorStyle::~CodeEditorStyle()
+{
+}
+
 bool CodeEditorStyle::operator!=(const CodeEditorStyle& rhs) const
 {
     return !(*this == rhs);

--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -59,7 +59,7 @@ public:
         const QColor& CmtFGColor, const QFont::Weight& CmtWeight,
         const QColor& SymbFGColor, const QColor& SymbBGColor,
         const QFont::Weight& SymbWeight);
-    ~CodeEditorStyle() {}
+    ~CodeEditorStyle();
 
     bool operator==(const CodeEditorStyle& rhs) const;
     bool operator!=(const CodeEditorStyle& rhs) const;

--- a/gui/csvreport.h
+++ b/gui/csvreport.h
@@ -36,7 +36,7 @@
 class CsvReport : public Report {
 public:
     explicit CsvReport(const QString &filename);
-    virtual ~CsvReport();
+    virtual ~CsvReport() override;
 
     /**
     * @brief Create the report (file).

--- a/gui/printablereport.h
+++ b/gui/printablereport.h
@@ -32,7 +32,7 @@
 class PrintableReport : public Report {
 public:
     PrintableReport();
-    virtual ~PrintableReport();
+    virtual ~PrintableReport() override;
 
     /**
     * @brief Create the report (file).

--- a/gui/resultsview.h
+++ b/gui/resultsview.h
@@ -47,7 +47,7 @@ public:
     explicit ResultsView(QWidget * parent = nullptr);
     void initialize(QSettings *settings, ApplicationList *list, ThreadHandler *checkThreadHandler);
     ResultsView(const ResultsView &) = delete;
-    virtual ~ResultsView();
+    virtual ~ResultsView() override;
     ResultsView &operator=(const ResultsView &) = delete;
 
     void setTags(const QStringList &tags) {

--- a/gui/threadresult.h
+++ b/gui/threadresult.h
@@ -39,7 +39,7 @@ class ThreadResult : public QObject, public ErrorLogger {
     Q_OBJECT
 public:
     ThreadResult();
-    virtual ~ThreadResult();
+    virtual ~ThreadResult() override;
 
     /**
     * @brief Get next unprocessed file

--- a/gui/txtreport.h
+++ b/gui/txtreport.h
@@ -36,7 +36,7 @@ class TxtReport : public Report {
 
 public:
     explicit TxtReport(const QString &filename);
-    virtual ~TxtReport();
+    virtual ~TxtReport() override;
 
     /**
     * @brief Create the report (file).

--- a/gui/xmlreport.cpp
+++ b/gui/xmlreport.cpp
@@ -31,6 +31,10 @@ XmlReport::XmlReport(const QString &filename) :
 {
 }
 
+XmlReport::~XmlReport()
+{
+}
+
 QString XmlReport::quoteMessage(const QString &message)
 {
     QString quotedMessage(message);

--- a/gui/xmlreport.h
+++ b/gui/xmlreport.h
@@ -36,6 +36,7 @@ class QObject;
 class XmlReport : public Report {
 public:
     explicit XmlReport(const QString &filename);
+    virtual ~XmlReport() override;
 
     /**
      * @brief Read contents of the report file.

--- a/gui/xmlreportv2.h
+++ b/gui/xmlreportv2.h
@@ -37,7 +37,7 @@
 class XmlReportV2 : public XmlReport {
 public:
     explicit XmlReportV2(const QString &filename);
-    virtual ~XmlReportV2();
+    virtual ~XmlReportV2() override;
 
     /**
     * @brief Create the report (file).


### PR DESCRIPTION
Numerous instances of inconsistent gui code where subclass of Qt definitions did not have appropriate destructor definitions. Warnings issued with clang++ and -Weverything.