### PR TITLE
Update gtk memory functions

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -393,9 +393,11 @@
     <alloc init="true">g_key_file_get_start_group</alloc>
     <alloc init="true">g_key_file_to_data</alloc>
     <alloc buffer-size="malloc">g_malloc</alloc>
+    <realloc buffer-size="malloc:2">g_realloc</realloc>
     <alloc init="true" buffer-size="malloc">g_malloc0</alloc>
     <alloc init="true" buffer-size="calloc">g_malloc0_n</alloc>
     <alloc buffer-size="calloc">g_malloc_n</alloc>
+    <realloc buffer-size="calloc:2,3">g_realloc_n</realloc>
     <alloc init="true">g_memdup</alloc>
     <alloc init="true">g_path_get_basename</alloc>
     <alloc init="true">g_path_get_dirname</alloc>
@@ -414,9 +416,11 @@
     <alloc init="true">g_strnfill</alloc>
     <alloc init="true">g_time_val_to_iso8601</alloc>
     <alloc buffer-size="malloc">g_try_malloc</alloc>
+    <realloc buffer-size="malloc:2">g_try_realloc</realloc>
     <alloc init="true" buffer-size="malloc">g_try_malloc0</alloc>
     <alloc init="true" buffer-size="calloc">g_try_malloc0_n</alloc>
     <alloc buffer-size="calloc">g_try_malloc_n</alloc>
+    <realloc buffer-size="calloc:2,3">g_try_realloc_n</realloc>
     <alloc init="true">g_ucs4_to_utf16</alloc>
     <alloc init="true">g_ucs4_to_utf8</alloc>
     <alloc init="true">g_unicode_canonical_decomposition</alloc>
@@ -441,10 +445,6 @@
     <alloc init="true">g_key_file_get_integer_list</alloc>
     <alloc init="true">g_key_file_get_double_list</alloc>
     <alloc init="true">g_key_file_get_comment</alloc>
-    <alloc>g_new</alloc>
-    <alloc init="true">g_new0</alloc>
-    <alloc>g_try_new</alloc>
-    <alloc init="true">g_try_new0</alloc>
     <alloc init="true">g_dbus_proxy_get_name_owner</alloc>
     <alloc init="true">g_file_info_get_attribute_as_string</alloc>
     <alloc init="true">g_file_attribute_matcher_to_string</alloc>
@@ -3646,6 +3646,7 @@
   <!-- gpointer g_try_malloc0 (gsize n_bytes); -->
   <function name="g_try_malloc,g_try_malloc0">
     <noreturn>false</noreturn>
+    <use-retval/>
     <returnValue type="gpointer"/>
     <arg nr="1" direction="in">
       <not-uninit/>
@@ -3658,6 +3659,7 @@
   <function name="g_try_malloc_n,g_try_malloc0_n">
     <noreturn>false</noreturn>
     <returnValue type="gpointer"/>
+    <use-retval/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
@@ -3668,13 +3670,33 @@
       <valid>0:</valid>
     </arg>
   </function>
+  <!-- gpointer g_try_realloc (gpointer mem, gsize n_bytes); -->
   <function name="g_try_realloc">
-    <leak-ignore/>
+    <returnValue type="gpointer"/>
+    <use-retval/>
     <noreturn>false</noreturn>
+    <arg nr="1"/>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
   </function>
+  <!-- gpointer g_try_realloc_n (gpointer mem, gsize n_blocks, gsize n_block_bytes); -->
   <function name="g_try_realloc_n">
-    <leak-ignore/>
+    <returnValue type="gpointer"/>
+    <use-retval/>
     <noreturn>false</noreturn>
+    <arg nr="1"/>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-uninit/>
+      <not-bool/>
+      <valid>0:</valid>
+    </arg>
   </function>
   <function name="g_unichar_break_type">
     <leak-ignore/>
@@ -4912,6 +4934,7 @@
   <!-- gpointer g_malloc0(gsize n_bytes); -->
   <function name="g_malloc,g_malloc0">
     <returnValue type="gpointer"/>
+    <use-retval/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>
@@ -4923,6 +4946,7 @@
   <!-- gpointer g_malloc0_n (gsize n_blocks, gsize n_block_bytes); -->
   <function name="g_malloc_n,g_malloc0_n">
     <returnValue type="gpointer"/>
