### PR TITLE
Lower recursion limit when using asan

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -284,7 +284,12 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                                   std::set<int> notzero,
                                   nonneg int recursiveCount)
 {
-    if (++recursiveCount > 1000)    // maximum number of "else if ()"
+#if ASAN
+    static const nonneg int recursiveLimit = 300;
+#else
+    static const nonneg int recursiveLimit = 1000;
+#endif
+    if (++recursiveCount > recursiveLimit)    // maximum number of "else if ()"
         throw InternalError(startToken, "Internal limit: CheckLeakAutoVar::checkScope() Maximum recursive count of 1000 reached.", InternalError::LIMIT);
 
     std::map<int, VarInfo::AllocInfo> &alloctype = varInfo->alloctype;

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -72,4 +72,18 @@ inline static int caseInsensitiveStringCompare(const std::string &lhs, const std
 #define nonneg
 #endif
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define ASAN 1
+#endif
+#endif
+
+#ifndef ASAN
+#ifdef  __SANITIZE_ADDRESS__
+#define ASAN 1
+#else
+#define ASAN 0
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
ASAN can use 3x more stack memory, so this lowers the limit from 1000 to 300 to avoid stack overflow errors in ASAN.