### PR TITLE
MISRA-C: fix false positive in 11.7

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1209,7 +1209,7 @@ class MisraChecker:
                 continue
             if (vt2.pointer > 0 and vt1.pointer == 0 and
                     not vt1.isIntegral() and not vt1.isEnum() and
-                    vt2.type != 'void'):
+                    vt1.type != 'void'):
                 self.reportError(token, 11, 7)
             elif (vt1.pointer > 0 and vt2.pointer == 0 and
                     not vt2.isIntegral() and not vt2.isEnum() and

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -258,6 +258,11 @@ void misra_11_7(int *p, float f) {
   y = ( int * ) f; //11.7
 }
 
+void misra_11_7_extra(int *p, float f, bool b) {
+  (void) p; // no-warning
+  (void) f; // no-warning
+}
+
 char * misra_11_8_const(const char *str) {  }
 char * misra_11_8(const char *str) {
   (void)misra_11_8_const(str); // no-warning


### PR DESCRIPTION
Casting a pointer to `(void)` triggered the rule, which shouldn't happen. Looked like a bug?