### PR TITLE
GUI: projectfiledialog.ui: Add note about addons requiring Python

### DIFF
--- a/gui/projectfiledialog.ui
+++ b/gui/projectfiledialog.ui
@@ -564,6 +564,16 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
+           <widget class="QLabel" name="label_addons_require_python">
+            <property name="text">
+             <string>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</string>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="mAddonY2038">
             <property name="text">
              <string>Y2038</string>


### PR DESCRIPTION
This fixes https://trac.cppcheck.net/ticket/9456 (Tell the user that the
addons require Python) regarding the GUI. Whether it is useful/necessary
to add something similar for the CLI must still be checked.