### PR TITLE
Fix the following compilation error on VC142 :

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -27,6 +27,7 @@
 #include "token.h"
 #include "valueflow.h"
 
+#include <iterator>
 #include <list>
 #include <stack>
 


### PR DESCRIPTION
Error C2039 'inserter': is not a member of 'std' cppcheck 
cppcheck\lib\astutils.cpp 1229