### PR TITLE
misra.py: Fix 18.8 crash on checking undefined id

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1806,6 +1806,9 @@ class MisraChecker:
             typetok = var.nameToken.next
             if not typetok or typetok.str != '[':
                 continue
+            # Unknown define or syntax error
+            if not typetok.astOperand2:
+                continue
             if not isConstantExpression(typetok.astOperand2):
                 self.reportError(var.nameToken, 18, 8)
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -664,6 +664,7 @@ void misra_18_8(int x) {
   int buf1[10];
   int buf2[sizeof(int)];
   int vla[x]; // 18.8
+  static const unsigned char arr18_8_1[] = UNDEFINED_ID;
 }
 
 union misra_19_2 { }; // 19.2


### PR DESCRIPTION
`typetok.astOperand2` could be `None`, if it's a library symbol which wasn't load by cppcheck.

For example, checking codebase with mbedtls:
```c
static const unsigned char bin[] = MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN;
```
Will cause `misra.py` crash with `AttributeError 'NoneType' object has no attribute 'isNumber' `.