### PR TITLE
Fix FP: Unitialized variable when using a pointer

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1299,7 +1299,7 @@ void CheckUninitVar::valueFlowUninit()
             }
             if (!tok->variable())
                 continue;
-            if (Token::simpleMatch(tok->astParent(), ".") && tok->astParent()->astOperand1() == tok)
+            if (Token::Match(tok->astParent(), ". %var%") && tok->astParent()->astOperand1() == tok)
                 continue;
             auto v = std::find_if(tok->values().begin(), tok->values().end(), std::mem_fn(&ValueFlow::Value::isUninitValue));
             if (v == tok->values().end())
@@ -1307,6 +1307,11 @@ void CheckUninitVar::valueFlowUninit()
             if (v->isInconclusive())
                 continue;
             if (!isVariableUsage(tok, tok->variable()->isPointer(), tok->variable()->isArray() ? ARRAY : NO_ALLOC))
+                continue;
+            if (v->indirect > 1 || v->indirect < 0)
+                continue;
+            bool unknown;
+            if (v->indirect == 1 && !CheckNullPointer::isPointerDeRef(tok, unknown, mSettings))
                 continue;
             if (isVariableChanged(tok, mSettings, mTokenizer->isCPP()))
                 continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5712,7 +5712,7 @@ ValueFlow::Value::Value(const Token *c, long long val)
       safe(false),
       conditional(false),
       defaultArg(false),
-      indirect(false),
+      indirect(0),
       lifetimeKind(LifetimeKind::Object),
       lifetimeScope(LifetimeScope::Local),
       valueKind(ValueKind::Possible)

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -101,6 +101,7 @@ namespace ValueFlow {
                    varId == rhs.varId &&
                    conditional == rhs.conditional &&
                    defaultArg == rhs.defaultArg &&
+                   indirect == rhs.indirect &&
                    valueKind == rhs.valueKind;
         }
 

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -172,7 +172,7 @@ namespace ValueFlow {
         /** Is this value passed as default parameter to the function? */
         bool defaultArg;
 
-        long long indirect;
+        int indirect;
 
         enum class LifetimeKind {Object, Lambda, Iterator, Address} lifetimeKind;
 

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -53,6 +53,7 @@ namespace ValueFlow {
               safe(false),
               conditional(false),
               defaultArg(false),
+              indirect(0),
               lifetimeKind(LifetimeKind::Object),
               lifetimeScope(LifetimeScope::Local),
               valueKind(ValueKind::Possible)
@@ -170,6 +171,8 @@ namespace ValueFlow {
 
         /** Is this value passed as default parameter to the function? */
         bool defaultArg;
+
+        long long indirect;
 
         enum class LifetimeKind {Object, Lambda, Iterator, Address} lifetimeKind;
 

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -4012,6 +4012,24 @@ private:
                         "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        valueFlowUninit("void f(bool * x) {\n"
+                        "    if (x != nullptr)\n"
+                        "        x = 1;\n"
+                        "}\n"
+                        "void g() {\n"
+                        "    bool x;\n"
+                        "    f(&x);\n"
+                        "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        valueFlowUninit("void f() {\n"
+                        "    bool b;\n"
+                        "    bool * x = &b;\n"
+                        "    if (x != nullptr)\n"
+                        "        x = 1;\n"
+                        "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         valueFlowUninit("struct A { bool b; };"
                         "void f(A * x) {\n"
                         "    x->b = false;\n"


### PR DESCRIPTION
This fixes the FP in cases like this:

```cpp
void f() {
    bool b;
    bool * x = &b;
    if (x != nullptr)
        x = 1;
}
```

It tracks the indirection of the uninit value in valueflow. 