### PR TITLE
Variable number of arguments for boost test suite macros

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -9,11 +9,11 @@
   <define name="BOOST_NORETURN" value="[[noreturn]]"/>
   <define name="BOOST_LIKELY(X)" value="(X)"/>
   <define name="BOOST_UNLIKELY(X)" value="(X)"/>
-  <define name="BOOST_FIXTURE_TEST_SUITE(suite_name, fixture_name)" value=""/>
+  <define name="BOOST_FIXTURE_TEST_SUITE(...)" value=""/>
   <define name="BOOST_FIXTURE_TEST_SUITE_END()" value=""/>
   <define name="BOOST_TEST_GLOBAL_FIXTURE(name)" value=""/>
   <define name="BOOST_PYTHON_FUNCTION_OVERLOADS(foo_overloads, foo, x, y)" value=""/>
-  <define name="BOOST_AUTO_TEST_SUITE(X)" value=""/>
+  <define name="BOOST_AUTO_TEST_SUITE(...)" value=""/>
   <define name="BOOST_AUTO_TEST_SUITE_END()" value=""/>
   <define name="BOOST_ASSERT(condition)" value="assert(condition)"/>
   <define name="BOOST_TEST(condition)" value="assert(condition)"/>
@@ -25,8 +25,8 @@
   <define name="BOOST_REQUIRE_EQUAL(a,b)" value="assert((a) == (b))"/>
   <define name="BOOST_LOG_ATTRIBUTE_KEYWORD(keyword, name_, value_type_)" value="value_type_ keyword;"/>
   <!-- Tell cppcheck to interpret BOOST_AUTO_TEST_CASE as a function definition -->
-  <define name="BOOST_AUTO_TEST_CASE(str)" value="void BOOST_AUTO_TEST_CASE_run(str)"/>
-  <define name="BOOST_FIXTURE_TEST_CASE(str1, str2)" value="void BOOST_FIXTURE_TEST_CASE_run(str1,str2)"/>
+  <define name="BOOST_AUTO_TEST_CASE(...)" value="void BOOST_AUTO_TEST_CASE_run(__VA_ARGS__)"/>
+  <define name="BOOST_FIXTURE_TEST_CASE(...)" value="void BOOST_FIXTURE_TEST_CASE_run(__VA_ARGS__)"/>
   <define name="BOOST_PYTHON_MODULE(str)" value="void BOOST_PYTHON_MODULE_definition(str)"/>
   <!-- ########## Boost containers ########## -->
   <!-- boost containers that are similar to std containers -->


### PR DESCRIPTION
The macros defined in unit_test_suite.hpp have a variable number of arguments if BOOST_PP_VARIADICS is defined.

See:
https://github.com/boostorg/test/blob/develop/include/boost/test/unit_test_suite.hpp