### PR TITLE
Configure xrealloc and adjust gnu memory functions

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -11,6 +11,8 @@
   <memory>
     <alloc init="false" buffer-size="malloc">xmalloc</alloc>
     <alloc init="true" buffer-size="calloc">xcalloc</alloc>
+    <alloc init="true" buffer-size="strdup">xstrdup</alloc>
+    <realloc init="false" buffer-size="malloc:2">xrealloc</realloc>
     <dealloc>free</dealloc>
   </memory>
   <!-- https://linux.die.net/man/3/backtrace -->
@@ -48,7 +50,6 @@
   <function name="xmalloc">
     <use-retval/>
     <returnValue type="void *"/>
-    <noreturn>false</noreturn>
     <arg nr="1" direction="in">
       <not-uninit/>
       <valid>0:</valid>
@@ -57,7 +58,6 @@
   </function>
   <!-- char *xstrdup(const char *s); -->
   <function name="xstrdup">
-    <noreturn>false</noreturn>
     <returnValue type="char *"/>
     <use-retval/>
     <arg nr="1" direction="in">
@@ -133,7 +133,6 @@
   <!-- void * xcalloc(size_t nitems, size_t size); -->
   <function name="xcalloc">
     <use-retval/>
-    <noreturn>false</noreturn>
     <returnValue type="void *"/>
     <arg nr="1" direction="in">
       <not-uninit/>
@@ -149,7 +148,6 @@
   <function name="xrealloc">
     <use-retval/>
     <returnValue type="void *"/>
-    <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>
     </arg>

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -15,6 +15,11 @@
 #include <sys/epoll.h>
 #endif
 
+// Declaration necessary because there is no specific / portable header.
+extern void *xcalloc(size_t nmemb, size_t size);
+extern void *xmalloc(size_t size);
+extern void *xrealloc(void *block, size_t newsize);
+
 void resourceLeak_mkostemps(char *template, int suffixlen, int flags)
 {
     // cppcheck-suppress unreadVariable
@@ -117,13 +122,23 @@ void bufferAccessOutOfBounds()
     // cppcheck-suppress bufferAccessOutOfBounds
     sethostname(buf, 4);
 
-    // Declaration necessary because there is no specific / portable header containing xcalloc.
-    extern void *xcalloc(size_t nmemb, size_t size);
     char * pAlloc1 = xcalloc(2, 4);
     memset(pAlloc1, 0, 8);
     // cppcheck-suppress bufferAccessOutOfBounds
     memset(pAlloc1, 0, 9);
     free(pAlloc1);
+
+    char * pAlloc2 = xmalloc(4);
+    memset(pAlloc2, 0, 4);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    memset(pAlloc2, 0, 5);
+
+    pAlloc2 = xrealloc(pAlloc2, 10);
+    memset(pAlloc2, 0, 10);
+    // cppcheck-suppress bufferAccessOutOfBounds
+    memset(pAlloc2, 0, 11);
+
+    free(pAlloc2);
 }
 
 void leakReturnValNotUsed()


### PR DESCRIPTION
Remove `<noreturn>` tag, since the functions do not return unless there
was no error.