### PR TITLE
Fix for MISRA rule 4.1 to avoid false positives for octal escape sequ…

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -715,21 +715,33 @@ class MisraChecker:
                     if not isHexDigit(token.str[pos1 + 2]):
                         self.reportError(token, 4, 1)
                         continue
+                    # Check for next or end of escape sequence. 
+                    # To match sequence which consists of single hexadecimal digit.
+                    if (token.str[pos1 + 3] == '\\') or (token.str[pos1 + 3] == '"'):
+                        continue
                     if not isHexDigit(token.str[pos1 + 3]):
                         self.reportError(token, 4, 1)
                         continue
                 elif isOctalDigit(token.str[pos1 + 1]):
+                    # Check for next or end of escape sequence.
+                    # To match sequence which consists of single octal digit.
+                    if (token.str[pos1 + 2] == '\\') or (token.str[pos1 + 2] == '\''):
+                        continue
                     if not isOctalDigit(token.str[pos1 + 2]):
                         self.reportError(token, 4, 1)
                         continue
-                    if not isOctalDigit(token.str[pos1 + 2]):
+                    # Check for next or end of escape sequence.
+                    # To match sequence which consists of two octal digits.
+                    if (token.str[pos1 + 3] == '\\') or (token.str[pos1 + 3] == '\''):
+                        continue
+                    if not isOctalDigit(token.str[pos1 + 3]):
                         self.reportError(token, 4, 1)
                         continue
                 else:
                     continue
 
                 c = token.str[pos1 + 4]
-                if c != '"' and c != '\\':
+                if c != '"' and c != '\'' and c != '\\':
                     self.reportError(token, 4, 1)
 
     def misra_5_1(self, data):

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -69,8 +69,19 @@ int misra_5_2_field_hides_field1_31y;//5.2
 const char *s41_1 = "\x41g"; // 4.1
 const char *s41_2 = "\x41\x42";
 const char *s41_3 = "\x41" "g";
+const char *s41_4 = "\x8g";  // 4.1
+const char *s41_5 = "\x8";
+const char *s41_6 = "\x41\xA";
+const char *s41_7 = "\xA\x41";
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
+int c41_5         = '\141';
+int c41_6         = '\0';
+int c41_7         = '\0\t';
+int c41_8         = '\0t';   // 4.1
+int c41_9         = '\12';
+int c41_10        = '\12\n';
+int c41_11        = '\12n';  // 4.1
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -73,15 +73,38 @@ const char *s41_4 = "\x8g";  // 4.1
 const char *s41_5 = "\x8";
 const char *s41_6 = "\x41\xA";
 const char *s41_7 = "\xA\x41";
-int c41_3         = '\141t'; // 4.1
+const char *s41_8 = "hello\xAg\x41";  //4.1
+int c41_3         = '\141t';   // 4.1
 int c41_4         = '\141\t';
 int c41_5         = '\141';
 int c41_6         = '\0';
 int c41_7         = '\0\t';
-int c41_8         = '\0t';   // 4.1
+int c41_8         = '\0t';     // 4.1
 int c41_9         = '\12';
 int c41_10        = '\12\n';
-int c41_11        = '\12n';  // 4.1
+int c41_11        = '\12n';    // 4.1
+int c41_12        = '\12323';  // 4.1
+int c41_13        = '\1232\3'; // 4.1
+
+void misra_4_1()
+{
+    (void)printf("\x41g");         // 4.1
+    (void)printf("\x8g");          // 4.1
+    (void)printf("hello\xAg\x41"); // 4.1
+    (void)printf("\x41\x42");
+    (void)printf("\x41" "g");
+    (void)printf("%i", '\141t');   // 4.1
+    (void)printf("%i", '\141\t');
+    (void)printf("%i", '\141');
+    (void)printf("%i", '\0t');     // 4.1
+    (void)printf("%i", '\0\t');
+    (void)printf("%i", '\0');
+    (void)printf("%i", '\12t');    // 4.1
+    (void)printf("%i", '\12\t');
+    (void)printf("%i", '\12');
+    (void)printf("%i", '\12323');  // 4.1
+    (void)printf("%i", '\1232\3'); // 4.1
+}
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}


### PR DESCRIPTION
…ences less than 3 octal digits and hexadecimal escape sequences less than 2 hexadecimal digits (ticket #9370).

Add end of sequence check for single quoted sequences.
Add compliant and non-compliant test cases for short escape sequences.