### PR TITLE
misra.py: Fix mutable default argument in "misra_17_2()"

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1645,7 +1645,9 @@ class MisraChecker:
 
     def misra_17_2(self, data):
         # find recursions..
-        def find_recursive_call(search_for_function, direct_call, calls_map, visited=set()):
+        def find_recursive_call(search_for_function, direct_call, calls_map, visited=None):
+            if visited is None:
+                visited = set()
             if direct_call == search_for_function:
                 return True
             for indirect_call in calls_map.get(direct_call, []):


### PR DESCRIPTION
PyCharm inspection warns for argument `visited=set()` with
"Default argument is mutable".
According to different sources one should nearly never use mutable
default arguments:
https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments
https://dev.to/florimondmanca/python-mutable-defaults-are-the-source-of-all-evil-6kk