### PR TITLE
gnu.cfg: Add configuration for __alignof__()

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -110,6 +110,17 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- https://gcc.gnu.org/onlinedocs/gcc-6.2.0/gcc/Alignment.html -->
+  <!-- __alignof__ is used like sizeof -->
+  <!-- Declaration for this GNU compiler extension could look like this: -->
+  <!-- size_t __alignof__(type); -->
+  <!-- size_t __alignof__(expression); -->
+  <function name="__alignof__">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in"/>
+  </function>
   <!-- int timerisset(struct timeval *tvp); -->
   <function name="timerisset">
     <noreturn>false</noreturn>

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -146,6 +146,8 @@ void valid_code(int argInt1, va_list valist_arg, int * parg)
 
     printf("%d", 0b010);
     printf("%d", __extension__ 0b10001000);
+
+    if (__alignof__(int) == 4) {}
 }
 
 void ignoreleak(void)


### PR DESCRIPTION
Reference: https://gcc.gnu.org/onlinedocs/gcc-6.2.0/gcc/Alignment.html