### PR TITLE
ValueFlow: Add test with hexadecimal floating point literal

### DIFF
--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -323,6 +323,7 @@ private:
 
     void valueFlowNumber() {
         ASSERT_EQUALS(123, valueOfTok("x=123;", "123").intvalue);
+        ASSERT_EQUALS_DOUBLE(192.0, valueOfTok("x=0x0.3p10;", "0x0.3p10").floatValue, 1e-5); // 3 * 16^-1 * 2^10 = 192
         ASSERT(std::fabs(valueOfTok("x=0.5;", "0.5").floatValue - 0.5f) < 0.1f);
         ASSERT_EQUALS(10, valueOfTok("enum {A=10,B=15}; x=A+0;", "+").intvalue);
         ASSERT_EQUALS(0, valueOfTok("x=false;", "false").intvalue);


### PR DESCRIPTION
See [#6514](https://trac.cppcheck.net/ticket/6514), which I believe can be closed, but I think it would be good to add a test case to test that valueflow understands these (there are tests of the tokenizer and mathlib, but no test that connects all components).