### PR TITLE
Add missing xml closing tag to manual.docbook

### DIFF
--- a/man/manual.docbook
+++ b/man/manual.docbook
@@ -1217,7 +1217,7 @@ Checking pen1.c...
   &lt;/resource&gt;
 &lt;/def&gt;</programlisting>
 
-        <para>Functions that reallocate memory can be configured using a realloc tag. The input argument which points to the memory that shall be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:
+        <para>Functions that reallocate memory can be configured using a realloc tag. The input argument which points to the memory that shall be reallocated can also be configured (the default is the first argument). As an example, here is a configuration file for the fopen, freopen and fclose functions from the c standard library:</para>
 
         <programlisting>&lt;?xml version="1.0"?&gt;
 &lt;def&gt;


### PR DESCRIPTION
This fixes xml parsing errors