### PR TITLE
Fixed a user-visible typo in lib/checkother.cpp. Corrected spelling errors found b…

### DIFF
--- a/externals/tinyxml/tinyxml2.h
+++ b/externals/tinyxml/tinyxml2.h
@@ -1831,7 +1831,7 @@ public:
     /// A (trivial) utility function that prints the ErrorStr() to stdout.
     void PrintError() const;
 
-    /// Return the line where the error occured, or zero if unknown.
+    /// Return the line where the error occurred, or zero if unknown.
     int ErrorLineNum() const
     {
         return _errorLineNum;

--- a/gui/common.h
+++ b/gui/common.h
@@ -109,7 +109,7 @@
  * Returns the path of specified type if not empty. Otherwise returns last check
  * path if valid or user's home directory.
  * @param type Type of path to obtain
- * @return Best path fo provided type
+ * @return Best path for provided type
  */
 QString getPath(const QString &type);
 

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1450,7 +1450,7 @@ void CheckOther::unknownSignCharArrayIndexError(const Token *tok)
                 Severity::portability,
                 "unknownSignCharArrayIndex",
                 "'char' type used as array index.\n"
-                "'char' type used as array index. Values greater that 127 will be "
+                "'char' type used as array index. Values greater than 127 will be "
                 "treated depending on whether 'char' is signed or unsigned on target platform.", CWE758, false);
 }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2921,7 +2921,7 @@ static bool valueFlowForward(Token * const               startToken,
             }
             // Variable changed
             for (int i:getIndirections(values)) {
-                // Remove unintialized values if modified
+                // Remove uninitialized values if modified
                 if (isVariableChanged(tok2, i, settings, tokenlist->isCPP()))
                     values.remove_if([&](const ValueFlow::Value& v) {
                     return v.isUninitValue() && v.indirect <= i;

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -522,7 +522,7 @@ private:
         ASSERT_EQUALS("",errout.str());
     }
 
-    void suppressingSyntaxErrors() { // syntaxErrors should be suppressable (#7076)
+    void suppressingSyntaxErrors() { // syntaxErrors should be suppressible (#7076)
         std::map<std::string, std::string> files;
         files["test.cpp"] = "if if\n";
 
@@ -530,7 +530,7 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void suppressingSyntaxErrorsInline() { // syntaxErrors should be suppressable (#5917)
+    void suppressingSyntaxErrorsInline() { // syntaxErrors should be suppressible (#5917)
         std::map<std::string, std::string> files;
         files["test.cpp"] = "double result(0.0);\n"
                             "_asm\n"
@@ -546,7 +546,7 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void suppressingSyntaxErrorsWhileFileRead() { // syntaxError while file read should be suppressable (PR #1333)
+    void suppressingSyntaxErrorsWhileFileRead() { // syntaxError while file read should be suppressible (PR #1333)
         std::map<std::string, std::string> files;
         files["test.cpp"] = "CONST (genType, KS_CONST) genService[KS_CFG_NR_OF_NVM_BLOCKS] =\n"
                             "{\n"


### PR DESCRIPTION
…y codespell in a few comments.