### PR TITLE
Fix #9253: leakNoVarFunctionCall: do not warn if freopen opens standa…

### DIFF
--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -115,6 +115,11 @@ public:
     AllocType getReallocationType(const Token *tok2, nonneg int varid) const;
 
     /**
+     * Check if token reopens a standard stream
+     * @param tok token to check
+     */
+    bool isReopenStandardStream(const Token *tok) const;
+    /**
      * Report that there is a memory leak (new/malloc/etc)
      * @param tok token where memory is leaked
      * @param varname name of variable

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2139,6 +2139,11 @@ private:
               "    42, strcmp(strdup(a), b);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Allocation with strdup, strcmp doesn't release it.\n", errout.str());
+
+        check("void f() {\n"
+              "   assert(freopen(\"/dev/null\", \"r\", stdin));\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void missingAssignment() {


### PR DESCRIPTION
…rd stream

This fixes false positives from daca@home where freopen is used to
reopen a standard stream. There is no longer a warning for

	void f() {
		assert(freopen("/dev/null", "r", stdin));
	}