### PR TITLE
misra.py: Skip execution of globally suppressed checks

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2211,6 +2211,14 @@ class MisraChecker:
 
         return ruleIsSuppressed
 
+    def isRuleGloballySuppressed(self, rule_num):
+        """
+        Check to see if a rule is globally suppressed.
+        :param rule_num: is the rule number in hundreds format
+        """
+        if rule_num not in self.suppressedRules:
+            return False
+        return None in self.suppressedRules[rule_num]
 
     def parseSuppressions(self):
         """
@@ -2433,6 +2441,16 @@ class MisraChecker:
         if not self.settings.quiet:
             print(*args, **kwargs)
 
+    def executeCheck(self, rule_num, check_function, arg):
+        """Execute check function for a single MISRA rule.
+
+        :param rule_num: Number of rule in hundreds format
+        :param check_function: Check function to execute
+        :param argv: Check function argument
+        """
+        if not self.isRuleGloballySuppressed(rule_num):
+            check_function(arg)
+
     def parseDump(self, dumpfile):
 
         data = cppcheckdata.parsedump(dumpfile)
@@ -2465,98 +2483,97 @@ class MisraChecker:
                 self.printStatus('Checking ' + dumpfile + ', config "' + cfg.name + '"...')
 
             if cfgNumber == 1:
-                self.misra_3_1(data.rawTokens)
-                self.misra_3_2(data.rawTokens)
-                self.misra_4_1(data.rawTokens)
-                self.misra_4_2(data.rawTokens)
-            self.misra_5_1(cfg)
-            self.misra_5_2(cfg)
-            self.misra_5_3(cfg)
-            self.misra_5_4(cfg)
-            self.misra_5_5(cfg)
+                self.executeCheck(301, self.misra_3_1, data.rawTokens)
+                self.executeCheck(302, self.misra_3_2, data.rawTokens)
+                self.executeCheck(401, self.misra_4_1, data.rawTokens)
+                self.executeCheck(402, self.misra_4_2, data.rawTokens)
+            self.executeCheck(501, self.misra_5_1, cfg)
+            self.executeCheck(502, self.misra_5_2, cfg)
+            self.executeCheck(503, self.misra_5_3, cfg)
+            self.executeCheck(504, self.misra_5_4, cfg)
+            self.executeCheck(505, self.misra_5_5, cfg)
             # 6.1 require updates in Cppcheck (type info for bitfields are lost)
             # 6.2 require updates in Cppcheck (type info for bitfields are lost)
             if cfgNumber == 1:
-                self.misra_7_1(data.rawTokens)
-                self.misra_7_3(data.rawTokens)
-            self.misra_8_11(cfg)
-            self.misra_8_12(cfg)
+                self.executeCheck(701, self.misra_7_1, data.rawTokens)
+                self.executeCheck(703, self.misra_7_3, data.rawTokens)
+            self.executeCheck(811, self.misra_8_11, cfg)
+            self.executeCheck(812, self.misra_8_12, cfg)
             if cfgNumber == 1:
-                self.misra_8_14(data.rawTokens)
-                self.misra_9_5(data.rawTokens)
-            self.misra_10_1(cfg)
-            self.misra_10_4(cfg)
-            self.misra_10_6(cfg)
-            self.misra_10_8(cfg)
-            self.misra_11_3(cfg)
-            self.misra_11_4(cfg)
-            self.misra_11_5(cfg)
-            self.misra_11_6(cfg)
-            self.misra_11_7(cfg)
-            self.misra_11_8(cfg)
-            self.misra_11_9(cfg)
+                self.executeCheck(814, self.misra_8_14, data.rawTokens)
+                self.executeCheck(905, self.misra_9_5, data.rawTokens)
+            self.executeCheck(1001, self.misra_10_1, cfg)
+            self.executeCheck(1004, self.misra_10_4, cfg)
+            self.executeCheck(1006, self.misra_10_6, cfg)
+            self.executeCheck(1008, self.misra_10_8, cfg)
+            self.executeCheck(1103, self.misra_11_3, cfg)
+            self.executeCheck(1104, self.misra_11_4, cfg)
+            self.executeCheck(1105, self.misra_11_5, cfg)
+            self.executeCheck(1106, self.misra_11_6, cfg)
+            self.executeCheck(1107, self.misra_11_7, cfg)
+            self.executeCheck(1108, self.misra_11_8, cfg)
+            self.executeCheck(1109, self.misra_11_9, cfg)
             if cfgNumber == 1:
-                self.misra_12_1_sizeof(data.rawTokens)
-            self.misra_12_1(cfg)
-            self.misra_12_2(cfg)
-            self.misra_12_3(cfg)
-            self.misra_12_4(cfg)
-            self.misra_13_1(cfg)
-            self.misra_13_3(cfg)
-            self.misra_13_4(cfg)
-            self.misra_13_5(cfg)
-            self.misra_13_6(cfg)
-            self.misra_14_1(cfg)
-            self.misra_14_2(cfg)
-            self.misra_14_4(cfg)
-            self.misra_15_1(cfg)
-            self.misra_15_2(cfg)
-            self.misra_15_3(cfg)
-            self.misra_15_5(cfg)
+                self.executeCheck(1201, self.misra_12_1_sizeof, data.rawTokens)
+            self.executeCheck(1201, self.misra_12_1, cfg)
+            self.executeCheck(1202, self.misra_12_2, cfg)
+            self.executeCheck(1203, self.misra_12_3, cfg)
+            self.executeCheck(1204, self.misra_12_4, cfg)
+            self.executeCheck(1301, self.misra_13_1, cfg)
+            self.executeCheck(1303, self.misra_13_3, cfg)
+            self.executeCheck(1304, self.misra_13_4, cfg)
+            self.executeCheck(1305, self.misra_13_5, cfg)
+            self.executeCheck(1306, self.misra_13_6, cfg)
+            self.executeCheck(1401, self.misra_14_1, cfg)
+            self.executeCheck(1402, self.misra_14_2, cfg)
+            self.executeCheck(1404, self.misra_14_4, cfg)
+            self.executeCheck(1501, self.misra_15_1, cfg)
+            self.executeCheck(1502, self.misra_15_2, cfg)
+            self.executeCheck(1503, self.misra_15_3, cfg)
+            self.executeCheck(1505, self.misra_15_5, cfg)
             if cfgNumber == 1:
-                self.misra_15_6(data.rawTokens)
-            self.misra_15_7(cfg)
-            self.misra_16_2(cfg)
+                self.executeCheck(1506, self.misra_15_6, data.rawTokens)
+            self.executeCheck(1507, self.misra_15_7, cfg)
+            self.executeCheck(1602, self.misra_16_2, cfg)
             if cfgNumber == 1:
-                self.misra_16_3(data.rawTokens)
-            self.misra_16_4(cfg)
-            self.misra_16_5(cfg)
-            self.misra_16_6(cfg)
-            self.misra_16_7(cfg)
-            self.misra_17_1(cfg)
-            self.misra_17_2(cfg)
+                self.executeCheck(1603, self.misra_16_3, data.rawTokens)
+            self.executeCheck(1604, self.misra_16_4, cfg)
+            self.executeCheck(1605, self.misra_16_5, cfg)
+            self.executeCheck(1606, self.misra_16_6, cfg)
+            self.executeCheck(1607, self.misra_16_7, cfg)
+            self.executeCheck(1701, self.misra_17_1, cfg)
+            self.executeCheck(1702, self.misra_17_2, cfg)
             if cfgNumber == 1:
-                self.misra_17_6(data.rawTokens)
-            self.misra_17_7(cfg)
-            self.misra_17_8(cfg)
-            self.misra_18_4(cfg)
-            self.misra_18_5(cfg)
-            self.misra_18_7(cfg)
-            self.misra_18_8(cfg)
-            self.misra_19_2(cfg)
-            self.misra_20_1(cfg)
-            self.misra_20_2(cfg)
+                self.executeCheck(1706, self.misra_17_6, data.rawTokens)
+            self.executeCheck(1707, self.misra_17_7, cfg)
+            self.executeCheck(1708, self.misra_17_8, cfg)
+            self.executeCheck(1804, self.misra_18_4, cfg)
+            self.executeCheck(1805, self.misra_18_5, cfg)
+            self.executeCheck(1807, self.misra_18_7, cfg)
+            self.executeCheck(1808, self.misra_18_8, cfg)
+            self.executeCheck(1902, self.misra_19_2, cfg)
+            self.executeCheck(2001, self.misra_20_1, cfg)
+            self.executeCheck(2002, self.misra_20_2, cfg)
             if cfgNumber == 1:
-                self.misra_20_3(data.rawTokens)
-            self.misra_20_4(cfg)
-            self.misra_20_5(cfg)
-            self.misra_20_7(cfg)
-            self.misra_20_10(cfg)
-            self.misra_20_13(cfg)
-            self.misra_20_14(cfg)
-            self.misra_21_1(cfg)
-            self.misra_21_3(cfg)
-            self.misra_21_4(cfg)
-            self.misra_21_5(cfg)
-            self.misra_21_6(cfg)
-            self.misra_21_7(cfg)
-            self.misra_21_8(cfg)
-            self.misra_21_9(cfg)
-            self.misra_21_10(cfg)
-            self.misra_21_11(cfg)
-            self.misra_21_12(cfg)
+                self.executeCheck(2003, self.misra_20_3, data.rawTokens)
+            self.executeCheck(2004, self.misra_20_4, cfg)
+            self.executeCheck(2005, self.misra_20_5, cfg)
+            self.executeCheck(2006, self.misra_20_7, cfg)
+            self.executeCheck(2010, self.misra_20_10, cfg)
+            self.executeCheck(2013, self.misra_20_13, cfg)
+            self.executeCheck(2014, self.misra_20_14, cfg)
+            self.executeCheck(2101, self.misra_21_1, cfg)
+            self.executeCheck(2103, self.misra_21_3, cfg)
+            self.executeCheck(2104, self.misra_21_4, cfg)
+            self.executeCheck(2105, self.misra_21_5, cfg)
+            self.executeCheck(2106, self.misra_21_6, cfg)
+            self.executeCheck(2107, self.misra_21_7, cfg)
+            self.executeCheck(2108, self.misra_21_8, cfg)
+            self.executeCheck(2109, self.misra_21_9, cfg)
+            self.executeCheck(2110, self.misra_21_10, cfg)
+            self.executeCheck(2111, self.misra_21_11, cfg)
+            self.executeCheck(2112, self.misra_21_12, cfg)
             # 22.4 is already covered by Cppcheck writeReadOnlyFile
-
 
 
 RULE_TEXTS_HELP = '''Path to text file of MISRA rules


### PR DESCRIPTION
Skip execution of globally suppressed checks. It is absolutely necessary when we gradually add MISRA rules checks in the large codebase, because now we have to perform all the checks, even if they disabled with `--suppress-rules`, which leads to a significant loss of time and resources.

@whoopsmith could you please review these changes?