### PR TITLE
Fix travis cmake error

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if (BUILD_TESTS)
     endif()
 
     add_dependencies(testrunner copy_cfg)
-    add_dependencies(check testrunner)
+    add_dependencies(check testrunner cppcheck)
 
     set(SKIP_TESTS "" CACHE STRING "A list of tests to skip")
 


### PR DESCRIPTION
This adds a dependency on cppcheck so it will be built when calling `make check`.