### PR TITLE
Add check for MISRA-C 2012 rule 3.2 and test cases.

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -746,6 +746,19 @@ class MisraChecker:
                 if ((not starts_with_double_slash) and '//' in s) or '/*' in s:
                     self.reportError(token, 3, 1)
 
+    def misra_3_2(self, rawTokens):
+        for token in rawTokens:
+            if token.str.startswith('//'):
+                # Check for comment ends with trigraph which might be replaced
+                # by a backslash.
+                if token.str.endswith('??/'):
+                    self.reportError(token, 3, 2)
+                # Check for comment which has been merged with subsequent line
+                # because it ends with backslash.
+                # The last backslash is no more part of the comment token thus
+                # check if next token exists and compare line numbers.
+                elif (token.next != None) and (token.linenr == token.next.linenr):
+                    self.reportError(token, 3, 2)
 
     def misra_4_1(self, rawTokens):
         for token in rawTokens:
@@ -2404,6 +2417,7 @@ class MisraChecker:
 
             if cfgNumber == 1:
                 self.misra_3_1(data.rawTokens)
+                self.misra_3_2(data.rawTokens)
                 self.misra_4_1(data.rawTokens)
                 self.misra_4_2(data.rawTokens)
             self.misra_5_1(cfg)

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -25,6 +25,22 @@ typedef unsigned long long u64;
 
 // http://example.com // no warning
 
+void misra_3_2(int enable)
+{
+	// This won't generate a violation because of subsequent blank line \
+	
+	int y = 0;
+    int x = 0;  // 3.2 non-compliant comment ends with backslash \
+    if (enable != 0)
+    {
+        ++x;    // This is always executed
+		// 3.2 potentially non-compliant comment ends with trigraph resolved to backslash ??/
+		++y;	// This is hidden if trigraph replacement is active
+    }
+
+	(void)printf("x=%i, y=%i\n", x, y);
+}
+
 extern int misra_5_1_extern_var_hides_var_x;
 extern int misra_5_1_extern_var_hides_var_y; //5.1
 int misra_5_1_var_hides_var________a;

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -27,18 +27,18 @@ typedef unsigned long long u64;
 
 void misra_3_2(int enable)
 {
-	// This won't generate a violation because of subsequent blank line \
+    // This won't generate a violation because of subsequent blank line \
 	
-	int y = 0;
+    int y = 0;
     int x = 0;  // 3.2 non-compliant comment ends with backslash \
     if (enable != 0)
     {
         ++x;    // This is always executed
-		// 3.2 potentially non-compliant comment ends with trigraph resolved to backslash ??/
-		++y;	// This is hidden if trigraph replacement is active
+        // 3.2 potentially non-compliant comment ends with trigraph resolved to backslash ??/
+        ++y;    // This is hidden if trigraph replacement is active
     }
 
-	(void)printf("x=%i, y=%i\n", x, y);
+    (void)printf("x=%i, y=%i\n", x, y);
 }
 
 extern int misra_5_1_extern_var_hides_var_x;


### PR DESCRIPTION
First i thought it should be easy to check for comment starting with "\\\\" and ending either with "\\" or trigraph "??/" which might be resolved to "\\".

NOTE: 
Comment ending with trigraph "??/" is not explicitly mentioned by MISRA-C 2012 Rule 3.2 but it has the same effect if trigraph replacement is active (Verified with Microsoft C/C++ compiler). 
Thus i added it to the check.

However then i faced that "\\" at end of line has been removed from raw token and the comment has been merged with subsequent line if it's not a blank line.

So i decided to split the check.

1. Check for trigraph "??/" at end of comment.
2. Else check if there is a next token to comment token and line numbers are equal.
   This is the case if comment line has been merged with subsequent line because last 
   character was "\\".
   
   NOTE:
   The second check has the following limitation.
   It won't find a non-compliant comment if there is no next token. This is if the comment 
   is at end of file or if there is a blank line between comment and next line. 
   However this limitation won't have impact to the code mentioned by Rule 3.2 of 
   MISRA-C 2012 document (comment out code by line-splicing) and thus it might also be
   compliant instead of being a limitation.

Following refines of the rule check should be clarified:
As MISRA-C 2012 Rule 3.2 just states one non-compliant example it's not completely clear
to me if the following examples which have no impact on code should be skipped creating
a violation.

1. non-compliant comment line followed by comment line
2. comment line which ends with trigraph "??/" followed by comment line
3. comment line which ends with trigraph "??/" followed by blank line or is last line of file
