### PR TITLE
leakNoReturnVar: Don't break early

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1000,7 +1000,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
             functionName == "free" ||
             functionName == "fclose" ||
             functionName == "realloc")
-            break;
+            continue;
 
         if (!CheckMemoryLeakInFunction::test_white_list(functionName, mSettings, mTokenizer->isCPP()))
             continue;
@@ -1016,7 +1016,6 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
             if (isReopenStandardStream(arg))
                 continue;
             functionCallLeak(arg, arg->str(), functionName);
-            break;
         }
 
     }

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2159,6 +2159,18 @@ private:
               "    return ret;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    free(malloc(1));\n"
+              "    strcpy(a, strdup(p));\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Allocation with strdup, strcpy doesn't release it.\n", errout.str());
+
+        check("void f() {\n"
+              "    memcmp(calloc(10, 10), strdup(q), 100);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (error) Allocation with calloc, memcmp doesn't release it.\n"
+                      "[test.cpp:2]: (error) Allocation with strdup, memcmp doesn't release it.\n", errout.str());
     }
 
     void missingAssignment() {


### PR DESCRIPTION
There seems to be no reason for stopping checking the scope if a call to
free() is seen (or fclose() or realloc()), so just continue checking.
Also, if there are multiple arguments, check all, perhaps there are more
memory leaks to warn about.