### PR TITLE
Simplify some suspicious code

### DIFF
--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -217,8 +217,8 @@ public:
          */
         bool isSameFamily(const TemplateSimplifier::TokenAndName &decl) const {
             // maks sure a family flag is set and matches
-            return (flags & (fIsClass | fIsFunction | fIsVariable)) &
-                   (decl.flags & (fIsClass | fIsFunction | fIsVariable));
+            const unsigned int flagsToTest = fIsClass | fIsFunction | fIsVariable;
+            return ((flags & flagsToTest) & (decl.flags & flagsToTest)) != 0;
         }
     };
 


### PR DESCRIPTION
This is for review only.

I changed the code to better underline the problem. Nothing in the surrounding code seems to prevent "flags" from being say "class | function" and "decl.cflags" from being say "function | variable" at the same time. If this happens then this code yields "true" although it doesn't look like "same family".

@danmar Is my analysis fair? Did I overlook anything?