### PR TITLE
use range loops / constness

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -736,9 +736,9 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             else if (std::strcmp(argv[i], "--doc") == 0) {
                 std::ostringstream doc;
                 // Get documentation..
-                for (std::list<Check *>::iterator it = Check::instances().begin(); it != Check::instances().end(); ++it) {
-                    const std::string& name((*it)->name());
-                    const std::string info((*it)->classInfo());
+                for (const Check * it : Check::instances()) {
+                    const std::string& name(it->name());
+                    const std::string info(it->classInfo());
                     if (!name.empty() && !info.empty())
                         doc << "## " << name << " ##\n"
                             << info << "\n";

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -313,8 +313,8 @@ void CheckBufferOverrun::arrayIndex()
         // Negative index
         bool neg = false;
         std::vector<const ValueFlow::Value *> negativeIndexes;
-        for (int i = 0; i < indexTokens.size(); ++i) {
-            const ValueFlow::Value *negativeValue = indexTokens[i]->getValueLE(-1, mSettings);
+        for (const Token * indexToken : indexTokens) {
+            const ValueFlow::Value *negativeValue = indexToken->getValueLE(-1, mSettings);
             negativeIndexes.emplace_back(negativeValue);
             if (negativeValue)
                 neg = true;

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -563,23 +563,23 @@ void CheckClass::initVar(nonneg int varid, const Scope *scope, std::vector<Usage
 
 void CheckClass::assignAllVar(std::vector<Usage> &usage)
 {
-    for (int i = 0; i < usage.size(); ++i)
-        usage[i].assign = true;
+    for (Usage & i : usage)
+        i.assign = true;
 }
 
 void CheckClass::clearAllVar(std::vector<Usage> &usage)
 {
-    for (int i = 0; i < usage.size(); ++i) {
-        usage[i].assign = false;
-        usage[i].init = false;
+    for (Usage & i : usage) {
+        i.assign = false;
+        i.init = false;
     }
 }
 
 bool CheckClass::isBaseClassFunc(const Token *tok, const Scope *scope)
 {
     // Iterate through each base class...
-    for (int i = 0; i < scope->definedType->derivedFrom.size(); ++i) {
-        const Type *derivedFrom = scope->definedType->derivedFrom[i].type;
+    for (const Type::BaseInfo & i : scope->definedType->derivedFrom) {
+        const Type *derivedFrom = i.type;
 
         // Check if base class exists in database
         if (derivedFrom && derivedFrom->classScope) {
@@ -1222,8 +1222,8 @@ void CheckClass::checkMemsetType(const Scope *start, const Token *tok, const Sco
     const bool printPortability = mSettings->isEnabled(Settings::PORTABILITY);
 
     // recursively check all parent classes
-    for (int i = 0; i < type->definedType->derivedFrom.size(); i++) {
-        const Type* derivedFrom = type->definedType->derivedFrom[i].type;
+    for (const Type::BaseInfo & i : type->definedType->derivedFrom) {
+        const Type* derivedFrom = i.type;
         if (derivedFrom && derivedFrom->classScope)
             checkMemsetType(start, tok, derivedFrom->classScope, allocation, parsedTypes);
     }
@@ -1680,10 +1680,10 @@ void CheckClass::virtualDestructor()
         const Token *derivedClass = derived->next();
 
         // Iterate through each base class...
-        for (int j = 0; j < scope->definedType->derivedFrom.size(); ++j) {
+        for (const Type::BaseInfo & j : scope->definedType->derivedFrom) {
             // Check if base class is public and exists in database
-            if (scope->definedType->derivedFrom[j].access != AccessControl::Private && scope->definedType->derivedFrom[j].type) {
-                const Type *derivedFrom = scope->definedType->derivedFrom[j].type;
+            if (j.access != AccessControl::Private && j.type) {
+                const Type *derivedFrom = j.type;
                 const Scope *derivedFromScope = derivedFrom->classScope;
                 if (!derivedFromScope)
                     continue;
@@ -1937,9 +1937,9 @@ bool CheckClass::isMemberVar(const Scope *scope, const Token *tok) const
     // not found in this class
     if (!scope->definedType->derivedFrom.empty()) {
         // check each base class
-        for (int i = 0; i < scope->definedType->derivedFrom.size(); ++i) {
+        for (const Type::BaseInfo & i : scope->definedType->derivedFrom) {
             // find the base class
-            const Type *derivedFrom = scope->definedType->derivedFrom[i].type;
+            const Type *derivedFrom = i.type;
 
             // find the function in the base class
             if (derivedFrom && derivedFrom->classScope) {
@@ -1976,9 +1976,9 @@ bool CheckClass::isMemberFunc(const Scope *scope, const Token *tok) const
     // not found in this class
     if (!scope->definedType->derivedFrom.empty()) {
         // check each base class
-        for (int i = 0; i < scope->definedType->derivedFrom.size(); ++i) {
+        for (const Type::BaseInfo & i : scope->definedType->derivedFrom) {
             // find the base class
-            const Type *derivedFrom = scope->definedType->derivedFrom[i].type;
+            const Type *derivedFrom = i.type;
 
             // find the function in the base class
             if (derivedFrom && derivedFrom->classScope) {
@@ -2001,9 +2001,9 @@ bool CheckClass::isConstMemberFunc(const Scope *scope, const Token *tok) const
     // not found in this class
     if (!scope->definedType->derivedFrom.empty()) {
         // check each base class
-        for (int i = 0; i < scope->definedType->derivedFrom.size(); ++i) {
+        for (const Type::BaseInfo & i : scope->definedType->derivedFrom) {
             // find the base class
-            const Type *derivedFrom = scope->definedType->derivedFrom[i].type;
+            const Type *derivedFrom = i.type;
 
             // find the function in the base class
             if (derivedFrom && derivedFrom->classScope) {

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1561,8 +1561,8 @@ bool CheckIO::ArgumentInfo::isStdVectorOrString()
         return true;
     } else if (variableInfo->type() && !variableInfo->type()->derivedFrom.empty()) {
         const std::vector<Type::BaseInfo>& derivedFrom = variableInfo->type()->derivedFrom;
-        for (std::size_t i = 0, size = derivedFrom.size(); i < size; ++i) {
-            const Token* nameTok = derivedFrom[i].nameTok;
+        for (const Type::BaseInfo & i : derivedFrom) {
+            const Token* nameTok = i.nameTok;
             if (Token::Match(nameTok, "std :: vector|array <")) {
                 typeToken = nameTok->tokAt(4);
                 _template = true;

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -184,8 +184,7 @@ void CheckString::checkSuspiciousStringCompare()
             // Pointer addition?
             if (varTok->str() == "+" && mTokenizer->isC()) {
                 const Token * const tokens[2] = { varTok->astOperand1(), varTok->astOperand2() };
-                for (int nr = 0; nr < 2; nr++) {
-                    const Token *t = tokens[nr];
+                for (const Token * t : tokens) {
                     while (t && (t->str() == "." || t->str() == "::"))
                         t = t->astOperand2();
                     if (t && t->variable() && t->variable()->isPointer())

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -638,8 +638,7 @@ std::string ErrorLogger::ErrorMessage::FileLocation::stringify() const
 std::string ErrorLogger::toxml(const std::string &str)
 {
     std::ostringstream xml;
-    for (std::size_t i = 0U; i < str.length(); i++) {
-        const unsigned char c = str[i];
+    for (unsigned char c : str) {
         switch (c) {
         case '<':
             xml << "&lt;";
@@ -678,8 +677,8 @@ std::string ErrorLogger::plistHeader(const std::string &version, const std::vect
          << "<string>cppcheck version " << version << "</string>\r\n"
          << " <key>files</key>\r\n"
          << " <array>\r\n";
-    for (unsigned int i = 0; i < files.size(); ++i)
-        ostr << "  <string>" << ErrorLogger::toxml(files[i]) << "</string>\r\n";
+    for (const std::string & file : files)
+        ostr << "  <string>" << ErrorLogger::toxml(file) << "</string>\r\n";
     ostr       << " </array>\r\n"
                << " <key>diagnostics</key>\r\n"
                << " <array>\r\n";

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -736,13 +736,13 @@ void ImportProject::importBcb6Prj(const std::string &projectFilename)
     {
         std::string arg;
 
-        for (int i = 0; i < cflag1.size(); ++i) {
-            if (cflag1.at(i) == ' ' && !arg.empty()) {
+        for (char i : cflag1) {
+            if (i == ' ' && !arg.empty()) {
                 cflags.insert(arg);
                 arg.clear();
                 continue;
             }
-            arg += cflag1.at(i);
+            arg += i;
         }
 
         if (!arg.empty()) {

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -869,8 +869,7 @@ std::string Library::getFunctionName(const Token *ftok, bool *error) const
             if (!scope->isClassOrStruct())
                 continue;
             const std::vector<Type::BaseInfo> &derivedFrom = scope->definedType->derivedFrom;
-            for (unsigned int i = 0; i < derivedFrom.size(); ++i) {
-                const Type::BaseInfo &baseInfo = derivedFrom[i];
+            for (const Type::BaseInfo & baseInfo : derivedFrom) {
                 const std::string name(baseInfo.name + "::" + ftok->str());
                 if (functions.find(name) != functions.end() && matchArguments(ftok, name))
                     return name;

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -347,8 +347,8 @@ MathLib::biguint MathLib::toULongNumber(const std::string & str)
 static unsigned int encodeMultiChar(const std::string& str)
 {
     unsigned int retval = 0;
-    for (std::string::const_iterator it=str.begin(); it!=str.end(); ++it) {
-        retval = (retval << 8) | *it;
+    for (char it : str) {
+        retval = (retval << 8) | it;
     }
     return retval;
 }
@@ -1338,10 +1338,10 @@ bool MathLib::isNullValue(const std::string &str)
     if (str.empty() || (!std::isdigit(static_cast<unsigned char>(str[0])) && (str[0] != '.' && str[0] != '-' && str[0] != '+')))
         return false; // Has to be a number
 
-    for (size_t i = 0; i < str.size(); i++) {
-        if (std::isdigit(static_cast<unsigned char>(str[i])) && str[i] != '0') // May not contain digits other than 0
+    for (char i : str) {
+        if (std::isdigit(static_cast<unsigned char>(i)) && i != '0') // May not contain digits other than 0
             return false;
-        if (str[i] == 'E' || str[i] == 'e')
+        if (i == 'E' || i == 'e')
             return true;
     }
     return true;

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -173,8 +173,8 @@ bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::strin
         filenames.push_back(filesdir + ("platforms/" + filename + ".xml"));
 #endif
         bool success = false;
-        for (int i = 0; i < filenames.size(); ++i) {
-            if (doc.LoadFile(filenames[i].c_str()) == tinyxml2::XML_SUCCESS) {
+        for (const std::string & filename : filenames) {
+            if (doc.LoadFile(filename.c_str()) == tinyxml2::XML_SUCCESS) {
                 success = true;
                 break;
             }

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -173,8 +173,8 @@ bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::strin
         filenames.push_back(filesdir + ("platforms/" + filename + ".xml"));
 #endif
         bool success = false;
-        for (const std::string & filename : filenames) {
-            if (doc.LoadFile(filename.c_str()) == tinyxml2::XML_SUCCESS) {
+        for (const std::string & f : filenames) {
+            if (doc.LoadFile(f.c_str()) == tinyxml2::XML_SUCCESS) {
                 success = true;
                 break;
             }

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -98,8 +98,8 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
         // Relative filename
         std::string relativeFilename(tok->location.file());
         if (mSettings.relativePaths) {
-            for (std::size_t j = 0U; j < mSettings.basePaths.size(); ++j) {
-                const std::string bp = mSettings.basePaths[j] + "/";
+            for (const std::string & basePath : mSettings.basePaths) {
+                const std::string bp = basePath + "/";
                 if (relativeFilename.compare(0,bp.size(),bp)==0) {
                     relativeFilename = relativeFilename.substr(bp.size());
                 }
@@ -891,8 +891,8 @@ static const std::uint32_t crc32Table[] = {
 static std::uint32_t crc32(const std::string &data)
 {
     std::uint32_t crc = ~0U;
-    for (std::string::const_iterator c = data.begin(); c != data.end(); ++c) {
-        crc = crc32Table[(crc ^ (unsigned char)(*c)) & 0xFF] ^ (crc >> 8);
+    for (char c : data) {
+        crc = crc32Table[(crc ^ (unsigned char)c) & 0xFF] ^ (crc >> 8);
     }
     return crc ^ ~0U;
 }

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -305,8 +305,8 @@ public:
      * @return true for the file to be excluded.
      */
     bool configurationExcluded(const std::string &file) const {
-        for (std::set<std::string>::const_iterator i=configExcludePaths.begin(); i!=configExcludePaths.end(); ++i) {
-            if (file.length()>=i->length() && file.compare(0,i->length(),*i)==0) {
+        for (const std::string & configExcludePath : configExcludePaths) {
+            if (file.length()>=configExcludePath.length() && file.compare(0,configExcludePath.length(),configExcludePath)==0) {
                 return true;
             }
         }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1223,8 +1223,8 @@ void SymbolDatabase::createSymbolDatabaseEnums()
             continue;
 
         // add enumerators to enumerator tokens
-        for (std::size_t i = 0, end = it->enumeratorList.size(); i < end; ++i)
-            const_cast<Token *>(it->enumeratorList[i].name)->enumerator(&it->enumeratorList[i]);
+        for (Enumerator & i : it->enumeratorList)
+            const_cast<Token *>(i.name)->enumerator(&i);
     }
 
     // fill in enumerator values
@@ -1234,9 +1234,7 @@ void SymbolDatabase::createSymbolDatabaseEnums()
 
         MathLib::bigint value = 0;
 
-        for (std::size_t i = 0, end = it->enumeratorList.size(); i < end; ++i) {
-            Enumerator & enumerator = it->enumeratorList[i];
-
+        for (Enumerator & enumerator : it->enumeratorList) {
             // look for initialization tokens that can be converted to enumerators and convert them
             if (enumerator.start) {
                 if (!enumerator.end)
@@ -2572,9 +2570,9 @@ const Function* Type::getFunction(const std::string& funcName) const
             return it->second;
     }
 
-    for (std::size_t i = 0; i < derivedFrom.size(); i++) {
-        if (derivedFrom[i].type) {
-            const Function* const func = derivedFrom[i].type->getFunction(funcName);
+    for (const Type::BaseInfo & i : derivedFrom) {
+        if (i.type) {
+            const Function* const func = i.type->getFunction(funcName);
             if (func)
                 return func;
         }
@@ -3039,21 +3037,21 @@ void SymbolDatabase::printOut(const char *title) const
 
         std::cout << "    derivedFrom[" << type->derivedFrom.size() << "] = (";
         std::size_t count = type->derivedFrom.size();
-        for (std::size_t i = 0; i < type->derivedFrom.size(); ++i) {
-            if (type->derivedFrom[i].isVirtual)
+        for (const Type::BaseInfo & i : type->derivedFrom) {
+            if (i.isVirtual)
                 std::cout << "Virtual ";
 
-            std::cout << (type->derivedFrom[i].access == AccessControl::Public    ? " Public" :
-                          type->derivedFrom[i].access == AccessControl::Protected ? " Protected" :
-                          type->derivedFrom[i].access == AccessControl::Private   ? " Private" :
+            std::cout << (i.access == AccessControl::Public    ? " Public" :
+                          i.access == AccessControl::Protected ? " Protected" :
+                          i.access == AccessControl::Private   ? " Private" :
                           " Unknown");
 
-            if (type->derivedFrom[i].type)
-                std::cout << " " << type->derivedFrom[i].type;
+            if (i.type)
+                std::cout << " " << i.type;
             else
                 std::cout << " Unknown";
 
-            std::cout << " " << type->derivedFrom[i].name;
+            std::cout << " " << i.name;
             if (count-- > 1)
                 std::cout << ",";
         }
@@ -3940,8 +3938,8 @@ const Enumerator * SymbolDatabase::findEnumerator(const Token * tok) const
 
         if (scope->definedType) {
             const std::vector<Type::BaseInfo> & derivedFrom = scope->definedType->derivedFrom;
-            for (size_t i = 0, end = derivedFrom.size(); i < end; ++i) {
-                const Type *derivedFromType = derivedFrom[i].type;
+            for (const Type::BaseInfo & i : derivedFrom) {
+                const Type *derivedFromType = i.type;
                 if (derivedFromType && derivedFromType ->classScope) {
                     enumerator = derivedFromType->classScope->findEnumerator(tokStr);
 
@@ -3982,8 +3980,8 @@ const Type* SymbolDatabase::findVariableTypeInBase(const Scope* scope, const Tok
 {
     if (scope && scope->definedType && !scope->definedType->derivedFrom.empty()) {
         const std::vector<Type::BaseInfo> &derivedFrom = scope->definedType->derivedFrom;
-        for (std::size_t i = 0; i < derivedFrom.size(); ++i) {
-            const Type *base = derivedFrom[i].type;
+        for (const Type::BaseInfo & i : derivedFrom) {
+            const Type *base = i.type;
             if (base && base->classScope) {
                 const Type * type = base->classScope->findType(typeTok->str());
                 if (type)
@@ -4131,8 +4129,8 @@ void Scope::findFunctionInBase(const std::string & name, nonneg int args, std::v
 {
     if (isClassOrStruct() && definedType && !definedType->derivedFrom.empty()) {
         const std::vector<Type::BaseInfo> &derivedFrom = definedType->derivedFrom;
-        for (std::size_t i = 0; i < derivedFrom.size(); ++i) {
-            const Type *base = derivedFrom[i].type;
+        for (const Type::BaseInfo & i : derivedFrom) {
+            const Type *base = i.type;
             if (base && base->classScope) {
                 if (base->classScope == this) // Ticket #5120, #5125: Recursive class; tok should have been found already
                     continue;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -989,9 +989,9 @@ public:
     std::vector<Enumerator> enumeratorList;
 
     const Enumerator * findEnumerator(const std::string & name) const {
-        for (int i = 0, end = enumeratorList.size(); i < end; ++i) {
-            if (enumeratorList[i].name->str() == name)
-                return &enumeratorList[i];
+        for (const Enumerator & i : enumeratorList) {
+            if (i.name->str() == name)
+                return &i;
         }
         return nullptr;
     }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3641,8 +3641,8 @@ void TemplateSimplifier::simplifyTemplates(
         }
 
         // remove explicit instantiations
-        for (size_t j = 0; j < mExplicitInstantiationsToDelete.size(); ++j) {
-            Token * start = mExplicitInstantiationsToDelete[j].token();
+        for (TokenAndName & j : mExplicitInstantiationsToDelete) {
+            Token * start = j.token();
             if (start) {
                 Token * end = start->next();
                 while (end && end->str() != ";")

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -185,8 +185,8 @@ bool Token::isUpperCaseName() const
 {
     if (!isName())
         return false;
-    for (size_t i = 0; i < mStr.length(); ++i) {
-        if (std::islower(mStr[i]))
+    for (char i : mStr) {
+        if (std::islower(i))
             return false;
     }
     return true;
@@ -1162,18 +1162,18 @@ void Token::stringify(std::ostream& os, bool varid, bool attributes, bool macro)
     if (macro && isExpandedMacro())
         os << "$";
     if (isName() && mStr.find(' ') != std::string::npos) {
-        for (std::size_t i = 0U; i < mStr.size(); ++i) {
-            if (mStr[i] != ' ')
-                os << mStr[i];
+        for (char i : mStr) {
+            if (i != ' ')
+                os << i;
         }
     } else if (mStr[0] != '\"' || mStr.find('\0') == std::string::npos)
         os << mStr;
     else {
-        for (std::size_t i = 0U; i < mStr.size(); ++i) {
-            if (mStr[i] == '\0')
+        for (char i : mStr) {
+            if (i == '\0')
                 os << "\\0";
             else
-                os << mStr[i];
+                os << i;
         }
     }
     if (varid && mImpl->mVarId != 0)

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -398,8 +398,8 @@ void TokenList::createTokens(const simplecpp::TokenList *tokenList)
     }
 
     if (mSettings && mSettings->relativePaths) {
-        for (std::size_t i = 0; i < mFiles.size(); i++)
-            mFiles[i] = Path::getRelativePath(mFiles[i], mSettings->basePaths);
+        for (std::string & mFile : mFiles)
+            mFile = Path::getRelativePath(mFile, mSettings->basePaths);
     }
 
     Token::assignProgressValues(mTokensFrontBack.front);
@@ -413,11 +413,11 @@ unsigned long long TokenList::calculateChecksum() const
     for (const Token* tok = front(); tok; tok = tok->next()) {
         const unsigned int subchecksum1 = tok->flags() + tok->varId() + tok->tokType();
         unsigned int subchecksum2 = 0;
-        for (std::size_t i = 0; i < tok->str().size(); i++)
-            subchecksum2 += (unsigned int)tok->str()[i];
+        for (char i : tok->str())
+            subchecksum2 += (unsigned int)i;
         if (!tok->originalName().empty()) {
-            for (std::size_t i = 0; i < tok->originalName().size(); i++)
-                subchecksum2 += (unsigned int) tok->originalName()[i];
+            for (char i : tok->originalName())
+                subchecksum2 += (unsigned int) i;
         }
 
         checksum ^= ((static_cast<unsigned long long>(subchecksum1) << 32) | subchecksum2);

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -94,12 +94,10 @@ private:
         // Check for error ids from this class.
         bool foundPurgedConfiguration = false;
         bool foundTooManyConfigs = false;
-        for (std::list<std::string>::iterator it = errorLogger.id.begin();
-             it != errorLogger.id.end();
-             ++it) {
-            if (*it == "purgedConfiguration")
+        for (const std::string & it : errorLogger.id) {
+            if (it == "purgedConfiguration")
                 foundPurgedConfiguration = true;
-            else if (*it == "toomanyconfigs")
+            else if (it == "toomanyconfigs")
                 foundTooManyConfigs = true;
         }
         ASSERT(foundPurgedConfiguration);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -258,12 +258,12 @@ private:
         preprocessor0.simplifyPragmaAsm(&tokens);
         const std::set<std::string> configs(preprocessor0.getConfigs(tokens));
         preprocessor0.setDirectives(tokens);
-        for (std::set<std::string>::const_iterator it = configs.begin(); it != configs.end(); ++it) {
+        for (const std::string & config : configs) {
             try {
-                const std::string &cfgcode = preprocessor0.getcode(tokens, *it, files, std::string(code).find("#file") != std::string::npos);
-                actual[*it] = cfgcode;
+                const std::string &cfgcode = preprocessor0.getcode(tokens, config, files, std::string(code).find("#file") != std::string::npos);
+                actual[config] = cfgcode;
             } catch (const simplecpp::Output &) {
-                actual[*it] = "";
+                actual[config] = "";
             } catch (...) {
             }
         }
@@ -282,8 +282,8 @@ private:
         tokens.removeComments();
         const std::set<std::string> configs = preprocessor.getConfigs(tokens);
         std::string ret;
-        for (std::set<std::string>::const_iterator it = configs.begin(); it != configs.end(); ++it)
-            ret += *it + '\n';
+        for (const std::string & config : configs)
+            ret += config + '\n';
         return ret;
     }
 

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -347,8 +347,8 @@ std::size_t TestFixture::runTests(const options& args)
 
     if (!missingLibs.empty()) {
         std::cerr << "Missing libraries: ";
-        for (std::set<std::string>::const_iterator i = missingLibs.begin(); i != missingLibs.end(); ++i)
-            std::cerr << *i << "  ";
+        for (const std::string & missingLib : missingLibs)
+            std::cerr << missingLib << "  ";
         std::cerr << std::endl << std::endl;
     }
     std::cerr.flush();

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -96,9 +96,9 @@ private:
                 currScope = currScope->nestedIn;
         }
         while (currScope) {
-            for (std::list<Function>::const_iterator i = currScope->functionList.begin(); i != currScope->functionList.end(); ++i) {
-                if (i->tokenDef->str() == str)
-                    return &*i;
+            for (const Function & i : currScope->functionList) {
+                if (i.tokenDef->str() == str)
+                    return &i;
             }
             currScope = currScope->nestedIn;
         }
@@ -1483,8 +1483,8 @@ private:
 
         if (db) {
             bool seen_something = false;
-            for (std::list<Scope>::const_iterator scope = db->scopeList.begin(); scope != db->scopeList.end(); ++scope) {
-                for (std::list<Function>::const_iterator func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
+            for (const Scope & scope : db->scopeList) {
+                for (std::list<Function>::const_iterator func = scope.functionList.begin(); func != scope.functionList.end(); ++func) {
                     ASSERT_EQUALS("Sub", func->token->str());
                     ASSERT_EQUALS(true, func->hasBody());
                     ASSERT_EQUALS(Function::eConstructor, func->type);
@@ -2256,9 +2256,9 @@ private:
 
         // Locate the scope for the class..
         const Scope *scope = nullptr;
-        for (std::list<Scope>::const_iterator it = db->scopeList.begin(); it != db->scopeList.end(); ++it) {
-            if (it->isClassOrStruct()) {
-                scope = &(*it);
+        for (const Scope & it : db->scopeList) {
+            if (it.isClassOrStruct()) {
+                scope = &it;
                 break;
             }
         }
@@ -2290,9 +2290,9 @@ private:
 
         // Locate the scope for the class..
         const Scope *scope = nullptr;
-        for (std::list<Scope>::const_iterator it = db->scopeList.begin(); it != db->scopeList.end(); ++it) {
-            if (it->isClassOrStruct()) {
-                scope = &(*it);
+        for (const Scope & it : db->scopeList) {
+            if (it.isClassOrStruct()) {
+                scope = &it;
                 break;
             }
         }
@@ -2580,9 +2580,9 @@ private:
 
         // Find the scope for the Fred struct..
         const Scope *fredScope = nullptr;
-        for (std::list<Scope>::const_iterator scope = db->scopeList.begin(); scope != db->scopeList.end(); ++scope) {
-            if (scope->isClassOrStruct() && scope->className == "Fred")
-                fredScope = &(*scope);
+        for (const Scope & scope : db->scopeList) {
+            if (scope.isClassOrStruct() && scope.className == "Fred")
+                fredScope = &scope;
         }
         ASSERT(fredScope != nullptr);
         if (fredScope == nullptr)
@@ -2594,11 +2594,11 @@ private:
         // Get linenumbers where the bodies for the constructor and destructor are..
         unsigned int constructor = 0;
         unsigned int destructor = 0;
-        for (std::list<Function>::const_iterator it = fredScope->functionList.begin(); it != fredScope->functionList.end(); ++it) {
-            if (it->type == Function::eConstructor)
-                constructor = it->token->linenr();  // line number for constructor body
-            if (it->type == Function::eDestructor)
-                destructor = it->token->linenr();  // line number for destructor body
+        for (const Function & it : fredScope->functionList) {
+            if (it.type == Function::eConstructor)
+                constructor = it.token->linenr();  // line number for constructor body
+            if (it.type == Function::eDestructor)
+                destructor = it.token->linenr();  // line number for destructor body
         }
 
         // The body for the constructor is located at line 5..


### PR DESCRIPTION
clang-tidy was used to detect these and its quick fixes were applied with the `auto` usage being reverted to the actual type. Adjusted costness in a few cases as well.