### PR TITLE
Fix FP leakVarNotUsed with freopen() and stdin

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1006,6 +1006,15 @@ void CheckMemoryLeakNoVar::checkForUnusedReturnValue(const Scope *scope)
         if (tok != tok->next()->astOperand1())
             continue;
 
+        if (getReallocationType(tok, 0) == File) {
+            const Library::AllocFunc *f = mSettings->library.getReallocFuncInfo(tok);
+            if (f && f->reallocArg > 0 && f->reallocArg <= numberOfArguments(tok)) {
+                const Token* arg = getArguments(tok).at(f->reallocArg - 1);
+                if (Token::Match(arg, "stdin|stdout|stderr"))
+                    continue;
+            }
+        }
+
         // get ast parent, skip casts
         const Token *parent = tok->next()->astParent();
         while (parent && parent->str() == "(" && !parent->astOperand2())

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2329,6 +2329,11 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:3]: (error) Return value of allocation function 'freopen' is not stored.\n", errout.str());
 
+        check("void foo() {\n"
+              "  freopen(\"file.txt\", \"r\", stdin);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("struct Holder {\n"
               "  Holder(FILE* f) : file(f) {}\n"
               "  ~Holder() { fclose(file); }\n"


### PR DESCRIPTION
One usecase for freopen() is to redirect input and output streams to
files. For that, the return value is not needed.