### PR TITLE
Add deeper analysis of when a function changes a containers size

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -120,6 +120,9 @@ bool isUniqueExpression(const Token* tok);
 /** Is scope a return scope (scope will unconditionally return) */
 bool isReturnScope(const Token *endToken, const Settings * settings = nullptr, bool functionScope=false);
 
+/// Return the token to the function and the argument number
+const Token * getTokenArgumentFunction(const Token * tok, int& argn);
+
 /** Is variable changed by function call?
  * In case the answer of the question is inconclusive, e.g. because the function declaration is not known
  * the return value is false and the output parameter inconclusive is set to true

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5324,8 +5324,13 @@ static bool isContainerSizeChangedByFunction(const Token *tok, int depth = 20)
         if (arg->isConst())
             return false;
         const Scope * scope = fun->functionScope;
-        if (scope && depth > 0 && isContainerSizeChanged(arg->declarationId(), scope->bodyStart, scope->bodyEnd, depth - 1))
-            return true;
+        if (scope) {
+            // Argument not used
+            if (!arg->nameToken())
+                return false;
+            if (depth > 0)
+                return isContainerSizeChanged(arg->declarationId(), scope->bodyStart, scope->bodyEnd, depth - 1);
+        }
     }
 
     bool inconclusive = false;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5312,6 +5312,9 @@ static bool isContainerSizeChangedByFunction(const Token *tok, int depth = 20)
     if (Token::simpleMatch(tok->astParent(), "["))
         return false;
 
+    // address of variable
+    const bool addressOf = tok->astParent() && tok->astParent()->isUnaryOp("&");
+
     int narg;
     const Token * ftok = getTokenArgumentFunction(tok, narg);
     if (!ftok)
@@ -5319,7 +5322,7 @@ static bool isContainerSizeChangedByFunction(const Token *tok, int depth = 20)
     const Function * fun = ftok->function();
     if (fun) {
         const Variable *arg = fun->getArgumentVar(narg);
-        if (!arg->isReference())
+        if (!arg->isReference() && !addressOf)
             return false;
         if (arg->isConst())
             return false;

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -3937,6 +3937,89 @@ private:
                "}";
         ASSERT(tokenValues(code, "x . front").empty());
 
+        code = "void g(std::list<int>&);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
+        code = "void g(const std::list<int>&);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(std::list<int>);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(int&);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x[0]);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(int&);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x.back());\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(std::list<int>&) {}\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(std::list<int>& y) { y.push_back(1); }\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
+        code = "void h(std::list<int>&);\n"
+               "void g(std::list<int>& y) { h(y); }\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
+        code = "void h(const std::list<int>&);\n"
+               "void g(std::list<int>& y) { h(y); }\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void h(const std::list<int>&);\n"
+               "void g(std::list<int>& y) { h(y); y.push_back(1); }\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
         code = "void f(std::vector<int> ints) {\n" // #8697
                "  if (ints.empty())\n"
                "    abort() << 123;\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -3945,6 +3945,14 @@ private:
                "}";
         ASSERT(tokenValues(code, "x . front").empty());
 
+        code = "void g(std::list<int>*);\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(&x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
         code = "void g(const std::list<int>&);\n"
                "void f() {\n"
                "  std::list<int> x;\n"
@@ -3989,6 +3997,22 @@ private:
                "void f() {\n"
                "  std::list<int> x;\n"
                "  g(x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT(tokenValues(code, "x . front").empty());
+
+        code = "void g(std::list<int>*) {}\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(&x);\n"
+               "  x.front();\n"
+               "}";
+        ASSERT_EQUALS("", isKnownContainerSizeValue(tokenValues(code, "x . front"), 0));
+
+        code = "void g(std::list<int>* y) { y->push_back(1); }\n"
+               "void f() {\n"
+               "  std::list<int> x;\n"
+               "  g(&x);\n"
                "  x.front();\n"
                "}";
         ASSERT(tokenValues(code, "x . front").empty());


### PR DESCRIPTION
This wont just assume a function changes the container. If possible, it will inspect the function to see if it changes the container size. If the function body is not available it falls back on `isVariableChangedByFunctionCall`.