### PR TITLE
avoid unnecessary copies of parameters

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -31,7 +31,7 @@
 #include <stack>
 
 
-void visitAstNodes(const Token *ast, std::function<ChildrenToVisit(const Token *)> visitor)
+void visitAstNodes(const Token *ast, const std::function<ChildrenToVisit(const Token *)>& visitor)
 {
     std::stack<const Token *> tokens;
     tokens.push(ast);

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -46,7 +46,7 @@ enum class ChildrenToVisit {
 /**
  * Visit AST nodes recursively. The order is not "well defined"
  */
-void visitAstNodes(const Token *ast, std::function<ChildrenToVisit(const Token *)> visitor);
+void visitAstNodes(const Token *ast, const std::function<ChildrenToVisit(const Token *)>& visitor);
 
 std::vector<const Token*> astFlatten(const Token* tok, const char* op);
 

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -60,7 +60,7 @@ namespace {
             return mDataIndex++;
         }
 
-        void newValue(const Token *tok, ExprEngine::ValuePtr value) {
+        void newValue(const Token *tok, const ExprEngine::ValuePtr& value) {
             if (!tok)
                 return;
             if (!value)
@@ -166,7 +166,7 @@ namespace {
             return value;
         }
 
-        void trackAssignment(const Token *tok, ExprEngine::ValuePtr value) {
+        void trackAssignment(const Token *tok, const ExprEngine::ValuePtr& value) {
             return mTrackExecution->newValue(tok, value);
         }
 
@@ -193,7 +193,7 @@ namespace {
     };
 }
 
-void ExprEngine::ArrayValue::assign(ExprEngine::ValuePtr index, ExprEngine::ValuePtr value)
+void ExprEngine::ArrayValue::assign(const ExprEngine::ValuePtr& index, const ExprEngine::ValuePtr& value)
 {
     auto i1 = std::dynamic_pointer_cast<ExprEngine::IntRange>(index);
     if (i1) {
@@ -202,7 +202,7 @@ void ExprEngine::ArrayValue::assign(ExprEngine::ValuePtr index, ExprEngine::Valu
     }
 }
 
-ExprEngine::ValuePtr ExprEngine::ArrayValue::read(ExprEngine::ValuePtr index)
+ExprEngine::ValuePtr ExprEngine::ArrayValue::read(const ExprEngine::ValuePtr& index)
 {
     auto i1 = std::dynamic_pointer_cast<ExprEngine::IntRange>(index);
     if (i1) {
@@ -283,7 +283,7 @@ int128_t ExprEngine::BinOpResult::evaluate(int test, const std::map<ExprEngine::
     throw std::runtime_error("Internal error: Unhandled operator;" + binop);
 }
 
-int128_t ExprEngine::BinOpResult::evaluateOperand(int test, const std::map<ExprEngine::ValuePtr, int> &valueBit, ExprEngine::ValuePtr value) const
+int128_t ExprEngine::BinOpResult::evaluateOperand(int test, const std::map<ExprEngine::ValuePtr, int> &valueBit, const ExprEngine::ValuePtr& value) const
 {
     auto binOpResult = std::dynamic_pointer_cast<ExprEngine::BinOpResult>(value);
     if (binOpResult)
@@ -342,7 +342,7 @@ static ExprEngine::ValuePtr getValueRangeFromValueType(const std::string &name, 
     return ExprEngine::ValuePtr();
 }
 
-static void call(const std::vector<ExprEngine::Callback> &callbacks, const Token *tok, ExprEngine::ValuePtr value)
+static void call(const std::vector<ExprEngine::Callback> &callbacks, const Token *tok, const ExprEngine::ValuePtr &value)
 {
     if (value) {
         for (ExprEngine::Callback f : callbacks) {

--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -106,7 +106,7 @@ namespace ExprEngine {
 
     class PointerValue: public Value {
     public:
-        PointerValue(const std::string &name, ValuePtr data) : Value(name), data(data) {}
+        PointerValue(const std::string &name, const ValuePtr& data) : Value(name), data(data) {}
         ValueType type() const override {
             return ValueType::PointerValue;
         }
@@ -133,8 +133,8 @@ namespace ExprEngine {
             return "[" + std::to_string(data.size()) + "]";
         }
 
-        void assign(ValuePtr index, ValuePtr value);
-        ValuePtr read(ValuePtr index);
+        void assign(const ValuePtr& index, const ValuePtr& value);
+        ValuePtr read(const ValuePtr& index);
 
         std::vector<ValuePtr> data;
     };
@@ -174,7 +174,7 @@ namespace ExprEngine {
 
     class BinOpResult : public Value {
     public:
-        BinOpResult(const std::string &binop, ValuePtr op1, ValuePtr op2)
+        BinOpResult(const std::string &binop, const ValuePtr& op1, const ValuePtr& op2)
             : Value("(" + op1->name + ")" + binop + "(" + op2->name + ")")
             , binop(binop)
             , op1(op1)
@@ -204,7 +204,7 @@ namespace ExprEngine {
         ValuePtr op2;
     private:
         int128_t evaluate(int test, const std::map<ValuePtr, int> &valueBit) const;
-        int128_t evaluateOperand(int test, const std::map<ValuePtr, int> &valueBit, ValuePtr value) const;
+        int128_t evaluateOperand(int test, const std::map<ValuePtr, int> &valueBit, const ValuePtr &value) const;
         std::set<ValuePtr> mLeafs;
     };
 

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -72,7 +72,7 @@ std::string Path::fromNativeSeparators(std::string path)
     return path;
 }
 
-std::string Path::simplifyPath(std::string originalPath)
+std::string Path::simplifyPath(const std::string& originalPath)
 {
     return simplecpp::simplifyPath(originalPath);
 }

--- a/lib/path.h
+++ b/lib/path.h
@@ -58,7 +58,7 @@ public:
      * @param originalPath path to be simplified, must have / -separators.
      * @return simplified path
      */
-    static std::string simplifyPath(std::string originalPath);
+    static std::string simplifyPath(const std::string& originalPath);
 
     /**
      * @brief Lookup the path part from a filename (e.g., '/tmp/a.h' -> '/tmp/', 'a.h' -> '')

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2080,7 +2080,7 @@ std::string Token::typeStr(const Token* tok)
     return r.first->stringifyList(r.second, false);
 }
 
-void Token::scopeInfo(std::shared_ptr<ScopeInfo2> newScopeInfo)
+void Token::scopeInfo(const std::shared_ptr<ScopeInfo2>& newScopeInfo)
 {
     mImpl->mScopeInfo = newScopeInfo;
 }

--- a/lib/token.h
+++ b/lib/token.h
@@ -1226,7 +1226,7 @@ public:
 
     void printValueFlow(bool xml, std::ostream &out) const;
 
-    void scopeInfo(std::shared_ptr<ScopeInfo2> newScopeInfo);
+    void scopeInfo(const std::shared_ptr<ScopeInfo2>& newScopeInfo);
     std::shared_ptr<ScopeInfo2> scopeInfo() const;
 
     void setCpp11init(bool cpp11init) const {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -427,7 +427,7 @@ static void fillProgramMemoryFromConditions(ProgramMemory& pm, const Token* tok,
     fillProgramMemoryFromConditions(pm, tok->scope(), tok, settings);
 }
 
-static void fillProgramMemoryFromAssignments(ProgramMemory& pm, const Token* tok, const ProgramMemory& state, std::unordered_map<nonneg int, ValueFlow::Value> vars)
+static void fillProgramMemoryFromAssignments(ProgramMemory& pm, const Token* tok, const ProgramMemory& state, const std::unordered_map<nonneg int, ValueFlow::Value>& vars)
 {
     int indentlevel = 0;
     for (const Token *tok2 = tok; tok2; tok2 = tok2->previous()) {


### PR DESCRIPTION
detected by clang-tidy

Cppcheck should probably detect these as well. I wasn't able to create a ticket for this as my account is currently suspended.