### PR TITLE
Move necessary code into valuetype

### DIFF
--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -326,19 +326,10 @@ static bool isNullablePointer(const Token* tok, const Settings* settings)
         return true;
     if (astIsSmartPointer(tok))
         return true;
-    // TODO: Move this logic into ValueType
     if (Token::simpleMatch(tok, "."))
         return isNullablePointer(tok->astOperand2(), settings);
     if (const Variable* var = tok->variable()) {
         return (var->isPointer() || var->isSmartPointer());
-    }
-    if (Token::Match(tok->previous(), "%name% (")) {
-        if (const Function* f = tok->previous()->function()) {
-            if (f->retDef) {
-                ValueType vt = ValueType::parseDecl(f->retDef, settings);
-                return vt.smartPointerTypeToken || vt.pointer > 0;
-            }
-        }
     }
     return false;
 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5420,6 +5420,9 @@ static const Token * parsedecl(const Token *type, ValueType * const valuetype, V
                 continue;
             valuetype->smartPointerTypeToken = argTok->next();
             valuetype->smartPointerType = argTok->next()->type();
+            valuetype->type = ValueType::Type::NONSTD;
+            type = argTok->link();
+            continue;
         } else if (Token::Match(type, "%name% :: %name%")) {
             std::string typestr;
             const Token *end = type;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5743,10 +5743,12 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings)
             }
             setValueType(tok, vt);
         } else if (tok->str() == "return" && tok->scope()) {
-            const Function *function = tok->scope()->function;
-            if (function && function->retDef) {
+            const Scope* fscope = tok->scope();
+            while (fscope && !fscope->function)
+                fscope = fscope->nestedIn;
+            if (fscope && fscope->function && fscope->function->retDef) {
                 ValueType vt;
-                parsedecl(function->retDef, &vt, mDefaultSignedness, mSettings);
+                parsedecl(fscope->function->retDef, &vt, mDefaultSignedness, mSettings);
                 setValueType(tok, vt);
             }
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3947,17 +3947,7 @@ static bool isDecayedPointer(const Token *tok, const Settings *settings)
         return true;
     if (!Token::simpleMatch(tok->astParent(), "return"))
         return false;
-    if (!tok->scope())
-        return false;
-    if (!tok->scope()->function)
-        return false;
-    if (!tok->scope()->function->retDef)
-        return false;
-    // TODO: Add valuetypes to return types of functions
-    ValueType vt = ValueType::parseDecl(tok->scope()->function->retDef, settings);
-    if (vt.pointer > 0)
-        return true;
-    return false;
+    return astIsPointer(tok->astParent());
 }
 
 static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger *errorLogger, const Settings *settings)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3499,17 +3499,6 @@ bool isLifetimeBorrowed(const Token *tok, const Settings *settings)
         if (!Token::simpleMatch(tok, "{")) {
             const ValueType *vt = tok->valueType();
             const ValueType *vtParent = tok->astParent()->valueType();
-            ValueType svt;
-            // TODO: Move logic to ValueType
-            if (!vtParent && Token::simpleMatch(tok->astParent(), "return")) {
-                const Scope* fscope = tok->scope();
-                while (fscope && !fscope->function)
-                    fscope = fscope->nestedIn;
-                if (fscope && fscope->function && fscope->function->retDef) {
-                    svt = ValueType::parseDecl(fscope->function->retDef, settings);
-                    vtParent = &svt;
-                }
-            }
             if (isLifetimeBorrowed(vt, vtParent))
                 return true;
             if (isLifetimeOwned(vt, vtParent))


### PR DESCRIPTION
This moves the extra `parseDecl` calls into valuetype where they actually belong.