### PR TITLE
Run test fixtures as seperate tests so they can run in parallel

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,16 @@
 if (BUILD_TESTS)
 
+    cmake_policy(SET CMP0064 NEW)
+    cmake_policy(SET CMP0057 NEW)
+
+    include(CTest)
+
+    find_package(Threads REQUIRED)
+    include(ProcessorCount)
+    ProcessorCount(N)
+    set(CTEST_PARALLEL_LEVEL ${N} CACHE STRING "CTest parallel level")
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C ${CMAKE_CFG_INTDIR} --timeout 90)
+
     include_directories(${PROJECT_SOURCE_DIR}/lib/ ${PROJECT_SOURCE_DIR}/cli/)
     include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/tinyxml)
     include_directories(${PROJECT_SOURCE_DIR}/externals/simplecpp/)
@@ -24,10 +35,35 @@ if (BUILD_TESTS)
     endif()
 
     add_dependencies(testrunner copy_cfg)
-
-    add_test(NAME testrunner COMMAND testrunner WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-
-    add_custom_target(check COMMAND $<TARGET_FILE:testrunner> -q WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     add_dependencies(check testrunner)
+
+    set(SKIP_TESTS "" CACHE STRING "A list of tests to skip")
+
+    function(add_fixture NAME)
+        if (${NAME} IN_LIST SKIP_TESTS)
+        else()
+            add_test(NAME ${NAME} COMMAND testrunner ${NAME} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        endif()
+    endfunction()
+
+    function(fixture_cost NAME COST)
+        if(TEST ${NAME})
+            set_tests_properties(${NAME} PROPERTIES COST ${COST})
+        endif()
+    endfunction()
+
+    foreach(SRC ${srcs})
+        file(STRINGS ${SRC} FIXTURE_LINE REGEX "TestFixture\\(" LIMIT_COUNT 1)
+        if(FIXTURE_LINE MATCHES "TestFixture\\(\"([a-zA-z0-9]+)\"\\)")
+            add_fixture(${CMAKE_MATCH_1})
+        endif()
+    endforeach()
+
+    # Set cost of the more expensive tests to help improve parallel scheduling
+    # of tests
+    fixture_cost(TestIO 20)
+    fixture_cost(TestThreadExecutor 5)
+    fixture_cost(TestLeakAutoVar 4)
+    fixture_cost(TestTokenizer 4)
 
 endif()


### PR DESCRIPTION
This improves the test run time on my machine from 1 minute down to 20 seconds.

I also added a cmake flag to skip some tests. The `TestIO` is really slow and takes about 18 seconds. I can set cmake to skip this test. This brings down the test run time to 4 seconds.