### PR TITLE
qt.cfg: Fix and enhance Qt container configuration

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -3600,7 +3600,7 @@
       <function name="crend" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtString" startPattern="QString" endPattern="" inherits="qtContainer" opLessAllowed="true" itEndPattern="&gt; :: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
+  <container id="qtString" startPattern="QString" endPattern="" inherits="qtContainer" opLessAllowed="true" itEndPattern=":: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <type string="std-like"/>
     <size>
       <function name="isNull" yields="empty"/>
@@ -3622,7 +3622,7 @@
       <function name="crend" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtStringList" startPattern="QStringList" inherits="qtList" opLessAllowed="true">
+  <container id="qtStringList" startPattern="QStringList" inherits="qtList" opLessAllowed="true" itEndPattern=":: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <size>
       <function name="removeDuplicates" action="change"/>
     </size>

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -3520,7 +3520,7 @@
     </arg>
   </function>
   <!-- ##### Container ##### -->
-  <container id="qtContainer" opLessAllowed="false">
+  <container id="qtContainer" opLessAllowed="false" itEndPattern="&gt; :: iterator|const_iterator">
     <type templateParameter="0"/>
     <size>
       <function name="append" action="push"/>
@@ -3542,24 +3542,50 @@
       <function name="constEnd" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtList" startPattern="QList &lt;" inherits="qtContainer" opLessAllowed="true">
-    <type string="std-like"/>
+  <container id="qtList" startPattern="QList &lt;" inherits="qtContainer" opLessAllowed="true" itEndPattern="&gt; :: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <size>
+      <function name="erase" action="erase" yields="iterator"/>
       <function name="resize" action="resize"/>
+      <function name="empty" yields="empty"/>
+      <function name="push_back" action="push"/>
+      <function name="push_front" action="push"/>
+      <function name="prepend" action="push"/>
+      <function name="pop_back" action="pop"/>
+      <function name="pop_front" action="pop"/>
+      <function name="removeAll" action="change"/>
+      <function name="removeAt" action="pop"/>
+      <function name="removeFirst" action="pop"/>
+      <function name="removeLast" action="pop"/>
+      <function name="takeAt" action="pop"/>
+      <function name="takeFirst" action="pop"/>
+      <function name="takeLast" action="pop"/>
     </size>
     <access indexOperator="array-like">
       <function name="at" yields="at_index"/>
       <function name="front" yields="item"/>
+      <function name="first" yields="item"/>
       <function name="back" yields="item"/>
+      <function name="last" yields="item"/>
+      <function name="reserve" action="change-internal"/>
+      <function name="rbegin" yields="start-iterator"/>
+      <function name="crbegin" yields="start-iterator"/>
+      <function name="rend" yields="end-iterator"/>
+      <function name="crend" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtVector" startPattern="QVector &lt;" inherits="qtContainer" opLessAllowed="true">
+  <container id="qtVector" startPattern="QVector &lt;" inherits="qtContainer" opLessAllowed="true" itEndPattern="&gt; :: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <size>
+      <function name="erase" action="erase" yields="iterator"/>
       <function name="resize" action="resize"/>
       <function name="push_back" action="push"/>
       <function name="push_front" action="push"/>
+      <function name="prepend" action="push"/>
       <function name="pop_back" action="pop"/>
       <function name="pop_front" action="pop"/>
+      <function name="empty" yields="empty"/>
+      <function name="shrink_to_fit" action="change-internal"/>
+      <function name="squeeze" action="change-internal"/>
+      <function name="reserve" action="change-internal"/>
     </size>
     <access indexOperator="array-like">
       <function name="at" yields="at_index"/>
@@ -3568,33 +3594,38 @@
       <function name="back" yields="item"/>
       <function name="last" yields="item"/>
       <function name="data" yields="buffer"/>
-      <function name="shrink_to_fit" action="change-internal"/>
-      <function name="squeeze" action="change-internal"/>
-      <function name="reserve" action="change-internal"/>
+      <function name="rbegin" yields="start-iterator"/>
+      <function name="crbegin" yields="start-iterator"/>
+      <function name="rend" yields="end-iterator"/>
+      <function name="crend" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtString" startPattern="QString" endPattern="" inherits="qtContainer" opLessAllowed="true">
+  <container id="qtString" startPattern="QString" endPattern="" inherits="qtContainer" opLessAllowed="true" itEndPattern="&gt; :: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <type string="std-like"/>
     <size>
       <function name="isNull" yields="empty"/>
       <function name="resize" action="resize"/>
