### PR TITLE
added missing OVERRIDE usage and removed redundant virtual

### DIFF
--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -48,7 +48,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~CppCheckExecutor();
+    ~CppCheckExecutor() OVERRIDE;
 
     /**
      * Starts the checking.
@@ -69,17 +69,17 @@ public:
      *
      * @param outmsg Progress message e.g. "Checking main.cpp..."
      */
-    virtual void reportOut(const std::string &outmsg) OVERRIDE;
+    void reportOut(const std::string &outmsg) OVERRIDE;
 
     /** xml output of errors */
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
 
     void reportProgress(const std::string &filename, const char stage[], const std::size_t value) OVERRIDE;
 
     /**
      * Output information messages.
      */
-    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
 
     /**
      * Information about how many files have been checked

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -47,13 +47,13 @@ class ThreadExecutor : public ErrorLogger {
 public:
     ThreadExecutor(const std::map<std::string, std::size_t> &files, Settings &settings, ErrorLogger &errorLogger);
     ThreadExecutor(const ThreadExecutor &) = delete;
-    virtual ~ThreadExecutor();
+    ~ThreadExecutor() OVERRIDE;
     void operator=(const ThreadExecutor &) = delete;
     unsigned int check();
 
-    virtual void reportOut(const std::string &outmsg) OVERRIDE;
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
-    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportOut(const std::string &outmsg) OVERRIDE;
+    void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
 
     /**
      * @brief Add content to a file, to be used in unit testing.

--- a/lib/checkassert.h
+++ b/lib/checkassert.h
@@ -50,7 +50,7 @@ public:
     }
 
     /** run checks, the token list is not simplified */
-    virtual void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
         CheckAssert checkAssert(tokenizer, settings, errorLogger);
         checkAssert.assertWithSideEffects();
     }

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -54,7 +54,7 @@ public:
     }
 
     /** run checks, the token list is not simplified */
-    virtual void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
         if (!tokenizer->isCPP()) {
             return;
         }

--- a/lib/checkvaarg.h
+++ b/lib/checkvaarg.h
@@ -48,7 +48,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {
     }
 
-    virtual void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
         CheckVaarg check(tokenizer, settings, errorLogger);
         check.va_start_argument();
         check.va_list_usage();

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -55,7 +55,7 @@ public:
     /**
      * @brief Destructor.
      */
-    virtual ~CppCheck();
+    ~CppCheck() OVERRIDE;
 
     /**
      * @brief This starts the actual checking. Note that you must call
@@ -186,14 +186,14 @@ private:
      * "[filepath:line number] Message", e.g.
      * "[main.cpp:4] Uninitialized member variable"
      */
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
 
     /**
      * @brief Information about progress is directed here.
      *
      * @param outmsg Message to show, e.g. "Checking main.cpp..."
      */
-    virtual void reportOut(const std::string &outmsg) OVERRIDE;
+    void reportOut(const std::string &outmsg) OVERRIDE;
 
     std::list<std::string> mErrorList;
     Settings mSettings;
@@ -203,7 +203,7 @@ private:
     /**
      * Output information messages.
      */
-    virtual void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportInfo(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
 
     ErrorLogger &mErrorLogger;
 

--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -88,7 +88,7 @@ namespace ExprEngine {
             , minValue(minValue)
             , maxValue(maxValue) {
         }
-        ~IntRange() {}
+        ~IntRange() OVERRIDE {}
 
         ValueType type() const override {
             return ValueType::IntRange;

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -37,10 +37,10 @@ private:
     public:
         std::list<std::string> id;
 
-        void reportOut(const std::string & /*outmsg*/) {
+        void reportOut(const std::string & /*outmsg*/) OVERRIDE {
         }
 
-        void reportErr(const ErrorLogger::ErrorMessage &msg) {
+        void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE {
             id.push_back(msg.id);
         }
     };

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -82,14 +82,14 @@ protected:
 
     void processOptions(const options& args);
 public:
-    virtual void reportOut(const std::string &outmsg) OVERRIDE;
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
+    void reportOut(const std::string &outmsg) OVERRIDE;
+    void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE;
     void run(const std::string &str);
     static void printHelp();
     const std::string classname;
 
     explicit TestFixture(const char * const _name);
-    virtual ~TestFixture() { }
+    ~TestFixture() OVERRIDE { }
 
     static std::size_t runTests(const options& args);
 };

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -50,10 +50,10 @@ public:
     SimpleSuppressor(Settings &settings, ErrorLogger *next)
         : settings(settings), next(next) {
     }
-    virtual void reportOut(const std::string &outmsg) OVERRIDE {
+    void reportOut(const std::string &outmsg) OVERRIDE {
         next->reportOut(outmsg);
     }
-    virtual void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE {
+    void reportErr(const ErrorLogger::ErrorMessage &msg) OVERRIDE {
         if (!msg.callStack.empty() && !settings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage()))
             next->reportErr(msg);
     }


### PR DESCRIPTION
detected by clang-tidy