### PR TITLE
donate-cpu.py: Do not report crash if no source file has been found.

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -40,7 +40,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.25"
+CLIENT_VERSION = "1.1.26"
 
 
 def check_requirements():
@@ -568,8 +568,12 @@ while True:
             current_cppcheck_dir = ver
         c, errout, info, t, cppcheck_options = scan_package(work_path, current_cppcheck_dir, jobs)
         if c < 0:
-            crash = True
-            count += ' Crash!'
+            if c == -101 and 'error: could not find or open any of the paths given.' in errout:
+                # No sourcefile found (for example only headers present)
+                count += ' 0'
+            else:
+                crash = True
+                count += ' Crash!'
         else:
             count += ' ' + str(c)
         elapsed_time += " {:.1f}".format(t)


### PR DESCRIPTION
Sometimes there are no relevant source files (.c, .cpp, ...) extracted,
but other files are (.h, ...).
There could be only header files for example. Then Cppcheck returns with
exit code 1 and prints an error message. This is no crash and now no
longer reported as such.