### PR TITLE
Fix FP with negative index and negated condition

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3894,6 +3894,7 @@ struct ValueFlowConditionHandler {
                             if (parent && (parent->str() == "!" || Token::simpleMatch(parent, "== false"))) {
                                 check_if = !check_if;
                                 check_else = !check_else;
+                                std::swap(cond.true_values, cond.false_values);
                             }
                             tok2 = parent;
                         }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -1379,6 +1379,14 @@ private:
               "  v[-11] = 123;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (error) Array index -11 is out of bounds.\n", errout.str());
+
+        check("int f(int x, const std::vector<int>& a) {\n"
+              "    if (!(x < 5))\n"
+              "        return a[x - 5];\n"
+              "    else\n"
+              "        return a[4 - x];\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
This wont warn of negative indices for cases like this:

```cpp
int f(int x, const std::vector<int>& a) {
    if (!(x < 5)) {
        return a[x - 5];
    } else {
        return a[4 - x];
    }
}
```