### PR TITLE
Fix issue 8897: Huge array initializations

### DIFF
--- a/lib/token.h
+++ b/lib/token.h
@@ -117,8 +117,12 @@ struct TokenImpl {
     };
     struct CppcheckAttributes *mCppcheckAttributes;
 
+    // For memoization, to speed up parsing of huge arrays #8897
+    enum Cpp11init {UNKNOWN, CPP11INIT, NOINIT} mCpp11init;
+
     void setCppcheckAttribute(CppcheckAttributes::Type type, MathLib::bigint value);
     bool getCppcheckAttribute(CppcheckAttributes::Type type, MathLib::bigint *value) const;
+
 
     TokenImpl()
         : mVarId(0)
@@ -139,6 +143,7 @@ struct TokenImpl {
         , mTemplateSimplifierPointers()
         , mScopeInfo(nullptr)
         , mCppcheckAttributes(nullptr)
+        , mCpp11init(UNKNOWN)
     {}
 
     ~TokenImpl();
@@ -1220,6 +1225,9 @@ public:
 
     void scopeInfo(std::shared_ptr<ScopeInfo2> newScopeInfo);
     std::shared_ptr<ScopeInfo2> scopeInfo() const;
+
+    void setCpp11init(bool cpp11init) const { mImpl->mCpp11init=cpp11init ? TokenImpl::CPP11INIT : TokenImpl::NOINIT; }
+    TokenImpl::Cpp11init isCpp11init() const { return mImpl->mCpp11init; }
 };
 
 /// @}

--- a/lib/token.h
+++ b/lib/token.h
@@ -118,11 +118,10 @@ struct TokenImpl {
     struct CppcheckAttributes *mCppcheckAttributes;
 
     // For memoization, to speed up parsing of huge arrays #8897
-    enum Cpp11init {UNKNOWN, CPP11INIT, NOINIT} mCpp11init;
+    enum class Cpp11init {UNKNOWN, CPP11INIT, NOINIT} mCpp11init;
 
     void setCppcheckAttribute(CppcheckAttributes::Type type, MathLib::bigint value);
     bool getCppcheckAttribute(CppcheckAttributes::Type type, MathLib::bigint *value) const;
-
 
     TokenImpl()
         : mVarId(0)
@@ -143,7 +142,7 @@ struct TokenImpl {
         , mTemplateSimplifierPointers()
         , mScopeInfo(nullptr)
         , mCppcheckAttributes(nullptr)
-        , mCpp11init(UNKNOWN)
+        , mCpp11init(Cpp11init::UNKNOWN)
     {}
 
     ~TokenImpl();
@@ -1226,7 +1225,7 @@ public:
     void scopeInfo(std::shared_ptr<ScopeInfo2> newScopeInfo);
     std::shared_ptr<ScopeInfo2> scopeInfo() const;
 
-    void setCpp11init(bool cpp11init) const { mImpl->mCpp11init=cpp11init ? TokenImpl::CPP11INIT : TokenImpl::NOINIT; }
+    void setCpp11init(bool cpp11init) const { mImpl->mCpp11init=cpp11init ? TokenImpl::Cpp11init::CPP11INIT : TokenImpl::Cpp11init::NOINIT; }
     TokenImpl::Cpp11init isCpp11init() const { return mImpl->mCpp11init; }
 };
 

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -543,17 +543,17 @@ static Token * findCppTypeInitPar(Token *tok)
 static bool iscpp11init_impl(const Token * const tok);
 static bool iscpp11init(const Token * const tok)
 {
-    if (tok->isCpp11init() == TokenImpl::UNKNOWN)
+    if (tok->isCpp11init() == TokenImpl::Cpp11init::UNKNOWN)
         tok->setCpp11init(iscpp11init_impl(tok));
-    return tok->isCpp11init() == TokenImpl::CPP11INIT;
+    return tok->isCpp11init() == TokenImpl::Cpp11init::CPP11INIT;
 }
 
 static bool iscpp11init_impl(const Token * const tok)
 {
     const Token *nameToken = tok;
     while (nameToken && nameToken->str() == "{") {
-        if(nameToken->isCpp11init() != TokenImpl::UNKNOWN)
-            return nameToken->isCpp11init() == TokenImpl::CPP11INIT;
+        if(nameToken->isCpp11init() != TokenImpl::Cpp11init::UNKNOWN)
+            return nameToken->isCpp11init() == TokenImpl::Cpp11init::CPP11INIT;
         nameToken = nameToken->previous();
         if (nameToken && nameToken->str() == "," && Token::simpleMatch(nameToken->previous(), "} ,"))
             nameToken = nameToken->linkAt(-1);

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -540,10 +540,20 @@ static Token * findCppTypeInitPar(Token *tok)
 }
 
 // X{} X<Y>{} etc
+static bool iscpp11init_impl(const Token * const tok);
 static bool iscpp11init(const Token * const tok)
+{
+    if (tok->isCpp11init() == TokenImpl::UNKNOWN)
+        tok->setCpp11init(iscpp11init_impl(tok));
+    return tok->isCpp11init() == TokenImpl::CPP11INIT;
+}
+
+static bool iscpp11init_impl(const Token * const tok)
 {
     const Token *nameToken = tok;
     while (nameToken && nameToken->str() == "{") {
+        if(nameToken->isCpp11init() != TokenImpl::UNKNOWN)
+            return nameToken->isCpp11init() == TokenImpl::CPP11INIT;
         nameToken = nameToken->previous();
         if (nameToken && nameToken->str() == "," && Token::simpleMatch(nameToken->previous(), "} ,"))
             nameToken = nameToken->linkAt(-1);


### PR DESCRIPTION
iscpp11init would take a lot of time when parsing huge arrays.
This patch add memoization to keeps track that we are parsing an array,
and allows to propagate the result without re-parsing the array for each
of its members.