### PR TITLE
misra.py: Fix Rule 4.1

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -21,6 +21,7 @@ import re
 import os
 import argparse
 import codecs
+import string
 
 
 typeBits = {
@@ -456,15 +457,15 @@ def getArguments(ftok):
 
 
 def isalnum(c):
-    return (c >= '0' and c <= '9') or (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z')
+    return c in string.digits or c in string.ascii_letters
 
 
 def isHexDigit(c):
-    return (c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F')
+    return c in string.hexdigits
 
 
 def isOctalDigit(c):
-    return c >= '0' and c <= '7'
+    return c in string.octdigits
 
 
 def isNoReturnScope(tok):

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -23,12 +23,15 @@ import argparse
 import codecs
 import string
 
-from itertools import izip
+try:
+    from itertools import izip as zip
+except ImportError:
+    pass
 
 
 def grouped(iterable, n):
     "s -> (s0,s1,s2,...sn-1), (sn,sn+1,sn+2,...s2n-1), (s2n,s2n+1,s2n+2,...s3n-1), ..."
-    return izip(*[iter(iterable)]*n)
+    return zip(*[iter(iterable)]*n)
 
 
 typeBits = {

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -475,7 +475,7 @@ def isHexEscapeSequence(symbols):
             hexademical-escape-sequence hexademical-digit
 
     Reference: n1570 6.4.4.4"""
-    if len(symbols) < 3 or symbols[0] != '\\' or symbols[1] != 'x':
+    if len(symbols) < 3 or symbols[:2] != '\\x':
         return False
     return all([s in string.hexdigits for s in symbols[2:]])
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -70,12 +70,17 @@ const char *s41_1 = "\x41g"; // 4.1
 const char *s41_2 = "\x41\x42";
 const char *s41_3 = "\x41" "\x42";
 const char *s41_4 = "\x41" "g";
+const char *s41_5 = "\x41\xA";
+const char *s41_6 = "\xA\x41";
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
 int c41_5         = '\0';
 int c41_6         = '\0\t';
 int c41_7         = '\12\t';
-int c41_8         = '\12';
+int c41_8         = '\0t';   // 4.1
+int c41_9         = '\12';
+int c41_10        = '\12\n';
+int c41_11        = '\12n';  // 4.1
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -76,6 +76,7 @@ const char *s41_7 = "\xAA\xg\x41"; // 4.1
 const char *s41_8 = "\xAA\x\x41"; // 4.1
 const char *s41_9 = "unknown\gsequence";
 const char *s41_10 = "simple\nsequence";
+const char *s41_11 = "string";
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
 int c41_5         = '\0';
@@ -88,6 +89,7 @@ int c41_11        = '\12n';  // 4.1
 int c41_12         = '\12323'; // 4.1
 int c41_13         = '\123\3';
 int c41_14         = '\777\777';
+int c41_15         = 'a';
 
 void misra_4_1()
 {

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -74,6 +74,8 @@ const char *s41_5 = "\x41\xA";
 const char *s41_6 = "\xA\x41";
 const char *s41_7 = "\xAA\xg\x41"; // 4.1
 const char *s41_8 = "\xAA\x\x41"; // 4.1
+const char *s41_9 = "unknown\gsequence";
+const char *s41_10 = "simple\nsequence";
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
 int c41_5         = '\0';
@@ -83,8 +85,16 @@ int c41_8         = '\0t';   // 4.1
 int c41_9         = '\12';
 int c41_10        = '\12\n';
 int c41_11        = '\12n';  // 4.1
-int c41_12         = '\12323';
-int c41_13         = '\1232\3';
+int c41_12         = '\12323'; // 4.1
+int c41_13         = '\123\3';
+int c41_14         = '\777\777';
+
+void misra_4_1()
+{
+    (void)printf("\x41g"); // 4.1
+    (void)printf("\x41\x42");
+    (void)printf("\x41" "g");
+}
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -68,8 +68,14 @@ int misra_5_2_field_hides_field1_31y;//5.2
 };
 const char *s41_1 = "\x41g"; // 4.1
 const char *s41_2 = "\x41\x42";
+const char *s41_3 = "\x41" "\x42";
+const char *s41_4 = "\x41" "g";
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
+int c41_5         = '\0';
+int c41_6         = '\0\t';
+int c41_7         = '\12\t';
+int c41_8         = '\12';
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -72,6 +72,8 @@ const char *s41_3 = "\x41" "\x42";
 const char *s41_4 = "\x41" "g";
 const char *s41_5 = "\x41\xA";
 const char *s41_6 = "\xA\x41";
+const char *s41_7 = "\xAA\xg\x41"; // 4.1
+const char *s41_8 = "\xAA\x\x41"; // 4.1
 int c41_3         = '\141t'; // 4.1
 int c41_4         = '\141\t';
 int c41_5         = '\0';
@@ -81,6 +83,8 @@ int c41_8         = '\0t';   // 4.1
 int c41_9         = '\12';
 int c41_10        = '\12\n';
 int c41_11        = '\12n';  // 4.1
+int c41_12         = '\12323';
+int c41_13         = '\1232\3';
 
 extern int misra_5_3_var_hides_var______31x;
 void misra_5_3_var_hides_function_31x (void) {}


### PR DESCRIPTION
This commit will fix issues with MISRA rule 4.1 caused by improper escape sequences handling.

References:
1. https://trac.cppcheck.net/ticket/9370
2. https://sourceforge.net/p/cppcheck/discussion/development/thread/7274ed3842/?limit=25#799a