### PR TITLE
std.cfg: Add configuration for std::map::at()

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7584,6 +7584,16 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
     </arg>
     <arg nr="any"/>
   </function>
+  <!-- T& std::map::at( const Key& key ); // since C++11 -->
+  <!-- const T& std::map::at( const Key& key ) const; // since C++11 -->
+  <function name="std::map::at">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
   <memory>
     <alloc init="false" buffer-size="malloc">malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc</alloc>


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/cpp/container/map/at