### PR TITLE
gnu.cfg: Define `__typeof__` as `typeof`, fix simplifyTypedef()

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -47,7 +47,7 @@
   <define name="__builtin_nanl(str)" value="nanl(str)"/>
   <define name="__builtin_signbit(value)" value="signbit(value)"/>
   <define name="__extension__" value=""/>
-  <define name="__typeof__" value="typeof"/>
+  <define name="__typeof__(T)" value="typeof(T)"/>
   <!-- void *__builtin_alloca (size_t size) -->
   <!-- alloca() is often defined as __builtin_alloca() so the define above does not work always -->
   <!-- void *alloca(size_t size); -->

--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -47,6 +47,7 @@
   <define name="__builtin_nanl(str)" value="nanl(str)"/>
   <define name="__builtin_signbit(value)" value="signbit(value)"/>
   <define name="__extension__" value=""/>
+  <define name="__typeof__" value="typeof"/>
   <!-- void *__builtin_alloca (size_t size) -->
   <!-- alloca() is often defined as __builtin_alloca() so the define above does not work always -->
   <!-- void *alloca(size_t size); -->

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -842,9 +842,8 @@ void Tokenizer::simplifyTypedef()
             }
         }
 
-        // typeof: typedef __typeof__ ( ... ) type;
-        else if ((Token::simpleMatch(tokOffset->previous(), "__typeof__ (") ||
-                  Token::simpleMatch(tokOffset->previous(), "typeof (")) &&
+        // typeof: typedef typeof ( ... ) type;
+        else if (Token::simpleMatch(tokOffset->previous(), "typeof (") &&
                  Token::Match(tokOffset->link(), ") %type% ;")) {
             argStart = tokOffset;
             argEnd = tokOffset->link();

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -843,7 +843,8 @@ void Tokenizer::simplifyTypedef()
         }
 
         // typeof: typedef __typeof__ ( ... ) type;
-        else if (Token::simpleMatch(tokOffset->previous(), "__typeof__ (") &&
+        else if ((Token::simpleMatch(tokOffset->previous(), "__typeof__ (") ||
+                  Token::simpleMatch(tokOffset->previous(), "typeof (")) &&
                  Token::Match(tokOffset->link(), ") %type% ;")) {
             argStart = tokOffset;
             argEnd = tokOffset->link();

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -1625,10 +1625,10 @@ private:
     }
 
     void simplifyTypedef64() {
-        const char code[] = "typedef __typeof__(__type1() + __type2()) __type;"
+        const char code[] = "typedef typeof(__type1() + __type2()) __type;"
                             "__type t;";
         const std::string actual(tok(code));
-        ASSERT_EQUALS("__typeof__ ( __type1 ( ) + __type2 ( ) ) t ;", actual);
+        ASSERT_EQUALS("typeof ( __type1 ( ) + __type2 ( ) ) t ;", actual);
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
`__typeof__` is just an alternative keyword for `typeof`, see
https://gcc.gnu.org/onlinedocs/gcc/Typeof.html
Since `typeof` is handled in several checkers it makes sense to define
`__typeof__` as `typeof`.
In Tokenizer::simplifyTypedef() only `__typeof__` was handled.
Handling `typeof` is added there now too.