### PR TITLE
Correcting the expected token for template within template. Token expected was "> class" while actual token is only "class"

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -690,7 +690,7 @@ bool TemplateSimplifier::removeTemplate(Token *tok)
         else if (indentlevel >= 2 && tok2->str() == ">")
             --indentlevel;
 
-        else if (Token::Match(tok2, "> class|struct|union %name% [,)]")) {
+        else if (Token::Match(tok2, "class|struct|union %name% [,)]")) {
             tok2 = tok2->next();
             eraseTokens(tok, tok2);
             deleteToken(tok);


### PR DESCRIPTION
Correcting the expected token for template within template. Token expected was "> class" while actual token is only "class".

Example code breaking the CppCheck is: 

```
template <
	class obj_type,
	template<class> class allocator = SmartPointerAllocator,
	template<class, class> class data_container = std::list
>
```