### PR TITLE
Remove useless check introduced by 717aa826d8c98dab533b7c2166eb412b14…

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -950,7 +950,7 @@ void CheckClass::initializationListUsage()
                 break;
             if (Token::Match(tok, "try|do {"))
                 break;
-            if (!Token::Match(tok, "%var% =") || tok->strAt(-1) == "*" || (tok->strAt(-1) == "." && tok->strAt(-2) != "this"))
+            if (!Token::Match(tok, "%var% =") || tok->strAt(-1) == "*" || tok->strAt(-1) == ".")
                 continue;
 
             const Variable* var = tok->variable();


### PR DESCRIPTION
…22b14d

I was confused by the naming in the forum entry (`this`/`that`). `this` would
be a pointer, there's no point checking for it there.

Sorry for the noise @danmar, I should have stayed in holiday one more day.