### PR TITLE
Fix #9399 (Build Failure on x86: error: unknown type name '__int128_t')

### DIFF
--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -38,7 +38,7 @@ class Settings;
 class Token;
 class Variable;
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && defined (__SIZEOF_INT128__)
 typedef __int128_t   int128_t;
 #else
 typedef long long    int128_t;


### PR DESCRIPTION
https://stackoverflow.com/questions/16088282/is-there-a-128-bit-integer-in-gcc
suggests to test for `__SIZEOF_INT128__`. This test is added now and
Cppcheck now also compiles for a 32 bit target with the expected
warning that there is no 128-bit integer. "make test" also works.