### PR TITLE
Triage tool ui improvement

### DIFF
--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -294,7 +294,7 @@ void MainWindow::findInFilesClicked() {
                 ++lineN;
                 line = in.readLine();
                 if (line.contains(text, Qt::CaseInsensitive)) {
-                    ui->inFilesResult->addItem(fileName.midRef(common_path_len) + QString{":"} + QString::number(lineN));
+                    ui->inFilesResult->addItem(fileName.mid(common_path_len) + QString{":"} + QString::number(lineN));
                     break;
                 }
             }
@@ -310,5 +310,5 @@ void MainWindow::searchResultsDoubleClick() {
     QString filename = ui->inFilesResult->currentItem()->text();
     const auto idx = filename.lastIndexOf(':');
     const int line = filename.midRef(idx + 1).toInt();
-    showSrcFile(WORK_FOLDER + QString{"/"} + filename.leftRef(idx), "", line);
+    showSrcFile(WORK_FOLDER + QString{"/"} + filename.left(idx), "", line);
 }

--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -264,12 +264,20 @@ void MainWindow::findInFilesClicked() {
     ui->inFilesResult->clear();
     const QString text = ui->lineEdit->text();
 
-    const QStringList filter {
-        "*.cpp","*.cxx","*.cc","*.c++","*.hpp","*.h","*.hxx","*.hh","*.tpp","*.txx","*.C","*.c","*.cl"
-    };
+    QStringList filter;
+    if(ui->hFilesFilter->isChecked())
+    {
+        filter << "*.hpp" << "*.h" << "*.hxx" << "*.hh" << "*.tpp" << "*.txx";
+    }
+    if(ui->srcFilter->isChecked())
+    {
+        filter << "*.cpp" << "*.cxx" << "*.cc" << "*.c++" << "*.C" << "*.c" << "*.cl";
+    }
 
     QMimeDatabase mimeDatabase;
     QDirIterator it(WORK_FOLDER, filter, QDir::AllEntries | QDir::NoSymLinks | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+
+    const auto common_path_len = WORK_FOLDER.length() + 1;  // let's remove common part of path imporve UI
 
     while (it.hasNext()) {
         const QString fileName = it.next();
@@ -288,7 +296,7 @@ void MainWindow::findInFilesClicked() {
                 ++lineN;
                 line = in.readLine();
                 if (line.contains(text, Qt::CaseInsensitive)) {
-                    ui->inFilesResult->addItem(fileName + ":" + QString::number(lineN));
+                    ui->inFilesResult->addItem(fileName.midRef(common_path_len) + ":" + QString::number(lineN));
                     break;
                 }
             }
@@ -304,5 +312,5 @@ void MainWindow::searchResultsDoubleClick() {
     QString filename = ui->inFilesResult->currentItem()->text();
     const auto idx = filename.lastIndexOf(':');
     const int line = filename.midRef(idx + 1).toInt();
-    showSrcFile(filename.left(idx), "", line);
+    showSrcFile(WORK_FOLDER + "/" + filename.leftRef(idx), "", line);
 }

--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -294,7 +294,7 @@ void MainWindow::findInFilesClicked() {
                 ++lineN;
                 line = in.readLine();
                 if (line.contains(text, Qt::CaseInsensitive)) {
-                    ui->inFilesResult->addItem(fileName.midRef(common_path_len) + ":" + QString::number(lineN));
+                    ui->inFilesResult->addItem(fileName.midRef(common_path_len) + QString{":"} + QString::number(lineN));
                     break;
                 }
             }
@@ -310,5 +310,5 @@ void MainWindow::searchResultsDoubleClick() {
     QString filename = ui->inFilesResult->currentItem()->text();
     const auto idx = filename.lastIndexOf(':');
     const int line = filename.midRef(idx + 1).toInt();
-    showSrcFile(WORK_FOLDER + "/" + filename.leftRef(idx), "", line);
+    showSrcFile(WORK_FOLDER + QString{"/"} + filename.leftRef(idx), "", line);
 }

--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -265,12 +265,10 @@ void MainWindow::findInFilesClicked() {
     const QString text = ui->lineEdit->text();
 
     QStringList filter;
-    if(ui->hFilesFilter->isChecked())
-    {
+    if(ui->hFilesFilter->isChecked()) {
         filter << "*.hpp" << "*.h" << "*.hxx" << "*.hh" << "*.tpp" << "*.txx";
     }
-    if(ui->srcFilter->isChecked())
-    {
+    if(ui->srcFilter->isChecked()) {
         filter << "*.cpp" << "*.cxx" << "*.cc" << "*.c++" << "*.C" << "*.c" << "*.cl";
     }
 

--- a/tools/triage/mainwindow.ui
+++ b/tools/triage/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1057</width>
-    <height>538</height>
+    <height>637</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,79 +16,7 @@
   <widget class="QWidget" name="centralWidget">
    <layout class="QHBoxLayout" name="horizontalLayout_2">
     <item>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QPushButton" name="loadFile">
-          <property name="text">
-           <string>Load from file</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="loadFromClipboard">
-          <property name="text">
-           <string>Load from clipboard</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QListWidget" name="results"/>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="random100">
-        <property name="text">
-         <string>Show 100 random results</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Version</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="version"/>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </item>
-    <item>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="middleLayout">
       <item>
        <widget class="CodeEditor" name="code">
         <property name="readOnly">
@@ -99,7 +27,7 @@
       <item>
        <layout class="QGridLayout" name="gridLayout">
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="urllabel">
           <property name="text">
            <string>url</string>
           </property>
@@ -109,7 +37,7 @@
          <widget class="QLineEdit" name="edit1"/>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
+         <widget class="QLabel" name="filelabel">
           <property name="text">
            <string>file</string>
           </property>
@@ -122,105 +50,103 @@
       </item>
      </layout>
     </item>
-    <item>
-     <layout class="QVBoxLayout" name="filesNavigatorLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLineEdit" name="lineEdit">
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="placeholderText">
-           <string>filter</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="inFilesButton">
-          <property name="text">
-           <string>In files</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QTabWidget" name="tabWidget">
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <widget class="QWidget" name="fsTab">
-         <attribute name="title">
-          <string>Filesystem</string>
-         </attribute>
-         <widget class="QTreeView" name="directoryTree">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>341</width>
-            <height>381</height>
-           </rect>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="itemsExpandable">
-           <bool>true</bool>
-          </property>
-          <attribute name="headerVisible">
-           <bool>false</bool>
-          </attribute>
-         </widget>
-        </widget>
-        <widget class="QWidget" name="inFilesTab">
-         <attribute name="title">
-          <string>In Files Result</string>
-         </attribute>
-         <widget class="QListWidget" name="inFilesResult">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>341</width>
-            <height>381</height>
-           </rect>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </widget>
-       </widget>
-      </item>
-     </layout>
-    </item>
    </layout>
+  </widget>
+  <widget class="QToolBar" name="mainToolBar">
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>false</bool>
+   </attribute>
+  </widget>
+  <widget class="QStatusBar" name="statusBar"/>
+  <widget class="QDockWidget" name="leftDock">
+   <property name="floating">
+    <bool>false</bool>
+   </property>
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="loadFile">
+           <property name="text">
+            <string>Load from file</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="loadFromClipboard">
+           <property name="text">
+            <string>Load from clipboard</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QListWidget" name="results"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="random100">
+         <property name="text">
+          <string>Show 100 random results</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <item>
+          <widget class="QLabel" name="versionLabel">
+           <property name="text">
+            <string>Version</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="version"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">
@@ -232,15 +158,132 @@
     </rect>
    </property>
   </widget>
-  <widget class="QToolBar" name="mainToolBar">
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
+  <widget class="QDockWidget" name="rightDock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>2</number>
    </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_5">
+    <layout class="QVBoxLayout" name="verticalLayout_4">
+     <item>
+      <layout class="QVBoxLayout" name="filesNavigatorLayout">
+       <item>
+        <layout class="QHBoxLayout" name="filterLayout">
+         <item>
+          <widget class="QLineEdit" name="lineEdit">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="placeholderText">
+            <string>filter</string>
+           </property>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="inFilesButton">
+           <property name="text">
+            <string>In files</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="currentIndex">
+          <number>0</number>
+         </property>
+         <widget class="QWidget" name="fsTab">
+          <attribute name="title">
+           <string>Filesystem</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <item>
+            <widget class="QTreeView" name="directoryTree">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="itemsExpandable">
+              <bool>true</bool>
+             </property>
+             <attribute name="headerVisible">
+              <bool>false</bool>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="inFilesTab">
+          <attribute name="title">
+           <string>In Files Result</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <item>
+            <widget class="QListWidget" name="inFilesResult">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="fileFilterLayout">
+             <item>
+              <widget class="QCheckBox" name="hFilesFilter">
+               <property name="text">
+                <string>*.h, *.hpp,...</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="srcFilter">
+               <property name="text">
+                <string>*.c, *.cpp,...</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
   </widget>
-  <widget class="QStatusBar" name="statusBar"/>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -252,86 +295,6 @@
  </customwidgets>
  <resources/>
  <connections>
-  <connection>
-   <sender>results</sender>
-   <signal>itemDoubleClicked(QListWidgetItem*)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>showResult(QListWidgetItem*)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>28</x>
-     <y>104</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>5</x>
-     <y>104</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>loadFile</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>loadFile()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>22</x>
-     <y>65</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>22</x>
-     <y>46</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>loadFromClipboard</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>loadFromClipboard()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>142</x>
-     <y>55</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>528</x>
-     <y>268</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>version</sender>
-   <signal>currentIndexChanged(QString)</signal>
-   <receiver>MainWindow</receiver>
-   <slot>filter(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>98</x>
-     <y>489</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>493</x>
-     <y>39</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>random100</sender>
-   <signal>clicked()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>refreshResults()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>30</x>
-     <y>464</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>3</x>
-     <y>460</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>lineEdit</sender>
    <signal>textChanged(QString)</signal>
@@ -393,6 +356,86 @@
     <hint type="destinationlabel">
      <x>454</x>
      <y>268</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>loadFile</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>loadFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>22</x>
+     <y>65</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>22</x>
+     <y>46</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>loadFromClipboard</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>loadFromClipboard()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>142</x>
+     <y>55</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>528</x>
+     <y>268</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>random100</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>refreshResults()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>30</x>
+     <y>464</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>3</x>
+     <y>460</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>results</sender>
+   <signal>itemDoubleClicked(QListWidgetItem*)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>showResult(QListWidgetItem*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>28</x>
+     <y>104</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>5</x>
+     <y>104</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>version</sender>
+   <signal>currentIndexChanged(QString)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>filter(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>98</x>
+     <y>489</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>493</x>
+     <y>39</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This patch should improve user interface of triage tool:
* resize for widgets in tabs now working :)
* ui improved by using dockwidget for left/right parts to allow manual resize or moving frame to bottom/top for example
* search in files: removed part of path from root to working dir in output
* added simple filter by file extension: header only, cpp only, both, all files(if both unchecked)

https://imgur.com/gallery/HiMjK0E