### PR TITLE
donate-cpu.py: Improve detection of Ruby library usage

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -40,7 +40,7 @@ import platform
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.33"
+CLIENT_VERSION = "1.1.34"
 
 
 def check_requirements():
@@ -290,7 +290,7 @@ def scan_package(work_path, cppcheck_path, jobs):
                        'openmp': ['<omp.h>'],
                        'python': ['<Python.h>', '"Python.h"'],
                        'qt': ['<QApplication>', '<QList>', '<QObject>', '<QString>', '<QWidget>', '<QtWidgets>', '<QtGui'],
-                       'ruby': ['<ruby.h>', '<ruby/'],
+                       'ruby': ['<ruby.h>', '<ruby/', '"ruby.h"'],
                        'sdl': ['<SDL.h>', '<SDL/SDL.h>', '<SDL2/SDL.h>'],
                        'sqlite3': ['<sqlite3.h>', '"sqlite3.h"'],
                        'tinyxml2': ['<tinyxml2', '"tinyxml2'],


### PR DESCRIPTION
I looked into many packages where the detection failed and they all use
`#include "ruby.h"`. Some of these packages seem to be Ruby modules,
others seem to be "normal" software.