### PR TITLE
9356: Prevent false positive when passing non-const reference to member constructor

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1299,6 +1299,8 @@ static bool isVariableMutableInInitializer(const Token* start, const Token * end
             const Token * memberTok = tok->astParent()->previous();
             if (Token::Match(memberTok, "%var% (") && memberTok->variable()) {
                 const Variable * memberVar = memberTok->variable();
+                if(memberVar->isClass())
+                    return true;
                 if (!memberVar->isReference())
                     continue;
                 if (memberVar->isConst())

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1300,6 +1300,8 @@ static bool isVariableMutableInInitializer(const Token* start, const Token * end
             if (Token::Match(memberTok, "%var% (") && memberTok->variable()) {
                 const Variable * memberVar = memberTok->variable();
                 if(memberVar->isClass())
+                    //TODO: check if the called constructor could live with a const variable
+                    // pending that, assume the worst (that it can't)
                     return true;
                 if (!memberVar->isReference())
                     continue;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -2098,6 +2098,90 @@ private:
               "void an();\n"
               "void h();\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("class C\n"
+              "{\n"
+              "public:\n"
+              "  explicit C(int&);\n"
+              "};\n"
+              "\n"
+              "class D\n"
+              "{\n"
+              "public:\n"
+              "  explicit D(int&);\n"
+              "\n"
+              "private:\n"
+              "  C c;\n"
+              "};\n"
+              "\n"
+              "D::D(int& i)\n"
+              "  : c(i)\n"
+              "{\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("class C\n"
+              "{\n"
+              "public:\n"
+              "  explicit C(const int&);\n"
+              "};\n"
+              "\n"
+              "class D\n"
+              "{\n"
+              "public:\n"
+              "  explicit D(int&);\n"
+              "\n"
+              "private:\n"
+              "  C c;\n"
+              "};\n"
+              "\n"
+              "D::D(int& i)\n"
+              "  : c(i)\n"
+              "{\n"
+              "}\n");
+        TODO_ASSERT_EQUALS("[test.cpp:16]: (style) Parameter 'i' can be declared with const\n", "", errout.str());
+
+        check("class C\n"
+              "{\n"
+              "public:\n"
+              "  explicit C(int);\n"
+              "};\n"
+              "\n"
+              "class D\n"
+              "{\n"
+              "public:\n"
+              "  explicit D(int&);\n"
+              "\n"
+              "private:\n"
+              "  C c;\n"
+              "};\n"
+              "\n"
+              "D::D(int& i)\n"
+              "  : c(i)\n"
+              "{\n"
+              "}\n");
+        TODO_ASSERT_EQUALS("[test.cpp:16]: (style) Parameter 'i' can be declared with const\n", "", errout.str());
+
+        check("class C\n"
+              "{\n"
+              "public:\n"
+              "  explicit C(int, int);\n"
+              "};\n"
+              "\n"
+              "class D\n"
+              "{\n"
+              "public:\n"
+              "  explicit D(int&);\n"
+              "\n"
+              "private:\n"
+              "  C c;\n"
+              "};\n"
+              "\n"
+              "D::D(int& i)\n"
+              "  : c(0, i)\n"
+              "{\n"
+              "}\n");
+        TODO_ASSERT_EQUALS("[test.cpp:16]: (style) Parameter 'i' can be declared with const\n", "", errout.str());
     }
 
     void switchRedundantAssignmentTest() {


### PR DESCRIPTION
    This workarounds false positives 'Parameter  can be declared with const [constParameter]'
    when said parameter is used in constructor call. It assume the
    constructor call might change the parameter (without any checks.
    The drawback is that we have false negative, in cases where we could
    check the constructor actually takes a const reference, or a copied by
    value parameter.

I'll try implementing smarter checks to handle more constructors (right now, only constructor that take only one parameter are considered), and to check if we can have the warning (in cases of const ref/copied by value parameter in the constructor).
However, this looks rather complex. I believe we currently don't have the facility to know which constructor is called; do we ? So fixing this would means find the called constructor (and handling the overload resolution properly) ?
Or am I missing something and we already have this information somewhere ?