### PR TITLE
Improve pointers processing in checkcondition

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -335,7 +335,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
     const Token * lastTok = precedes(tok, end) ? end : tok;
     // If this is in a loop then check if variables are modified in the entire scope
     const Token * endToken = (isInLoopCondition(tok) || isInLoopCondition(varTok) || var->scope() != tok->scope()) ? var->scope()->bodyEnd : lastTok;
-    if (!var->isConst() && (!precedes(varTok, endToken) || isVariableChanged(varTok, endToken, tok->varId(), false, nullptr, cpp)))
+    if (!var->isConst() && (!precedes(varTok, endToken) || isVariableChanged(varTok, endToken, tok->varId(), false, nullptr, cpp, true)))
         return tok;
     if (precedes(varTok, endToken) && isAliased(varTok, endToken, tok->varId()))
         return tok;
@@ -363,7 +363,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
                 return tok;
             if (var2->isStatic() && !var2->isConst())
                 return tok;
-            if (!var2->isConst() && (!precedes(tok2, endToken2) || isVariableChanged(tok2, endToken2, tok2->varId(), false, nullptr, cpp)))
+            if (!var2->isConst() && (!precedes(tok2, endToken2) || isVariableChanged(tok2, endToken2, tok2->varId(), false, nullptr, cpp, true)))
                 return tok;
             if (precedes(tok2, endToken2) && isAliased(tok2, endToken2, tok2->varId()))
                 return tok;

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -132,8 +132,27 @@ bool isVariableChangedByFunctionCall(const Token *tok, nonneg int varid, const S
  */
 bool isVariableChangedByFunctionCall(const Token *tok, const Settings *settings, bool *inconclusive);
 
+/** Is variable changed by function call?
+ * In case the answer of the question is inconclusive, e.g. because the function declaration is not known
+ * the return value is false and the output parameter inconclusive is set to true
+ *
+ * @param tok           token of variable in function call
+ * @param settings      program settings
+ * @param pointedvalue  if true return true also if tok is a pointer and the pointed value is changed
+ *                      if false, we only care if tok is changed (we don't care if it is a pointer or if the pointed value is changed or not)
+ * @param inconclusive pointer to output variable which indicates that the answer of the question is inconclusive
+ */
+bool isVariableChangedByFunctionCall(const Token *tok, bool pointedvalue, const Settings *settings, bool *inconclusive);
+
 /** Is variable changed in block of code? */
 bool isVariableChanged(const Token *start, const Token *end, const nonneg int varid, bool globalvar, const Settings *settings, bool cpp, int depth = 20);
+
+/**
+ * @param pointedvalue  if true return true also if tok is a pointer and the pointed value is changed
+ *                      if false, we only care if tok is changed (we don't care if it is a pointer or if the pointed value is changed or not)
+ */
+bool isVariableChanged(const Token *start, const Token *end, const nonneg int varid, bool globalvar, const Settings *settings, bool cpp, bool pointedvalue, int depth = 20);
+
 
 bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp, int depth = 20);
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -23,6 +23,7 @@
 #include "checkcondition.h"
 
 #include "astutils.h"
+#include "checknullpointer.h" // <- CheckNullPointer::isPointerDeRef
 #include "errorlogger.h"
 #include "settings.h"
 #include "symboldatabase.h"