+    <use-retval/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -57,10 +57,157 @@ void validCode(int argInt)
 
 void g_malloc_test()
 {
+    // cppcheck-suppress ignoredReturnValue
     // cppcheck-suppress leakReturnValNotUsed
     g_malloc(8);
 
     gpointer gpt = g_malloc(1);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_malloc0_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_malloc0(8);
+
+    gpointer gpt = g_malloc0(1);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_malloc_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_malloc_n(8, 1);
+
+    gpointer gpt = g_malloc_n(1, 2);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_malloc0_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_malloc0_n(8, 1);
+
+    gpointer gpt = g_malloc0_n(1, 2);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_malloc_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_try_malloc(8);
+
+    gpointer gpt = g_try_malloc(1);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_malloc0_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_try_malloc0(8);
+
+    gpointer gpt = g_try_malloc0(1);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_malloc_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_try_malloc_n(8, 1);
+
+    gpointer gpt = g_try_malloc_n(1, 2);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_malloc0_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // cppcheck-suppress leakReturnValNotUsed
+    g_try_malloc0_n(8, 1);
+
+    gpointer gpt = g_try_malloc0_n(1, 2);
+
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_realloc_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_realloc(NULL, 1);
+
+    gpointer gpt = g_malloc(1);
+    gpt = g_realloc(gpt, 2); // No memleakOnRealloc since g_realloc aborts if it fails
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_realloc_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_realloc_n(NULL, 1, 2);
+
+    gpointer gpt = g_malloc_n(1, 2);
+    gpt = g_realloc_n(gpt, 2, 3); // No memleakOnRealloc since g_realloc_n aborts if it fails
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_realloc_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_try_realloc(NULL, 1);
+
+    gpointer gpt = g_try_malloc(1);
+    // cppcheck-suppress memleakOnRealloc
+    gpt = g_try_realloc(gpt, 2);
+    printf("%p", gpt);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_realloc_n_test()
+{
+    // cppcheck-suppress ignoredReturnValue
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_try_realloc_n(NULL, 1, 2);
+
+    gpointer gpt = g_try_malloc_n(1, 2);
+    // TODO cppcheck-suppress memleakOnRealloc
+    gpt = g_try_realloc_n(gpt, 2, 3);
     printf("%p", gpt);
 
     // cppcheck-suppress memleak
@@ -120,6 +267,41 @@ void g_new_if_test()
     // cppcheck-suppress memleak
 }
 
+void g_new0_test()
+{
+    struct a {
+        int b;
+    };
+    // valid
+    struct a * pNew1 = g_new0(struct a, 5);
+    printf("%p", pNew1);
+    g_free(pNew1);
+
+    // cppcheck-suppress leakReturnValNotUsed
+    g_new0(struct a, 1);
+
+    struct a * pNew2 = g_new0(struct a, 2);
+    printf("%p", pNew2);
+    // cppcheck-suppress memleak
+}
+
+void g_try_new_test()
+{
+    struct a {
+        int b;
+    };
+    // valid
+    struct a * pNew1 = g_try_new(struct a, 5);
+    printf("%p", pNew1);
+    g_free(pNew1);
+
+    // cppcheck-suppress leakReturnValNotUsed
+    g_try_new(struct a, 1);
+
+    struct a * pNew2 = g_try_new(struct a, 2);
+    printf("%p", pNew2);
+    // cppcheck-suppress memleak
+}
 void g_try_new0_test()
 {
     struct a {
@@ -135,6 +317,37 @@ void g_try_new0_test()
 
     struct a * pNew2 = g_try_new0(struct a, 2);
     printf("%p", pNew2);
+    // cppcheck-suppress memleak
+}
+
+void g_renew_test()
+{
+    struct a {
+        int b;
+    };
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_renew(struct a, NULL, 1);
+
+    struct a * pNew = g_new(struct a, 1);
+    pNew = g_renew(struct a, pNew, 2); // No memleakOnRealloc since g_renew aborts if it fails
+    printf("%p", pNew);
+
+    // cppcheck-suppress memleak
+}
+
+void g_try_renew_test()
+{
+    struct a {
+        int b;
+    };
+    // TODO cppcheck-suppress leakReturnValNotUsed
+    g_try_renew(struct a, NULL, 1);
+
+    struct a * pNew = g_try_new(struct a, 1);
+    // TODO cppcheck-suppress memleakOnRealloc
+    pNew = g_try_renew(struct a, pNew, 2);
+    printf("%p", pNew);
+
     // cppcheck-suppress memleak
 }
 


### PR DESCRIPTION
* Improve configuration of g_try_realloc and g_try_realloc_n
* Mark g_realloc and similar functions as realloc functions
* Remove g_new, g_new0, etc as <alloc> functions, these are defined as
  macros and handled as the functions they're expanded to.
* Add tests. TODO tests will be resolved by using the library
  configuration in the checker.