### PR TITLE
Fix #9472 (Syntax error on valid C++ code)

### DIFF
--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -797,6 +797,8 @@ private:
     /** Find end of SQL (or PL/SQL) block */
     static const Token *findSQLBlockEnd(const Token *tokSQLStart);
 
+    bool operatorEnd(const Token * tok) const;
+
 public:
 
     /** Was there templates in the code? */

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -1627,12 +1627,8 @@ private:
     }
 
     void garbageCode206() {
-        {
-            ASSERT_EQUALS("[test.cpp:1] syntax error", getSyntaxError("void foo() { for (auto operator new : int); }"));
-        }
-        {
-            ASSERT_EQUALS("[test.cpp:1] syntax error", getSyntaxError("void foo() { for (a operator== :) }"));
-        }
+        ASSERT_EQUALS("[test.cpp:1] syntax error: operator", getSyntaxError("void foo() { for (auto operator new : int); }"));
+        ASSERT_EQUALS("[test.cpp:1] syntax error: operator", getSyntaxError("void foo() { for (a operator== :) }"));
     }
 
     void syntaxErrorFirstToken() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -400,6 +400,8 @@ private:
         TEST_CASE(simplifyOperatorName13); // user defined literal
         TEST_CASE(simplifyOperatorName14); // std::complex operator "" if
         TEST_CASE(simplifyOperatorName15); // ticket #9468 syntaxError
+        TEST_CASE(simplifyOperatorName16); // ticket #9472
+        TEST_CASE(simplifyOperatorName17);
 
         TEST_CASE(simplifyNullArray);
 
@@ -6392,6 +6394,52 @@ private:
                       "operatorchar ( ) ; "
                       "} ;",
                       tokenizeAndStringify(code));
+    }
+
+    void simplifyOperatorName16() { // ticket #9472
+        {
+            const char code[] = "class I : public A { iterator& operator++() override; };";
+            ASSERT_EQUALS("class I : public A { iterator & operator++ ( ) override ; } ;",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "class I : public A { iterator& operator++() override { } };";
+            ASSERT_EQUALS("class I : public A { iterator & operator++ ( ) override { } } ;",
+                          tokenizeAndStringify(code));
+        }
+    }
+
+    void simplifyOperatorName17() {
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator>() == d; }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator> ( ) == d ; }",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator>() == (d + 1); }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator> ( ) == ( d + 1 ) ; }",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator<() == d; }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator< ( ) == d ; }",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator>() == (d + 1); }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator> ( ) == ( d + 1 ) ; }",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator++() == d; }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator++ ( ) == d ; }",
+                          tokenizeAndStringify(code));
+        }
+        {
+            const char code[] = "template <class a> void b(a c, a d) { c.operator++() == (d + 1); }";
+            ASSERT_EQUALS("template < class a > void b ( a c , a d ) { c . operator++ ( ) == ( d + 1 ) ; }",
+                          tokenizeAndStringify(code));
+        }
     }
 
     void simplifyNullArray() {


### PR DESCRIPTION
There are probably a lot more valid code patterns that generates syntax
errors so I added "operator" to the error message to make it easier to
find them.