### PR TITLE
misra-test.c: Add more tests for rule 14.2 (including FP and FN)

### DIFF
--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -398,10 +398,26 @@ void misra_14_1() {
 
 }
 
-void misra_14_2() {
+void misra_14_2_init_value(int32_t *var) {
+    *var = 0;
+}
+void misra_14_2(bool b) {
   for (dostuff();a<10;a++) {} // 14.2
   for (;i++<10;) {} // 14.2
   for (;i<10;dostuff()) {} // TODO
+  int32_t g = 0;
+  for (int32_t i2 = 0; i2 < 8; ++i2) {
+      i2 += 2; // FIXME False negative for "14.2"
+      g += 2; // no-warning
+  }
+  for (misra_14_2_init_value(&i); i < 10; ++i) {} // no-warning FIXME: False positive for 14.2
+  bool abort = false;
+  for (i = 0; (i < 10) && !abort; ++i) { // no-warning
+      if (b) {
+        abort = true;
+      }
+  }
+  for (;;) {} // no-warning
   // TODO check more variants
 }
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -407,10 +407,10 @@ void misra_14_2(bool b) {
   for (;i<10;dostuff()) {} // TODO
   int32_t g = 0;
   for (int32_t i2 = 0; i2 < 8; ++i2) {
-      i2 += 2; // FIXME False negative for "14.2"
+      i2 += 2; // FIXME False negative for "14.2". Trac #9490
       g += 2; // no-warning
   }
-  for (misra_14_2_init_value(&i); i < 10; ++i) {} // no-warning FIXME: False positive for 14.2
+  for (misra_14_2_init_value(&i); i < 10; ++i) {} // no-warning FIXME: False positive for 14.2 Trac #9491
   bool abort = false;
   for (i = 0; (i < 10) && !abort; ++i) { // no-warning
       if (b) {


### PR DESCRIPTION
Adding more tests for rule 14.2 revealed a false negative when the
loop counter is changed inside the loop.
Corresponding line in the example suite:
https://gitlab.com/MISRA/MISRA-C/MISRA-C-2012/Example-Suite/blob/master/R_14_02.c#L39
Also a false positive has been revealed when the loop counter is
initialized in a function that is called in the first `for` clause.
Corresponding line in the example suite:
https://gitlab.com/MISRA/MISRA-C/MISRA-C-2012/Example-Suite/blob/master/R_14_02.c#L43