### PR TITLE
misra.py: Fix R21.1 crash on C++ code

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1975,6 +1975,8 @@ class MisraChecker:
                 token = i.nameToken
             elif isinstance(i, cppcheckdata.Function):
                 token = i.tokenDef
+            if not token:
+                continue
             if len(token.str) < 2:
                 continue
             if token.str == 'errno':


### PR DESCRIPTION
Variables from `cppcheckdata.Variable` have no nameToken if they are objects of user-defined classes.