### PR TITLE
leakNoVarFunctionCall: Use AST more (fix #9252)

### DIFF
--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2058,7 +2058,6 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
-        tokenizer.simplifyTokenList2();
 
         // Check for memory leaks..
         CheckMemoryLeakNoVar checkMemoryLeakNoVar(&tokenizer, &settings, this);
@@ -2142,6 +2141,22 @@ private:
 
         check("void f() {\n"
               "   assert(freopen(\"/dev/null\", \"r\", stdin));\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void x() {\n"
+              "    strcpy(a, (void*)strdup(p));\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Allocation with strdup, strcpy doesn't release it.\n", errout.str());
+
+        check("void* malloc1() {\n"
+              "    return (malloc(1));\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("char *x() {\n"
+              "    char *ret = (char*)strcpy(malloc(10), \"abc\");\n"
+              "    return ret;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
Use the AST a little bit more to improve the check. In order to do so,
rewrite the check to work from the outer function first and then check
the arguments, instead of the other way around.

It also fixes Trac ticket #9252, no warning is now given for

	void* malloc1() {
		return(malloc1(1));
	}

This FP seems to be common in daca results.

It also makes it possible to improve handling of casts, for example
cppcheck now warns about

	void f() {
		strcpy(a, (void*) strdup(p));
	}

But not for

	char* f() {
		char* ret = (char*)strcpy(malloc(10), "abc");
		return ret;
	}

These FP/FN were introduced when the check was switched to use the
simplified token list.