### PR TITLE
Add tests with prefixed string and char literals

### DIFF
--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -1995,6 +1995,46 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
 
+        check("void f() {\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[10]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Array 'str[4]' accessed at index 10, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[4]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'str[4]' accessed at index 4, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = L\"abc\";\n"
+              "    bar(str[3]);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "    const char32_t *str = U\"abc\";\n"
+              "    bar(str[10]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Array 'str[4]' accessed at index 10, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = U\"abc\";\n"
+              "    bar(str[4]);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'str[4]' accessed at index 4, which is out of bounds.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    const wchar_t *str = U\"abc\";\n"
+              "    bar(str[3]);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f()\n"
               "{\n"
               "    const char *str = \"a\tc\";\n"
@@ -2735,6 +2775,34 @@ private:
               "  return x[20];\n" // <- array index out of bounds when x is "abcde"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (error) Array 'x[6]' accessed at index 20, which is out of bounds.\n", errout.str());
+
+        check("char f() {\n"
+              "  const wchar_t *x = s;\n"
+              "  if (cond) x = L\"abcde\";\n"
+              "  return x[8];\n" // <- array index out of bounds when x is L"abcde"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'x[6]' accessed at index 8, which is out of bounds.\n", errout.str());
+
+        check("char f() {\n"
+              "  const char8_t *x = s;\n"
+              "  if (cond) x = u8\"abcde\";\n"
+              "  return x[8];\n" // <- array index out of bounds when x is u8"abcde"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'x[6]' accessed at index 8, which is out of bounds.\n", errout.str());
+
+        check("char f() {\n"
+              "  const char16_t *x = s;\n"
+              "  if (cond) x = u\"abcde\";\n"
+              "  return x[8];\n" // <- array index out of bounds when x is u"abcde"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'x[6]' accessed at index 8, which is out of bounds.\n", errout.str());
+
+        check("char f() {\n"
+              "  const char32_t *x = s;\n"
+              "  if (cond) x = U\"abcde\";\n"
+              "  return x[8];\n" // <- array index out of bounds when x is U"abcde"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Array 'x[6]' accessed at index 8, which is out of bounds.\n", errout.str());
     }
 
     void pointer_out_of_bounds_1() {

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -400,8 +400,23 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Char literal compared with pointer 'c'. Did you intend to dereference it?\n", errout.str());
 
+        check("bool foo(char16_t* c) {\n"
+              "    return c == u'x';\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) Char literal compared with pointer 'c'. Did you intend to dereference it?\n", errout.str());
+
+        check("bool foo(char32_t* c) {\n"
+              "    return c == U'x';\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) Char literal compared with pointer 'c'. Did you intend to dereference it?\n", errout.str());
+
         check("bool foo(char* c) {\n"
               "    return '\\0' != c;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) Char literal compared with pointer 'c'. Did you intend to dereference it?\n", errout.str());
+
+        check("bool foo(char8_t* c) {\n"
+              "    return 'u\\0' != c;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Char literal compared with pointer 'c'. Did you intend to dereference it?\n", errout.str());
 
@@ -411,6 +426,11 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("bool foo(char c) {\n"
+              "    return c == 0;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("bool foo(wchar_t c) {\n"
               "    return c == 0;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
@@ -606,7 +626,17 @@ private:
         ASSERT_EQUALS("[test.cpp:2]: (warning) String literal \"Hello\" doesn't match length argument for substr().\n", errout.str());
 
         check("int f() {\n"
+              "    return test.substr( 0 , 4 ) == U\"Hello\" ? 0 : 1 ;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) String literal \"Hello\" doesn't match length argument for substr().\n", errout.str());
+
+        check("int f() {\n"
               "    return test.substr( 0 , 5 ) == \"Hello\" ? 0 : 1 ;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() {\n"
+              "    return test.substr( 0 , 5 ) == U\"Hello\" ? 0 : 1 ;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
 
@@ -621,7 +651,17 @@ private:
         ASSERT_EQUALS("[test.cpp:2]: (warning) String literal \"Hello\" doesn't match length argument for substr().\n", errout.str());
 
         check("int f() {\n"
+              "    return u\"Hello\" == foo.bar<int>().z[1].substr(i+j*4, 4) ? 0 : 1 ;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) String literal \"Hello\" doesn't match length argument for substr().\n", errout.str());
+
+        check("int f() {\n"
               "    return \"Hello\" == test.substr( 0 , 5 ) ? 0 : 1 ;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() {\n"
+              "    return u\"Hello\" == test.substr( 0 , 5 ) ? 0 : 1 ;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
 
@@ -632,6 +672,11 @@ private:
 
         check("int f() {\n"
               "    if (\"Hello\" && test) { }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (warning) Conversion of string literal \"Hello\" to bool always evaluates to true.\n", errout.str());
+
+        check("int f() {\n"
+              "    if (u8\"Hello\" && test) { }\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Conversion of string literal \"Hello\" to bool always evaluates to true.\n", errout.str());
 
@@ -661,6 +706,11 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         check("int f() {\n"
+              "    assert (test && L\"Hello\");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() {\n"
               "    assert (\"Hello\" || test);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Conversion of string literal \"Hello\" to bool always evaluates to true.\n", errout.str());
@@ -684,13 +734,19 @@ private:
         check("void f() {\n"
               "  if('a'){}\n"
               "  if(L'b'){}\n"
+              "  if(u8'b'){}\n"
+              "  if(u'b'){}\n"
+              "  if(U'b'){}\n"
               "  if(1 && 'c'){}\n"
               "  int x = 'd' ? 1 : 2;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Conversion of char literal 'a' to bool always evaluates to true.\n"
                       "[test.cpp:3]: (warning) Conversion of char literal 'b' to bool always evaluates to true.\n"
-                      "[test.cpp:4]: (warning) Conversion of char literal 'c' to bool always evaluates to true.\n"
-                      "[test.cpp:5]: (warning) Conversion of char literal 'd' to bool always evaluates to true.\n"
+                      "[test.cpp:4]: (warning) Conversion of char literal 'b' to bool always evaluates to true.\n"
+                      "[test.cpp:5]: (warning) Conversion of char literal 'b' to bool always evaluates to true.\n"
+                      "[test.cpp:6]: (warning) Conversion of char literal 'b' to bool always evaluates to true.\n"
+                      "[test.cpp:7]: (warning) Conversion of char literal 'c' to bool always evaluates to true.\n"
+                      "[test.cpp:8]: (warning) Conversion of char literal 'd' to bool always evaluates to true.\n"
                       , errout.str());
 
         check("void f() {\n"
@@ -701,10 +757,16 @@ private:
 
         check("void f() {\n"
               "  if('\\0' || cond){}\n"
+              "  if(u8'\\0' || cond){}\n"
+              "  if(u'\\0' || cond){}\n"
+              "  if(U'\\0' || cond){}\n"
               "  if(L'\\0' || cond){}\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n"
-                      "[test.cpp:3]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n", errout.str());
+                      "[test.cpp:3]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n"
+                      "[test.cpp:4]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n"
+                      "[test.cpp:5]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n"
+                      "[test.cpp:6]: (warning) Conversion of char literal '\\0' to bool always evaluates to false.\n", errout.str());
     }
 
     void deadStrcmp() {


### PR DESCRIPTION
I'm picking up #1754 (in a way #2257 is also part of this), the end goal is that cppcheck should handle prefixed string and char literals (`U"hello"`, `L'a'`, etc) better, but to reduce the size of the PR, I want to merge some tests that already work as expected first (both as documentation that cppcheck already works as expected, and as a precaution that I don't introduce regressions when I actually start changing things).