### PR TITLE
fix #8965 ("(debug) Executable scope 'x' with unknown function." with…

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2318,18 +2318,6 @@ bool Tokenizer::simplifyTokens1(const std::string &configuration)
         createSymbolDatabase();
     }
 
-    // Use symbol database to identify rvalue references. Split && to & &. This is safe, since it doesn't delete any tokens (which might be referenced by symbol database)
-    for (const Variable* var : mSymbolDatabase->variableList()) {
-        if (var && var->isRValueReference()) {
-            Token* endTok = const_cast<Token*>(var->typeEndToken());
-            endTok->str("&");
-            endTok->astOperand1(nullptr);
-            endTok->astOperand2(nullptr);
-            endTok->insertToken("&");
-            endTok->next()->scope(endTok->scope());
-        }
-    }
-
     if (mTimerResults) {
         Timer t("Tokenizer::simplifyTokens1::setValueType", mSettings->showtime, mTimerResults);
         mSymbolDatabase->setValueTypeInTokenList(true);
@@ -4635,8 +4623,6 @@ bool Tokenizer::simplifyTokenList1(const char FileName[])
     simplifyEmptyNamespaces();
 
     elseif();
-
-    SimplifyNamelessRValueReferences();
 
     validate();
 
@@ -11236,17 +11222,6 @@ void Tokenizer::setPodTypes()
             if (prev && !Token::Match(prev, ";|{|}|,|("))
                 continue;
             tok->isStandardType(true);
-        }
-    }
-}
-
-void Tokenizer::SimplifyNamelessRValueReferences()
-{
-    // Simplify nameless rValue references - named ones are simplified later
-    for (Token* tok = list.front(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "&& [,)]")) {
-            tok->str("&");
-            tok->insertToken("&");
         }
     }
 }

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -154,8 +154,6 @@ public:
     */
     bool simplifyTokenList1(const char FileName[]);
 
