### PR TITLE
Fix #9322: bsd.cfg, gnu.cfg: Fix FP for mmap when argument "fd" is -1

### DIFF
--- a/cfg/bsd.cfg
+++ b/cfg/bsd.cfg
@@ -263,6 +263,36 @@
       <valid>0:</valid>
     </arg>
   </function>
+  <!-- https://www.freebsd.org/cgi/man.cgi?query=mmap -->
+  <!-- void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset); -->
+  <!-- In contrast to POSIX, the BSD mmap requires fd to be -1 if MAP_ANONYMOUS or MAP_ANON is specified -->
+  <function name="mmap">
+    <use-retval/>
+    <returnValue type="void *"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <valid>1:</valid>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="4" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="5" direction="in">
+      <not-uninit/>
+      <valid>-1:</valid>
+    </arg>
+    <arg nr="6" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <podtype name="FTS"/>
   <podtype name="FTSENT"/>
 </def>

--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -1290,6 +1290,36 @@
       <not-bool/>
     </arg>
   </function>
+  <!-- http://man7.org/linux/man-pages/man2/mmap.2.html -->
+  <!-- void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset); -->
+  <!-- In contrast to POSIX, the GNU mmap allows/requires (depends on the implementation) fd to be -1 if MAP_ANONYMOUS or MAP_ANON is specified -->
+  <function name="mmap">
+    <use-retval/>
+    <returnValue type="void *"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <valid>1:</valid>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="4" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="5" direction="in">
+      <not-uninit/>
+      <valid>-1:</valid>
+    </arg>
+    <arg nr="6" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- ########## Resource allocation ########## -->
   <resource>
     <alloc init="true">mkostemp</alloc>

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/time.h>
+#include <sys/mman.h>
 #ifndef __CYGWIN__
 #include <sys/epoll.h>
 #endif
@@ -148,6 +149,10 @@ void valid_code(int argInt1, va_list valist_arg, int * parg)
     printf("%d", __extension__ 0b10001000);
 
     if (__alignof__(int) == 4) {}
+
+    void * p_mmap = mmap(NULL, 1, PROT_NONE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    printf("%p", p_mmap);
+    munmap(p_mmap, 1);
 }
 
 void ignoreleak(void)
@@ -172,6 +177,13 @@ void memleak_xmalloc()
 {
     char *p = (char*)xmalloc(10);
     p[9] = 0;
+    // cppcheck-suppress memleak
+}
+
+void memleak_mmap()
+{
+    void * p_mmap = mmap(NULL, 1, PROT_NONE, MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    printf("%p", p_mmap);
     // cppcheck-suppress memleak
 }
 


### PR DESCRIPTION
In contrast to POSIX, GNU and BSD allow or even require the argument
"fd" to be set to -1 if MAP_ANONYMOUS or MAP_ANON is specified.
Corresponding Trac ticket: https://trac.cppcheck.net/ticket/9322