### PR TITLE
dmake: Fix check of last header file in lib.pri

### DIFF
--- a/lib/lib.pri
+++ b/lib/lib.pri
@@ -50,8 +50,7 @@ HEADERS += $${PWD}/check.h \
            $${PWD}/token.h \
            $${PWD}/tokenize.h \
            $${PWD}/tokenlist.h \
-           $${PWD}/valueflow.h \
-
+           $${PWD}/valueflow.h
 
 SOURCES += $${PWD}/analyzerinfo.cpp \
            $${PWD}/astutils.cpp \

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
                     continue;   // shouldn't happen
                 fname.erase(fname.find(".cpp"));
                 fout1 << std::string(11, ' ') << "$${PWD}/" << fname << ".h";
-                if (i + 1 < testfiles.size())
+                if (i + 1 < libfiles.size())
                     fout1 << " \\\n";
             }
             fout1 << "\n\nSOURCES += ";


### PR DESCRIPTION
Since the number of test files is larger than the number of lib files,
this only caused an extra harmless '\' being printed after the last
header file in lib.pri. If the number of test files would have been
smaller than the number of lib files, the generated lib.pri would have
been broken.