### PR TITLE
testnullpointer.cpp: Add test for dereferencing returned NULL pointer

### DIFF
--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -2062,6 +2062,14 @@ private:
               "    typeof(*NULL) y;\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+
+        check("int * f() {\n"
+              "    return NULL;\n"
+              "}\n"
+              "int main() {\n"
+              "  return *f();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Null pointer dereference: f()\n", errout.str());
     }
 
     void gcc_statement_expression() {


### PR DESCRIPTION
This adds a regression test to make sure that directly dereferencing a
returned NULL pointer issues a warning.
This has been asked on Stack Overflow:
https://stackoverflow.com/q/58981369
Cppcheck 1.89 does not warn for such a code, but 1.90 dev does. So it
is a good idea to make sure it is detected in the future too I guess.