### PR TITLE
std.cfg: Add support for C11 functions thrd_*() and mtx_*()

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7594,6 +7594,14 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <not-uninit/>
     </arg>
   </function>
+  <!-- _Noreturn void thrd_exit( int res ); // since C11 -->
+  <function name="thrd_exit">
+    <noreturn>true</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
   <memory>
     <alloc init="false" buffer-size="malloc">malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc</alloc>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7594,12 +7594,157 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <not-uninit/>
     </arg>
   </function>
+  <!-- C Threads https://en.cppreference.com/w/c/thread -->
+  <!-- int thrd_create( thrd_t *thr, thrd_start_t func, void *arg ); // since C11 -->
+  <function name="thrd_create">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="out">
+      <not-null/>
+    </arg>
+    <arg nr="2"/>
+    <arg nr="3"/>
+  </function>
+  <!-- thrd_t thrd_current(void); // since C11 -->
+  <function name="thrd_current">
+    <noreturn>false</noreturn>
+    <returnValue type="thrd_t"/>
+    <use-retval/>
+  </function>
+  <!-- int thrd_detach( thrd_t thr ); // since C11 -->
+  <function name="thrd_detach">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int thrd_equal( thrd_t lhs, thrd_t rhs ); // since C11 -->
+  <function name="thrd_equal">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- _Noreturn void thrd_exit( int res ); // since C11 -->
   <function name="thrd_exit">
     <noreturn>true</noreturn>
     <returnValue type="void"/>
+    <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
+    </arg>
+  </function>
+  <!-- int thrd_join( thrd_t thr, int *res ); // since C11 -->
+  <function name="thrd_join">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="out">
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int thrd_sleep( const struct timespec* duration, struct timespec* remaining ); // since C11 -->
+  <function name="thrd_sleep">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="out">
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- void thrd_yield(void); // since C11 -->
+  <function name="thrd_yield">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+  </function>
+  <!-- Mutual exclusion https://en.cppreference.com/w/c/thread -->
+  <!-- void mtx_destroy( mtx_t *mutex ); // since C11 -->
+  <function name="mtx_destroy">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int mtx_init( mtx_t* mutex, int type ); // since C11 -->
+  <function name="mtx_init">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="out">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int mtx_lock( mtx_t* mutex ); // since C11 -->
+  <function name="mtx_lock">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="inout">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int mtx_timedlock( mtx_t *restrict mutex, const struct timespec *restrict time_point ); // since C11 -->
+  <function name="mtx_timedlock">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="inout">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int mtx_trylock( mtx_t *mutex ); // since C11 -->
+  <function name="mtx_trylock">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="inout">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int mtx_unlock( mtx_t *mutex ); // since C11 -->
+  <function name="mtx_unlock">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <leak-ignore/>
+    <arg nr="1" direction="inout">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
     </arg>
   </function>
   <memory>


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/c/thread/thrd_exit