### PR TITLE
Use fixed number of iterations for valueflow loop

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6298,10 +6298,9 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
     valueFlowSameExpressions(tokenlist);
     valueFlowFwdAnalysis(tokenlist, settings);
 
-    // Temporary hack.. run valueflow until there is nothing to update or timeout expires
-    const std::time_t timeout = std::time(nullptr) + TIMEOUT;
     std::size_t values = 0;
-    while (std::time(nullptr) < timeout && values < getTotalValues(tokenlist)) {
+    std::size_t n = 4;
+    while (n > 0 && values < getTotalValues(tokenlist)) {
         values = getTotalValues(tokenlist);
         valueFlowPointerAliasDeref(tokenlist);
         valueFlowArrayBool(tokenlist);
@@ -6324,6 +6323,7 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
             valueFlowContainerAfterCondition(tokenlist, symboldatabase, errorLogger, settings);
         }
         valueFlowSafeFunctions(tokenlist, symboldatabase, errorLogger, settings);
+        n--;
     }
 
     valueFlowDynamicBufferSize(tokenlist, symboldatabase, errorLogger, settings);


### PR DESCRIPTION
Using a timeout loop is not very deterministic. ValueFlow can produce different values depending if sanitizers or debugger is used. Instead, this will use a fixed max number of loops.