### PR TITLE
Fix xml syntax in token-matching.xml

### DIFF
--- a/rules/token-matching.xml
+++ b/rules/token-matching.xml
@@ -1,34 +1,36 @@
 <?xml version="1.0"?>
-<rule version="1">
-    <pattern>Token :: (?:findm|(?:simple|)M)atch \([^,]+,\s+"(?:\s+|[^"]+?\s+")</pattern>
-    <message>
-        <id>TokenMatchSpacing</id>
-        <severity>style</severity>
-        <summary>Useless extra spacing for Token::*Match.</summary>
-    </message>
-</rule>
-<rule version="1">
-    <pattern>(?U)Token :: Match \([^,]+,\s+"[^%|!\[\]]+"</pattern>
-    <message>
-    <id>UseTokensimpleMatch</id>
-    <severity>error</severity>
-    <summary>Token::simpleMatch should be used to match tokens
+<rules>
+    <rule version="1">
+        <pattern>Token :: (?:findm|(?:simple|)M)atch \([^,]+,\s+"(?:\s+|[^"]+?\s+")</pattern>
+        <message>
+            <id>TokenMatchSpacing</id>
+            <severity>style</severity>
+            <summary>Useless extra spacing for Token::*Match.</summary>
+        </message>
+    </rule>
+    <rule version="1">
+        <pattern>(?U)Token :: Match \([^,]+,\s+"[^%|!\[\]]+"</pattern>
+        <message>
+            <id>UseTokensimpleMatch</id>
+            <severity>error</severity>
+            <summary>Token::simpleMatch should be used to match tokens
 without special pattern requirements.</summary>
-    </message>
-</rule>
-<rule version="1">
-    <pattern>\b[\w_]+ \. tokAt \( 0 \)</pattern>
-    <message>
-    <id>TokentokAt0</id>
-    <severity>error</severity>
-    <summary>tok->tokAt(0) is a slow way to say tok.</summary>
-    </message>
-</rule>
-<rule version="1">
-    <pattern>\b[\w_]+ \. strAt \( 0 \)</pattern>
-    <message>
-    <id>TokenstrAt0</id>
-    <severity>error</severity>
-    <summary>tok->strAt(0) is a slow way to say tok->str()</summary>
-    </message>
-</rule>
+        </message>
+    </rule>
+    <rule version="1">
+        <pattern>\b[\w_]+ \. tokAt \( 0 \)</pattern>
+        <message>
+            <id>TokentokAt0</id>
+            <severity>error</severity>
+            <summary>tok->tokAt(0) is a slow way to say tok.</summary>
+        </message>
+    </rule>
+    <rule version="1">
+        <pattern>\b[\w_]+ \. strAt \( 0 \)</pattern>
+        <message>
+            <id>TokenstrAt0</id>
+            <severity>error</severity>
+            <summary>tok->strAt(0) is a slow way to say tok->str()</summary>
+        </message>
+    </rule>
+</rules>


### PR DESCRIPTION
The file token-matching.xml contains multiple rules
- Add `<rules></rules>` xml tags
- Fixes the following xmllint error:
  `./rules/token-matching.xml:10: parser error :`
  `Extra content at the end of the document`
  `<rule version="1">`
  `^`