### PR TITLE
Loosen restrictions on MISRA rules text structure

### DIFF
--- a/addons/test/misra/misra_rules_multiple_lines.txt
+++ b/addons/test/misra/misra_rules_multiple_lines.txt
@@ -18,7 +18,7 @@ Rule 1.5
 Should
  starts from lowercase letter.
 Rule 1.6
-Should
+Can
 
-not contain empty lines.
+contain empty lines.
 

--- a/addons/test/test-misra.py
+++ b/addons/test/test-misra.py
@@ -49,7 +49,7 @@ def test_loadRuleTexts_mutiple_lines(checker):
     assert(checker.ruleTexts[103].text == "Multiple lines text.")
     assert(checker.ruleTexts[104].text == "Should")
     assert(checker.ruleTexts[105].text == "Should")
-    assert(checker.ruleTexts[106].text == "Should")
+    assert(checker.ruleTexts[106].text == "Can contain empty lines.")
 
 
 def test_verifyRuleTexts(checker, capsys):


### PR DESCRIPTION
Version 1.88 changed the parsing of the MISRA rules file adding a
severity setting.  This caused a regression in rule parsing.

In particular the following format used to parse cleanly and produce
rule output that would show the severity as part of the rule text.

    Rule 1.2

    Advisory

    Rule text goes here.

    Rule 1.3

    Required

    More rule text goes here.

As of 1.88 a file structured like above would parse as having no rules.

The problem is the use of blank lines as a rule delimiter.   The
modified rule parser wants to see a rules formatted like below:

    Rule 3.1 Required
    R3.1 text.
    Rule 4.1 Required
    R4.1 text.

or:

    Rule 1.1
    Add this rule and parse to next, skipping empty lines.

    Rule 1.2
    Rule text.

Any rule text that did not fall into one of the above formats would
result in incomplete rule text parsing.

Change the parsing of the rule text file so that blank lines are ignored
instead of treating them as a delimiter between rules. Instead use the
start of the next rule as a delimiter for the end of the previous rule.
This allows both of the newer formats but also supports the behavior of
pre-1.88 versions.

Change units tests that were specifically forbidding the use of blank
lines to ones that allow blank lines.