-    void SimplifyNamelessRValueReferences();
-
     /**
     * Most aggressive simplification of tokenlist
     *

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1034,6 +1034,15 @@ static void compileLogicAnd(Token *&tok, AST_state& state)
     compileOr(tok, state);
     while (tok) {
         if (tok->str() == "&&") {
+            if (!tok->astOperand1()) {
+                Token* tok2 = tok->next();
+                if (!tok2)
+                    break;
+                if (state.cpp && Token::Match(tok2, ",|)")) {
+                    tok = tok2;
+                    break; // rValue reference
+                }
+            }
             compileBinOp(tok, state, compileOr);
         } else break;
     }

--- a/test/testinternal.cpp
+++ b/test/testinternal.cpp
@@ -445,13 +445,13 @@ private:
 
         check("void f() {\n"
               "    const Token *tok;\n"
-              "    if(a && b && && c && tok && Token::Match(tok, \"5str% foobar\")) {};\n"
+              "    if(a && b && c && tok && Token::Match(tok, \"5str% foobar\")) {};\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (style) Unnecessary check of \"tok\", match-function already checks if it is null.\n", errout.str());
 
         check("void f() {\n"
               "    const Token *tok;\n"
-              "    if(a && b && && c && tok && d && Token::Match(tok, \"5str% foobar\")) {};\n"
+              "    if(a && b && c && tok && d && Token::Match(tok, \"5str% foobar\")) {};\n"
               "}");
         ASSERT_EQUALS("", errout.str());
 

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -3000,19 +3000,19 @@ private:
                                "a<int> c ; "
                                "template < typename d > "
                                "template < typename b > "
-                               "const decltype ( auto ) a < d > :: operator() ( b & & ) const { } "
+                               "const decltype ( auto ) a < d > :: operator() ( b && ) const { } "
                                "struct a<int> { "
-                               "template < typename b > const decltype ( auto ) operator() ( b & & ) const ; "
+                               "template < typename b > const decltype ( auto ) operator() ( b && ) const ; "
                                "} ;";
             const char act[] = "struct a<int> ; "
                                "a<int> c ; "
                                "template < typename d > "
                                "template < typename b > "
-                               "const decltype ( auto ) a < d > :: operator() ( b & & ) const { } "
+                               "const decltype ( auto ) a < d > :: operator() ( b && ) const { } "
                                "struct a<int> { "
-                               "template < typename b > const decltype ( auto ) operator() ( b & & ) const ; "
+                               "template < typename b > const decltype ( auto ) operator() ( b && ) const ; "
                                "} ; "
-                               "const decltype ( auto ) a<int> :: operator() ( b & & ) const { }";
+                               "const decltype ( auto ) a<int> :: operator() ( b && ) const { }";
             TODO_ASSERT_EQUALS(exp, act, tok(code));
         }
         {

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -2221,8 +2221,8 @@ private:
 
     void simplifyTypedef109() {
         const char code[] = "typedef int&& rref;\n"
-                            "rref var;";
-        const char expected[] = "int & & var ;";
+                            "rref var = 0;";
+        const char expected[] = "int && var ; var = 0 ;";
         ASSERT_EQUALS(expected, tok(code));
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1559,7 +1559,7 @@ private:
             ASSERT(ctor && ctor->retDef == nullptr);
         }
         {
-            GET_SYMBOL_DB("class Foo { Foo(Foo & & f, int default = 1, bool defaultToo = true); };");
+            GET_SYMBOL_DB("class Foo { Foo(Foo&& f, int default = 1, bool defaultToo = true); };");
             const Function* ctor = tokenizer.tokens()->tokAt(3)->function();
             ASSERT(db && ctor && ctor->type == Function::eMoveConstructor);
             ASSERT(ctor && ctor->retDef == nullptr);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7269,7 +7269,11 @@ private:
         ASSERT_EQUALS("catch...(", testAst("try {} catch (...) {}"));
 
         ASSERT_EQUALS("FooBar(", testAst("void Foo(Bar&);"));
-        ASSERT_EQUALS("FooBar(", testAst("void Foo(Bar& &);")); // Rvalue reference - simplified from && to & & by real tokenizer
+        ASSERT_EQUALS("FooBar(", testAst("void Foo(Bar&&);"));
+
+        ASSERT_EQUALS("FooBarb&(", testAst("void Foo(Bar& b);"));
+        ASSERT_EQUALS("FooBarb&&(", testAst("void Foo(Bar&& b);"));
+
         ASSERT_EQUALS("DerivedDerived::(", testAst("Derived::~Derived() {}"));
 
         ASSERT_EQUALS("ifCA_FarReadfilenew(,sizeofobjtype(,(!(", testAst("if (!CA_FarRead(file, (void far *)new, sizeof(objtype)))")); // #5910 - don't hang if C code is parsed as C++

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -2222,18 +2222,18 @@ private:
     }
 
     void varid_rvalueref() {
-        ASSERT_EQUALS("1: int & & a@1 ;\n", tokenize("int&& a;"));
+        ASSERT_EQUALS("1: int && a@1 ;\n", tokenize("int&& a;"));
 
-        ASSERT_EQUALS("1: void foo ( int & & a@1 ) { }\n", tokenize("void foo(int&& a) {}"));
+        ASSERT_EQUALS("1: void foo ( int && a@1 ) { }\n", tokenize("void foo(int&& a) {}"));
 
         ASSERT_EQUALS("1: class C {\n"
-                      "2: C ( int & & a@1 ) ;\n"
+                      "2: C ( int && a@1 ) ;\n"
                       "3: } ;\n",
                       tokenize("class C {\n"
                                "    C(int&& a);\n"
                                "};"));
 
-        ASSERT_EQUALS("1: void foo ( int & & ) ;\n", tokenize("void foo(int&&);"));
+        ASSERT_EQUALS("1: void foo ( int && ) ;\n", tokenize("void foo(int&&);"));
     }
 
     void varid_arrayFuncPar() {


### PR DESCRIPTION
… rvalue parameter in method)

I fixed the AST enough to pass testrunner but I don't believe it is
correct.

This code:

void Foo4(int&&b);

has this AST:

( 'void'
|-Foo4
`-&& 'bool'
  |-int
  `-b 'signed int'

but I don't believe && should have `bool`.