### PR TITLE
Avoid giant C4267 warning in 64-bit Visual C++ build

### DIFF
--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1069,7 +1069,10 @@ public:
     void addVariable(const Token *token_, const Token *start_,
                      const Token *end_, AccessControl access_, const Type *type_,
                      const Scope *scope_, const Settings* settings) {
-        varlist.emplace_back(token_, start_, end_, varlist.size(),
+        // keep possible size_t -> int truncation outside emplace_back() to have a single line
+        // C4267 VC++ warning instead of several dozens lines
+        const int varIndex = varlist.size();
+        varlist.emplace_back(token_, start_, end_, varIndex,
                              access_,
                              type_, scope_, settings);
     }


### PR DESCRIPTION
@danmar Could you please evaluate this change? Currently 64-bit VC++ build logs look this https://ci.appveyor.com/project/danmar/cppcheck/builds/29014253/job/uqdl9mmvb3x96rp1?fullLog=true

For every translation unit the following warning is emitted (yes, it's foot long single warning):

    xmemory0(600): warning C4267: 'argument' : conversion from 'size_t' to 'int', possible loss of data (astutils.cpp) [cppcheck.vcxproj]
          xmemory0(723) : see reference to function template instantiation 'void std::allocator<_Other>::construct<_Objty,const Token*&,const Token*&,const Token*&,_Ty,AccessControl&,const Type*&,const Scope*&,const Settings*&>(_Objty *,const Token *&,const Token *&,const Token *&,_Ty &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Other=std::_List_node<Variable,void *>
      ,            _Objty=Variable
      ,            _Ty=unsigned __int64
          ]
          xmemory0(723) : see reference to function template instantiation 'void std::allocator<_Other>::construct<_Objty,const Token*&,const Token*&,const Token*&,_Ty,AccessControl&,const Type*&,const Scope*&,const Settings*&>(_Objty *,const Token *&,const Token *&,const Token *&,_Ty &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Other=std::_List_node<Variable,void *>
      ,            _Objty=Variable
      ,            _Ty=unsigned __int64
          ]
          xmemory0(872) : see reference to function template instantiation 'void std::allocator_traits<_Alloc>::construct<_Ty,const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::allocator<_Other> &,_Objty *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Alloc=std::allocator<std::_List_node<Variable,void *>>
      ,            _Ty=Variable
      ,            _Other=std::_List_node<Variable,void *>
      ,            _Objty=Variable
          ]
          xmemory0(872) : see reference to function template instantiation 'void std::allocator_traits<_Alloc>::construct<_Ty,const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::allocator<_Other> &,_Objty *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Alloc=std::allocator<std::_List_node<Variable,void *>>
      ,            _Ty=Variable
      ,            _Other=std::_List_node<Variable,void *>
      ,            _Objty=Variable
          ]
          list(835) : see reference to function template instantiation 'void std::_Wrap_alloc<std::allocator<_Other>>::construct<_Ty,const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(_Ty *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Other=std::_List_node<Variable,void *>
      ,            _Ty=Variable
          ]
          list(835) : see reference to function template instantiation 'void std::_Wrap_alloc<std::allocator<_Other>>::construct<_Ty,const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(_Ty *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Other=std::_List_node<Variable,void *>
      ,            _Ty=Variable
          ]
          list(1062) : see reference to function template instantiation 'std::_List_node<Variable,void *> *std::_List_buy<_Ty,_Alloc>::_Buynode<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::_List_node<Variable,void *> *,std::_List_node<Variable,void *> *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
      ,            _Alloc=std::allocator<Variable>
          ]
          list(1062) : see reference to function template instantiation 'std::_List_node<Variable,void *> *std::_List_buy<_Ty,_Alloc>::_Buynode<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::_List_node<Variable,void *> *,std::_List_node<Variable,void *> *,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
      ,            _Alloc=std::allocator<Variable>
          ]
          list(1040) : see reference to function template instantiation 'void std::list<Variable,std::allocator<_Ty>>::_Insert<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::_List_unchecked_const_iterator<std::_List_val<std::_List_simple_types<_Ty>>,std::_Iterator_base0>,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
          ]
          list(1040) : see reference to function template instantiation 'void std::list<Variable,std::allocator<_Ty>>::_Insert<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(std::_List_unchecked_const_iterator<std::_List_val<std::_List_simple_types<_Ty>>,std::_Iterator_base0>,const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
          ]
          symboldatabase.h(1074) : see reference to function template instantiation 'void std::list<Variable,std::allocator<_Ty>>::emplace_back<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
          ]
          symboldatabase.h(1074) : see reference to function template instantiation 'void std::list<Variable,std::allocator<_Ty>>::emplace_back<const Token*&,const Token*&,const Token*&,unsigned __int64,AccessControl&,const Type*&,const Scope*&,const Settings*&>(const Token *&,const Token *&,const Token *&,unsigned __int64 &&,AccessControl &,const Type *&,const Scope *&,const Settings *&)' being compiled
          with
          [
              _Ty=Variable
          ]

Such logs are rather hard to review.

The change keeps the warning in place but makes it a single line and also outlines the potential problem better. Do you like this?
