### PR TITLE
avoid some unnecessary copies in emplace_back() calls

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -745,10 +745,10 @@ bool TemplateSimplifier::getTemplateDeclarations()
                     TokenAndName decl(tok, tok->scopeInfo()->name, parmEnd->tokAt(namepos), parmEnd);
                     if (decl.isForwardDeclaration()) {
                         // Declaration => add to mTemplateForwardDeclarations
-                        mTemplateForwardDeclarations.emplace_back(decl);
+                        mTemplateForwardDeclarations.emplace_back(std::move(decl));
                     } else {
                         // Implementation => add to mTemplateDeclarations
-                        mTemplateDeclarations.emplace_back(decl);
+                        mTemplateDeclarations.emplace_back(std::move(decl));
                     }
                     break;
                 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5122,7 +5122,7 @@ static bool evaluate(const Token *expr, const std::vector<std::list<ValueFlow::V
                 res.valueType = ValueFlow::Value::INT;
                 res.tokvalue = nullptr;
                 res.intvalue = Token::getStrLength(argvalue.tokvalue);
-                result->emplace_back(res);
+                result->emplace_back(std::move(res));
             }
         }
         return !result->empty();
@@ -5141,7 +5141,7 @@ static bool evaluate(const Token *expr, const std::vector<std::list<ValueFlow::V
             for (ValueFlow::Value v: opvalues) {
                 if (v.isIntValue()) {
                     v.intvalue = -v.intvalue;
-                    result->emplace_back(v);
+                    result->emplace_back(std::move(v));
                 }
             }
             return true;
@@ -5890,7 +5890,7 @@ static void valueFlowContainerAfterCondition(TokenList *tokenlist,
             ValueFlow::Value value(tok, 0LL);
             value.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
             cond.true_values.emplace_back(value);
-            cond.false_values.emplace_back(value);
+            cond.false_values.emplace_back(std::move(value));
             cond.vartok = vartok;
             return cond;
         }
@@ -5911,7 +5911,7 @@ static void valueFlowContainerAfterCondition(TokenList *tokenlist,
             ValueFlow::Value value(tok, Token::getStrLength(strtok));
             value.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
             cond.false_values.emplace_back(value);
-            cond.true_values.emplace_back(value);
+            cond.true_values.emplace_back(std::move(value));
             cond.vartok = vartok;
             return cond;
         }


### PR DESCRIPTION
Found by reviewing all emplace_back() usages. Some initial changes had to be reverted since the object are trivially copy-able so std::move() has no effect.

There already exists a ticket about adding a check for this to Cppcheck - https://trac.cppcheck.net/ticket/8945