### PR TITLE
cert.py: Add ENV33-C-EX1 exception

### DIFF
--- a/addons/cert.py
+++ b/addons/cert.py
@@ -242,7 +242,8 @@ def int31(data, platform):
 def env33(data):
     for token in data.tokenlist:
         if isFunctionCall(token, ('system',), 1):
-            reportError(token, 'style', 'Do not call system()', 'ENV33-C')
+            if not simpleMatch(token, "system ( NULL )") and not simpleMatch(token, "system ( 0 )"):
+                reportError(token, 'style', 'Do not call system()', 'ENV33-C')
 
 
 # MSC24-C

--- a/addons/cert.py
+++ b/addons/cert.py
@@ -242,8 +242,19 @@ def int31(data, platform):
 def env33(data):
     for token in data.tokenlist:
         if isFunctionCall(token, ('system',), 1):
-            if not simpleMatch(token, "system ( NULL )") and not simpleMatch(token, "system ( 0 )"):
-                reportError(token, 'style', 'Do not call system()', 'ENV33-C')
+
+            # Invalid syntax
+            if not token.next.astOperand2:
+                continue
+
+            # ENV33-C-EX1: It is permissible to call system() with a null
+            # pointer argument to determine the presence of a command processor
+            # for the system.
+            argValue = token.next.astOperand2.getValue(0)
+            if argValue and argValue.intvalue == 0 and argValue.isKnown():
+                continue
+
+            reportError(token, 'style', 'Do not call system()', 'ENV33-C')
 
 
 # MSC24-C

--- a/addons/test/cert-test.c
+++ b/addons/test/cert-test.c
@@ -77,8 +77,11 @@ unsigned char int31(int x)
 void env33()
 {
     system("chmod -x $(which chmod)"); // cert-ENV33-C
+    system(""); // cert-ENV33-C
     system(NULL); // no-warning
     system(0); // no-warning
+    const int *np = NULL;
+    system(np); // no-warning
     int system;
 }
 

--- a/addons/test/cert-test.c
+++ b/addons/test/cert-test.c
@@ -77,6 +77,8 @@ unsigned char int31(int x)
 void env33()
 {
     system("chmod -x $(which chmod)"); // cert-ENV33-C
+    system(NULL); // no-warning
+    system(0); // no-warning
     int system;
 }
 


### PR DESCRIPTION
There is [following exception](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=87152177):

> ENV33-C-EX1: It is permissible to call system() with a null pointer argument to determine the presence of a command processor for the system.

This has been reported in [this thread](https://sourceforge.net/p/cppcheck/discussion/development/thread/0ff41d92b7/?limit=25#3240).