### PR TITLE
Donate cpu server crash locations

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -76,7 +76,7 @@ def overviewReport():
     return html
 
 
-def fmt(a, b, c, d, e):
+def fmt(a, b, c=None, d=None, e=None):
     column_width = [40, 10, 5, 6, 6, 8]
     ret = a
     while len(ret) < column_width[0]:
@@ -142,7 +142,7 @@ def crashReport(results_path):
     html = '<html><head><title>Crash report</title></head><body>\n'
     html += '<h1>Crash report</h1>\n'
     html += '<pre>\n'
-    html += '<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head', None) + '</b>\n'
+    html += '<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head') + '</b>\n'
     current_year = datetime.date.today().year
     for filename in sorted(glob.glob(os.path.expanduser(results_path + '/*'))):
         if not os.path.isfile(filename):
@@ -171,7 +171,7 @@ def crashReport(results_path):
             c1 = ''
             if counts[1] == 'Crash!':
                 c1 = 'Crash'
-            html += fmt(package, datestr, c2, c1, None) + '\n'
+            html += fmt(package, datestr, c2, c1) + '\n'
             break
     html += '</pre>\n'
 
@@ -183,7 +183,7 @@ def staleReport(results_path):
     html = '<html><head><title>Stale report</title></head><body>\n'
     html += '<h1>Stale report</h1>\n'
     html += '<pre>\n'
-    html += '<b>' + fmt('Package', 'Date       Time', None, None, None) + '</b>\n'
+    html += '<b>' + fmt('Package', 'Date       Time') + '</b>\n'
     current_year = datetime.date.today().year
     for filename in sorted(glob.glob(os.path.expanduser(results_path + '/*'))):
         if not os.path.isfile(filename):
@@ -199,7 +199,7 @@ def staleReport(results_path):
             if diff.days < 30:
                 continue
             package = filename[filename.rfind('/')+1:]
-            html += fmt(package, datestr, None, None, None) + '\n'
+            html += fmt(package, datestr) + '\n'
             break
     html += '</pre>\n'
 

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -190,7 +190,7 @@ def crashReport(results_path):
     html += '</pre>\n'
     html += '<pre>\n'
     html += '<b>' + fmt('HEAD Crash locations', 'Count', link=False) + '</b>\n'
-    for crash_location in sorted(crash_locations.items(), key=lambda (l, c): (-c, l)):
+    for crash_location in sorted(crash_locations.items(), key=lambda x: (-x[1], x[0])):
         html += fmt(crash_location[0], str(crash_location[1]), link=False) + '\n'
     html += '</pre>\n'
 

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -176,7 +176,7 @@ def crashReport(results_path):
                     html += fmt(package, datestr, c2, c1) + '\n'
                     if c1 != 'Crash':
                         break
-                if line.startswith('Program received signal '):
+                if line.find(' received signal ') != -1:
                     crash_line = next(file, '')
                     location_index = crash_line.rindex(' at ')
                     if location_index > 0:

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -76,7 +76,7 @@ def overviewReport():
     return html
 
 
-def fmt(a, b, c=None, d=None, e=None):
+def fmt(a, b, c=None, d=None, e=None, link=True):
     column_width = [40, 10, 5, 6, 6, 8]
     ret = a
     while len(ret) < column_width[0]:
@@ -93,7 +93,7 @@ def fmt(a, b, c=None, d=None, e=None):
         ret += d.rjust(column_width[4]) + ' '
     if not e is None:
         ret += e.rjust(column_width[5])
-    if a != 'Package':
+    if link:
         pos = ret.find(' ')
         ret = '<a href="' + a + '">' + a + '</a>' + ret[pos:]
     return ret
@@ -102,7 +102,7 @@ def fmt(a, b, c=None, d=None, e=None):
 def latestReport(latestResults):
     html = '<html><head><title>Latest daca@home results</title></head><body>\n'
     html += '<h1>Latest daca@home results</h1>\n'
-    html += '<pre>\n<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head', 'Diff') + '</b>\n'
+    html += '<pre>\n<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head', 'Diff', link=False) + '</b>\n'
 
     # Write report for latest results
     for filename in latestResults:
@@ -142,7 +142,7 @@ def crashReport(results_path):
     html = '<html><head><title>Crash report</title></head><body>\n'
     html += '<h1>Crash report</h1>\n'
     html += '<pre>\n'
-    html += '<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head') + '</b>\n'
+    html += '<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head', link=False) + '</b>\n'
     current_year = datetime.date.today().year
     for filename in sorted(glob.glob(os.path.expanduser(results_path + '/*'))):
         if not os.path.isfile(filename):
@@ -183,7 +183,7 @@ def staleReport(results_path):
     html = '<html><head><title>Stale report</title></head><body>\n'
     html += '<h1>Stale report</h1>\n'
     html += '<pre>\n'
-    html += '<b>' + fmt('Package', 'Date       Time') + '</b>\n'
+    html += '<b>' + fmt('Package', 'Date       Time', link=False) + '</b>\n'
     current_year = datetime.date.today().year
     for filename in sorted(glob.glob(os.path.expanduser(results_path + '/*'))):
         if not os.path.isfile(filename):

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -18,7 +18,7 @@ import operator
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.1.6"
+SERVER_VERSION = "1.1.7"
 
 OLD_VERSION = '1.89'
 

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -184,7 +184,7 @@ def crashReport(results_path):
                         stack_trace = []
                         while True:
                             l = next(file, '')
-                            m = re.search('(?P<number>#\d+) .* (?P<function>.+)\(.*\) at (?P<location>.*)$', l)
+                            m = re.search(r'(?P<number>#\d+) .* (?P<function>.+)\(.*\) at (?P<location>.*)$', l)
                             if not m:
                                 break
                             stack_trace.append(m.group('number') + ' ' + m.group('function') + '(...) at ' + m.group('location'))


### PR DESCRIPTION
Refactor `donate-cpu-server.py` slightly, then add the number of crashes per file and line.

I think this could be useful when there are lots of crashes in daca@home (like now for example), to get an overview where the crashes occur, if there are multiple problems, etc. Some input on this would be good (for example, should it be formatted differently? Would it be useful to generate new html-pages for each file/line with links to the packages that crashed?). The changes are easiest to review if you ignore white-space changes, since a fairly large chunk had its indentation changed in `crashReport()`.

Example output:
<h1>Crash report</h1>
<pre>
<b>Package                                  Date        Time   1.89   Head </b>
<a href="ace">ace</a>                                      2019-10-16 19:43         Crash 
<a href="actor-framework">actor-framework</a>                          2019-10-16 19:58         Crash 
<a href="amarok">amarok</a>                                   2019-10-16 21:42         Crash 
<a href="libffado">libffado</a>                                 2019-10-16 21:44         Crash 
<a href="zathura">zathura</a>                                  2019-10-16 22:25         Crash 
</pre>
<pre>
<b>HEAD Crash locations                     Count      </b>
lib/symboldatabase.h:342                 2          
build/valueflow.cpp:3775                 1          
lib/token.h:201                          1          
</pre>