### PR TITLE
cmdlineparser.cpp: printHelp(): Replace deprecated option in example

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1188,7 +1188,7 @@ void CmdLineParser::printHelp()
               "  cppcheck --quiet ../myproject/\n"
               "\n"
               "  # Check test.cpp, enable all checks:\n"
-              "  cppcheck --enable=all --inconclusive --std=posix test.cpp\n"
+              "  cppcheck --enable=all --inconclusive --library=posix test.cpp\n"
               "\n"
               "  # Check f.cpp and search include files from inc1/ and inc2/:\n"
               "  cppcheck -I inc1/ -I inc2/ f.cpp\n"


### PR DESCRIPTION
`--std=posix` is deprecated and will be removed in the future.