### PR TITLE
reduce.py: Allow reducing error messages, print output in case of error

### DIFF
--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -59,7 +59,7 @@ def runtool():
         out = comm[0] + '\n' + comm[1]
         if EXPECTED in out:
             return True
-    if p.returncode != 0:
+    else:
         # Something could be wrong, for example the command line for Cppcheck (CMD).
         # Print the output to give a hint how to fix it.
         print('Error: {}\n{}'.format(comm[0], comm[1]))

--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -57,8 +57,12 @@ def runtool():
             return True
     elif p.returncode == 0:
         out = comm[0] + '\n' + comm[1]
-        if 'error:' not in out and EXPECTED in out:
+        if EXPECTED in out:
             return True
+    if p.returncode != 0:
+        # Something could be wrong, for example the command line for Cppcheck (CMD).
+        # Print the output to give a hint how to fix it.
+        print('Error: {}\n{}'.format(comm[0], comm[1]))
     return False
 
 


### PR DESCRIPTION
Allow reducing code that triggers (false positive) error messages.
Print Cppcheck output in case Cppcheck returns unsuccessfully and no
segfault is expected. This helps fixing messed up command lines (for
example issues with the path).