### PR TITLE
misra: fix rule 5.4 false positive

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -880,7 +880,8 @@ class MisraChecker:
 
         for x, m_var1 in enumerate(macro):
             for y, m_var2 in enumerate(macro):
-                if x < y and macro[m_var1]["name"][:num_sign_chars] == macro[m_var2]["name"][:num_sign_chars]:
+                if x < y and macro[m_var1]["name"] != macro[m_var2]["name"] and \
+                    macro[m_var1]["name"][:num_sign_chars] == macro[m_var2]["name"][:num_sign_chars]:
                     if m_var1.linenr > m_var2.linenr:
                         self.reportError(m_var1, 5, 4)
                     else:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -104,6 +104,11 @@ void misra_5_3_enum_hidesfunction_31y(void) {} //5.3
 #define misra_5_4_macro_hides_macro__31y 2 //5.4
 #define m1(misra_5_4_param_hides_macro__31y) 1 //5.4
 #define m2(misra_5_4_param_hides_param__31x,misra_5_4_param_hides_param__31y) 1 //5.4
+#ifdef misra_5_4_macro_hides_macro__31x
+#define misra_5_4_macro 1 // no warning
+#else
+#define misra_5_4_macro 2 // no warning
+#endif
 
 #define misra_5_5_var_hides_macro____31x 1
 #define misra_5_5_functionhides_macro31x 1


### PR DESCRIPTION
I apologize if I'm jumping the gun since I'm evaluating cppcheck but I don't have a copy of the MISRA rules yet. But from I've deduced, cppcheck misra.py raises a false positive when a macro is defined "twice" in a #if/#else, e.g.

```
#ifdef misra_5_4_macro_hides_macro__31x
#define misra_5_4_macro 1 // no warning
#else
#define misra_5_4_macro 2 // no warning
#endif
```

misra.py thinks these are two distinct macros that have the same 31/63-character prefix, which would violate rule 5.4.
