### PR TITLE
donate-cpu.py: Verify argument for jobs (-jN)

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -45,6 +45,10 @@ for arg in sys.argv[1:]:
         stop_time = arg[-5:]
         print('Stop time:' + stop_time)
     elif arg.startswith('-j'):
+        if not re.match(r'-j\d+', arg):
+            print('Argument "{}" is invalid.'.format(arg))
+            print('"-j" must be followed by a positive number.')
+            sys.exit(1)
         jobs = arg
         print('Jobs:' + jobs[2:])
     elif arg.startswith('--package='):


### PR DESCRIPTION
Yesterday, I observed that some client with a wrong jobs setting
(only "-j") requested one package after another and always uploaded
results where it only said that the argument "-j" is invalid for
Cppcheck.
This check should avoid such cases where results are overwritten with
useless data and the server is kept busy for nothing.