@@ -452,8 +453,10 @@ void CheckCondition::duplicateCondition()
 
         bool modified = false;
         visitAstNodes(cond1, [&](const Token *tok3) {
+            bool unknown = false;
+            const bool varIsDereferenced = tok3->variable() && tok3->variable()->isPointer() && CheckNullPointer::isPointerDeRef(tok3, unknown, mSettings);
             if (tok3->varId() > 0 &&
-                isVariableChanged(scope.classDef->next(), cond2, tok3->varId(), false, mSettings, mTokenizer->isCPP())) {
+                isVariableChanged(scope.classDef->next(), cond2, tok3->varId(), false, mSettings, mTokenizer->isCPP(), varIsDereferenced)) {
                 modified = true;
                 return ChildrenToVisit::done;
             }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2704,7 +2704,7 @@ void CheckOther::checkAccessOfMovedVariable()
                 else
                     inconclusive = true;
             } else {
-                const bool isVariableChanged = isVariableChangedByFunctionCall(tok, mSettings, &inconclusive);
+                const bool isVariableChanged = isVariableChangedByFunctionCall(tok, true, mSettings, &inconclusive);
                 accessOfMoved = !isVariableChanged && checkUninitVar.isVariableUsage(tok, false, CheckUninitVar::NO_ALLOC);
                 if (inconclusive) {
                     accessOfMoved = !isMovedParameterAllowedForInconclusiveFunction(tok);

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -413,7 +413,7 @@ static std::list<std::pair<const Token *, MathLib::bigint>> getUnsafeFunction(co
             tok2 = tok2->linkAt(1);
             if (Token::findmatch(tok2->link(), "return|throw", tok2))
                 return ret;
-            if (isVariableChanged(tok2->link(), tok2, argvar->declarationId(), false, settings, tokenizer->isCPP()))
+            if (isVariableChanged(tok2->link(), tok2, argvar->declarationId(), false, settings, tokenizer->isCPP(), true))
                 return ret;
         }
         if (Token::Match(tok2, "%oror%|&&|?")) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2304,7 +2304,7 @@ static bool valueFlowForward(Token * const               startToken,
                 return false;
             }
 
-            if (isVariableChanged(start, end, varid, var->isGlobal(), settings, tokenlist->isCPP())) {
+            if (isVariableChanged(start, end, varid, var->isGlobal(), settings, tokenlist->isCPP(), true)) {
                 if ((!read || number_of_if == 0) &&
                     Token::simpleMatch(tok2, "if (") &&
                     !(Token::simpleMatch(end, "} else {") &&

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3164,6 +3164,7 @@ private:
     }
 
     void duplicateCondition() {
+        
         check("void f(bool x) {\n"
               "    if(x) {}\n"
               "    if(x) {}\n"
@@ -3222,6 +3223,61 @@ private:
               "  if (y.empty()) return;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(int *x) {\n"
+              "    if(*x == 1) {}\n"
+              "    if(*x == 1) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The if condition is the same as the previous if condition\n",
+                      errout.str());
+                      
+
+        
+        check("void f(int *x) {\n"
+              "    if(*x == 1) { *x = 0; }\n"
+              "    if(*x == 1) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int *x, int *y) {\n"
+              "    if(x == y) { *x = 0; }\n"
+              "    if(x == y) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) The if condition is the same as the previous if condition\n",
+                      errout.str());
+                      
+
+        check("void g(int *a);\n"
+              "void f(int *x) {\n"
+              "    if(*x == 1) { g(x); }\n"
+              "    if(*x == 1) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        
+        check("void g(int &a);\n"
+              "void f(int x) {\n"
+              "    if(x == 1) { g(x); }\n"
+              "    if(x == 1) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void g(const int &a);\n"
+              "void f(int x) {\n"
+              "    if(x == 1) { g(x); }\n"
+              "    if(x == 1) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (style) The if condition is the same as the previous if condition\n",
+                      errout.str());
+
+        check("void g(int *a);\n"
+              "void f(int *x) {\n"
+              "    if(x == nullptr) { g(x); }\n"
+              "    if(x == nullptr) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (style) The if condition is the same as the previous if condition\n",
+                      errout.str());
+                      
     }
 
     void checkInvalidTestForOverflow() {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2554,7 +2554,7 @@ private:
               "    if (a != 0)\n"
               "      *p = 0;\n"
               "}", true);
-        TODO_ASSERT_EQUALS("[test.cpp:3]: (warning) Possible null pointer dereference if the default parameter value is used: p\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Possible null pointer dereference if the default parameter value is used: p\n", errout.str());
 
         check("void f(int *p = 0) {\n"
               "    p = a;\n"


### PR DESCRIPTION
* Improve pointers processing in checkcondition

Condition with pointers used to confused cppcheck.
Typically, there were FP with the following:
```
void g(int *a);
void f(int *x) {
    if(*x == 1) { g(x); }
    if(*x == 1) {}
}
```
[test.cpp:3] -> [test.cpp:4]: (style) The if condition is the same as
the previous if condition

* Fix regression after changing isVariableChanged*

There might be other if they are not covered by the tests...
