### PR TITLE
Extend lifetime checking to temporaries

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -220,6 +220,25 @@ const Token * astIsVariableComparison(const Token *tok, const std::string &comp,
     return ret;
 }
 
+bool isTemporary(bool cpp, const Token* tok)
+{
+    if (!tok)
+        return false;
+    if (Token::simpleMatch(tok, "."))
+        return isTemporary(cpp, tok->astOperand1()) || isTemporary(cpp, tok->astOperand2());
+    if (Token::Match(tok, ",|::"))
+        return isTemporary(cpp, tok->astOperand2());
+    if (Token::Match(tok, "?|.|[|++|--|%name%|%assign%"))
+        return false;
+    if (tok->isUnaryOp("*"))
+        return false;
+    if (Token::Match(tok, "&|<<|>>") && isLikelyStream(cpp, tok->astOperand1()))
+        return false;
+    if (Token::Match(tok->previous(), "%name% ("))
+        return tok->previous()->function() && !Function::returnsReference(tok->previous()->function(), true);
+    return true;
+}
+
 static bool isFunctionCall(const Token* tok)
 {
     if (Token::Match(tok, "%name% ("))

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -87,6 +87,8 @@ std::string astCanonicalType(const Token *expr);
 /** Is given syntax tree a variable comparison against value */
 const Token * astIsVariableComparison(const Token *tok, const std::string &comp, const std::string &rhs, const Token **vartok=nullptr);
 
+bool isTemporary(bool cpp, const Token* tok);
+
 const Token * nextAfterAstRightmostLeaf(const Token * tok);
 
 Token* astParentSkipParens(Token* tok);

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -444,9 +444,9 @@ static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
 {
     if (!tok)
         return false;
-    if (Token::Match(tok, ",|."))
+    if (Token::Match(tok, ",|.|::"))
         return isDeadTemporary(cpp, tok->astOperand2(), expr);
-    if (Token::Match(tok, "?|.|[|++|--|%var%|%assign%"))
+    if (Token::Match(tok, "?|.|[|++|--|%name%|%assign%"))
         return false;
     if (tok->isUnaryOp("*"))
         return false;

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -446,7 +446,7 @@ static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
         return false;
     if (Token::simpleMatch(tok, ","))
         return isDeadTemporary(cpp, tok->astOperand2(), expr);
-    if (Token::Match(tok, ".|[|++|--|%var%|%assign%"))
+    if (Token::Match(tok, "?|.|[|++|--|%var%|%assign%"))
         return false;
     if (tok->isUnaryOp("*"))
         return false;

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -448,6 +448,8 @@ static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
         return isDeadTemporary(cpp, tok->astOperand2(), expr);
     if (Token::Match(tok, ".|[|++|--|%var%|%assign%"))
         return false;
+    if (tok->isUnaryOp("*"))
+        return false;
     if (Token::Match(tok, "&|<<|>>") && isLikelyStream(cpp, tok->astOperand1()))
         return false;
     if (expr && !precedes(nextAfterAstRightmostLeaf(tok->astTop()), nextAfterAstRightmostLeaf(expr->astTop())))

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -442,20 +442,10 @@ static int getPointerDepth(const Token *tok)
 
 static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
 {
-    if (!tok)
-        return false;
-    if (Token::Match(tok, ",|.|::"))
-        return isDeadTemporary(cpp, tok->astOperand2(), expr);
-    if (Token::Match(tok, "?|.|[|++|--|%name%|%assign%"))
-        return false;
-    if (tok->isUnaryOp("*"))
-        return false;
-    if (Token::Match(tok, "&|<<|>>") && isLikelyStream(cpp, tok->astOperand1()))
+    if (!isTemporary(cpp, tok))
         return false;
     if (expr && !precedes(nextAfterAstRightmostLeaf(tok->astTop()), nextAfterAstRightmostLeaf(expr->astTop())))
         return false;
-    if (Token::Match(tok->previous(), "%name% ("))
-        return tok->previous()->function() && !Function::returnsReference(tok->previous()->function(), true);
     return true;
 }
 

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -444,7 +444,7 @@ static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
 {
     if (!tok)
         return false;
-    if (Token::simpleMatch(tok, ","))
+    if (Token::Match(tok, ",|."))
         return isDeadTemporary(cpp, tok->astOperand2(), expr);
     if (Token::Match(tok, "?|.|[|++|--|%var%|%assign%"))
         return false;

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -502,7 +502,8 @@ void CheckAutoVariables::checkVarLifetimeScope(const Token * start, const Token 
                     continue;
                 if (!isLifetimeBorrowed(tok, mSettings))
                     continue;
-                if ((val.tokvalue->variable() && isInScope(val.tokvalue->variable()->nameToken(), scope)) || isDeadTemporary(mTokenizer->isCPP(), val.tokvalue, tok)) {
+                if ((val.tokvalue->variable() && isInScope(val.tokvalue->variable()->nameToken(), scope)) ||
+                    isDeadTemporary(mTokenizer->isCPP(), val.tokvalue, tok)) {
                     errorReturnDanglingLifetime(tok, &val);
                     break;
                 }
@@ -579,7 +580,7 @@ void CheckAutoVariables::errorInvalidLifetime(const Token *tok, const ValueFlow:
     reportError(errorPath, Severity::error, "invalidLifetime", msg + " that is out of scope.", CWE562, inconclusive);
 }
 
-void CheckAutoVariables::errorDanglingTemporaryLifetime(const Token *tok, const ValueFlow::Value* val)
+void CheckAutoVariables::errorDanglingTemporaryLifetime(const Token* tok, const ValueFlow::Value* val)
 {
     const bool inconclusive = val ? val->isInconclusive() : false;
     ErrorPath errorPath = val ? val->errorPath : ErrorPath();
@@ -614,10 +615,11 @@ void CheckAutoVariables::errorDanglingReference(const Token *tok, const Variable
     reportError(errorPath, Severity::error, "danglingReference", msg, CWE562, false);
 }
 
-void CheckAutoVariables::errorReturnTempReference(const Token *tok, ErrorPath errorPath, bool inconclusive)
+void CheckAutoVariables::errorReturnTempReference(const Token* tok, ErrorPath errorPath, bool inconclusive)
 {
     errorPath.emplace_back(tok, "");
-    reportError(errorPath, Severity::error, "returnTempReference", "Reference to temporary returned.", CWE562, inconclusive);
+    reportError(
+        errorPath, Severity::error, "returnTempReference", "Reference to temporary returned.", CWE562, inconclusive);
 }
 
 void CheckAutoVariables::errorInvalidDeallocation(const Token *tok, const ValueFlow::Value *val)

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -548,7 +548,7 @@ static bool isDeadTemporary(bool cpp, const Token* tok, const Token* expr)
     if (expr && !precedes(nextAfterAstRightmostLeaf(tok->astTop()), nextAfterAstRightmostLeaf(expr->astTop())))
         return false;
     if (Token::Match(tok->previous(), "%name% ("))
-        return tok->previous()->function() && !Function::returnsReference(tok->previous()->function());
+        return tok->previous()->function() && !Function::returnsReference(tok->previous()->function(), true);
     return true;
 }
 

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -85,6 +85,7 @@ private:
     void errorReturnDanglingLifetime(const Token *tok, const ValueFlow::Value* val);
     void errorInvalidLifetime(const Token *tok, const ValueFlow::Value* val);
     void errorDanglngLifetime(const Token *tok, const ValueFlow::Value *val);
+    void errorDanglingTemporaryLifetime(const Token *tok, const ValueFlow::Value *val);
     void errorReturnReference(const Token* tok, ErrorPath errorPath, bool inconclusive);
     void errorDanglingReference(const Token *tok, const Variable *var, ErrorPath errorPath);
     void errorReturnTempReference(const Token *tok, ErrorPath errorPath, bool inconclusive);
@@ -109,6 +110,7 @@ private:
         c.errorReturnDanglingLifetime(nullptr, nullptr);
         c.errorInvalidLifetime(nullptr, nullptr);
         c.errorDanglngLifetime(nullptr, nullptr);
+        c.errorDanglingTemporaryLifetime(nullptr, nullptr);
     }
 
     static std::string myName() {

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -52,7 +52,6 @@ public:
     void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
         CheckAutoVariables checkAutoVariables(tokenizer, settings, errorLogger);
         checkAutoVariables.assignFunctionArg();
-        checkAutoVariables.returnReference();
         checkAutoVariables.checkVarLifetime();
         checkAutoVariables.autoVariables();
     }
@@ -63,21 +62,11 @@ public:
     /** Check auto variables */
     void autoVariables();
 
-    /** Returning reference to local/temporary variable */
-    void returnReference();
-
     void checkVarLifetime();
 
     void checkVarLifetimeScope(const Token * start, const Token * end);
 
 private:
-    /**
-     * Returning a temporary object?
-     * @param tok pointing at the "return" token
-     * @return true if a temporary object is returned
-     */
-    static bool returnTemporary(const Token *tok);
-
     void errorReturnAddressToAutoVariable(const Token *tok);
     void errorReturnAddressToAutoVariable(const Token *tok, const ValueFlow::Value *value);
     void errorReturnPointerToLocalArray(const Token *tok);

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -74,10 +74,10 @@ private:
     void errorReturnDanglingLifetime(const Token *tok, const ValueFlow::Value* val);
     void errorInvalidLifetime(const Token *tok, const ValueFlow::Value* val);
     void errorDanglngLifetime(const Token *tok, const ValueFlow::Value *val);
-    void errorDanglingTemporaryLifetime(const Token *tok, const ValueFlow::Value *val);
+    void errorDanglingTemporaryLifetime(const Token* tok, const ValueFlow::Value* val);
     void errorReturnReference(const Token* tok, ErrorPath errorPath, bool inconclusive);
     void errorDanglingReference(const Token *tok, const Variable *var, ErrorPath errorPath);
-    void errorReturnTempReference(const Token *tok, ErrorPath errorPath, bool inconclusive);
+    void errorReturnTempReference(const Token* tok, ErrorPath errorPath, bool inconclusive);
     void errorInvalidDeallocation(const Token *tok, const ValueFlow::Value *val);
     void errorReturnAddressOfFunctionParameter(const Token *tok, const std::string &varname);
     void errorUselessAssignmentArg(const Token *tok);

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -87,7 +87,7 @@ private:
     void errorDanglngLifetime(const Token *tok, const ValueFlow::Value *val);
     void errorReturnReference(const Token* tok, ErrorPath errorPath, bool inconclusive);
     void errorDanglingReference(const Token *tok, const Variable *var, ErrorPath errorPath);
-    void errorReturnTempReference(const Token *tok);
+    void errorReturnTempReference(const Token *tok, ErrorPath errorPath, bool inconclusive);
     void errorInvalidDeallocation(const Token *tok, const ValueFlow::Value *val);
     void errorReturnAddressOfFunctionParameter(const Token *tok, const std::string &varname);
     void errorUselessAssignmentArg(const Token *tok);
@@ -101,7 +101,7 @@ private:
         c.errorReturnPointerToLocalArray(nullptr);
         c.errorReturnReference(nullptr, errorPath, false);
         c.errorDanglingReference(nullptr, nullptr, errorPath);
-        c.errorReturnTempReference(nullptr);
+        c.errorReturnTempReference(nullptr, errorPath, false);
         c.errorInvalidDeallocation(nullptr, nullptr);
         c.errorReturnAddressOfFunctionParameter(nullptr, "parameter");
         c.errorUselessAssignmentArg(nullptr);

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2180,13 +2180,22 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
     return false;
 }
 
-bool Function::returnsReference(const Function *function)
+bool Function::returnsReference(const Function *function, bool unknown)
 {
     if (!function)
         return false;
     if (function->type != Function::eFunction)
         return false;
-    return function->tokenDef->strAt(-1) == "&";
+    const Token* defEnd = function->returnDefEnd();
+    if (defEnd->strAt(-1) == "&")
+        return true;
+    // Check for unknown types, which could be a reference
+    const Token *start = function->retDef;
+    while(Token::Match(start, "const|volatile"))
+        start = start->next();
+    if (start->tokAt(1) == defEnd && !start->type() && !start->isStandardType())
+        return unknown;
+    return false;
 }
 
 const Token * Function::constructorMemberInitialization() const

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2180,7 +2180,7 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
     return false;
 }
 
-bool Function::returnsReference(const Function *function, bool unknown)
+bool Function::returnsReference(const Function* function, bool unknown)
 {
     if (!function)
         return false;
@@ -2190,8 +2190,8 @@ bool Function::returnsReference(const Function *function, bool unknown)
     if (defEnd->strAt(-1) == "&")
         return true;
     // Check for unknown types, which could be a reference
-    const Token *start = function->retDef;
-    while(Token::Match(start, "const|volatile"))
+    const Token* start = function->retDef;
+    while (Token::Match(start, "const|volatile"))
         start = start->next();
     if (start->tokAt(1) == defEnd && !start->type() && !start->isStandardType())
         return unknown;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -865,7 +865,7 @@ public:
 
     static bool argsMatch(const Scope *scope, const Token *first, const Token *second, const std::string &path, nonneg int path_length);
 
-    static bool returnsReference(const Function *function, bool unknown=false);
+    static bool returnsReference(const Function* function, bool unknown = false);
 
     const Token* returnDefEnd() const {
         if (this->hasTrailingReturnType()) {

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -865,7 +865,7 @@ public:
 
     static bool argsMatch(const Scope *scope, const Token *first, const Token *second, const std::string &path, nonneg int path_length);
 
-    static bool returnsReference(const Function *function);
+    static bool returnsReference(const Function *function, bool unknown=false);
 
     const Token* returnDefEnd() const {
         if (this->hasTrailingReturnType()) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3344,7 +3344,7 @@ std::vector<LifetimeToken> getLifetimeTokens(const Token* tok, ValueFlow::Value:
             } else if (Token::simpleMatch(var->declEndToken(), "=")) {
                 errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
                 const Token *vartok = var->declEndToken()->astOperand2();
-                if (vartok == tok)
+                if (vartok == tok || (var->isConst() && isTemporary(true, vartok)))
                     return {{tok, true, std::move(errorPath)}};
                 if (vartok)
                     return getLifetimeTokens(vartok, std::move(errorPath), depth - 1);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -101,6 +101,7 @@ private:
         TEST_CASE(returnReference6);
         TEST_CASE(returnReference7);
         TEST_CASE(returnReference8);
+        TEST_CASE(returnReference9);
         TEST_CASE(returnReferenceFunction);
         TEST_CASE(returnReferenceContainer);
         TEST_CASE(returnReferenceLiteral);
@@ -1146,6 +1147,13 @@ private:
               "    std::vector<int>::iterator it = v.begin();\n"
               "    int& value = *it;\n"
               "    return value;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void returnReference9() {
+        check("int& f(bool b, int& x, int& y) {\n"
+              "    return b ? x : y;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -1298,7 +1298,9 @@ private:
               "const std::string &a() {\n"
               "    return f(\"foo\");\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:1] -> [test.cpp:3] -> [test.cpp:3]: (error) Reference to temporary returned.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:1] -> [test.cpp:1] -> [test.cpp:3] -> [test.cpp:3]: (error) Reference to temporary returned.\n",
+            errout.str());
 
         check("const char * f(const char * x) { return x; }\n"
               "const std::string &a() {\n"
@@ -1744,7 +1746,10 @@ private:
               "auto f() {\n"
               "    return g().begin();\n"
               "}\n");
-        TODO_ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:3]: (error) Returning iterator that will be invalid when returning.\n", "", errout.str());
+        TODO_ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:3]: (error) Returning iterator that will be invalid when returning.\n",
+            "",
+            errout.str());
 
         check("std::vector<int> f();\n"
               "auto f() {\n"
@@ -1752,7 +1757,7 @@ private:
               "    return it;\n"
               "}\n");
         TODO_ASSERT_EQUALS("error", "", errout.str());
-        
+
         check("std::vector<int> f();\n"
               "int& f() {\n"
               "    return *g().begin();\n"
@@ -2221,7 +2226,8 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void danglingTemporaryLifetime() {
+    void danglingTemporaryLifetime()
+    {
         check("const int& g(const int& x) {\n"
               "    return x;\n"
               "}\n"
@@ -2229,7 +2235,9 @@ private:
               "    int* x = &g(0);\n"
               "    i += *x;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:1] -> [test.cpp:2] -> [test.cpp:5] -> [test.cpp:5] -> [test.cpp:6]: (error) Using pointer to temporary.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:1] -> [test.cpp:2] -> [test.cpp:5] -> [test.cpp:5] -> [test.cpp:6]: (error) Using pointer to temporary.\n",
+            errout.str());
     }
 
     void invalidLifetime() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -102,6 +102,7 @@ private:
         TEST_CASE(returnReference7);
         TEST_CASE(returnReference8);
         TEST_CASE(returnReference9);
+        TEST_CASE(returnReference10);
         TEST_CASE(returnReferenceFunction);
         TEST_CASE(returnReferenceContainer);
         TEST_CASE(returnReferenceLiteral);
@@ -1156,6 +1157,15 @@ private:
               "    return b ? x : y;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void returnReference10() {
+        check("class A { int f() const; };\n"
+              "int& g() {\n"
+              "    A a;\n"
+              "    return a.f();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Reference to temporary returned.\n", errout.str());
     }
 
     void returnReferenceFunction() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -100,6 +100,7 @@ private:
         TEST_CASE(returnReference5);
         TEST_CASE(returnReference6);
         TEST_CASE(returnReference7);
+        TEST_CASE(returnReference8);
         TEST_CASE(returnReferenceFunction);
         TEST_CASE(returnReferenceContainer);
         TEST_CASE(returnReferenceLiteral);
@@ -1137,6 +1138,15 @@ private:
               "std::string &b() {\n"
               "    return a(12);\n"
               "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void returnReference8() {
+        check("int& f(std::vector<int> &v) {\n"
+              "    std::vector<int>::iterator it = v.begin();\n"
+              "    int& value = *it;\n"
+              "    return value;\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -103,6 +103,8 @@ private:
         TEST_CASE(returnReference8);
         TEST_CASE(returnReference9);
         TEST_CASE(returnReference10);
+        TEST_CASE(returnReference11);
+        TEST_CASE(returnReference12);
         TEST_CASE(returnReferenceFunction);
         TEST_CASE(returnReferenceContainer);
         TEST_CASE(returnReferenceLiteral);
@@ -1166,6 +1168,48 @@ private:
               "    return a.f();\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:4]: (error) Reference to temporary returned.\n", errout.str());
+
+        check("class A { int& f() const; };\n"
+              "int& g() {\n"
+              "    A a;\n"
+              "    return a.f();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void returnReference11() {
+        check("class A { static int f(); };\n"
+              "int& g() {\n"
+              "    return A::f();\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Reference to temporary returned.\n", errout.str());
+
+        check("class A { static int& f(); };\n"
+              "int& g() {\n"
+              "    return A::f();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("namespace A { int& f(); }\n"
+              "int& g() {\n"
+              "    return A::f();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void returnReference12() {
+        check("class A { static int& f(); };\n"
+              "auto g() {\n"
+              "    return &A::f;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("class A { static int& f(); };\n"
+              "auto g() {\n"
+              "    auto x = &A::f;\n"
+              "    return x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void returnReferenceFunction() {


### PR DESCRIPTION
This also removes the old `returnTemporary` check.