### PR TITLE
avoid detection of configurations if an imported project does not con…

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -205,6 +205,7 @@ unsigned int CppCheck::check(const ImportProject::FileSettings &fs)
     if (!temp.mSettings.userDefines.empty())
         temp.mSettings.userDefines += ';';
     temp.mSettings.userDefines += fs.cppcheckDefines();
+    temp.mSettings.userDefinesSet = fs.definesSet;
     temp.mSettings.includePaths = fs.includePaths;
     temp.mSettings.userUndefs = fs.undefs;
     if (fs.platformType != Settings::Unspecified) {
@@ -386,7 +387,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         preprocessor.setPlatformInfo(&tokens1);
 
         // Get configurations..
-        if (mSettings.userDefines.empty() || mSettings.force) {
+        if ((mSettings.userDefines.empty() && !mSettings.userDefinesSet) || mSettings.force) {
             Timer t("Preprocessor::getConfigs", mSettings.showtime, &S_timerResults);
             configurations = preprocessor.getConfigs(tokens1);
         } else {

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -107,6 +107,7 @@ void ImportProject::FileSettings::setDefines(std::string defs)
     if (!eq && !defs.empty())
         defs += "=1";
     defines.swap(defs);
+    definesSet = true;
 }
 
 static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std::string, cppcheck::stricmp> &variables)

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -61,7 +61,7 @@ public:
 
     /** File settings. Multiple configurations for a file is allowed. */
     struct CPPCHECKLIB FileSettings {
-        FileSettings() : platformType(cppcheck::Platform::Unspecified), msc(false), useMfc(false) {}
+        FileSettings() : platformType(cppcheck::Platform::Unspecified), msc(false), useMfc(false), definesSet(false) {}
         std::string cfg;
         std::string filename;
         std::string defines;
@@ -75,6 +75,7 @@ public:
         cppcheck::Platform::PlatformType platformType;
         bool msc;
         bool useMfc;
+        bool definesSet;
 
         void parseCommand(const std::string &command);
         void setDefines(std::string defs);

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -60,7 +60,8 @@ Settings::Settings()
       showtime(SHOWTIME_MODES::SHOWTIME_NONE),
       verbose(false),
       xml(false),
-      xml_version(2)
+      xml_version(2),
+      userDefinesSet(false)
 {
 }
 

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -302,6 +302,9 @@ public:
     /** @brief XML version (--xml-version=..) */
     int xml_version;
 
+    /** @brief indicated that user defines were provided */
+    bool userDefinesSet;
+
     /**
      * @brief return true if a included file is to be excluded in Preprocessor::getConfigs
      * @return true for the file to be excluded.


### PR DESCRIPTION
…tain any defines

The members could probably get better names and I guess there's a unit test to be written for this.