### PR TITLE
Fix FP when using a pointer to a container

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -823,12 +823,11 @@ void CheckStl::invalidContainer()
                 for (const ValueFlow::Value& val:info.tok->values()) {
                     if (!val.isLocalLifetimeValue())
                         continue;
+                    if (val.lifetimeKind == ValueFlow::Value::LifetimeKind::Address)
+                        continue;
                     if (!val.tokvalue->variable())
                         continue;
                     if (val.tokvalue->varId() != tok->varId())
-                        continue;
-                    // Skip possible temporaries
-                    if (val.tokvalue == tok)
                         continue;
                     ErrorPath ep;
                     // Check the iterator is created before the change

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2771,7 +2771,7 @@ static const Token *getLifetimeToken(const Token *tok, ValueFlow::Value::ErrorPa
                 return tok;
             if (var->isArgument()) {
                 errorPath.emplace_back(var->declEndToken(), "Passed to reference.");
-                return var->nameToken();
+                return tok;
             } else if (Token::simpleMatch(var->declEndToken(), "=")) {
                 errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
                 const Token *vartok = var->declEndToken()->astOperand2();

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -2083,8 +2083,7 @@ private:
               "    void* v = &i->foo;\n"
               "    return v;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:1] -> [test.cpp:5] -> [test.cpp:3] -> [test.cpp:1] -> [test.cpp:6]: (error) Using pointer to local variable 'bars' that may be invalid.\n"
-                      "[test.cpp:4] -> [test.cpp:1] -> [test.cpp:5] -> [test.cpp:4] -> [test.cpp:1] -> [test.cpp:6]: (error) Using pointer to local variable 'bars' that may be invalid.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:1] -> [test.cpp:5] -> [test.cpp:4] -> [test.cpp:1] -> [test.cpp:6]: (error) Using pointer to local variable 'bars' that may be invalid.\n", errout.str());
     }
 
     void insert2() {
@@ -3864,6 +3863,22 @@ private:
               "    std::string::const_iterator d = f.begin();\n"
               "    if (d != f.end()) {}\n"
               "  }\n"
+              "}\n",
+              true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(std::vector<int> &v) {\n"
+              "    int *v0 = &v[0];\n"
+              "    v.push_back(123);\n"
+              "    std::cout << (*v0)[0] << std::endl;\n"
+              "}\n",
+              true);
+        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:3] -> [test.cpp:1] -> [test.cpp:4]: (error) Using pointer to local variable 'v' that may be invalid.\n", errout.str());
+
+        check("void f(std::vector<int> &v) {\n"
+              "    std::vector<int> *v0 = &v;\n"
+              "    v.push_back(123);\n"
+              "    std::cout << (*v0)[0] << std::endl;\n"
               "}\n",
               true);
         ASSERT_EQUALS("", errout.str());


### PR DESCRIPTION
This fixes issue when using direct pointer to containers. There should no longer be warning about this:

```cpp
void f(std::vector<int> &v) {
    std::vector<int> *v0 = &v;
    v.push_back(123);
    std::cout << (*v0)[0] << std::endl;
}
```