### PR TITLE
posix.cfg: Fix vsyslog() configuration

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -2165,15 +2165,16 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- void vsyslog(int priority, const char *format, va_list ap); -->
   <function name="vsyslog">
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
     <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
     </arg>
-    <formatstr/>
     <arg nr="2" direction="in">
+      <not-uninit/>
       <formatstr/>
     </arg>
-    <arg nr="any">
+    <arg nr="3" direction="in">
       <not-uninit/>
     </arg>
   </function>

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -20,6 +20,8 @@
 #include <time.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <syslog.h>
+#include <stdarg.h>
 
 void memleak_scandir(void)
 {
@@ -53,11 +55,15 @@ void no_memleak_scandir(void)
     free(namelist);
 }
 
-void validCode()
+void validCode(va_list valist_arg1, va_list valist_arg2)
 {
     void *ptr;
     if (posix_memalign(&ptr, sizeof(void *), sizeof(void *)) == 0)
         free(ptr);
+    syslog(LOG_ERR, "err %u", 0U);
+    syslog(LOG_WARNING, "warn %d %d", 5, 1);
+    vsyslog(LOG_EMERG, "emerg %d", valist_arg1);
+    vsyslog(LOG_INFO, "test %s %d %p", valist_arg2);
 }
 
 void bufferAccessOutOfBounds(int fd)


### PR DESCRIPTION
Add tests to make sure no false positives are reported.
Found the issue via daca@home