### PR TITLE
Add missing ending tag in XML example

### DIFF
--- a/man/manual.md
+++ b/man/manual.md
@@ -360,7 +360,7 @@ Here is a sample report:
 
     <?xml version="1.0" encoding="UTF-8"?>
     <results version="2">
-      <cppcheck version="1.66">
+      <cppcheck version="1.66"/>
       <errors>
         <error id="someError" severity="error" msg="short error text"
            verbose="long error text" inconclusive="true" cwe="312">


### PR DESCRIPTION
Hi, I just noticed an invalid XML output example in the manual, so I fixes it.
(Yes, this is just one character fix 😄)
