### PR TITLE
Fix #9438 (Don't warn for return (void*) malloc(1))

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -999,7 +999,8 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
         if ((mTokenizer->isCPP() && functionName == "delete") ||
             functionName == "free" ||
             functionName == "fclose" ||
-            functionName == "realloc")
+            functionName == "realloc" ||
+            functionName == "return")
             continue;
 
         if (!CheckMemoryLeakInFunction::test_white_list(functionName, mSettings, mTokenizer->isCPP()))

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2171,6 +2171,16 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (error) Allocation with calloc, memcmp doesn't release it.\n"
                       "[test.cpp:2]: (error) Allocation with strdup, memcmp doesn't release it.\n", errout.str());
+
+        check("void* f(int size) {\n"
+              "    return (void*) malloc(size);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int* f(int size) {\n"
+              "    return static_cast<int*>(malloc(size));\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void missingAssignment() {


### PR DESCRIPTION
There are 1700 warnings (out of 5000 total) about "return doesn't release memory" in daca@home (http://cppcheck1.osuosl.org:8000/head-leakNoVarFunctionCall). Just whitelist return instead of trying to deal with the cast explicitly.