### PR TITLE
Fix crashes in valueflow

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3200,7 +3200,7 @@ static void valueFlowForward(Token* startToken,
                              const Settings* settings)
 {
     const Token* expr = solveExprValues(exprTok, values);
-    if (Token::Match(expr, "%var%")) {
+    if (Token::Match(expr, "%var%") && expr->variable()) {
         valueFlowForwardVariable(startToken,
                                  endToken,
                                  expr->variable(),

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -128,6 +128,8 @@ private:
         TEST_CASE(valueFlowUnknownFunctionReturn);
 
         TEST_CASE(valueFlowPointerAliasDeref);
+
+        TEST_CASE(valueFlowCrashIncompleteCode);
     }
 
     static bool isNotTokValue(const ValueFlow::Value &val) {
@@ -4277,6 +4279,17 @@ private:
                "  return x;\n"
                "}\n";
         ASSERT_EQUALS(true, testValueOfX(code, 5U, 123));
+    }
+
+    void valueFlowCrashIncompleteCode() {
+        const char* code;
+
+        code = "void SlopeFloor::setAttr(const Value &val) {\n"
+               "    int x = val;\n"
+               "    if (x >= -1)\n"
+               "        state = x;\n"
+               "}\n";
+        valueOfTok(code, "=");
     }
 };
 


### PR DESCRIPTION
http://cppcheck1.osuosl.org:8000/crash.html

For instance in http://cppcheck1.osuosl.org:8000/styx
```
==19651==ERROR: AddressSanitizer: SEGV on unknown address 0x00000000001c (pc 0x556f21abc3df bp 0x7ffc140d2720 sp 0x7ffc140d2710 T0)
==19651==The signal is caused by a READ memory access.
==19651==Hint: address points to the zero page.
    #0 0x556f21abc3de in Variable::isGlobal() const ../lib/symboldatabase.h:342
    #1 0x556f221f801a in valueFlowForwardVariable ../lib/valueflow.cpp:2471
    #2 0x556f22208130 in valueFlowForward ../lib/valueflow.cpp:3204
    #3 0x556f221e9e14 in valueFlowReverse ../lib/valueflow.cpp:1892
    #4 0x556f221f1a43 in valueFlowBeforeCondition ../lib/valueflow.cpp:2200
    #5 0x556f2223dbb5 in ValueFlow::setValues(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) ../lib/valueflow.cpp:6521
    #6 0x556f220e5991 in Tokenizer::simplifyTokens1(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../lib/tokenize.cpp:2342
    #7 0x556f21d8d066 in CppCheck::checkFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::istream&) ../lib/cppcheck.cpp:508
    #8 0x556f21d84cd3 in CppCheck::check(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../lib/cppcheck.cpp:192
    #9 0x556f21a28796 in CppCheckExecutor::check_internal(CppCheck&, int, char const* const*) ../cli/cppcheckexecutor.cpp:884
    #10 0x556f21a24be8 in CppCheckExecutor::check(int, char const* const*) ../cli/cppcheckexecutor.cpp:198
    #11 0x556f22313063 in main ../cli/main.cpp:95
```