### PR TITLE
Fixed null pointer deref and vector out of bounds reference.

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1662,7 +1662,7 @@ struct FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const 
             // TODO: Handle these better
             // Is expr variable used in expression?
             const Token *end = tok->findExpressionStartEndTokens().second->next();
-            for (const Token *tok2 = tok; tok2 != end; tok2 = tok2->next()) {
+            for (const Token *tok2 = tok; tok2 && tok2 != end; tok2 = tok2->next()) {
                 if (!local && Token::Match(tok2, "%name% ("))
                     return Result(Result::Type::READ);
                 if (tok2->varId() && exprVarIds.find(tok2->varId()) != exprVarIds.end())

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -68,7 +68,7 @@ static const Token *getAstParentSkipPossibleCastAndAddressOf(const Token *vartok
         return nullptr;
     if (parent->isUnaryOp("&"))
         parent = parent->astParent();
-    else if (parent->str() == "&" && vartok == parent->astOperand2() && Token::Match(parent->astOperand1()->previous(), "( %type% )")) {
+    else if (parent->astOperand1() && parent->str() == "&" && vartok == parent->astOperand2() && Token::Match(parent->astOperand1()->previous(), "( %type% )")) {
         parent = parent->astParent();
         if (unknown)
             *unknown = true;

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1334,13 +1334,13 @@ std::pair<const Token *, const Token *> Token::findExpressionStartEndTokens() co
 
     // find start node in AST tree
     const Token *start = top;
-    while (start->astOperand1() &&
+    while (start && start->astOperand1() &&
            (start->astOperand2() || !start->isUnaryPreOp() || Token::simpleMatch(start, "( )") || start->str() == "{"))
         start = start->astOperand1();
 
     // find end node in AST tree
     const Token *end = top;
-    while (end->astOperand1() && (end->astOperand2() || end->isUnaryPreOp())) {
+    while (end && end->astOperand1() && (end->astOperand2() || end->isUnaryPreOp())) {
         // lambda..
         if (end->str() == "[") {
             const Token *lambdaEnd = findLambdaEndToken(end);

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1319,7 +1319,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
                 decl = true;
             typetok = typetok->next();
         }
-        if (decl && Token::Match(typetok->previous(), "[*&] %var% ="))
+        if (decl && typetok && Token::Match(typetok->previous(), "[*&] %var% ="))
             tok = typetok;
     }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2880,8 +2880,8 @@ static bool valueFlowForwardVariable(Token* const startToken,
 
                 const std::pair<const Token *, const Token *> startEnd0 = expr0->findExpressionStartEndTokens();
                 const std::pair<const Token *, const Token *> startEnd1 = expr1->findExpressionStartEndTokens();
-                const bool changed0 = isVariableChanged(startEnd0.first, startEnd0.second->next(), varid, var->isGlobal(), settings, tokenlist->isCPP());
-                const bool changed1 = isVariableChanged(startEnd1.first, startEnd1.second->next(), varid, var->isGlobal(), settings, tokenlist->isCPP());
+                const bool changed0 = (var && startEnd0.second ? isVariableChanged(startEnd0.first, startEnd0.second->next(), varid, var->isGlobal(), settings, tokenlist->isCPP()) : 0);
+                const bool changed1 = (var && startEnd1.second ? isVariableChanged(startEnd1.first, startEnd1.second->next(), varid, var->isGlobal(), settings, tokenlist->isCPP()) : 0);
 
                 if (changed0 && changed1) {
                     if (settings->debugwarnings)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5437,8 +5437,10 @@ static bool evaluate(const Token *expr, const std::vector<std::list<ValueFlow::V
         return !result->empty();
     }
     if (expr->str().compare(0,3,"arg")==0) {
-        *result = values[expr->str()[3] - '1'];
-        return true;
+        if (values.size() > expr->str()[3] - '1') {
+            *result = values[expr->str()[3] - '1'];
+            return true;
+        }
     }
     if (expr->isNumber()) {
         result->emplace_back(ValueFlow::Value(MathLib::toLongNumber(expr->str())));


### PR DESCRIPTION
I've fixed some null pointer dereferences and one vector out of bounds, in each of the commits I included a hex dump of an example input file that will cause a crash that that commit is fixing.