+      <function name="push_back" action="push"/>
+      <function name="push_front" action="push"/>
+      <function name="prepend" action="push"/>
+      <function name="shrink_to_fit" action="change-internal"/>
+      <function name="squeeze" action="change-internal"/>
+      <function name="reserve" action="change-internal"/>
     </size>
     <access indexOperator="array-like">
       <function name="at" yields="at_index"/>
       <function name="front" yields="item"/>
       <function name="back" yields="item"/>
+      <function name="rbegin" yields="start-iterator"/>
+      <function name="crbegin" yields="start-iterator"/>
+      <function name="rend" yields="end-iterator"/>
+      <function name="crend" yields="end-iterator"/>
     </access>
   </container>
-  <container id="qtStringList" startPattern="QStringList" inherits="qtContainer" opLessAllowed="true">
-    <type string="std-like"/>
+  <container id="qtStringList" startPattern="QStringList" inherits="qtList" opLessAllowed="true">
     <size>
-      <function name="resize" action="resize"/>
+      <function name="removeDuplicates" action="change"/>
     </size>
-    <access indexOperator="array-like">
-      <function name="at" yields="at_index"/>
-      <function name="front" yields="item"/>
-      <function name="back" yields="item"/>
-    </access>
   </container>
   <define name="Q_ARG(type, data)" value="QArgument&lt;type &gt;(#type, data)"/>
   <!-- TODO: Enable when ticket 8479 got fixed

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -3622,6 +3622,7 @@
       <function name="crend" yields="end-iterator"/>
     </access>
   </container>
+  <!-- TODO: Inheriting from qtList also inherits from qtContainer which sets "<type templateParameter="0"/>". This is not correct, but seems to do no harm. Currently this can not be unset. -->
   <container id="qtStringList" startPattern="QStringList" inherits="qtList" opLessAllowed="true" itEndPattern=":: iterator|const_iterator|reverse_iterator|const_reverse_iterator">
     <size>
       <function name="removeDuplicates" action="change"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -31,6 +31,19 @@ int QString2()
     return s.size();
 }
 
