### PR TITLE
.travis.yml: Run addon tests also with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 before_install:
 # install needed deps
  - travis_retry sudo apt-get update -qq
- - travis_retry sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet python3-dev liblua5.3-dev libcurl3 libcairo2-dev
+ - travis_retry sudo apt-get install -qq python-pygments python3-pip qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet python3-dev liblua5.3-dev libcurl3 libcairo2-dev
 # Python 2 modules 
  - travis_retry python2 -m pip install --user pytest==4.6.4
  - travis_retry python2 -m pip install --user pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -224,6 +224,7 @@ script:
   - cd -
 # Testing addons
   - python -m pytest addons/test/test-*.py
+  - PYTHONPATH=./addons python3 -m pytest addons/test/test-*.py
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,13 @@ before_install:
 # install needed deps
  - travis_retry sudo apt-get update -qq
  - travis_retry sudo apt-get install -qq python-pygments qt5-default qt5-qmake qtbase5-dev qtcreator libxml2-utils libpcre3 gdb unzip wx-common xmlstarlet python3-dev liblua5.3-dev libcurl3 libcairo2-dev
+# Python 2 modules 
  - travis_retry python2 -m pip install --user pytest==4.6.4
  - travis_retry python2 -m pip install --user pylint
  - travis_retry python2 -m pip install --user unittest2
  - travis_retry python2 -m pip install --user pexpect
+# Python 3 modules
+ - travis_retry python3 -m pip install --user pytest
 
 matrix:
 # do notify immediately about it when a job of a build fails.


### PR DESCRIPTION
Python 3 does not search parent directories of the initially executed
script for modules imported by modules in this parent directory by
default. So simply set the PYTHONPATH to the ./addons directory. Thus
all scripts are found. It is similar to running the test-*.py script
from the ./addons directory, but this way all the paths in the test-*.py
scripts do not have to be changed (for example to find the cppcheck
executable.
For more details regarding the parent directory issue see for example:
https://stackoverflow.com/questions/11393492/python-package-import-from-parent-directory
For details about the used PYTHONPATH solution see:
https://stackoverflow.com/questions/4580101/python-add-pythonpath-during-command-line-module-run