### PR TITLE
std.cfg: Add some missing std::map::*() function configurations

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -7746,6 +7746,53 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <not-bool/>
     </arg>
   </function>
+  <!-- std::pair<iterator,iterator> std::map::equal_range( const Key& key ); -->
+  <!-- std::pair<const_iterator,const_iterator> std::map::equal_range( const Key& key ) const; -->
+  <!-- template< class K > std::pair<iterator,iterator> std::map::equal_range( const K& x ); // since C++14 -->
+  <!-- template< class K > std::pair<const_iterator,const_iterator> std::map::equal_range( const K& x ) const; // since C++14 -->
+  <function name="std::map::equal_range">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- iterator std::map::lower_bound( const Key& key ); -->
+  <!-- const_iterator lower_bound( const Key& key ) const; -->
+  <!-- template< class K > iterator std::map::lower_bound(const K& x); // since C++14 -->
+  <!-- template< class K > const_iterator std::map::lower_bound(const K& x) const; // since C++14 -->
+  <function name="std::map::lower_bound">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- iterator std::map::upper_bound( const Key& key ); -->
+  <!-- const_iterator std::map::upper_bound( const Key& key ) const; -->
+  <!-- template< class K > iterator std::map::upper_bound( const K& x ); // since C++14 -->
+  <!-- template< class K > const_iterator std::map::upper_bound( const K& x ) const; // since C++14 -->
+  <function name="std::map::upper_bound">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- bool std::map::contains( const Key& key ) const; // since C++20 -->
+  <!-- template< class K > bool std::map::contains( const K& x ) const; // since C++20 -->
+  <function name="std::map::contains">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
   <memory>
     <alloc init="false" buffer-size="malloc">malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc</alloc>


### PR DESCRIPTION
Reference:
https://en.cppreference.com/w/cpp/container/map/equal_range
https://en.cppreference.com/w/cpp/container/map/lower_bound
https://en.cppreference.com/w/cpp/container/map/upper_bound
https://en.cppreference.com/w/cpp/container/map/contains