### PR TITLE
gnu.cfg: Add xfree()

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -14,6 +14,7 @@
     <alloc init="true" buffer-size="strdup">xstrdup</alloc>
     <realloc init="false" buffer-size="malloc:2">xrealloc</realloc>
     <dealloc>free</dealloc>
+    <dealloc>xfree</dealloc>
   </memory>
   <!-- https://linux.die.net/man/3/backtrace -->
   <memory>
@@ -64,6 +65,13 @@
       <not-null/>
       <not-uninit/>
       <not-bool/>
+    </arg>
+  </function>
+  <!-- void xfree(void *block); -->
+  <function name="xfree">
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-uninit/>
     </arg>
   </function>
   <!-- ssize_t splice(int fd_in, loff_t *off_in, int fd_out, loff_t *off_out, size_t len, unsigned int flags); -->

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -19,6 +19,7 @@
 extern void *xcalloc(size_t nmemb, size_t size);
 extern void *xmalloc(size_t size);
 extern void *xrealloc(void *block, size_t newsize);
+extern void xfree(void *ptr);
 
 void resourceLeak_mkostemps(char *template, int suffixlen, int flags)
 {
@@ -76,8 +77,19 @@ int no_resourceLeak_mkostemp_02(char *template, int flags)
 
 void valid_code(int argInt1)
 {
+    char *p;
+
     if (__builtin_expect(argInt1, 0)) {}
     if (__builtin_expect_with_probability(argInt1 + 1, 2, 0.5)) {}
+
+    p = (char *)malloc(10);
+    free(p);
+    p = (char *)malloc(5);
+    xfree(p);
+    p = (char *)xmalloc(10);
+    free(p);
+    p = (char *)xmalloc(5);
+    xfree(p);
 }
 
 void ignoreleak(void)
@@ -96,6 +108,13 @@ void memleak_asprintf(char **ptr, const char *fmt, const int arg)
     if (-1 != asprintf(ptr,fmt,arg)) {
         // TODO: Related to #8980 cppcheck-suppress memleak
     }
+}
+
+void memleak_xmalloc()
+{
+    char *p = (char*)xmalloc(10);
+    p[9] = 0;
+    // cppcheck-suppress memleak
 }
 
 void uninitvar__builtin_memset(void)


### PR DESCRIPTION
It is hard to find good references, one that describes it a bit can
be found here:
https://manpages.ubuntu.com/manpages/bionic/man3/xmalloc.3pub.html

xfree() can be used instead of free().
A check, to verify that a memory leak is found if the memory allocated
via xmalloc() is not freed, has also been added.