### PR TITLE
Add check for MISRA-C 2012 Rule 2.7 and test cases.

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -738,6 +738,28 @@ class MisraChecker:
         else:
             return 31
 
+    def misra_2_7(self, data):
+        for func in data.functions:
+            # Skip function with no parameter
+            if (len(func.argument) == 0):
+                continue
+            # Setup list of function parameters
+            func_param_list = list()
+            for arg in func.argument:
+                func_param_list.append(func.argument[arg])
+            # Search for scope of current function
+            for scope in data.scopes:
+                if (scope.type == "Function") and (scope.function == func):
+                    # Search function body: remove referenced function parameter from list
+                    token = scope.bodyStart
+                    while (token.next != None and token != scope.bodyEnd and len(func_param_list) > 0):
+                        if (token.variable != None and token.variable in func_param_list):
+                            func_param_list.remove(token.variable)
+                        token = token.next
+                    if (len(func_param_list) > 0):
+                        # At least one parameter has not been referenced in function body
+                        self.reportError(func.tokenDef, 2, 7)
+
     def misra_3_1(self, rawTokens):
         for token in rawTokens:
             starts_with_double_slash = token.str.startswith('//')
@@ -2497,6 +2519,7 @@ class MisraChecker:
             if len(data.configurations) > 1:
                 self.printStatus('Checking ' + dumpfile + ', config "' + cfg.name + '"...')
 
+            self.executeCheck(207, self.misra_2_7, cfg)
             if cfgNumber == 1:
                 self.executeCheck(301, self.misra_3_1, data.rawTokens)
                 self.executeCheck(302, self.misra_3_2, data.rawTokens)

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -26,6 +26,17 @@ typedef unsigned long long u64;
 
 // http://example.com // no warning
 
+void misra_2_7_unused_param (int *param1, int unused_param)  // 2.7
+{
+    *param1 = 42U;
+}
+
+void misra_2_7_used_params (int *param1, int param2, int param3)
+{
+    (void)param3;
+    *param1 = param2;
+}
+
 void misra_3_2(int enable)
 {
     // This won't generate a violation because of subsequent blank line \

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -185,7 +185,7 @@ void misra_5_3_enum_hidesfunction_31y(void) {} //5.3
 #define misra_5_5_hides_macro________31x 1
 
 int misra_5_5_var_hides_macro____31y; //5.5
-void misra_5_5_functionhides_macro31y(int misra_5_5_param_hides_macro__31y){} //5.5
+void misra_5_5_functionhides_macro31y(int misra_5_5_param_hides_macro__31y){(void)misra_5_5_param_hides_macro__31y;} //5.5
 struct misra_5_5_tag_hides_macro____31y { //5.5
 int x;
 };
@@ -228,7 +228,7 @@ enum misra_8_12_c { misra_c1 = misra_a1, misra_c2 = 1 }; // no-warning
 enum misra_8_12_d { misra_d1 = 1, misra_d2 = 2, misra_d3 = misra_d1 }; // no-warning
 enum misra_8_12_e { misra_e1 = sizeof(int), misra_e2}; // no-crash
 
-void misra_8_14(char * restrict str) {} // 8.14
+void misra_8_14(char * restrict str) {(void)str;} // 8.14
 
 void misra_9_5() {
   int x[] = {[0]=23}; // 9.5
@@ -302,9 +302,10 @@ void misra_11_7(int *p, float f) {
 void misra_11_7_extra(int *p, float f, bool b) {
   (void) p; // no-warning
   (void) f; // no-warning
+  (void) b;
 }
 
-char * misra_11_8_const(const char *str) {  }
+char * misra_11_8_const(const char *str) {(void)str;}
 char * misra_11_8(const char *str) {
   (void)misra_11_8_const(str); // no-warning
   return (char *)str; // 11.8
@@ -662,7 +663,7 @@ void misra_17_2_5(void) {
   misra_17_2_1(); // no-warning
 }
 
-void misra_17_6(int x[static 20]) {} // 17.6
+void misra_17_6(int x[static 20]) {void(x);} // 17.6
 
 int calculation(int x) { return x + 1; }
 void misra_17_7(void) {

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -302,7 +302,7 @@ void misra_11_7(int *p, float f) {
 void misra_11_7_extra(int *p, float f, bool b) {
   (void) p; // no-warning
   (void) f; // no-warning
-  (void) b;
+  (void) b; // no-warning
 }
 
 char * misra_11_8_const(const char *str) {(void)str;}
@@ -663,7 +663,7 @@ void misra_17_2_5(void) {
   misra_17_2_1(); // no-warning
 }
 
-void misra_17_6(int x[static 20]) {void(x);} // 17.6
+void misra_17_6(int x[static 20]) {(void)x;} // 17.6
 
 int calculation(int x) { return x + 1; }
 void misra_17_7(void) {


### PR DESCRIPTION
Implementation of MISRA-C 2012 Rule 2.7 check: 
There should be no unused parameters in functions (Category: Advisory).
 
 - Add rule check to misra.py
 - Add test cases to misra-test.c

NOTE:
Some test patterns for other MISRA rule checks in misra-test.c use functions with unused parameters which will be listed as MISRA-C 2012 Rule 2.7 finding.
Usually compiler reports unused function parameters too (verified by GCC and Microsoft C/C++ compiler).