### PR TITLE
Fix false positive in initializationListUsage

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -950,7 +950,7 @@ void CheckClass::initializationListUsage()
                 break;
             if (Token::Match(tok, "try|do {"))
                 break;
-            if (!Token::Match(tok, "%var% =") || tok->strAt(-1) == "*")
+            if (!Token::Match(tok, "%var% =") || tok->strAt(-1) == "*" || (tok->strAt(-1) == "." && tok->strAt(-2) != "this"))
                 continue;
 
             const Variable* var = tok->variable();

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6692,6 +6692,15 @@ private:
                                      "    }\n"
                                      "};");
         ASSERT_EQUALS("", errout.str());
+
+        // don't warn if some other instance's members are assigned to
+        checkInitializationListUsage("class C {\n"
+                             "public:\n"
+                             "    C(C& c) : m_i(c.m_i) { c.m_i = (Foo)-1; }\n"
+                             "private:\n"
+                             "    Foo m_i;\n"
+                             "};");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
https://sourceforge.net/p/cppcheck/discussion/general/thread/d5b690ef19/
Check that we warn only about using the initializer list when we assign
the object being constructed.