### PR TITLE
std.cfg: Add podtype char8_t

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7770,6 +7770,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
   <smart-pointer class-name="std::shared_ptr"/>
   <smart-pointer class-name="std::unique_ptr"/>
   <smart-pointer class-name="std::weak_ptr"/>
+  <podtype name="char8_t,std::char8_t" sign="u" size="1"/>
   <podtype name="char16_t,std::char16_t" sign="u" size="2"/>
   <podtype name="char32_t,std::char32_t" sign="u" size="4"/>
   <podtype name="int8_t,std::int8_t" sign="s" size="1"/>
@@ -7845,6 +7846,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
   <podtype name="std::atomic_ulong" stdtype="long" sign="u"/>
   <podtype name="std::atomic_llong" stdtype="long long" sign="s"/>
   <podtype name="std::atomic_ullong" stdtype="long long" sign="u"/>
+  <podtype name="std::atomic_char8_t" size="1"/>
   <podtype name="std::atomic_char16_t" size="2"/>
   <podtype name="std::atomic_char32_t" size="4"/>
   <podtype name="std::atomic_wchar_t" size="2"/>


### PR DESCRIPTION
c++20 introduced type char8_t.

From https://en.cppreference.com/w/cpp/language/types:

char8_t - type for UTF-8 character representation, required to be large
enough to represent any UTF-8 code unit (8 bits). It has the same size,
signedness, and alignment as unsigned char (and. therefore, the same size
and alignment as char and signed char), but is a distinct type.