### PR TITLE
htmlreport: Also check "cppcheck-htmlreport" with pylint on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,9 +100,11 @@ matrix:
         - python3 -m compileall ./addons
 # run pylint
         - pylint --rcfile=pylintrc_travis addons/*.py
+        - pylint --rcfile=pylintrc_travis htmlreport/cppcheck-htmlreport
         - pylint --rcfile=pylintrc_travis htmlreport/*.py
         - pylint --rcfile=pylintrc_travis --ignore=donate-cpu-server.py tools/*.py
         - python3 -m pylint --rcfile=pylintrc_travis addons/*.py
+        - python3 -m pylint --rcfile=pylintrc_travis htmlreport/cppcheck-htmlreport
         - python3 -m pylint --rcfile=pylintrc_travis htmlreport/*.py
         - python3 -m pylint --rcfile=pylintrc_travis tools/*.py
 # check python syntax by compiling some selected scripts

--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -11,7 +11,7 @@ import operator
 from collections import Counter
 from pygments import highlight
 from pygments.lexers import guess_lexer, guess_lexer_for_filename
-from pygments.formatters import HtmlFormatter
+from pygments.formatters import HtmlFormatter  # pylint: disable=no-name-in-module
 from pygments.util import ClassNotFound
 from xml.sax import parse as xml_parse
 from xml.sax import SAXParseException as XmlParseException


### PR DESCRIPTION
The error that pylint does not find HtmlFormatter in pygments.formatters
is known and the common solution is to suppress this error.
See https://github.com/PyCQA/pylint/issues/491