### PR TITLE
Triage tool usability improvement

### DIFF
--- a/tools/triage/.gitignore
+++ b/tools/triage/.gitignore
@@ -1,0 +1,6 @@
+moc_*.cpp
+moc_*.h
+ui_*.h
+.qmake.stash
+Makefile
+triage

--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -264,7 +264,7 @@ void MainWindow::findInFilesClicked() {
     ui->inFilesResult->clear();
     const QString text = ui->lineEdit->text();
 
-    QStringList filter {
+    const QStringList filter {
         "*.cpp","*.cxx","*.cc","*.c++","*.hpp","*.h","*.hxx","*.hh","*.tpp","*.txx","*.C","*.c","*.cl"
     };
 
@@ -300,7 +300,7 @@ void MainWindow::directorytreeDoubleClick() {
     showSrcFile(fsmodel.filePath(ui->directoryTree->currentIndex()), "", 1);
 }
 
-void MainWindow::searchResultsDoubleClick(/*QModelIndex idx*/) {
+void MainWindow::searchResultsDoubleClick() {
     QString filename = ui->inFilesResult->currentItem()->text();
     const auto idx = filename.lastIndexOf(':');
     const int line = filename.midRef(idx + 1).toInt();

--- a/tools/triage/mainwindow.h
+++ b/tools/triage/mainwindow.h
@@ -29,7 +29,7 @@ public slots:
     void fileTreeFilter(QString str);
     void findInFilesClicked();
     void directorytreeDoubleClick();
-    void searchResultsDoubleClick(/*QModelIndex*/);
+    void searchResultsDoubleClick();
 
 private:
     Ui::MainWindow *ui;

--- a/tools/triage/mainwindow.h
+++ b/tools/triage/mainwindow.h
@@ -5,6 +5,7 @@
 #include <QListWidgetItem>
 #include <QString>
 #include <QTextStream>
+#include <QFileSystemModel>
 
 namespace Ui {
     class MainWindow;
@@ -16,8 +17,8 @@ class MainWindow : public QMainWindow {
 public:
     explicit MainWindow(QWidget *parent = Q_NULLPTR);
     MainWindow(const MainWindow &) = delete;
-    ~MainWindow();
     MainWindow &operator=(const MainWindow &) = delete;
+    ~MainWindow();
 
 public slots:
     void loadFile();
@@ -25,6 +26,10 @@ public slots:
     void filter(QString filter);
     void showResult(QListWidgetItem *item);
     void refreshResults();
+    void fileTreeFilter(QString str);
+    void findInFilesClicked();
+    void directorytreeDoubleClick();
+    void searchResultsDoubleClick(/*QModelIndex*/);
 
 private:
     Ui::MainWindow *ui;
@@ -33,8 +38,10 @@ private:
     bool runProcess(const QString &programName, const QStringList & arguments);
     bool wget(const QString &url);
     bool unpackArchive(const QString &archiveName);
+    void showSrcFile(const QString &fileName, const QString &url, const int lineNumber);
 
     QStringList mAllErrors;
+    QFileSystemModel fsmodel;
 };
 
 #endif // MAINWINDOW_H

--- a/tools/triage/mainwindow.ui
+++ b/tools/triage/mainwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>MainWindow</string>
+   <string>daca triage tool</string>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/tools/triage/mainwindow.ui
+++ b/tools/triage/mainwindow.ui
@@ -122,6 +122,104 @@
       </item>
      </layout>
     </item>
+    <item>
+     <layout class="QVBoxLayout" name="filesNavigatorLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLineEdit" name="lineEdit">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="placeholderText">
+           <string>filter</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="inFilesButton">
+          <property name="text">
+           <string>In files</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QTabWidget" name="tabWidget">
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="fsTab">
+         <attribute name="title">
+          <string>Filesystem</string>
+         </attribute>
+         <widget class="QTreeView" name="directoryTree">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>341</width>
+            <height>381</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="itemsExpandable">
+           <bool>true</bool>
+          </property>
+          <attribute name="headerVisible">
+           <bool>false</bool>
+          </attribute>
+         </widget>
+        </widget>
+        <widget class="QWidget" name="inFilesTab">
+         <attribute name="title">
+          <string>In Files Result</string>
+         </attribute>
+         <widget class="QListWidget" name="inFilesResult">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>341</width>
+            <height>381</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menuBar">
@@ -130,7 +228,7 @@
      <x>0</x>
      <y>0</y>
      <width>1057</width>
-     <height>25</height>
+     <height>30</height>
     </rect>
    </property>
   </widget>
@@ -234,6 +332,70 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>lineEdit</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>fileTreeFilter(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>940</x>
+     <y>275</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>528</x>
+     <y>268</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>inFilesButton</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>findInFilesClicked()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>776</x>
+     <y>68</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>413</x>
+     <y>268</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>directoryTree</sender>
+   <signal>doubleClicked(QModelIndex)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>directorytreeDoubleClick()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>780</x>
+     <y>314</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>454</x>
+     <y>268</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>inFilesResult</sender>
+   <signal>doubleClicked(QModelIndex)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>searchResultsDoubleClick()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>755</x>
+     <y>314</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>454</x>
+     <y>268</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>loadFile()</slot>
@@ -241,5 +403,9 @@
   <slot>loadFromClipboard()</slot>
   <slot>filter(QString)</slot>
   <slot>refreshResults()</slot>
+  <slot>fileTreeFilter(QString)</slot>
+  <slot>findInFilesClicked()</slot>
+  <slot>directorytreeDoubleClick()</slot>
+  <slot>searchResultsDoubleClick()</slot>
  </slots>
 </ui>


### PR DESCRIPTION
Hello

I realized that triage tool doesn't have useful functions to navigate across files and simple search in files by text. This patch should add this functionality.

Drawbacks: I didn't realized how to force widgets inside tabwidget to grew up together w/ window. Also it has 1/3 division ratio which is not beautiful.
I haven't enough experience in qt, will be glad to get advice

Here is a simple example: https://imgur.com/gallery/IlAlYGc