### PR TITLE
deleted methods should be public

### DIFF
--- a/lib/check.h
+++ b/lib/check.h
@@ -184,12 +184,12 @@ protected:
      * will call this method
      */
     bool wrongData(const Token *tok, bool condition, const char *str);
-private:
-    const std::string mName;
 
     /** disabled assignment operator and copy constructor */
     void operator=(const Check &) = delete;
     Check(const Check &) = delete;
+private:
+    const std::string mName;
 };
 
 /// @}

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -884,13 +884,13 @@ public:
 
     void calculateScopes();
 
-private:
     /** Disable copy constructor */
     Tokenizer(const Tokenizer &) = delete;
 
     /** Disable assignment operator */
     Tokenizer &operator=(const Tokenizer &) = delete;
 
+private:
     Token *processFunc(Token *tok2, bool inOperator) const;
 
     /**


### PR DESCRIPTION
detected by clang-tidy