### PR TITLE
addons: Change shebang to use Python 3 instead of Python 2

### DIFF
--- a/addons/cert.py
+++ b/addons/cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Cert: Some extra CERT checkers
 #

--- a/addons/findcasts.py
+++ b/addons/findcasts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Locate casts in the code
 #

--- a/addons/misc.py
+++ b/addons/misc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Misc: Uncategorized checks that might be moved to some better addon later
 #

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # MISRA C 2012 checkers
 #

--- a/addons/naming.py
+++ b/addons/naming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # cppcheck addon for naming conventions
 #

--- a/addons/threadsafety.py
+++ b/addons/threadsafety.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This script analyses Cppcheck dump files to locate threadsafety issues
 # - warn about static local objects

--- a/addons/y2038.py
+++ b/addons/y2038.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # cppcheck addon for Y2038 safeness detection
 #


### PR DESCRIPTION
Use Python 3 instead of Python 2 if addons are executed directly.
Running cert.py and misra.py against test/cfg/std.c.dump shows that
Python 3 needs only half the time compared to Python 2. I have tested
it repeatedly and the results are always the same. This is no surprise
at all. The memory footprint is very likely also significantly better
but i have not tested it.