### PR TITLE
print stack trace for UBSAN errors / enabled detect_stack_use_after_r…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
 #   unfortunately we need this to stay within 50min timelimit given by travis.
     - CXXFLAGS="${ORIGINAL_CXXFLAGS} -O2 -march=native -Wstrict-aliasing=2 -Werror=strict-aliasing"
     - CPPCHECK=${TRAVIS_BUILD_DIR}/cppcheck
+    - ASAN_OPTIONS=detect_stack_use_after_return=1
+    - UBSAN_OPTIONS=print_stacktrace=1
   matrix:
     - CXXFLAGS="${CXXFLAGS} -DCHECK_INTERNAL"
     - CXXFLAGS="${CXXFLAGS} -DCHECK_INTERNAL" MAKEFLAGS="HAVE_RULES=yes" MATCHCOMPILER=yes VERIFY=1


### PR DESCRIPTION
…eturn for ASAN

I wanted to define these environment variables for the builds and not globally but I am not familiar with Travis CI and wouldn't find anything but this in the documentation.

There's some additional UBSAN checks which could be enabled also.