### PR TITLE
Fix crashes in checkleakautovar

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -936,7 +936,7 @@ void CheckLeakAutoVar::ret(const Token *tok, const VarInfo &varInfo)
                     continue;
 
                 tok2 = tok2->next();
-                while (tok2 && tok2->isCast() && (tok2->valueType()->pointer || (tok2->valueType()->typeSize(*mSettings) >= mSettings->sizeof_pointer)))
+                while (tok2 && tok2->isCast() && (tok2->valueType() && (tok2->valueType()->pointer || (tok2->valueType()->typeSize(*mSettings) >= mSettings->sizeof_pointer))))
                     tok2 = tok2->astOperand2() ? tok2->astOperand2() : tok2->astOperand1();
                 if (Token::Match(tok2, "%varid%", varid))
                     tok2 = tok2->next();


### PR DESCRIPTION
Crashes found by daca@home
http://cppcheck1.osuosl.org:8000/crash.html

For instance
```
2019-09-20 16:27
ftp://ftp.se.debian.org/debian/pool/main/n/nedit/nedit_5.7.orig.tar.gz
cppcheck-options: -j1 --library=posix --library=gnu --library=motif -D__GNUC__ --check-library --inconclusive --enable=style,information --platform=unix64 --template=daca2 -rp=temp temp
platform: Linux-4.19.0-6-amd64-x86_64-with-debian-10.1
python: 2.7.16
client-version: 1.1.37
cppcheck: head 1.89
head-info: 38dec6a9a (2019-09-20 16:46:57 +0200)
count: Crash! 934
elapsed-time: -11.0 9.0
head results:
Checking temp/nedit-5.7/source/shell.c: __GNUC__=1...

Program received signal SIGSEGV, Segmentation fault.
0x000055555564b862 in CheckLeakAutoVar::ret (this=0x7fffffffb8c0, tok=0x5555582ea9e0, varInfo=...) at lib/token.h:340
340	        return mImpl->mValueType;
 #0  0x000055555564b862 in CheckLeakAutoVar::ret (this=0x7fffffffb8c0, tok=0x5555582ea9e0, varInfo=...) at lib/token.h:340
 #1  0x0000555555651764 in CheckLeakAutoVar::check (this=0x7fffffffb8c0) at build/checkleakautovar.cpp:714
 #2  0x0000555555652b37 in CheckLeakAutoVar::runChecks (this=<optimized out>, tokenizer=0x7fffffffc3a0, settings=<optimized out>, errorLogger=<optimized out>) at lib/checkleakautovar.h:108
 #3  0x00005555556bc833 in CppCheck::checkNormalTokens (this=0x7fffffffce50, tokenizer=...) at build/cppcheck.cpp:732
 #4  0x00005555556bf694 in CppCheck::checkFile (this=0x7fffffffce50, filename=..., cfgname=..., fileStream=...) at build/cppcheck.cpp:542
 #5  0x00005555556c1cb8 in CppCheck::check (this=this@entry=0x7fffffffce50, path="temp/nedit-5.7/source/shell.c") at /usr/include/c++/8/bits/basic_string.h:936
 #6  0x00005555557fd63f in CppCheckExecutor::check_internal (this=0x7fffffffdbd0, cppcheck=..., argv=<optimized out>) at cli/cppcheckexecutor.cpp:884
 #7  0x00005555557fda92 in CppCheckExecutor::check (this=this@entry=0x7fffffffdbd0, argc=argc@entry=14, argv=argv@entry=0x7fffffffdf58) at cli/cppcheckexecutor.cpp:198
 #8  0x00005555555e6358 in main (argc=14, argv=0x7fffffffdf58) at cli/main.cpp:95

DONE
```