### PR TITLE
Update readme files concerning Visual Studio

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,9 +63,9 @@ make
 
 ### Visual Studio
 
-Use the cppcheck.sln file. The file is configured for Visual Studio 2015, but the platform toolset can be changed easily to older or newer versions. The solution contains platform targets for both x86 and x64.
+Use the cppcheck.sln file. The file is configured for Visual Studio 2019, but the platform toolset can be changed easily to older or newer versions. The solution contains platform targets for both x86 and x64.
 
-To compile with rules, select "Release-PCRE" or "Debug-PCRE" configuration. pcre.lib (pcre64.lib for x64 builds) and pcre.h are expected to be in /externals then.
+To compile with rules, select "Release-PCRE" or "Debug-PCRE" configuration. pcre.lib (pcre64.lib for x64 builds) and pcre.h are expected to be in /externals then. A current version of PCRE for Visual Studio can be obtained using [vcpkg](https://github.com/microsoft/vcpkg).
 
 ### Qt Creator + MinGW
 

--- a/readme.txt
+++ b/readme.txt
@@ -57,12 +57,14 @@ Compiling
 
     Visual Studio
     =============
-        Use the cppcheck.sln file. The file is configured for Visual Studio 2015, but the platform
+        Use the cppcheck.sln file. The file is configured for Visual Studio 2019, but the platform
         toolset can be changed easily to older or newer versions. The solution contains platform
         targets for both x86 and x64.
 
         To compile with rules, select "Release-PCRE" or "Debug-PCRE" configuration.
         pcre.lib (pcre64.lib for x64 builds) and pcre.h are expected to be in /externals then.
+        A current version of PCRE for Visual Studio can be obtained using vcpkg:
+        https://github.com/microsoft/vcpkg
 
     Qt Creator + mingw
     ==================


### PR DESCRIPTION
- The cppcheck.sln file is configured for Visual Studio 2019
  See commit: ae86536
- Add information on how to obtain a current version of PCRE for
  Visual Studio using vcpkg from https://github.com/microsoft/vcpkg