### PR TITLE
manuals: Fix missing/wrong table of contents in HTML files

### DIFF
--- a/man/buildman.sh
+++ b/man/buildman.sh
@@ -2,8 +2,8 @@
 # To install required tools in debian:
 # sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra
 
-pandoc manual.md -o manual.pdf -s --number-sections
-pandoc manual.md -o manual.html -s --number-sections
+pandoc manual.md -o manual.pdf -s --number-sections --toc
+pandoc manual.md -o manual.html -s --number-sections --toc
 
-pandoc reference-cfg-format.md -o reference-cfg-format.pdf -s --number-sections
-pandoc reference-cfg-format.md -o reference-cfg-format.html -s --number-sections
+pandoc reference-cfg-format.md -o reference-cfg-format.pdf -s --number-sections --toc
+pandoc reference-cfg-format.md -o reference-cfg-format.html -s --number-sections --toc

--- a/man/manual.md
+++ b/man/manual.md
@@ -3,7 +3,6 @@ title: Cppcheck manual
 subtitle: Version 1.90 dev
 author: Cppcheck team
 lang: en
-toc: true
 documentclass: report
 ---
 

--- a/man/reference-cfg-format.md
+++ b/man/reference-cfg-format.md
@@ -3,7 +3,6 @@ title: Cppcheck .cfg format
 subtitle: Version 1.90 dev
 author: Cppcheck team
 lang: en
-toc: true
 documentclass: report
 ---
 


### PR DESCRIPTION
The YAML setting `toc: true` works for PDF creation but for HTML it
simply prints `true` as the table of contents.
It looks like a misconception and the only acceptable solution I have
found is to use `--toc` on the command line instead of the `toc: true`
setting in the YAML header.
It is a known issue, here are more details:
https://github.com/jgm/pandoc/issues/2872
With this fix I get table of contents not only for PDF but for HTML too.
The PDF looks like before for me, the table of contents and the outline
are still present as it was before.