### PR TITLE
MISRA: add exception to rule 3.1

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -740,9 +740,10 @@ class MisraChecker:
 
     def misra_3_1(self, rawTokens):
         for token in rawTokens:
-            if token.str.startswith('/*') or token.str.startswith('//'):
+            starts_with_double_slash = token.str.startswith('//')
+            if token.str.startswith('/*') or starts_with_double_slash:
                 s = token.str.lstrip('/')
-                if '//' in s or '/*' in s:
+                if (not starts_with_double_slash and '//' in s) or '/*' in s:
                     self.reportError(token, 3, 1)
 
 

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -743,7 +743,7 @@ class MisraChecker:
             starts_with_double_slash = token.str.startswith('//')
             if token.str.startswith('/*') or starts_with_double_slash:
                 s = token.str.lstrip('/')
-                if (not starts_with_double_slash and '//' in s) or '/*' in s:
+                if ((not starts_with_double_slash) and '//' in s) or '/*' in s:
                     self.reportError(token, 3, 1)
 
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -19,8 +19,11 @@ typedef unsigned int       u32;
 typedef signed int         s32;
 typedef unsigned long long u64;
 
-//   // 3.1
+/* // */   // 3.1
+/* /* */   // 3.1
 ////
+
+// http://example.com // no warning
 
 extern int misra_5_1_extern_var_hides_var_x;
 extern int misra_5_1_extern_var_hides_var_y; //5.1


### PR DESCRIPTION
MISRA-C 2012 states that `//` is allowed in a `//` comment, as an exception