### PR TITLE
Correct Signal/Slot signatures

### DIFF
--- a/gui/codeeditstylecontrols.h
+++ b/gui/codeeditstylecontrols.h
@@ -37,7 +37,7 @@ public:
     const QColor& getColor();
 
 signals:
-    void colorChanged(QColor& newColor);
+    void colorChanged(const QColor& newColor);
 
 public slots:
     void updateColor();
@@ -58,7 +58,7 @@ public:
     const QFont::Weight& getWeight();
 
 signals:
-    void weightChanged(QFont::Weight& newWeight);
+    void weightChanged(const QFont::Weight& newWeight);
 
 public slots:
     void updateWeight();

--- a/gui/codeeditstyledialog.cpp
+++ b/gui/codeeditstyledialog.cpp
@@ -157,38 +157,38 @@ StyleEditDialog::StyleEditDialog(const CodeEditorStyle& newStyle,
             this, SLOT(setStyleDefaultLight()));
     connect(mBtnDefaultDark, SIGNAL(clicked()),
             this, SLOT(setStyleDefaultDark()));
-    connect(mBtnWidgetColorFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedWidgetFG(QColor&)));
-    connect(mBtnWidgetColorBG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedWidgetBG(QColor&)));
-    connect(mBtnHighlightBG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedHighlightBG(QColor&)));
-    connect(mBtnLineNumFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedLineNumFG(QColor&)));
-    connect(mBtnLineNumBG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedLineNumBG(QColor&)));
-    connect(mBtnKeywordFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedKeywordFG(QColor&)));
-    connect(mCBKeywordWeight, SIGNAL(weightChanged(QFont::Weight&)),
-            this, SLOT(weightChangedKeyword(QFont::Weight&)));
-    connect(mBtnClassFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedClassFG(QColor&)));
-    connect(mCBClassWeight, SIGNAL(weightChanged(QFont::Weight&)),
-            this, SLOT(weightChangedClass(QFont::Weight&)));
-    connect(mBtnQuoteFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedQuoteFG(QColor&)));
-    connect(mCBQuoteWeight, SIGNAL(weightChanged(QFont::Weight&)),
-            this, SLOT(weightChangedQuote(QFont::Weight&)));
-    connect(mBtnCommentFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedCommentFG(QColor&)));
-    connect(mCBCommentWeight, SIGNAL(weightChanged(QFont::Weight&)),
-            this, SLOT(weightChangedComment(QFont::Weight&)));
-    connect(mBtnSymbolFG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedSymbolFG(QColor&)));
-    connect(mBtnSymbolBG, SIGNAL(colorChanged(QColor&)),
-            this, SLOT(colorChangedSymbolBG(QColor&)));
-    connect(mCBSymbolWeight, SIGNAL(weightChanged(QFont::Weight&)),
-            this, SLOT(weightChangedSymbol(QFont::Weight&)));
+    connect(mBtnWidgetColorFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedWidgetFG(const QColor&)));
+    connect(mBtnWidgetColorBG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedWidgetBG(const QColor&)));
+    connect(mBtnHighlightBG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedHighlightBG(const QColor&)));
+    connect(mBtnLineNumFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedLineNumFG(const QColor&)));
+    connect(mBtnLineNumBG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedLineNumBG(const QColor&)));
+    connect(mBtnKeywordFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedKeywordFG(const QColor&)));
+    connect(mCBKeywordWeight, SIGNAL(weightChanged(const QFont::Weight&)),
+            this, SLOT(weightChangedKeyword(const QFont::Weight&)));
+    connect(mBtnClassFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedClassFG(const QColor&)));
+    connect(mCBClassWeight, SIGNAL(weightChanged(const QFont::Weight&)),
+            this, SLOT(weightChangedClass(const QFont::Weight&)));
+    connect(mBtnQuoteFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedQuoteFG(const QColor&)));
+    connect(mCBQuoteWeight, SIGNAL(weightChanged(const QFont::Weight&)),
+            this, SLOT(weightChangedQuote(const QFont::Weight&)));
+    connect(mBtnCommentFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedCommentFG(const QColor&)));
+    connect(mCBCommentWeight, SIGNAL(weightChanged(const QFont::Weight&)),
+            this, SLOT(weightChangedComment(const QFont::Weight&)));
+    connect(mBtnSymbolFG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedSymbolFG(const QColor&)));
+    connect(mBtnSymbolBG, SIGNAL(colorChanged(const QColor&)),
+            this, SLOT(colorChangedSymbolBG(const QColor&)));
+    connect(mCBSymbolWeight, SIGNAL(weightChanged(const QFont::Weight&)),
+            this, SLOT(weightChangedSymbol(const QFont::Weight&)));
 }
 
 void StyleEditDialog::updateControls()


### PR DESCRIPTION
Previous commit had updated declarations in Code Editor Style Dialog to use
const QColor& and const QFont::Weight& variables. This change was not totally
complete as const usage was not propagated to Signal/Slot connect statements.

This commit corrects that oversight.