### PR TITLE
Makefile/dmake: Increase stack size to 8M for Cygwin builds to avoid segfaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,15 @@ ifndef CXXFLAGS
     CXXFLAGS=-pedantic -Wall -Wextra -Wcast-qual -Wno-deprecated-declarations -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-shadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar $(CPPCHK_GLIBCXX_DEBUG) -g
 endif
 
+# Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.
+ifdef COMSPEC
+    uname_S := $(shell uname -s)
+
+    ifneq (,$(findstring CYGWIN,$(uname_S)))
+        CXXFLAGS+=-Wl,--stack,8388608
+    endif # CYGWIN
+endif # COMSPEC
+
 ifeq (g++, $(findstring g++,$(CXX)))
     override CXXFLAGS += -std=c++0x
 else ifeq (clang++, $(findstring clang++,$(CXX)))

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -320,6 +320,16 @@ int main(int argc, char **argv)
                                 "-g");
     }
 
+    fout << "# Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.\n"
+         << "ifdef COMSPEC\n"
+         << "    uname_S := $(shell uname -s)\n"
+         << "\n"
+         << "    ifneq (,$(findstring CYGWIN,$(uname_S)))\n"
+         << "        CXXFLAGS+=-Wl,--stack,8388608\n"
+         << "    endif # CYGWIN\n"
+         << "endif # COMSPEC\n"
+         << "\n";
+
     fout << "ifeq (g++, $(findstring g++,$(CXX)))\n"
          << "    override CXXFLAGS += -std=c++0x\n"
          << "else ifeq (clang++, $(findstring clang++,$(CXX)))\n"


### PR DESCRIPTION
See https://github.com/danmar/cppcheck/pull/1988
and https://github.com/danmar/cppcheck/pull/1998