### PR TITLE
Run more tests on full token list

### DIFF
--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -41,7 +41,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
-        tokenizer.simplifyTokenList2();
 
         // Check class constructors..
         CheckClass checkClass(&tokenizer, &settings, this);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1853,7 +1853,6 @@ private:
         Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, filename);
-        tokenizer.simplifyTokenList2();
 
         // force symbol database creation
         tokenizer.createSymbolDatabase();

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3933,7 +3933,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
-        tokenizer.simplifyTokenList2();
 
         // Check code..
         CheckUninitVar check(&tokenizer, &settings, this);
@@ -3951,8 +3950,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
-
-        tokenizer.simplifyTokenList2();
 
         // Check for redundant code..
         CheckUninitVar checkuninitvar(&tokenizer, &settings, this);

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -105,7 +105,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(&tokens2);
         tokenizer.simplifyTokens1("");
-        tokenizer.simplifyTokenList2();
 
         // Check for unused private functions..
         CheckClass checkClass(&tokenizer, &settings, this);


### PR DESCRIPTION
Since all checks are run on the full token list and not the simplified
one, run the tests on the full token list as well.

Note: There are more tests that run on the simplified token list, but these were
the ones were it was "simple" to remove them (no test failures), so pick the lowest
hanging fruit first.