### PR TITLE
fix #9391 uninited member var

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -145,7 +145,7 @@ void CheckClass::constructors()
         std::vector<Usage> usage(scope->varlist.size());
 
         for (const Function &func : scope->functionList) {
-            if (!func.hasBody() || !(func.isConstructor() || func.type == Function::eOperatorEqual))
+            if (!(func.hasBody() || func.isDefault()) || !(func.isConstructor() || func.type == Function::eOperatorEqual))
                 continue;
 
             // Bail: If initializer list is not recognized as a variable or type then skip since parsing is incomplete
@@ -159,7 +159,8 @@ void CheckClass::constructors()
             clearAllVar(usage);
 
             std::list<const Function *> callstack;
-            initializeVarList(func, callstack, scope, usage);
+            if (func.hasBody())
+                initializeVarList(func, callstack, scope, usage);
 
             // Check if any variables are uninitialized
             int count = -1;

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -385,14 +385,37 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void simple10() { // ticket #4388
+    void simple10() { // tickets #4388, #9391
         check("class Fred {\n"
               "public:\n"
               "    Fred() = default;\n"
               "private:\n"
               "    int x;\n"
               "};");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Fred::x' is not initialized in the constructor.\n", errout.str());
+
+        check("class Fred {\n"
+          "public:\n"
+          "    Fred() = default;\n"
+          "    int x;\n"
+          "};");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Fred::x' is not initialized in the constructor.\n", errout.str());
+
+        check("class Fred {\n"
+          "public:\n"
+          "    Fred();\n"
+          "    int x;\n"
+          "};\n"
+          "Fred::Fred()=default;");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Fred::x' is not initialized in the constructor.\n", errout.str());
+
+		check("class Fred {\n"
+			"public:\n"
+			"    Fred() = default;\n"
+			"private:\n"
+			"    int x = 0;\n"
+			"};");
+		ASSERT_EQUALS("", errout.str());
     }
 
     void simple11() { // ticket #4536, #6214


### PR DESCRIPTION
This change is a fix on #9391.
Cppcheck detects uninitialized member vairables if there is ctor is marked as default