+QString::iterator QString3()
+{
+    QString qstring1;
+    QString qstring2;
+    // cppcheck-suppress iterators2
+    for (QString::iterator it = qstring1.begin(); it != qstring2.end(); ++it)
+    {}
+
+    QString::iterator it = qstring1.begin();
+    // cppcheck-suppress returnDanglingLifetime
+    return it;
+}
+
 void QList1(QList<int> intListArg)
 {
     for (int i = 0; i <= intListArg.size(); ++i) {
@@ -55,7 +68,10 @@ void QList1(QList<int> intListArg)
 
     QList<QString> qstringList3;
     qstringList3 << "one" << "two";
-    //(void)qstringList3[1]; // TODO: no containerOutOfBounds error should be shown #9242
+    // FIXME: The following containerOutOfBounds suppression is wrong #9242
+    // Please remove the suppression as soon as this is fixed
+    // cppcheck-suppress containerOutOfBounds
+    (void)qstringList3[1];
     // cppcheck-suppress ignoredReturnValue
     qstringList3.startsWith("one");
     // cppcheck-suppress ignoredReturnValue
@@ -81,6 +97,76 @@ void QList1(QList<int> intListArg)
     (void)qstringList4[0];
 }
 
+QList<int>::iterator QList3()
+{
+    QList<int> qlist1;
+    QList<int> qlist2;
+    // cppcheck-suppress iterators2
+    for (QList<int>::iterator it = qlist1.begin(); it != qlist2.end(); ++it)
+    {}
+
+    QList<int>::iterator it = qlist1.begin();
+    // TODO: cppcheck-suppress returnDanglingLifetime
+    return it;
+}
+
+void QStringList1(QStringList stringlistArg)
+{
+    for (int i = 0; i <= stringlistArg.size(); ++i) {
+        // cppcheck-suppress stlOutOfBounds
+        stringlistArg[i] = "abc";
+    }
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    stringlistArg[stringlistArg.length()] = "ab";
+    stringlistArg[stringlistArg.length() - 1] = "ab"; // could be valid
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    stringlistArg[stringlistArg.count()] = "12";
+    stringlistArg[stringlistArg.count() - 1] = "12"; // could be valid
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    (void)stringlistArg[stringlistArg.size()];
+    (void)stringlistArg[stringlistArg.size() - 1]; // could be valid
+
+    QStringList qstringlist1{"one", "two"};
+    (void)qstringlist1[1];
+
+    QStringList qstringlist2 = {"one", "two"};
+    (void)qstringlist2[1];
+
+    QStringList qstringlist3;
+    qstringlist3 << "one" << "two";
+    // FIXME: The following containerOutOfBounds suppression is wrong #9242
+    // Please remove the suppression as soon as this is fixed
+    // cppcheck-suppress containerOutOfBounds
+    (void)qstringlist3[1];
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.startsWith("one");
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.endsWith("one");
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.count();
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.length();
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.size();
+    // cppcheck-suppress ignoredReturnValue
+    qstringlist3.at(5);
+    // cppcheck-suppress invalidFunctionArg
+    (void)qstringlist3.at(-5);
+}
+
+QStringList::iterator QStringList2()
+{
+    QStringList qstringlist1;
+    QStringList qstringlist2;
+    // cppcheck-suppress iterators2
+    for (QStringList::iterator it = qstringlist1.begin(); it != qstringlist2.end(); ++it)
+    {}
+
+    QStringList::iterator it = qstringlist1.begin();
+    // cppcheck-suppress returnDanglingLifetime
+    return it;
+}
+
 void QVector1(QVector<int> intVectorArg)
 {
     for (int i = 0; i <= intVectorArg.size(); ++i) {
@@ -102,7 +188,10 @@ void QVector1(QVector<int> intVectorArg)
 
     QVector<QString> qstringVector3;
     qstringVector3 << "one" << "two";
-    //(void)qstringVector3[1]; // TODO: no containerOutOfBounds error should be shown #9242
+    // FIXME: The following containerOutOfBounds suppression is wrong #9242
+    // Please remove the suppression as soon as this is fixed
+    // cppcheck-suppress containerOutOfBounds
+    (void)qstringVector3[1];
     // cppcheck-suppress ignoredReturnValue
     qstringVector3.startsWith("one");
     // cppcheck-suppress ignoredReturnValue
@@ -117,6 +206,19 @@ void QVector1(QVector<int> intVectorArg)
     qstringVector3.at(5);
     // cppcheck-suppress invalidFunctionArg
     (void)qstringVector3.at(-5);
+}
+
+QVector<int>::iterator QVector2()
+{
+    QVector<int> qvector1;
+    QVector<int> qvector2;
+    // cppcheck-suppress iterators2
+    for (QVector<int>::iterator it = qvector1.begin(); it != qvector2.end(); ++it)
+    {}
+
+    QVector<int>::iterator it = qvector1.begin();
+    // TODO cppcheck-suppress returnDanglingLifetime
+    return it;
 }
 
 // Verify that Qt macros do not result in syntax errors, false positives or other issues.

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -31,6 +31,56 @@ int QString2()
     return s.size();
 }
 
+void QList1(QList<int> intListArg)
+{
+    for (int i = 0; i <= intListArg.size(); ++i) {
+        // cppcheck-suppress stlOutOfBounds
+        intListArg[i] = 1;
+    }
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    intListArg[intListArg.length()] = 5;
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    intListArg[intListArg.count()] = 10;
+    // cppcheck-suppress containerOutOfBoundsIndexExpression
+    printf("val: %d\n", intListArg[intListArg.size()]);
+
+    QList<QString> qstringList1{"one", "two"};
+    (void)qstringList1[1];
+
+    QList<QString> qstringList2 = {"one", "two"};
+    (void)qstringList2[1];
+    qstringList2.clear();
+    // TODO: cppcheck-suppress containerOutOfBounds #9243
+    (void)qstringList2[1];
+
+    QList<QString> qstringList3;
+    qstringList3 << "one" << "two";
+    //(void)qstringList3[1]; // TODO: no containerOutOfBounds error should be shown #9242
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.startsWith("one");
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.endsWith("one");
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.count();
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.length();
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.size();
+    // cppcheck-suppress ignoredReturnValue
+    qstringList3.at(5);
+    // cppcheck-suppress invalidFunctionArg
+    (void)qstringList3.at(-5);
+
+    QList<QString> qstringList4;
+    // cppcheck-suppress containerOutOfBounds
+    (void)qstringList4[0];
+    qstringList4.append("a");
+    (void)qstringList4[0];
+    qstringList4.clear();
+    // TODO: cppcheck-suppress containerOutOfBounds #9243
+    (void)qstringList4[0];
+}
+
 void QVector1(QVector<int> intVectorArg)
 {
     for (int i = 0; i <= intVectorArg.size(); ++i) {


### PR DESCRIPTION
- Add iterator end patterns
- Add/fix size and access functions
- Remove marking QList and QStringList as std-like strings
- QStringList configuration now inherits from QList like it is actually the case