### PR TITLE
GUI: Fix and update translation files

### DIFF
--- a/gui/cppcheck_de.ts
+++ b/gui/cppcheck_de.ts
@@ -418,13 +418,13 @@ Parameter: -l(line) (file)
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -978,23 +978,23 @@ Möchten Sie stattdessen diese öffnen?</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Lizenz</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Autoren</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Speichert die Berichtdatei</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML-Dateien (*.xml)</translation>
     </message>
@@ -1053,39 +1053,39 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
           Das Einlesen einer XML-Datei löscht die aktuellen Ergebnisse. Fortfahren?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Berichtdatei öffnen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Textdateien (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV-Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Projektdateien (*.cppcheck);;Alle Dateien(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Projektdatei auswählen</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Projekt:</translation>
     </message>
@@ -1139,7 +1139,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
 Wollen sie fortfahren, ohne diese Projektdateien zu nutzen?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1150,7 +1150,7 @@ Eine neue XML-Datei zu öffnen wird die aktuellen Ergebnisse löschen
 Möchten sie fortfahren?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
@@ -1159,37 +1159,37 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 Wollen sie die Analyse abbrechen und Cppcheck beenden?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation>XML-Dateien (*.xml);;Textdateien (*.txt);;CSV-Dateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation>Erstellungsverzeichnis &apos;%1&apos; existiert nicht. Erstellen?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation>Import von &apos;%1&apos; fehlgeschlagen; Analyse wurde abgebrochen.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation>Projektdateien (*.cppcheck)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Projektnamen auswählen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>Keine Projektdatei geladen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1341,22 +1341,22 @@ Options:
         <translation>Addons und Werkzeuge</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation>MISRA C 2012</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation>Misra-Regeltexte</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Text aus Anhang A &amp;quot;Summary of guidelines&amp;quot; aus der MISRA-C-2012-PDF in eine Textdatei einfügen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -1479,7 +1479,12 @@ Options:
         <translation>Quelldateien in Pfaden ausschließen</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation>Hinweis: Addons setzen voraus, dass &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; installiert ist.</translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation>Externe Werkzeuge</translation>
     </message>
@@ -1509,32 +1514,32 @@ Options:
         <translation>Add-Ons</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation>Y2038</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation>Threadsicherheit</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation>Programmierstandards</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation>Cert</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation>Clang-Analyzer</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation>Clang-Tidy</translation>
     </message>

--- a/gui/cppcheck_es.ts
+++ b/gui/cppcheck_es.ts
@@ -420,13 +420,13 @@ Parameters: -l(line) (file)</source>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1049,13 +1049,13 @@ This is probably because the settings were changed between the Cppcheck versions
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>Archivos XML (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Abrir informe</translation>
     </message>
@@ -1068,12 +1068,12 @@ Do you want to stop the checking and exit Cppcheck?</source>
 ¿Quieres parar la comprobación y salir del Cppcheck?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Licencia</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Autores</translation>
     </message>
@@ -1082,7 +1082,7 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">Archivos XML versión 2 (*.xml);;Archivos XML versión 1 (*.xml);;Archivos de texto (*.txt);;Archivos CSV (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Guardar informe</translation>
     </message>
@@ -1166,34 +1166,34 @@ Abrir un nuevo fichero XML eliminará los resultados actuales. ¿Desea continuar
         <translation type="obsolete">Archivos XML versión 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Ficheros de texto (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>Ficheros CVS (*.cvs)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Ficheros de proyecto (*.cppcheck;;Todos los ficheros (*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Selecciona el archivo de proyecto</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Proyecto:</translation>
     </message>
@@ -1245,7 +1245,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1253,44 +1253,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Selecciona el nombre del proyecto</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>No hay ningún proyecto cargado</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1470,22 +1470,22 @@ Options:
         <translation>Nota: Ponga sus propios archivos .cfg en la misma carpeta que el proyecto. Debería verlos arriba.</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1573,7 +1573,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1659,32 +1664,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_fi.ts
+++ b/gui/cppcheck_fi.ts
@@ -404,13 +404,13 @@ Parameters: -l(line) (file)</source>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -972,12 +972,12 @@ Do you want to load this project file instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Lisenssi</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Tekijät</translation>
     </message>
@@ -987,13 +987,13 @@ Do you want to load this project file instead?</source>
         <translation type="obsolete">XML-tiedostot (*.xml);;Tekstitiedostot (*.txt);;CSV-tiedostot (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Tallenna raportti</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML-tiedostot (*xml)</translation>
     </message>
@@ -1055,39 +1055,39 @@ This is probably because the settings were changed between the Cppcheck versions
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Tekstitiedostot (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1139,7 +1139,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1147,44 +1147,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1338,22 +1338,22 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1476,7 +1476,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1506,32 +1511,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_fr.ts
+++ b/gui/cppcheck_fr.ts
@@ -1,35 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr_FR" sourcelanguage="en_GB">
+<TS version="2.1" language="fr_FR">
 <context>
     <name>About</name>
     <message>
+        <location filename="about.ui" line="14"/>
         <source>About Cppcheck</source>
         <translation>A propos</translation>
     </message>
     <message>
+        <location filename="about.ui" line="64"/>
         <source>Version %1</source>
         <translation>Version %1</translation>
     </message>
     <message>
+        <location filename="about.ui" line="71"/>
         <source>Cppcheck - A tool for static C/C++ code analysis.</source>
         <translation>Cppcheck - Un outil d&apos;analyse statique de code C/C++.</translation>
     </message>
     <message>
+        <location filename="about.ui" line="91"/>
         <source>This program is licensed under the terms
 of the GNU General Public License version 3</source>
         <translation>Ce programme est sous licence GNU
 General Public License version 3</translation>
     </message>
     <message>
+        <location filename="about.ui" line="102"/>
         <source>Visit Cppcheck homepage at %1</source>
         <translation>Visitez le site Cppcheck : %1</translation>
     </message>
     <message>
+        <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-2019 Cppcheck team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="about.ui" line="115"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Many thanks to these libraries that we use:&lt;/p&gt;&lt;ul&gt;
 &lt;li&gt;tinyxml2&lt;/li&gt;
@@ -42,34 +49,42 @@ General Public License version 3</translation>
 <context>
     <name>ApplicationDialog</name>
     <message>
+        <location filename="application.ui" line="23"/>
         <source>Add an application</source>
         <translation>Ajouter une application</translation>
     </message>
     <message>
+        <location filename="application.ui" line="138"/>
         <source>Browse</source>
         <translation>Parcourir</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="59"/>
         <source>Executable files (*.exe);;All files(*.*)</source>
         <translation>Fichier exécutable (*.exe);;Tous les fichiers(*.*)</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="62"/>
         <source>Select viewer application</source>
         <translation>Sélection de l&apos;application</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="77"/>
         <source>Cppcheck</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="application.ui" line="86"/>
         <source>&amp;Executable:</source>
         <translation>&amp;Exécutable : </translation>
     </message>
     <message>
+        <location filename="application.ui" line="96"/>
         <source>&amp;Parameters:</source>
         <translation>&amp;Paramètres : </translation>
     </message>
     <message>
+        <location filename="application.ui" line="41"/>
         <source>Here you can add an application that can open error files. Specify a name for the application, the application executable and command line parameters for the application.
 
 The following texts in parameters are replaced with appropriate values when application is executed:
@@ -94,10 +109,12 @@ Exécutable : kate
 Paramètres : -l(ligne) (fichier)</translation>
     </message>
     <message>
+        <location filename="application.ui" line="76"/>
         <source>&amp;Name:</source>
         <translation>&amp;Nom : </translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="78"/>
         <source>You must specify a name, a path and optionally parameters for the application!</source>
         <translation>Vous devez spécifier un nom, un chemin, et eventuellement des paramètres en option à l&apos;application !</translation>
     </message>
@@ -105,14 +122,18 @@ Paramètres : -l(ligne) (fichier)</translation>
 <context>
     <name>FileViewDialog</name>
     <message>
+        <location filename="fileviewdialog.cpp" line="42"/>
         <source>Could not find the file: %1</source>
         <translation>Ne trouve pas le fichier : %1</translation>
     </message>
     <message>
+        <location filename="fileviewdialog.cpp" line="46"/>
+        <location filename="fileviewdialog.cpp" line="60"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="fileviewdialog.cpp" line="56"/>
         <source>Could not read the file: %1</source>
         <translation>Ne peut pas lire le fichier : %1</translation>
     </message>
@@ -120,14 +141,17 @@ Paramètres : -l(ligne) (fichier)</translation>
 <context>
     <name>LibraryAddFunctionDialog</name>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="23"/>
         <source>Add function</source>
         <translation>Ajouter une fonction</translation>
     </message>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="34"/>
         <source>Function name(s)</source>
         <translation>Nom(s) de la fonction</translation>
     </message>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="44"/>
         <source>Number of arguments</source>
         <translation>Nombre d&apos;arguments</translation>
     </message>
@@ -135,98 +159,125 @@ Paramètres : -l(ligne) (fichier)</translation>
 <context>
     <name>LibraryDialog</name>
     <message>
+        <location filename="librarydialog.ui" line="14"/>
         <source>Library Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="22"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="29"/>
         <source>Save</source>
         <translation type="unfinished">Sauvegarder</translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="62"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="111"/>
         <source>Add</source>
         <translation type="unfinished">Ajouter</translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="204"/>
         <source>noreturn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="212"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="217"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="222"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="232"/>
         <source>return value must be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="239"/>
         <source>ignore function in leaks checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="246"/>
         <source>Arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="258"/>
         <source>Edit</source>
         <translation type="unfinished">Editer</translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="82"/>
+        <location filename="librarydialog.cpp" line="154"/>
         <source>Library files (*.cfg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="84"/>
         <source>Open library file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="71"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="131"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="164"/>
         <source>Comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="36"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="95"/>
+        <location filename="librarydialog.cpp" line="107"/>
+        <location filename="librarydialog.cpp" line="144"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="157"/>
         <source>Save the library as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="108"/>
         <source>Failed to load %1. %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="96"/>
         <source>Cannot open file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="145"/>
         <source>Cannot save file %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -234,10 +285,12 @@ Paramètres : -l(ligne) (fichier)</translation>
 <context>
     <name>LibraryEditArgDialog</name>
     <message>
+        <location filename="libraryeditargdialog.ui" line="14"/>
         <source>Edit argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Is bool value allowed? For instance result from comparison or from &apos;!&apos; operator.&lt;/p&gt;
 &lt;p&gt;Typically, set this if the argument is a pointer, size, etc.&lt;/p&gt;
@@ -247,10 +300,12 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="28"/>
         <source>Not bool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="35"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Is a null parameter value allowed?&lt;/p&gt;
 &lt;p&gt;Typically this should be used on any pointer parameter that does not allow null.&lt;/p&gt;
@@ -260,58 +315,79 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="43"/>
         <source>Not null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="50"/>
         <source>Not uninit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="57"/>
         <source>String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="70"/>
         <source>Format string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="92"/>
         <source>Min size of buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="101"/>
+        <location filename="libraryeditargdialog.ui" line="203"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="109"/>
+        <location filename="libraryeditargdialog.ui" line="214"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="114"/>
+        <location filename="libraryeditargdialog.ui" line="219"/>
         <source>argvalue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="119"/>
+        <location filename="libraryeditargdialog.ui" line="224"/>
         <source>mul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="124"/>
+        <location filename="libraryeditargdialog.ui" line="229"/>
         <source>strlen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="132"/>
+        <location filename="libraryeditargdialog.ui" line="237"/>
         <source>Arg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="159"/>
+        <location filename="libraryeditargdialog.ui" line="264"/>
         <source>Arg2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="194"/>
         <source>and</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="310"/>
         <source>Valid values</source>
         <translation type="unfinished"></translation>
     </message>
@@ -319,18 +395,35 @@ Paramètres : -l(ligne) (fichier)</translation>
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="mainwindow.ui" line="26"/>
+        <location filename="mainwindow.ui" line="595"/>
+        <location filename="mainwindow.cpp" line="328"/>
+        <location filename="mainwindow.cpp" line="480"/>
+        <location filename="mainwindow.cpp" line="553"/>
+        <location filename="mainwindow.cpp" line="658"/>
+        <location filename="mainwindow.cpp" line="680"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="70"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="89"/>
         <source>&amp;View</source>
         <translation>&amp;Affichage</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="121"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
@@ -339,38 +432,47 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">&amp;Vérifier</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="170"/>
         <source>&amp;Edit</source>
         <translation>&amp;Édition</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="183"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="231"/>
         <source>&amp;License...</source>
         <translation>&amp;Licence...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="236"/>
         <source>A&amp;uthors...</source>
         <translation>A&amp;uteurs...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="245"/>
         <source>&amp;About...</source>
         <translation>À &amp;Propos...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="250"/>
         <source>&amp;Files...</source>
         <translation>&amp;Fichiers...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="259"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="268"/>
         <source>&amp;Directory...</source>
         <translation>&amp;Répertoires...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="277"/>
         <source>Ctrl+D</source>
         <translation type="unfinished"></translation>
     </message>
@@ -379,62 +481,77 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">&amp;Revérifier les fichiers</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="289"/>
         <source>Ctrl+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="307"/>
         <source>&amp;Stop</source>
         <translation>&amp;Arrêter</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="316"/>
         <source>Esc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="325"/>
         <source>&amp;Save results to file...</source>
         <translation>&amp;Sauvegarder les résultats dans un fichier...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="328"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="333"/>
         <source>&amp;Quit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="342"/>
         <source>&amp;Clear results</source>
         <translation>&amp;Effacer les résultats</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="351"/>
         <source>&amp;Preferences</source>
         <translation>&amp;Préférences</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="392"/>
         <source>&amp;Check all</source>
         <translation>&amp;Tout cocher</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="397"/>
         <source>&amp;Uncheck all</source>
         <translation>&amp;Tout décocher</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="402"/>
         <source>Collapse &amp;all</source>
         <translation>&amp;Tout réduire</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="407"/>
         <source>&amp;Expand all</source>
         <translation>&amp;Tout dérouler</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="423"/>
         <source>&amp;Contents</source>
         <translation>&amp;Contenus</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="426"/>
         <source>Open the help contents</source>
         <translation>Ouvir l&apos;aide</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="429"/>
         <source>F1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -447,38 +564,48 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Sélectionner le répertoire à vérifier</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Licence</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Sauvegarder le rapport</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>Fichiers XML (*.xml)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Fichiers Texte (*.txt)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>Fichiers CSV (*.csv)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="93"/>
         <source>&amp;Toolbars</source>
         <translation>&amp;Boite à outils</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="201"/>
         <source>Categories</source>
         <translation>Catégories</translation>
     </message>
@@ -499,6 +626,8 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Avertissement de style</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="366"/>
+        <location filename="mainwindow.ui" line="369"/>
         <source>Show style warnings</source>
         <translation>Afficher les avertissements de style</translation>
     </message>
@@ -507,58 +636,73 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Erreurs</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="384"/>
+        <location filename="mainwindow.ui" line="387"/>
         <source>Show errors</source>
         <translation>Afficher les erreurs</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="415"/>
         <source>&amp;Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="418"/>
         <source>Standard items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="434"/>
         <source>Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="442"/>
         <source>&amp;Categories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="445"/>
         <source>Error categories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="450"/>
         <source>&amp;Open XML...</source>
         <translation>&amp;Ouvrir un fichier XML...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="459"/>
         <source>Open P&amp;roject File...</source>
         <translation>Ouvrir un P&amp;rojet...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="473"/>
         <source>&amp;New Project File...</source>
         <translation>&amp;Nouveau Projet...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="478"/>
         <source>&amp;Log View</source>
         <translation>&amp;Journal</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="481"/>
         <source>Log View</source>
         <translation>Journal</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="489"/>
         <source>C&amp;lose Project File</source>
         <translation>F&amp;ermer le projet</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="497"/>
         <source>&amp;Edit Project File...</source>
         <translation>&amp;Editer le projet</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="509"/>
         <source>&amp;Statistics</source>
         <translation>Statistiques</translation>
     </message>
@@ -567,6 +711,8 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Avertissements</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="524"/>
+        <location filename="mainwindow.ui" line="527"/>
         <source>Show warnings</source>
         <translation>Afficher les avertissements</translation>
     </message>
@@ -575,18 +721,24 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Avertissements de performance</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="542"/>
+        <location filename="mainwindow.ui" line="545"/>
         <source>Show performance warnings</source>
         <translation>Afficher les avertissements de performance</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="553"/>
         <source>Show &amp;hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="769"/>
+        <location filename="mainwindow.cpp" line="807"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="568"/>
         <source>Show information messages</source>
         <translation>Afficher les messages d&apos;information</translation>
     </message>
@@ -595,14 +747,17 @@ Paramètres : -l(ligne) (fichier)</translation>
         <translation type="obsolete">Portabilité</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="583"/>
         <source>Show portability warnings</source>
         <translation>Afficher les problèmes de portabilité</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="554"/>
         <source>You must close the project file before selecting new files or directories!</source>
         <translation>Vous devez d&apos;abord fermer le projet avant de choisir des fichiers/répertoires</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Ouvrir le rapport</translation>
     </message>
@@ -615,50 +770,63 @@ Do you want to stop the checking and exit Cppcheck?</source>
 Voulez-vous arrêter la vérification et quitter CppCheck ?</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="323"/>
         <source>There was a problem with loading the editor application settings.
 
 This is probably because the settings were changed between the Cppcheck versions. Please check (and fix) the editor application settings, otherwise the editor program might not start correctly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="621"/>
         <source>&amp;Filter</source>
         <translation>&amp;Filtre</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="624"/>
         <source>Filter results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="87"/>
         <source>Quick Filter:</source>
         <translation>Filtre rapide : </translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="659"/>
         <source>Found project file: %1
 
 Do you want to load this project file instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="159"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Projet : </translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -669,26 +837,32 @@ Do you want to remove the file from the recently used projects -list?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="220"/>
         <source>Filter</source>
         <translation>Filtre</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="640"/>
         <source>Windows 32-bit ANSI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="648"/>
         <source>Windows 32-bit Unicode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="656"/>
         <source>Unix 32-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="664"/>
         <source>Unix 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="672"/>
         <source>Windows 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -705,74 +879,91 @@ L&apos;ouverture d&apos;un nouveau fichier XML effacera les resultats. Voulez-vo
         <translation type="obsolete">Sélectionner les fichiers à vérifier</translation>
     </message>
     <message>
+        <location filename="main.cpp" line="121"/>
         <source>Cppcheck GUI - Command line parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="135"/>
         <source>C++ standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="828"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="778"/>
         <source>File not found</source>
         <translation>Fichier introuvable</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="781"/>
         <source>Bad XML</source>
         <translation>Mauvais fichier XML</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="784"/>
         <source>Missing attribute</source>
         <translation>Attribut manquant</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="787"/>
         <source>Bad attribute value</source>
         <translation>Mauvaise valeur d&apos;attribut</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="807"/>
         <source>Failed to load the selected library &apos;%1&apos;.
 %2</source>
         <translation>Echec lors du chargement de la bibliothèque &apos;%1&apos;.
 %2</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="790"/>
         <source>Unsupported format</source>
         <translation>Format non supporté</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="769"/>
         <source>The library &apos;%1&apos; contains unknown elements:
 %2</source>
         <translation>La bibliothèque &apos;%1&apos; contient des éléments inconnus:
 %2</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="793"/>
         <source>Duplicate platform type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="796"/>
         <source>Platform type redefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="742"/>
         <source>&amp;Print...</source>
         <translation> &amp;Imprimer...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="745"/>
         <source>Print the Current Report</source>
         <translation>Imprimer le rapport</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="750"/>
         <source>Print Pre&amp;view...</source>
         <translation>Apercu d&apos;impression...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="753"/>
         <source>Open a Print Preview Dialog for the Current Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="761"/>
         <source>Open library editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -789,18 +980,22 @@ L&apos;ouverture d&apos;un nouveau fichier XML effacera les resultats. Voulez-vo
         <translation type="obsolete">&amp;Revérifier tous les fichiers</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="799"/>
         <source>Unknown element</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="802"/>
         <source>Unknown issue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="629"/>
         <source>Select configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="main.cpp" line="106"/>
         <source>Cppcheck GUI.
 
 Syntax:
@@ -818,202 +1013,254 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="828"/>
         <source>Failed to load %1. Your Cppcheck installation is broken. You can use --data-dir=&lt;directory&gt; at the command line to specify where this file is located. Please note that --data-dir is supposed to be used by installation scripts and therefore the GUI does not start when it is used, all that happens is that the setting is configured.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="253"/>
+        <location filename="mainwindow.ui" line="256"/>
         <source>Analyze files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="271"/>
+        <location filename="mainwindow.ui" line="274"/>
         <source>Analyze directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="286"/>
         <source>&amp;Reanalyze modified files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="310"/>
+        <location filename="mainwindow.ui" line="313"/>
         <source>Stop analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="481"/>
         <source>No suitable files found to analyze!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="574"/>
         <source>Select files to analyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="589"/>
         <source>Select directory to analyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="629"/>
         <source>Select the configuration that will be analyzed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="681"/>
         <source>Found project files from the directory.
 
 Do you want to proceed analysis without using any of these project files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="131"/>
         <source>A&amp;nalyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="145"/>
         <source>&amp;C standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="298"/>
         <source>Reanal&amp;yze all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="363"/>
         <source>Style war&amp;nings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="381"/>
         <source>E&amp;rrors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="468"/>
         <source>Sh&amp;ow Scratchpad...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="521"/>
         <source>&amp;Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="539"/>
         <source>Per&amp;formance warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="565"/>
         <source>&amp;Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="580"/>
         <source>&amp;Portability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="598"/>
         <source>Show Cppcheck results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="610"/>
         <source>Clang</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="613"/>
         <source>Show Clang results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="680"/>
         <source>P&amp;latforms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="694"/>
         <source>C++&amp;11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="705"/>
         <source>C&amp;99</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="713"/>
         <source>&amp;Posix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="721"/>
         <source>C&amp;11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="729"/>
         <source>&amp;C89</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="737"/>
         <source>&amp;C++03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="758"/>
         <source>&amp;Library Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="769"/>
         <source>&amp;Auto-detect language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="777"/>
         <source>&amp;Enforce C++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="785"/>
         <source>E&amp;nforce C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="796"/>
         <source>C++14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="804"/>
         <source>Reanalyze and check library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="812"/>
         <source>Check configuration (defines, includes)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="820"/>
         <source>C++17</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="831"/>
         <source>C++20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="568"/>
         <source>C/C++ Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="569"/>
         <source>Compile database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="570"/>
         <source>Visual Studio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="571"/>
         <source>Borland C++ Builder 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1024,26 +1271,32 @@ Do you want to proceed?</source>
 <context>
     <name>NewSuppressionDialog</name>
     <message>
+        <location filename="newsuppressiondialog.ui" line="17"/>
         <source>New suppression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="25"/>
         <source>Error ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="32"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="42"/>
         <source>Line number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="52"/>
         <source>Symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.cpp" line="52"/>
         <source>Edit suppression</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1051,26 +1304,32 @@ Do you want to proceed?</source>
 <context>
     <name>Platforms</name>
     <message>
+        <location filename="platforms.cpp" line="38"/>
         <source>Unix 32-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="39"/>
         <source>Unix 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="40"/>
         <source>Windows 32-bit ANSI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="41"/>
         <source>Windows 32-bit Unicode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="42"/>
         <source>Windows 64-bit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="37"/>
         <source>Native</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1089,14 +1348,17 @@ Do you want to proceed?</source>
 <context>
     <name>ProjectFile</name>
     <message>
+        <location filename="projectfiledialog.ui" line="14"/>
         <source>Project File</source>
         <translation>Fichier Projet</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="86"/>
         <source>Paths:</source>
         <translation>Chemins : </translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="153"/>
         <source>Defines:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1105,14 +1367,24 @@ Do you want to proceed?</source>
         <translation type="obsolete">Projet</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="113"/>
+        <location filename="projectfiledialog.ui" line="228"/>
+        <location filename="projectfiledialog.ui" line="461"/>
         <source>Add...</source>
         <translation>Ajouter...</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="120"/>
+        <location filename="projectfiledialog.ui" line="235"/>
+        <location filename="projectfiledialog.ui" line="468"/>
         <source>Edit</source>
         <translation>Editer</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="127"/>
+        <location filename="projectfiledialog.ui" line="242"/>
+        <location filename="projectfiledialog.ui" line="475"/>
+        <location filename="projectfiledialog.ui" line="518"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
@@ -1129,10 +1401,12 @@ Do you want to proceed?</source>
         <translation type="obsolete">Répertoire racine</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="262"/>
         <source>Up</source>
         <translation>Monter</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="269"/>
         <source>Down</source>
         <translation>Descendre</translation>
     </message>
@@ -1145,6 +1419,7 @@ Do you want to proceed?</source>
         <translation type="obsolete">Bibliothèques</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="500"/>
         <source>Suppressions</source>
         <translation>Suppressions</translation>
     </message>
@@ -1153,201 +1428,256 @@ Do you want to proceed?</source>
         <translation type="obsolete">Liste de suppressions</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="511"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="393"/>
         <source>Note: Put your own custom .cfg files in the same folder as the project file. You should see them above.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="197"/>
         <source>Include Paths:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="24"/>
         <source>Paths and Defines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="69"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You have a choice:&lt;/p&gt;&lt;p&gt; * Analyze all Debug and Release configurations&lt;/p&gt;&lt;p&gt; * Only analyze the first matching Debug configuration&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="72"/>
         <source>Analyze all Visual Studio configurations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="426"/>
         <source>Root path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="438"/>
         <source>Warning tags (separated by semicolon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="300"/>
         <source>Cppcheck build dir (whole program analysis, incremental analysis, statistics, etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="384"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="563"/>
         <source>Addons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="60"/>
+        <location filename="projectfiledialog.ui" line="309"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="163"/>
         <source>Defines must be separated by a semicolon. Example: DEF1;DEF2=5;DEF3=int</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="294"/>
         <source>Checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="319"/>
         <source>Platform</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="420"/>
         <source>Warning options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="557"/>
         <source>Addons and tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="30"/>
         <source>Import Project (Visual studio / compile database/ Borland C++ Builder 6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="174"/>
         <source>Undefines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="184"/>
         <source>Undefines must be separated by a semicolon. Example: UNDEF1;UNDEF2;UNDEF3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="331"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="337"/>
         <source>Check code in headers  (slower analysis, more results)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="347"/>
         <source>Check code in unused templates  (slower and less accurate analysis)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="356"/>
         <source>Max CTU depth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="450"/>
         <source>Exclude source files in paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProjectFileDialog</name>
     <message>
+        <location filename="projectfiledialog.cpp" line="71"/>
         <source>Project file: %1</source>
         <translation>Fichier projet : %1</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="637"/>
         <source>Select include directory</source>
         <translation>Selectionner un répertoire à inclure</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="657"/>
         <source>Select directory to ignore</source>
         <translation>Selectionner un répertoire à ignorer</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="617"/>
         <source>Select a directory to check</source>
         <translation>Selectionner un répertoire à vérifier</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="409"/>
         <source>Select Cppcheck build dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="448"/>
         <source>Import Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="311"/>
         <source>Clang-tidy (not found)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="305"/>
         <source>(no rule texts file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="742"/>
         <source>Select MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="742"/>
         <source>Misra rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="445"/>
         <source>Visual Studio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="446"/>
         <source>Compile database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="447"/>
         <source>Borland C++ Builder 6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1355,18 +1685,22 @@ Do you want to proceed?</source>
 <context>
     <name>QDialogButtonBox</name>
     <message>
+        <location filename="translationhandler.cpp" line="34"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="35"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="36"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="37"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
@@ -1374,130 +1708,162 @@ Do you want to proceed?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="translationhandler.cpp" line="132"/>
         <source>Language file %1 not found!</source>
         <translation>Fichier de langue %1 non trouvé !</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="138"/>
         <source>Failed to load translation for language %1 from file %2</source>
         <translation>Erreur lors du chargement de la langue %1 depuis le fichier %2</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="104"/>
         <source>Unknown language specified!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="cppchecklibrarydata.cpp" line="33"/>
         <source>line %1: Unhandled element %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="226"/>
         <source> (Not found)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="69"/>
         <source>Thin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="71"/>
         <source>ExtraLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="73"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="75"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="77"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="79"/>
         <source>DemiBold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="81"/>
         <source>Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="83"/>
         <source>ExtraBold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="85"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="69"/>
         <source>Editor Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="72"/>
         <source>Editor Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="75"/>
         <source>Highlight Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="78"/>
         <source>Line Number Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="81"/>
         <source>Line Number Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="84"/>
         <source>Keyword Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="87"/>
         <source>Keyword Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="93"/>
         <source>Class Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="96"/>
         <source>Quote Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="99"/>
         <source>Quote Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="102"/>
         <source>Comment Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="105"/>
         <source>Comment Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="108"/>
         <source>Symbol Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="111"/>
         <source>Symbol Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="114"/>
         <source>Symbol Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="130"/>
         <source>Set to Default Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="132"/>
         <source>Set to Default Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="90"/>
         <source>Class Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1505,18 +1871,22 @@ Do you want to proceed?</source>
 <context>
     <name>QPlatformTheme</name>
     <message>
+        <location filename="translationhandler.cpp" line="39"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="40"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="41"/>
         <source>Close</source>
         <translation type="unfinished">Fermer</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="42"/>
         <source>Save</source>
         <translation type="unfinished">Sauvegarder</translation>
     </message>
@@ -1524,18 +1894,22 @@ Do you want to proceed?</source>
 <context>
     <name>ResultsTree</name>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>File</source>
         <translation type="unfinished">Fichier</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Severity</source>
         <translation type="unfinished">Sévérité</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Line</source>
         <translation type="unfinished">Ligne</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="136"/>
         <source>Undefined file</source>
         <translation>Fichier indéterminé</translation>
     </message>
@@ -1552,10 +1926,13 @@ Do you want to proceed?</source>
         <translation type="obsolete">Copier le message</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="693"/>
+        <location filename="resultstree.cpp" line="707"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="783"/>
         <source>Could not start %1
 
 Please check the application path and parameters are correct.</source>
@@ -1564,22 +1941,27 @@ Please check the application path and parameters are correct.</source>
 Merci de vérifier que le chemin de l&apos;application et que les paramètres sont corrects.</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="294"/>
         <source>style</source>
         <translation>erreur de style</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="297"/>
         <source>error</source>
         <translation>erreur</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Summary</source>
         <translation>Résumé</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="615"/>
         <source>Hide</source>
         <translation>Cacher</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="737"/>
         <source>Could not find the file!</source>
         <translation>Fichier introuvable !</translation>
     </message>
@@ -1592,42 +1974,51 @@ Please select the directory where file is located.</source>
 Veuillez sélectionner le répertoire où est situé le fichier.</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="805"/>
         <source>Select Directory</source>
         <translation>Selectionner dossier</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="300"/>
         <source>warning</source>
         <translation>avertissement</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="303"/>
         <source>performance</source>
         <translation>performance</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="306"/>
         <source>portability</source>
         <translation>portabilité</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="309"/>
         <source>information</source>
         <translation>information</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="312"/>
         <source>debug</source>
         <translation>débogage</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="694"/>
         <source>No editor application configured.
 
 Configure the editor application for Cppcheck in preferences/Applications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="708"/>
         <source>No default editor application selected.
 
 Please select the default editor application in preferences/Applications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
@@ -1636,58 +2027,73 @@ Please select the default editor application in preferences/Applications.</sourc
         <translation type="obsolete">Copier l&apos;identifiant du message</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="616"/>
         <source>Hide all with id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="618"/>
         <source>Open containing folder</source>
         <translation>Ouvrir l&apos;emplacement du fichier</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Inconclusive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="613"/>
         <source>Recheck</source>
         <translation>Revérifier</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="249"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="617"/>
         <source>Suppress selected id(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="648"/>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="650"/>
         <source>No tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Since date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="797"/>
         <source>Could not find file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="801"/>
         <source>Please select the folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="802"/>
         <source>Select Directory &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="804"/>
         <source>Please select the directory where file is located.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="614"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1695,32 +2101,42 @@ Please select the default editor application in preferences/Applications.</sourc
 <context>
     <name>ResultsView</name>
     <message>
+        <location filename="resultsview.ui" line="26"/>
         <source>Results</source>
         <translation>Résultats</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="277"/>
+        <location filename="resultsview.cpp" line="288"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="278"/>
         <source>No errors found.</source>
         <translation>Pas d&apos;erreurs trouvées.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="285"/>
         <source>Errors were found, but they are configured to be hidden.
 To toggle what kind of errors are shown, open view menu.</source>
         <translation>Des erreurs ont été trouvées mais sont configurées pour rester cachées.
 Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="159"/>
         <source>No errors found, nothing to save.</source>
         <translation>Pas d&apos;erreurs trouvées, rien à sauvegarder.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="183"/>
+        <location filename="resultsview.cpp" line="191"/>
         <source>Failed to save the report.</source>
         <translation>Erreur lors de la sauvegarde du rapport.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="331"/>
+        <location filename="resultsview.cpp" line="350"/>
         <source>Failed to read the report.</source>
         <translation>Erreur lors de la lecture du rapport</translation>
     </message>
@@ -1733,46 +2149,57 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
         <translation type="obsolete">Message</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="264"/>
         <source>%p% (%1 of %2 files checked)</source>
         <translation>%p% (%1 fichiers sur %2 vérifiés)</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="402"/>
         <source>Id</source>
         <translation>Id</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="201"/>
         <source>Print Report</source>
         <translation>Imprimer le rapport</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="220"/>
         <source>No errors found, nothing to print.</source>
         <translation>Aucune erreur trouvée. Il n&apos;y a rien à imprimer</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="399"/>
         <source>First included by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="338"/>
         <source>XML format version 1 is no longer supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.ui" line="82"/>
         <source>Analysis Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.ui" line="104"/>
         <source>Warning Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="471"/>
         <source>Clear Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="472"/>
         <source>Copy this Log entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="473"/>
         <source>Copy complete Log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1780,22 +2207,27 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>ScratchPad</name>
     <message>
+        <location filename="scratchpad.ui" line="14"/>
         <source>Scratchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="71"/>
         <source>filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="78"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="20"/>
         <source>Copy or write some C/C++ code here:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="37"/>
         <source>Optionally enter a filename (mainly for automatic language detection) and click on &quot;Check&quot;:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1803,38 +2235,47 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>Settings</name>
     <message>
+        <location filename="settings.ui" line="14"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="24"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="41"/>
         <source>Number of threads: </source>
         <translation>Nombre de fils : </translation>
     </message>
     <message>
+        <location filename="settings.ui" line="121"/>
         <source>Show full path of files</source>
         <translation>Montrer le chemin complet des fichiers</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="128"/>
         <source>Show &quot;No errors found&quot; message when no errors found</source>
         <translation>Afficher un message &quot;Pas d&apos;erreur trouvée&quot; lorsque aucune erreur est trouvée</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="184"/>
         <source>Applications</source>
         <translation>Applications</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="239"/>
         <source>Reports</source>
         <translation>Rapports</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="245"/>
         <source>Save all errors when creating report</source>
         <translation>Sauvegarder toutes les erreurs lorsqu&apos;un rapport est créé</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="252"/>
         <source>Save full path to files in reports</source>
         <translation>Sauvegarder le chemin complet des fichiers dans les rapports</translation>
     </message>
@@ -1843,22 +2284,27 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
         <translation type="obsolete">Inclure les chemins</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="195"/>
         <source>Add...</source>
         <translation>Ajouter...</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="85"/>
         <source>Ideal count:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="114"/>
         <source>Force checking all #ifdef configurations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="142"/>
         <source>Enable inline suppressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="273"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
@@ -1871,94 +2317,120 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
         <translation type="obsolete">Editer</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="209"/>
         <source>Remove</source>
         <translation>Supprimer</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="202"/>
+        <location filename="settings.ui" line="467"/>
         <source>Edit...</source>
         <translation>Editer...</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="216"/>
         <source>Set as default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="135"/>
         <source>Display error Id in column &quot;Id&quot;</source>
         <translation>Afficher l&apos;identifiant d&apos;erreur Id dans la colonne &quot;Id&quot;</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="149"/>
         <source>Check for inconclusive errors also</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="176"/>
         <source>Show internal warnings in log</source>
         <translation>Montrer les avertissements internes dans le journal</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="156"/>
         <source>Show statistics on check completion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="287"/>
         <source>Addons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="293"/>
         <source>Python binary (leave this empty to use python in the PATH)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="302"/>
+        <location filename="settings.ui" line="334"/>
+        <location filename="settings.ui" line="379"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="360"/>
         <source>Clang</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="366"/>
         <source>Clang path (leave empty to use system PATH)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="389"/>
         <source>Visual Studio headers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="395"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Paths to Visual Studio headers, separated by semicolon &apos;;&apos;.&lt;/p&gt;&lt;p&gt;You can open a Visual Studio command prompt, write &amp;quot;SET INCLUDE&amp;quot;. Then copy/paste the paths.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="312"/>
         <source>Misra addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="320"/>
         <source>Misra rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="327"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="425"/>
         <source>Code Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="431"/>
         <source>Code Editor Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="444"/>
         <source>Default Light Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="451"/>
         <source>Default Dark Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="460"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="437"/>
         <source>System Style</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1966,14 +2438,17 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>SettingsDialog</name>
     <message>
+        <location filename="settingsdialog.cpp" line="200"/>
         <source>Add a new application</source>
         <translation>Ajouter une nouvelle application</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="233"/>
         <source>Modify an application</source>
         <translation>Modifier une application</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="100"/>
         <source>N/A</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1982,22 +2457,27 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
         <translation type="obsolete">Selectionner un répertoire à inclure</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="263"/>
         <source>[Default]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="238"/>
         <source> [Default]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="318"/>
         <source>Select python binary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="356"/>
         <source>Select clang path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="325"/>
         <source>Select MISRA File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2005,194 +2485,253 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>StatsDialog</name>
     <message>
+        <location filename="stats.ui" line="14"/>
+        <location filename="stats.ui" line="248"/>
+        <location filename="statsdialog.cpp" line="137"/>
+        <location filename="statsdialog.cpp" line="184"/>
         <source>Statistics</source>
         <translation>Statistiques</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="27"/>
+        <location filename="statsdialog.cpp" line="175"/>
         <source>Project</source>
         <translation>Projet</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="33"/>
         <source>Project:</source>
         <translation>Projet :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="53"/>
         <source>Paths:</source>
         <translation>Chemins :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="85"/>
         <source>Include paths:</source>
         <translation>Inclure les chemins :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="108"/>
         <source>Defines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="165"/>
+        <location filename="statsdialog.cpp" line="180"/>
         <source>Previous Scan</source>
         <translation>Analyse précédente</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="171"/>
         <source>Path Selected:</source>
         <translation>Chemin sélectionné :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="181"/>
         <source>Number of Files Scanned:</source>
         <translation>Nombre de fichiers analysés :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="201"/>
         <source>Scan Duration:</source>
         <translation>Durée de l&apos;analyse :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="256"/>
         <source>Errors:</source>
         <translation>Erreurs :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="274"/>
         <source>Warnings:</source>
         <translation>Avertissements</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="292"/>
         <source>Stylistic warnings:</source>
         <translation>Avertissements de style</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="310"/>
         <source>Portability warnings:</source>
         <translation>Avertissements de portabilité</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="328"/>
         <source>Performance issues:</source>
         <translation>Problème de performance</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="346"/>
         <source>Information messages:</source>
         <translation>Messages d&apos;information :</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="407"/>
         <source>Copy to Clipboard</source>
         <translation>Copier vers le presse-papier</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="113"/>
         <source>1 day</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="113"/>
         <source>%1 days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="115"/>
         <source>1 hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="115"/>
         <source>%1 hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="117"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="117"/>
         <source>%1 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="119"/>
         <source>1 second</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="119"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="123"/>
         <source>0.%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="125"/>
         <source> and </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="174"/>
         <source>Project Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="176"/>
         <source>Paths</source>
         <translation type="unfinished">Chemins</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="177"/>
         <source>Include paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="178"/>
         <source>Defines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="181"/>
         <source>Path selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="182"/>
         <source>Number of files scanned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="183"/>
         <source>Scan duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="139"/>
+        <location filename="statsdialog.cpp" line="185"/>
         <source>Errors</source>
         <translation type="unfinished">Erreurs</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="141"/>
+        <location filename="statsdialog.cpp" line="186"/>
         <source>Warnings</source>
         <translation type="unfinished">Avertissements</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="143"/>
+        <location filename="statsdialog.cpp" line="187"/>
         <source>Style warnings</source>
         <translation type="unfinished">Avertissement de style</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="145"/>
+        <location filename="statsdialog.cpp" line="188"/>
         <source>Portability warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="147"/>
+        <location filename="statsdialog.cpp" line="189"/>
         <source>Performance warnings</source>
         <translation type="unfinished">Avertissements de performance</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="149"/>
+        <location filename="statsdialog.cpp" line="190"/>
         <source>Information messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="414"/>
         <source>Pdf Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="152"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="363"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="369"/>
         <source>File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="65"/>
         <source>File: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="65"/>
         <source>No cppcheck build dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="131"/>
         <source>Undefines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="179"/>
         <source>Undefines</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2200,6 +2739,7 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>ThreadResult</name>
     <message>
+        <location filename="threadresult.cpp" line="54"/>
         <source>%1 of %2 files checked</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2207,6 +2747,7 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
 <context>
     <name>TranslationHandler</name>
     <message>
+        <location filename="translationhandler.cpp" line="145"/>
         <source>Failed to change the user interface language:
 
 %1
@@ -2215,6 +2756,7 @@ The user interface language has been reset to English. Open the Preferences-dial
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="151"/>
         <source>Cppcheck</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2222,6 +2764,7 @@ The user interface language has been reset to English. Open the Preferences-dial
 <context>
     <name>TxtReport</name>
     <message>
+        <location filename="txtreport.cpp" line="73"/>
         <source>inconclusive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2229,10 +2772,12 @@ The user interface language has been reset to English. Open the Preferences-dial
 <context>
     <name>toFilterString</name>
     <message>
+        <location filename="common.cpp" line="52"/>
         <source>All supported files (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="common.cpp" line="57"/>
         <source>All files (%1)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_it.ts
+++ b/gui/cppcheck_it.ts
@@ -432,13 +432,13 @@ Parametri: -l(line) (file)
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1067,12 +1067,12 @@ Vuoi procedere alla scansione senza usare qualcuno di questi file di progetto?</
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Licenza</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Autori</translation>
     </message>
@@ -1081,13 +1081,13 @@ Vuoi procedere alla scansione senza usare qualcuno di questi file di progetto?</
         <translation type="obsolete">File XML Versione 2 (*.xml);;File XML Versione 1 (*.xml);;File di testo (*.txt);;File CSV (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Salva il file di rapporto</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>File XML (*.xml)</translation>
     </message>
@@ -1154,7 +1154,7 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 L&apos;apertura di un nuovo file XML ripulirà i risultati correnti. Vuoi procedere?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Apri il file di rapporto</translation>
     </message>
@@ -1175,17 +1175,17 @@ Vuoi fermare la scansione ed uscire da Cppcheck?</translation>
         <translation type="obsolete">Files XML versione 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>File di testo (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>Files CSV (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
@@ -1202,19 +1202,19 @@ The user interface language has been reset to English. Open the Preferences-dial
 L&apos;interfaccia utente è stata risettata in Inglese. Apri la finestra di dialogo Preferenze per selezionare una qualunque lingua a disposizione.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Files di progetto (*.cppcheck);;Tutti i files(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Seleziona il file di progetto</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Progetto:</translation>
     </message>
@@ -1266,7 +1266,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1274,44 +1274,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Seleziona il nome del file di progetto</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>Nessun file di progetto caricato</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1487,22 +1487,22 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1590,7 +1590,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1672,32 +1677,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_ja.ts
+++ b/gui/cppcheck_ja.ts
@@ -451,13 +451,13 @@ Parameters: -l(line) (file)</translation>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1176,13 +1176,13 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 新しくXMLファイルを開くと現在の結果が削除されます。実行しますか？</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML ファイル (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>レポートを開く</translation>
     </message>
@@ -1195,12 +1195,12 @@ Do you want to stop the checking and exit Cppcheck?</source>
 解析を停止してCppcheckを終了しますか？.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>ライセンス</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>作者</translation>
     </message>
@@ -1210,7 +1210,7 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML ファイル (*.xml);;テキストファイル (*.txt);;CSV形式ファイル (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>レポートを保存</translation>
     </message>
@@ -1223,34 +1223,34 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XMLファイルのバージョン2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>テキストファイル (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV形式ファイル (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>プロジェクトファイル (*.cppcheck);;すべてのファイル(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>プロジェクトファイルを選択</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>プロジェクト:</translation>
     </message>
@@ -1304,7 +1304,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
 みつかったプロジェクトファイルを使用せずにチェックしますか?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1314,7 +1314,7 @@ Do you want to proceed?</source>
 新しくXMLファイルを開くと現在の結果が削除されます。実行しますか？</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
@@ -1323,37 +1323,37 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 チェックを中断して、Cppcheckを終了しますか?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation>XML ファイル (*.xml);;テキストファイル (*.txt);;CSVファイル (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation>ビルドディレクトリ&apos;%1&apos;がありません。作成しますか?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation>&apos;%1&apos;のインポートに失敗しました。(チェック中断)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation>プロジェクトファイル (*.cppcheck)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>プロジェクトファイル名を選択</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>プロジェクトファイルが読み込まれていません</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1543,22 +1543,22 @@ Options:
         <translation type="obsolete">除外するパス</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation>MISRA C 2012</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation>Misra ルールテキスト</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;MISRA C 2012 pdfのAppendix A &amp;quot;Summary of guidelines&amp;quot; からテキストをコピーペーストしてください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -1646,7 +1646,12 @@ Options:
         <translation>除外するソースファイルのPATH</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation>外部ツール</translation>
     </message>
@@ -1732,22 +1737,22 @@ Options:
         <translation>アドオン</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation>Y2038</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation>スレッドセーフ</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation>コーディング標準</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation>CERT</translation>
     </message>
@@ -1760,12 +1765,12 @@ Options:
         <translation type="obsolete">複数ツールの併用はよい結果を生みます。</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation>Clang Analyzer</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation>Clang-tidy</translation>
     </message>

--- a/gui/cppcheck_ko.ts
+++ b/gui/cppcheck_ko.ts
@@ -1,35 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="ko-KR">
 <context>
     <name>About</name>
     <message>
+        <location filename="about.ui" line="14"/>
         <source>About Cppcheck</source>
         <translation>Cppcheck 정보</translation>
     </message>
     <message>
+        <location filename="about.ui" line="64"/>
         <source>Version %1</source>
         <translation>버전 %1</translation>
     </message>
     <message>
+        <location filename="about.ui" line="71"/>
         <source>Cppcheck - A tool for static C/C++ code analysis.</source>
         <translation>Cppcheck - 정적 C/C++ 코드 분석 도구.</translation>
     </message>
     <message>
+        <location filename="about.ui" line="91"/>
         <source>This program is licensed under the terms
 of the GNU General Public License version 3</source>
         <translation>이 프로그램은 GNU General Public License version 3을
 준수합니다</translation>
     </message>
     <message>
+        <location filename="about.ui" line="102"/>
         <source>Visit Cppcheck homepage at %1</source>
         <translation>Cppcheck 홈페이지(%1)를 방문해보세요</translation>
     </message>
     <message>
+        <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-2019 Cppcheck team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="about.ui" line="115"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Many thanks to these libraries that we use:&lt;/p&gt;&lt;ul&gt;
 &lt;li&gt;tinyxml2&lt;/li&gt;
@@ -42,10 +49,12 @@ of the GNU General Public License version 3</source>
 <context>
     <name>ApplicationDialog</name>
     <message>
+        <location filename="application.ui" line="23"/>
         <source>Add an application</source>
         <translation>응용 프로그램 추가</translation>
     </message>
     <message>
+        <location filename="application.ui" line="41"/>
         <source>Here you can add an application that can open error files. Specify a name for the application, the application executable and command line parameters for the application.
 
 The following texts in parameters are replaced with appropriate values when application is executed:
@@ -70,30 +79,37 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
 인자: -l(line) (file)</translation>
     </message>
     <message>
+        <location filename="application.ui" line="76"/>
         <source>&amp;Name:</source>
         <translation>이름(&amp;N):</translation>
     </message>
     <message>
+        <location filename="application.ui" line="86"/>
         <source>&amp;Executable:</source>
         <translation>실행 파일(&amp;E):</translation>
     </message>
     <message>
+        <location filename="application.ui" line="96"/>
         <source>&amp;Parameters:</source>
         <translation>명령행 인자(&amp;P):</translation>
     </message>
     <message>
+        <location filename="application.ui" line="138"/>
         <source>Browse</source>
         <translation>찾기</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="59"/>
         <source>Executable files (*.exe);;All files(*.*)</source>
         <translation>실행 파일(*.exe);;모든 파일(*.*)</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="62"/>
         <source>Select viewer application</source>
         <translation>뷰어 프로그램 선택</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="77"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -102,6 +118,7 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">응용 프로그램의 이름, 경로 및 인자를 명시해야 합니다!</translation>
     </message>
     <message>
+        <location filename="applicationdialog.cpp" line="78"/>
         <source>You must specify a name, a path and optionally parameters for the application!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -109,14 +126,18 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
 <context>
     <name>FileViewDialog</name>
     <message>
+        <location filename="fileviewdialog.cpp" line="42"/>
         <source>Could not find the file: %1</source>
         <translation>파일 찾기 실패: %1</translation>
     </message>
     <message>
+        <location filename="fileviewdialog.cpp" line="46"/>
+        <location filename="fileviewdialog.cpp" line="60"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
     <message>
+        <location filename="fileviewdialog.cpp" line="56"/>
         <source>Could not read the file: %1</source>
         <translation>파일 읽기 실패: %1</translation>
     </message>
@@ -124,14 +145,17 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
 <context>
     <name>LibraryAddFunctionDialog</name>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="23"/>
         <source>Add function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="34"/>
         <source>Function name(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryaddfunctiondialog.ui" line="44"/>
         <source>Number of arguments</source>
         <translation type="unfinished"></translation>
     </message>
@@ -139,109 +163,138 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
 <context>
     <name>LibraryDialog</name>
     <message>
+        <location filename="librarydialog.ui" line="14"/>
         <source>Library Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="22"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="29"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="62"/>
         <source>Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="111"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="204"/>
         <source>noreturn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="212"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="217"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="222"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="232"/>
         <source>return value must be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="239"/>
         <source>ignore function in leaks checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="246"/>
         <source>Arguments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="258"/>
         <source>Edit</source>
         <translation type="unfinished">편집</translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="82"/>
+        <location filename="librarydialog.cpp" line="154"/>
         <source>Library files (*.cfg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="84"/>
         <source>Open library file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="71"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="131"/>
         <source>Filter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="164"/>
         <source>Comments</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.ui" line="36"/>
         <source>Save as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="95"/>
+        <location filename="librarydialog.cpp" line="107"/>
+        <location filename="librarydialog.cpp" line="144"/>
         <source>Cppcheck</source>
         <translation type="unfinished">Cppcheck</translation>
     </message>
     <message>
-        <source>Can not open file %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Can not save file %1.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="librarydialog.cpp" line="157"/>
         <source>Save the library as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="librarydialog.cpp" line="108"/>
         <source>Failed to load %1. %2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="librarydialog.cpp" line="96"/>
+        <source>Cannot open file %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="librarydialog.cpp" line="145"/>
+        <source>Cannot save file %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryEditArgDialog</name>
     <message>
+        <location filename="libraryeditargdialog.ui" line="14"/>
         <source>Edit argument</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="20"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Is bool value allowed? For instance result from comparison or from &apos;!&apos; operator.&lt;/p&gt;
 &lt;p&gt;Typically, set this if the argument is a pointer, size, etc.&lt;/p&gt;
@@ -251,10 +304,12 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="28"/>
         <source>Not bool</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="35"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;
 &lt;p&gt;Is a null parameter value allowed?&lt;/p&gt;
 &lt;p&gt;Typically this should be used on any pointer parameter that does not allow null.&lt;/p&gt;
@@ -264,58 +319,79 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="43"/>
         <source>Not null</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="50"/>
         <source>Not uninit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="57"/>
         <source>String</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="70"/>
         <source>Format string</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="92"/>
         <source>Min size of buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="101"/>
+        <location filename="libraryeditargdialog.ui" line="203"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="109"/>
+        <location filename="libraryeditargdialog.ui" line="214"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="114"/>
+        <location filename="libraryeditargdialog.ui" line="219"/>
         <source>argvalue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="119"/>
+        <location filename="libraryeditargdialog.ui" line="224"/>
         <source>mul</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="124"/>
+        <location filename="libraryeditargdialog.ui" line="229"/>
         <source>strlen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="132"/>
+        <location filename="libraryeditargdialog.ui" line="237"/>
         <source>Arg</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="159"/>
+        <location filename="libraryeditargdialog.ui" line="264"/>
         <source>Arg2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="194"/>
         <source>and</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="libraryeditargdialog.ui" line="310"/>
         <source>Valid values</source>
         <translation type="unfinished"></translation>
     </message>
@@ -350,22 +426,40 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
 <context>
     <name>MainWindow</name>
     <message>
+        <location filename="mainwindow.ui" line="26"/>
+        <location filename="mainwindow.ui" line="595"/>
+        <location filename="mainwindow.cpp" line="328"/>
+        <location filename="mainwindow.cpp" line="480"/>
+        <location filename="mainwindow.cpp" line="553"/>
+        <location filename="mainwindow.cpp" line="658"/>
+        <location filename="mainwindow.cpp" line="680"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="70"/>
         <source>&amp;File</source>
         <translation>파일(&amp;F)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="89"/>
         <source>&amp;View</source>
         <translation>보기(&amp;V)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="93"/>
         <source>&amp;Toolbars</source>
         <translation>도구바(&amp;T)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="121"/>
         <source>&amp;Help</source>
         <translation>도움말(&amp;H)</translation>
     </message>
@@ -374,34 +468,42 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">검사(&amp;C)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="170"/>
         <source>&amp;Edit</source>
         <translation>편집(&amp;E)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="183"/>
         <source>Standard</source>
         <translation>표준 도구</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="201"/>
         <source>Categories</source>
         <translation>분류 도구</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="220"/>
         <source>Filter</source>
         <translation>필터 도구</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="231"/>
         <source>&amp;License...</source>
         <translation>저작권(&amp;L)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="236"/>
         <source>A&amp;uthors...</source>
         <translation>제작자(&amp;u)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="245"/>
         <source>&amp;About...</source>
         <translation>정보(&amp;A)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="250"/>
         <source>&amp;Files...</source>
         <translation>파일(&amp;F)...</translation>
     </message>
@@ -410,10 +512,12 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">파일 검사</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="259"/>
         <source>Ctrl+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="268"/>
         <source>&amp;Directory...</source>
         <translation>디렉토리(&amp;D)...</translation>
     </message>
@@ -422,6 +526,7 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">디렉토리 검사</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="277"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
@@ -430,10 +535,12 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">파일 재검사(&amp;R)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="289"/>
         <source>Ctrl+R</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="307"/>
         <source>&amp;Stop</source>
         <translation>중지(&amp;S)</translation>
     </message>
@@ -442,26 +549,32 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">검사 중지</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="316"/>
         <source>Esc</source>
         <translation>Esc</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="325"/>
         <source>&amp;Save results to file...</source>
         <translation>결과를 파일에 저장(&amp;S)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="328"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="333"/>
         <source>&amp;Quit</source>
         <translation>종료(&amp;Q)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="342"/>
         <source>&amp;Clear results</source>
         <translation>결과 지우기(&amp;C)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="351"/>
         <source>&amp;Preferences</source>
         <translation>설정(&amp;P)</translation>
     </message>
@@ -470,6 +583,8 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">스타일 경고</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="366"/>
+        <location filename="mainwindow.ui" line="369"/>
         <source>Show style warnings</source>
         <translation>스타일 경고 표시</translation>
     </message>
@@ -478,86 +593,108 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">에러</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="384"/>
+        <location filename="mainwindow.ui" line="387"/>
         <source>Show errors</source>
         <translation>애러 표시</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="392"/>
         <source>&amp;Check all</source>
         <translation>전체 선택(&amp;C)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="397"/>
         <source>&amp;Uncheck all</source>
         <translation>전체 해제(&amp;U)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="402"/>
         <source>Collapse &amp;all</source>
         <translation>전체 접기(&amp;A)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="407"/>
         <source>&amp;Expand all</source>
         <translation>전체 펼치기(&amp;E)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="415"/>
         <source>&amp;Standard</source>
         <translation>표준 도구(&amp;S)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="418"/>
         <source>Standard items</source>
         <translation>표준 아이템</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="423"/>
         <source>&amp;Contents</source>
         <translation>내용(&amp;C)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="426"/>
         <source>Open the help contents</source>
         <translation>도움말을 엽니다</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="429"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="434"/>
         <source>Toolbar</source>
         <translation>도구바</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="442"/>
         <source>&amp;Categories</source>
         <translation>분류 도구(&amp;C)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="445"/>
         <source>Error categories</source>
         <translation>에러 종류</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="450"/>
         <source>&amp;Open XML...</source>
         <translation>XML 열기(&amp;O)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="459"/>
         <source>Open P&amp;roject File...</source>
         <translation>프로젝트 파일 열기(&amp;R)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="473"/>
         <source>&amp;New Project File...</source>
         <translation>새 프로젝트 파일(&amp;N)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="478"/>
         <source>&amp;Log View</source>
         <translation>로그 보기(&amp;L)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="481"/>
         <source>Log View</source>
         <translation>로그 보기</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="489"/>
         <source>C&amp;lose Project File</source>
         <translation>프로젝트 파일 닫기(&amp;L)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="497"/>
         <source>&amp;Edit Project File...</source>
         <translation>프로젝트 파일 편집(&amp;E)...</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="509"/>
         <source>&amp;Statistics</source>
         <translation>통계 보기(&amp;S)</translation>
     </message>
@@ -566,6 +703,8 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">경고</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="524"/>
+        <location filename="mainwindow.ui" line="527"/>
         <source>Show warnings</source>
         <translation>경고 표시</translation>
     </message>
@@ -574,18 +713,24 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">성능 경고</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="542"/>
+        <location filename="mainwindow.ui" line="545"/>
         <source>Show performance warnings</source>
         <translation>성능 경고 표시</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="553"/>
         <source>Show &amp;hidden</source>
         <translation>숨기기 보기(&amp;H)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="769"/>
+        <location filename="mainwindow.cpp" line="807"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="568"/>
         <source>Show information messages</source>
         <translation>정보 표시</translation>
     </message>
@@ -594,34 +739,42 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">이식성 경고</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="583"/>
         <source>Show portability warnings</source>
         <translation>이식성 경고 표시</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="621"/>
         <source>&amp;Filter</source>
         <translation>필터 도구(&amp;F)</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="624"/>
         <source>Filter results</source>
         <translation>필터링 결과</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="640"/>
         <source>Windows 32-bit ANSI</source>
         <translation>Windows 32-bit ANSI</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="648"/>
         <source>Windows 32-bit Unicode</source>
         <translation>Windows 32-bit Unicode</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="656"/>
         <source>Unix 32-bit</source>
         <translation>Unix 32-bit</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="664"/>
         <source>Unix 64-bit</source>
         <translation>Unix 64-bit</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="672"/>
         <source>Windows 64-bit</source>
         <translation>Windows 64-bit</translation>
     </message>
@@ -642,10 +795,12 @@ Kate로 파일을 열고, 해당 행으로 이동하는 예제:
         <translation type="obsolete">Posix</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="87"/>
         <source>Quick Filter:</source>
         <translation>빠른 필터:</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="323"/>
         <source>There was a problem with loading the editor application settings.
 
 This is probably because the settings were changed between the Cppcheck versions. Please check (and fix) the editor application settings, otherwise the editor program might not start correctly.</source>
@@ -658,6 +813,7 @@ Cppcheck 버전간 설정 방법 차이때문인 것으로 보입니다. 편집�
         <translation type="obsolete">검사할 수 있는 파일이 없습니다!</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="554"/>
         <source>You must close the project file before selecting new files or directories!</source>
         <translation>새로운 파일이나 디렉토리를 선택하기 전에 프로젝트 파일을 닫으세요!</translation>
     </message>
@@ -666,6 +822,7 @@ Cppcheck 버전간 설정 방법 차이때문인 것으로 보입니다. 편집�
         <translation type="obsolete">검사할 디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="659"/>
         <source>Found project file: %1
 
 Do you want to load this project file instead?</source>
@@ -682,10 +839,13 @@ Do you want to proceed checking without using any of these project files?</sourc
 이 프로젝트 파일을 사용하지 않고 검사를 계속하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML 파일 (*.xml)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>보고서 파일 열기</translation>
     </message>
@@ -698,10 +858,12 @@ Do you want to stop the checking and exit Cppcheck?</source>
 검사를 중지하고 Cppcheck을 종료하시겠습니까?</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>저작권</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>제작자</translation>
     </message>
@@ -710,6 +872,7 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML 파일 버전 2 (*.xml);;XML 파일 버전 1 (*.xml);;텍스트 파일 (*.txt);;CSV 파일 (*.csv)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>보고서 파일 저장</translation>
     </message>
@@ -722,14 +885,17 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML 파일 버전 2 (*.xml)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>텍스트 파일 (*.txt)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV 파일 (*.csv)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
@@ -746,26 +912,34 @@ The user interface language has been reset to English. Open the Preferences-dial
 언어가 영어로 초기화 됐습니다. 설정창을 열어서 설정 가능한 언어를 선택하세요.</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>프로젝트 파일 (*.cppcheck);;모든 파일(*.*)</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>프로젝트 파일 선택</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="159"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>프로젝트:</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>프로젝트 파일이름 선택</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>프로젝트 파일 불러오기 실패</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -782,20 +956,16 @@ Do you want to remove the file from the recently used projects -list?</source>
 최근 프로젝트 목록에서 파일을 제거하시겠습니까?</translation>
     </message>
     <message>
-        <source>Current results will be cleared.
-
-Opening a new XML file will clear current results.Do you want to proceed?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Select files to check</source>
         <translation type="obsolete">검사할 파일 선택</translation>
     </message>
     <message>
+        <location filename="main.cpp" line="121"/>
         <source>Cppcheck GUI - Command line parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="135"/>
         <source>C++ standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -812,80 +982,99 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
         <translation type="obsolete">C++03</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="828"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="778"/>
         <source>File not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="781"/>
         <source>Bad XML</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="784"/>
         <source>Missing attribute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="787"/>
         <source>Bad attribute value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="807"/>
         <source>Failed to load the selected library &apos;%1&apos;.
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="790"/>
         <source>Unsupported format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="769"/>
         <source>The library &apos;%1&apos; contains unknown elements:
 %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="793"/>
         <source>Duplicate platform type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="796"/>
         <source>Platform type redefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="742"/>
         <source>&amp;Print...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="745"/>
         <source>Print the Current Report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="750"/>
         <source>Print Pre&amp;view...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="753"/>
         <source>Open a Print Preview Dialog for the Current Results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="761"/>
         <source>Open library editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="799"/>
         <source>Unknown element</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="802"/>
         <source>Unknown issue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="629"/>
         <source>Select configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="main.cpp" line="106"/>
         <source>Cppcheck GUI.
 
 Syntax:
@@ -903,209 +1092,290 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="828"/>
         <source>Failed to load %1. Your Cppcheck installation is broken. You can use --data-dir=&lt;directory&gt; at the command line to specify where this file is located. Please note that --data-dir is supposed to be used by installation scripts and therefore the GUI does not start when it is used, all that happens is that the setting is configured.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="253"/>
+        <location filename="mainwindow.ui" line="256"/>
         <source>Analyze files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="271"/>
+        <location filename="mainwindow.ui" line="274"/>
         <source>Analyze directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="286"/>
         <source>&amp;Reanalyze modified files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="310"/>
+        <location filename="mainwindow.ui" line="313"/>
         <source>Stop analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="481"/>
         <source>No suitable files found to analyze!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="574"/>
         <source>Select files to analyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="589"/>
         <source>Select directory to analyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="629"/>
         <source>Select the configuration that will be analyzed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="681"/>
         <source>Found project files from the directory.
 
 Do you want to proceed analysis without using any of these project files?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="131"/>
         <source>A&amp;nalyze</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="145"/>
         <source>&amp;C standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="298"/>
         <source>Reanal&amp;yze all files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="363"/>
         <source>Style war&amp;nings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="381"/>
         <source>E&amp;rrors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="468"/>
         <source>Sh&amp;ow Scratchpad...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="521"/>
         <source>&amp;Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="539"/>
         <source>Per&amp;formance warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="565"/>
         <source>&amp;Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="580"/>
         <source>&amp;Portability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="598"/>
         <source>Show Cppcheck results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="610"/>
         <source>Clang</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="613"/>
         <source>Show Clang results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="680"/>
         <source>P&amp;latforms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="694"/>
         <source>C++&amp;11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="705"/>
         <source>C&amp;99</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="713"/>
         <source>&amp;Posix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="721"/>
         <source>C&amp;11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="729"/>
         <source>&amp;C89</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="737"/>
         <source>&amp;C++03</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="758"/>
         <source>&amp;Library Editor...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="769"/>
         <source>&amp;Auto-detect language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="777"/>
         <source>&amp;Enforce C++</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="785"/>
         <source>E&amp;nforce C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="796"/>
         <source>C++14</source>
         <translation type="unfinished">C++14</translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="804"/>
         <source>Reanalyze and check library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="812"/>
         <source>Check configuration (defines, includes)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="820"/>
         <source>C++17</source>
         <translation type="unfinished">C++17</translation>
     </message>
     <message>
+        <location filename="mainwindow.ui" line="831"/>
         <source>C++20</source>
         <translation type="unfinished">C++20</translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="568"/>
+        <source>C/C++ Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="569"/>
+        <source>Compile database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="570"/>
+        <source>Visual Studio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="571"/>
+        <source>Borland C++ Builder 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="mainwindow.cpp" line="1118"/>
+        <source>Current results will be cleared.
+
+Opening a new XML file will clear current results.
+Do you want to proceed?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NewSuppressionDialog</name>
     <message>
+        <location filename="newsuppressiondialog.ui" line="17"/>
         <source>New suppression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="25"/>
         <source>Error ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="32"/>
         <source>File name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="42"/>
         <source>Line number</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.ui" line="52"/>
         <source>Symbol name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="newsuppressiondialog.cpp" line="52"/>
         <source>Edit suppression</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1113,22 +1383,27 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 <context>
     <name>Platforms</name>
     <message>
+        <location filename="platforms.cpp" line="38"/>
         <source>Unix 32-bit</source>
         <translation>Unix 32-bit</translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="39"/>
         <source>Unix 64-bit</source>
         <translation>Unix 64-bit</translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="40"/>
         <source>Windows 32-bit ANSI</source>
         <translation>Windows 32-bit ANSI</translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="41"/>
         <source>Windows 32-bit Unicode</source>
         <translation>Windows 32-bit Unicode</translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="42"/>
         <source>Windows 64-bit</source>
         <translation>Windows 64-bit</translation>
     </message>
@@ -1137,6 +1412,7 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">내장 방식</translation>
     </message>
     <message>
+        <location filename="platforms.cpp" line="37"/>
         <source>Native</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1159,6 +1435,7 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 <context>
     <name>ProjectFile</name>
     <message>
+        <location filename="projectfiledialog.ui" line="14"/>
         <source>Project File</source>
         <translation>프로젝트 파일</translation>
     </message>
@@ -1167,6 +1444,7 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">프로젝트</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="153"/>
         <source>Defines:</source>
         <translation>Defines:</translation>
     </message>
@@ -1175,18 +1453,29 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">Root:</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="86"/>
         <source>Paths:</source>
         <translation>경로:</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="113"/>
+        <location filename="projectfiledialog.ui" line="228"/>
+        <location filename="projectfiledialog.ui" line="461"/>
         <source>Add...</source>
         <translation>추가...</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="120"/>
+        <location filename="projectfiledialog.ui" line="235"/>
+        <location filename="projectfiledialog.ui" line="468"/>
         <source>Edit</source>
         <translation>편집</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="127"/>
+        <location filename="projectfiledialog.ui" line="242"/>
+        <location filename="projectfiledialog.ui" line="475"/>
+        <location filename="projectfiledialog.ui" line="518"/>
         <source>Remove</source>
         <translation>제거</translation>
     </message>
@@ -1199,10 +1488,12 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">Include 디렉토리:</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="262"/>
         <source>Up</source>
         <translation>위로</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="269"/>
         <source>Down</source>
         <translation>아래로</translation>
     </message>
@@ -1211,212 +1502,284 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">Exclude</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="500"/>
         <source>Suppressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="511"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="393"/>
         <source>Note: Put your own custom .cfg files in the same folder as the project file. You should see them above.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="197"/>
         <source>Include Paths:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="24"/>
         <source>Paths and Defines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="69"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;You have a choice:&lt;/p&gt;&lt;p&gt; * Analyze all Debug and Release configurations&lt;/p&gt;&lt;p&gt; * Only analyze the first matching Debug configuration&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="72"/>
         <source>Analyze all Visual Studio configurations</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="426"/>
         <source>Root path:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="438"/>
         <source>Warning tags (separated by semicolon)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="300"/>
         <source>Cppcheck build dir (whole program analysis, incremental analysis, statistics, etc)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="384"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="563"/>
         <source>Addons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="60"/>
+        <location filename="projectfiledialog.ui" line="309"/>
         <source>Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="163"/>
         <source>Defines must be separated by a semicolon. Example: DEF1;DEF2=5;DEF3=int</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="294"/>
         <source>Checking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="319"/>
         <source>Platform</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="420"/>
         <source>Warning options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="557"/>
         <source>Addons and tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="30"/>
         <source>Import Project (Visual studio / compile database/ Borland C++ Builder 6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="174"/>
         <source>Undefines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="184"/>
         <source>Undefines must be separated by a semicolon. Example: UNDEF1;UNDEF2;UNDEF3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="331"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="337"/>
         <source>Check code in headers  (slower analysis, more results)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="347"/>
         <source>Check code in unused templates  (slower and less accurate analysis)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="356"/>
         <source>Max CTU depth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.ui" line="450"/>
         <source>Exclude source files in paths</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ProjectFileDialog</name>
     <message>
+        <location filename="projectfiledialog.cpp" line="71"/>
         <source>Project file: %1</source>
         <translation>프로젝트 파일: %1</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="637"/>
         <source>Select include directory</source>
         <translation>Include 디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="617"/>
         <source>Select a directory to check</source>
         <translation>검사할 디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="657"/>
         <source>Select directory to ignore</source>
         <translation>무시할 디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="409"/>
         <source>Select Cppcheck build dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="448"/>
         <source>Import Project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="311"/>
         <source>Clang-tidy (not found)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="305"/>
         <source>(no rule texts file)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="742"/>
         <source>Select MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="742"/>
         <source>Misra rule texts file (%1)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.cpp" line="445"/>
+        <source>Visual Studio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.cpp" line="446"/>
+        <source>Compile database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.cpp" line="447"/>
+        <source>Borland C++ Builder 6</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QDialogButtonBox</name>
     <message>
+        <location filename="translationhandler.cpp" line="34"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="35"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="36"/>
         <source>Close</source>
         <translation type="unfinished">닫기</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="37"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1424,149 +1787,185 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="translationhandler.cpp" line="104"/>
         <source>Unknown language specified!</source>
         <translation>알 수 없는 언어입니다!</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="132"/>
         <source>Language file %1 not found!</source>
         <translation>언어 파일(%1)이 없습니다!</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="138"/>
         <source>Failed to load translation for language %1 from file %2</source>
         <translation>파일(%2)로부터 언어(%1) 불러오기 실패</translation>
     </message>
     <message>
+        <location filename="cppchecklibrarydata.cpp" line="33"/>
         <source>line %1: Unhandled element %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="projectfiledialog.cpp" line="226"/>
         <source> (Not found)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="69"/>
         <source>Thin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="71"/>
         <source>ExtraLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="73"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="75"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="77"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="79"/>
         <source>DemiBold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="81"/>
         <source>Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="83"/>
         <source>ExtraBold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstylecontrols.cpp" line="85"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="69"/>
         <source>Editor Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="72"/>
         <source>Editor Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="75"/>
         <source>Highlight Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="78"/>
         <source>Line Number Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="81"/>
         <source>Line Number Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="84"/>
         <source>Keyword Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="87"/>
         <source>Keyword Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Class ForegroundColor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="codeeditstyledialog.cpp" line="93"/>
         <source>Class Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="96"/>
         <source>Quote Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="99"/>
         <source>Quote Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="102"/>
         <source>Comment Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="105"/>
         <source>Comment Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="108"/>
         <source>Symbol Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="111"/>
         <source>Symbol Background Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="114"/>
         <source>Symbol Font Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="130"/>
         <source>Set to Default Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="codeeditstyledialog.cpp" line="132"/>
         <source>Set to Default Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="codeeditstyledialog.cpp" line="90"/>
+        <source>Class Foreground Color</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>QPlatformTheme</name>
     <message>
+        <location filename="translationhandler.cpp" line="39"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="40"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="41"/>
         <source>Close</source>
         <translation type="unfinished">닫기</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="42"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1574,22 +1973,27 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 <context>
     <name>ResultsTree</name>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>File</source>
         <translation>파일</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Severity</source>
         <translation>분류</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Line</source>
         <translation>행</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Summary</source>
         <translation>요약</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="136"/>
         <source>Undefined file</source>
         <translation>미정의된 파일</translation>
     </message>
@@ -1598,30 +2002,37 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">[불확실]</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="294"/>
         <source>style</source>
         <translation>스타일</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="297"/>
         <source>error</source>
         <translation>에러</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="300"/>
         <source>warning</source>
         <translation>경고</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="303"/>
         <source>performance</source>
         <translation>성능</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="306"/>
         <source>portability</source>
         <translation>이식성</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="309"/>
         <source>information</source>
         <translation>정보</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="312"/>
         <source>debug</source>
         <translation>디버그</translation>
     </message>
@@ -1638,14 +2049,18 @@ Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="obsolete">메시지 복사</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="615"/>
         <source>Hide</source>
         <translation>숨기기</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="693"/>
+        <location filename="resultstree.cpp" line="707"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="694"/>
         <source>No editor application configured.
 
 Configure the editor application for Cppcheck in preferences/Applications.</source>
@@ -1654,6 +2069,7 @@ Configure the editor application for Cppcheck in preferences/Applications.</sour
 [설정 - 응용 프로그램]에서 편집기를 설정하세요.</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="708"/>
         <source>No default editor application selected.
 
 Please select the default editor application in preferences/Applications.</source>
@@ -1662,10 +2078,12 @@ Please select the default editor application in preferences/Applications.</sourc
 [설정 - 응용 프로그램]에서 기본 편집기를 선택하세요.</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="737"/>
         <source>Could not find the file!</source>
         <translation>파일을 찾을 수 없습니다!</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="783"/>
         <source>Could not start %1
 
 Please check the application path and parameters are correct.</source>
@@ -1682,66 +2100,83 @@ Please select the directory where file is located.</source>
 파일이 위치한 디렉토리를 선택하세요.</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="805"/>
         <source>Select Directory</source>
         <translation>디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="616"/>
         <source>Hide all with id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="618"/>
         <source>Open containing folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Inconclusive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="613"/>
         <source>Recheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="249"/>
         <source>note</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="617"/>
         <source>Suppress selected id(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="648"/>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="650"/>
         <source>No tag</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="1343"/>
         <source>Since date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="797"/>
         <source>Could not find file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="801"/>
         <source>Please select the folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="802"/>
         <source>Select Directory &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="804"/>
         <source>Please select the directory where file is located.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultstree.cpp" line="614"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1749,36 +2184,47 @@ Please select the directory where file is located.</source>
 <context>
     <name>ResultsView</name>
     <message>
+        <location filename="resultsview.ui" line="26"/>
         <source>Results</source>
         <translation>결과</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="159"/>
         <source>No errors found, nothing to save.</source>
         <translation>에러가 발견되지 않았고, 저장할 내용이 없습니다.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="183"/>
+        <location filename="resultsview.cpp" line="191"/>
         <source>Failed to save the report.</source>
         <translation>결과 저장 실패.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="264"/>
         <source>%p% (%1 of %2 files checked)</source>
         <translation>%p% (%2 중 %1 파일 검사됨)</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="277"/>
+        <location filename="resultsview.cpp" line="288"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="278"/>
         <source>No errors found.</source>
         <translation>에러가 발견되지 않았습니다.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="285"/>
         <source>Errors were found, but they are configured to be hidden.
 To toggle what kind of errors are shown, open view menu.</source>
         <translation>에러가 발견되었지만, 감추도록 설정되어 있습니다.
 에러 종류를 표시하도록 설정하려면, 보기 메뉴를 선택하세요.</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="331"/>
+        <location filename="resultsview.cpp" line="350"/>
         <source>Failed to read the report.</source>
         <translation>결과 불러오기 실패.</translation>
     </message>
@@ -1791,42 +2237,52 @@ To toggle what kind of errors are shown, open view menu.</source>
         <translation type="obsolete">내용</translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="402"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="201"/>
         <source>Print Report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="220"/>
         <source>No errors found, nothing to print.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="399"/>
         <source>First included by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="338"/>
         <source>XML format version 1 is no longer supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.ui" line="82"/>
         <source>Analysis Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.ui" line="104"/>
         <source>Warning Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="471"/>
         <source>Clear Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="472"/>
         <source>Copy this Log entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="resultsview.cpp" line="473"/>
         <source>Copy complete Log</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1834,22 +2290,27 @@ To toggle what kind of errors are shown, open view menu.</source>
 <context>
     <name>ScratchPad</name>
     <message>
+        <location filename="scratchpad.ui" line="14"/>
         <source>Scratchpad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="71"/>
         <source>filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="78"/>
         <source>Check</source>
         <translation type="unfinished">검사</translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="20"/>
         <source>Copy or write some C/C++ code here:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="scratchpad.ui" line="37"/>
         <source>Optionally enter a filename (mainly for automatic language detection) and click on &quot;Check&quot;:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1857,34 +2318,42 @@ To toggle what kind of errors are shown, open view menu.</source>
 <context>
     <name>Settings</name>
     <message>
+        <location filename="settings.ui" line="14"/>
         <source>Preferences</source>
         <translation>설정</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="24"/>
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="41"/>
         <source>Number of threads: </source>
         <translation>쓰레드 수: </translation>
     </message>
     <message>
+        <location filename="settings.ui" line="85"/>
         <source>Ideal count:</source>
         <translation>최적 값:</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="114"/>
         <source>Force checking all #ifdef configurations</source>
         <translation>모든 #ifdef 설정을 강제로 검사</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="121"/>
         <source>Show full path of files</source>
         <translation>파일의 전체 경로 표시</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="128"/>
         <source>Show &quot;No errors found&quot; message when no errors found</source>
         <translation>에러가 발견되지 않는 경우 &quot;에러가 없습니다.&quot; 메시지 표시</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="142"/>
         <source>Enable inline suppressions</source>
         <translation>Inline suppression 사용</translation>
     </message>
@@ -1897,6 +2366,7 @@ To toggle what kind of errors are shown, open view menu.</source>
         <translation type="obsolete">Include 경로:</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="195"/>
         <source>Add...</source>
         <translation>추가...</translation>
     </message>
@@ -1905,34 +2375,43 @@ To toggle what kind of errors are shown, open view menu.</source>
         <translation type="obsolete">편집</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="209"/>
         <source>Remove</source>
         <translation>제거</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="184"/>
         <source>Applications</source>
         <translation>응용 프로그램</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="202"/>
+        <location filename="settings.ui" line="467"/>
         <source>Edit...</source>
         <translation>편집...</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="216"/>
         <source>Set as default</source>
         <translation>기본으로 지정</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="239"/>
         <source>Reports</source>
         <translation>보고서</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="245"/>
         <source>Save all errors when creating report</source>
         <translation>보고서 생성 시 모든 에러 저장</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="252"/>
         <source>Save full path to files in reports</source>
         <translation>보고서에 파일의 전체 경로 저장</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="273"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
@@ -1949,97 +2428,127 @@ To toggle what kind of errors are shown, open view menu.</source>
         <translation type="obsolete">로그에 내부 경고 표시(&amp;H)</translation>
     </message>
     <message>
+        <location filename="settings.ui" line="135"/>
         <source>Display error Id in column &quot;Id&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="149"/>
         <source>Check for inconclusive errors also</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="176"/>
         <source>Show internal warnings in log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="156"/>
         <source>Show statistics on check completion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="287"/>
         <source>Addons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="293"/>
         <source>Python binary (leave this empty to use python in the PATH)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="302"/>
+        <location filename="settings.ui" line="334"/>
+        <location filename="settings.ui" line="379"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="360"/>
         <source>Clang</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="366"/>
         <source>Clang path (leave empty to use system PATH)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="389"/>
         <source>Visual Studio headers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="395"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Paths to Visual Studio headers, separated by semicolon &apos;;&apos;.&lt;/p&gt;&lt;p&gt;You can open a Visual Studio command prompt, write &amp;quot;SET INCLUDE&amp;quot;. Then copy/paste the paths.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="312"/>
         <source>Misra addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="320"/>
         <source>Misra rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="327"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="425"/>
         <source>Code Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="431"/>
         <source>Code Editor Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="444"/>
         <source>Default Light Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="451"/>
         <source>Default Dark Style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settings.ui" line="460"/>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="settings.ui" line="437"/>
+        <source>System Style</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsDialog</name>
     <message>
+        <location filename="settingsdialog.cpp" line="100"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="200"/>
         <source>Add a new application</source>
         <translation>새 응용 프로그램 추가</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="233"/>
         <source>Modify an application</source>
         <translation>응용 프로그램 편집</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="263"/>
         <source>[Default]</source>
         <translation>[기본]</translation>
     </message>
@@ -2048,18 +2557,22 @@ To toggle what kind of errors are shown, open view menu.</source>
         <translation type="obsolete">Include 디렉토리 선택</translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="238"/>
         <source> [Default]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="318"/>
         <source>Select python binary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="356"/>
         <source>Select clang path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="settingsdialog.cpp" line="325"/>
         <source>Select MISRA File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2067,194 +2580,253 @@ To toggle what kind of errors are shown, open view menu.</source>
 <context>
     <name>StatsDialog</name>
     <message>
+        <location filename="stats.ui" line="14"/>
+        <location filename="stats.ui" line="248"/>
+        <location filename="statsdialog.cpp" line="137"/>
+        <location filename="statsdialog.cpp" line="184"/>
         <source>Statistics</source>
         <translation>통계</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="27"/>
+        <location filename="statsdialog.cpp" line="175"/>
         <source>Project</source>
         <translation>프로젝트</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="33"/>
         <source>Project:</source>
         <translation>프로젝트:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="53"/>
         <source>Paths:</source>
         <translation>경로:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="85"/>
         <source>Include paths:</source>
         <translation>Include 경로:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="108"/>
         <source>Defines:</source>
         <translation>Defines:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="165"/>
+        <location filename="statsdialog.cpp" line="180"/>
         <source>Previous Scan</source>
         <translation>직전 검사</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="171"/>
         <source>Path Selected:</source>
         <translation>선택된 경로:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="181"/>
         <source>Number of Files Scanned:</source>
         <translation>검사된 파일 수:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="201"/>
         <source>Scan Duration:</source>
         <translation>검사 시간:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="256"/>
         <source>Errors:</source>
         <translation>에러:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="274"/>
         <source>Warnings:</source>
         <translation>경고:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="292"/>
         <source>Stylistic warnings:</source>
         <translation>스타일 경고:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="310"/>
         <source>Portability warnings:</source>
         <translation>이식성 경고:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="328"/>
         <source>Performance issues:</source>
         <translation>성능 경고:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="346"/>
         <source>Information messages:</source>
         <translation>정보 메시지:</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="407"/>
         <source>Copy to Clipboard</source>
         <translation>클립보드에 복사</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="113"/>
         <source>1 day</source>
         <translation>1일</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="113"/>
         <source>%1 days</source>
         <translation>%1일</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="115"/>
         <source>1 hour</source>
         <translation>1시간</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="115"/>
         <source>%1 hours</source>
         <translation>%1시간</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="117"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="117"/>
         <source>%1 minutes</source>
         <translation>%1분</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="119"/>
         <source>1 second</source>
         <translation>1초</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="119"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="123"/>
         <source>0.%1 seconds</source>
         <translation>0.%1초</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="125"/>
         <source> and </source>
         <translation> 및 </translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="174"/>
         <source>Project Settings</source>
         <translation>프로젝트 설정</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="176"/>
         <source>Paths</source>
         <translation>경로</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="177"/>
         <source>Include paths</source>
         <translation>Include 경로</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="178"/>
         <source>Defines</source>
         <translation>Defines</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="181"/>
         <source>Path selected</source>
         <translation>선택된 경로</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="182"/>
         <source>Number of files scanned</source>
         <translation>검사된 파일 수</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="183"/>
         <source>Scan duration</source>
         <translation>검사 시간</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="139"/>
+        <location filename="statsdialog.cpp" line="185"/>
         <source>Errors</source>
         <translation>에러</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="141"/>
+        <location filename="statsdialog.cpp" line="186"/>
         <source>Warnings</source>
         <translation>경고</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="143"/>
+        <location filename="statsdialog.cpp" line="187"/>
         <source>Style warnings</source>
         <translation>스타일 경고</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="145"/>
+        <location filename="statsdialog.cpp" line="188"/>
         <source>Portability warnings</source>
         <translation>이식성 경고</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="147"/>
+        <location filename="statsdialog.cpp" line="189"/>
         <source>Performance warnings</source>
         <translation>성능 경고</translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="149"/>
+        <location filename="statsdialog.cpp" line="190"/>
         <source>Information messages</source>
         <translation>정보 메시지</translation>
     </message>
     <message>
+        <location filename="stats.ui" line="414"/>
         <source>Pdf Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="152"/>
         <source>Export PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="363"/>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="369"/>
         <source>File:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="65"/>
         <source>File: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="65"/>
         <source>No cppcheck build dir</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="stats.ui" line="131"/>
         <source>Undefines:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="statsdialog.cpp" line="179"/>
         <source>Undefines</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2262,6 +2834,7 @@ To toggle what kind of errors are shown, open view menu.</source>
 <context>
     <name>ThreadResult</name>
     <message>
+        <location filename="threadresult.cpp" line="54"/>
         <source>%1 of %2 files checked</source>
         <translation>%2 중 %1 파일 검사됨</translation>
     </message>
@@ -2269,6 +2842,7 @@ To toggle what kind of errors are shown, open view menu.</source>
 <context>
     <name>TranslationHandler</name>
     <message>
+        <location filename="translationhandler.cpp" line="145"/>
         <source>Failed to change the user interface language:
 
 %1
@@ -2281,6 +2855,7 @@ The user interface language has been reset to English. Open the Preferences-dial
 언어가 영어로 초기화 됐습니다. 설정창을 열어서 설정 가능한 언어를 선택하세요.</translation>
     </message>
     <message>
+        <location filename="translationhandler.cpp" line="151"/>
         <source>Cppcheck</source>
         <translation type="unfinished">Cppcheck</translation>
     </message>
@@ -2288,6 +2863,7 @@ The user interface language has been reset to English. Open the Preferences-dial
 <context>
     <name>TxtReport</name>
     <message>
+        <location filename="txtreport.cpp" line="73"/>
         <source>inconclusive</source>
         <translation>불확실</translation>
     </message>
@@ -2295,10 +2871,12 @@ The user interface language has been reset to English. Open the Preferences-dial
 <context>
     <name>toFilterString</name>
     <message>
+        <location filename="common.cpp" line="52"/>
         <source>All supported files (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="common.cpp" line="57"/>
         <source>All files (%1)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_nl.ts
+++ b/gui/cppcheck_nl.ts
@@ -433,13 +433,13 @@ Parameters: -l(lijn) (bestand)</translation>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1033,12 +1033,12 @@ Wil je verder wilt gaan zonder controle van deze project bestanden?</translation
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Licentie</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
@@ -1048,13 +1048,13 @@ Wil je verder wilt gaan zonder controle van deze project bestanden?</translation
         <translation type="obsolete">XML bestanden (*.xml);;Tekst bestanden (*.txt);;CSV bestanden (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Rapport opslaan </translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML bestanden (*.xml)</translation>
     </message>
@@ -1126,7 +1126,7 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 Een nieuw XML-bestand openen zal de huidige resultaten wissen Wilt u verder gaan?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Open het rapport bestand</translation>
     </message>
@@ -1147,34 +1147,34 @@ Wil je het controleren stoppen en Cppcheck sluiten?</translation>
         <translation type="obsolete">XML files version 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Tekst bestanden (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV bestanden (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Project bestanden (*.cppcheck);;Alle bestanden(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Selecteer project bestand</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Project:</translation>
     </message>
@@ -1226,7 +1226,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1234,44 +1234,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Selecteer project bestandsnaam</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>Geen project bestand geladen</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1469,22 +1469,22 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1572,7 +1572,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1654,32 +1659,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_ru.ts
+++ b/gui/cppcheck_ru.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ru_RU" sourcelanguage="ru_RU">
+<TS version="2.1" language="ru_RU">
 <context>
     <name>About</name>
     <message>
@@ -439,13 +439,13 @@ Parameters: -l(line) (file)</source>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -771,11 +771,11 @@ Parameters: -l(line) (file)</source>
     </message>
     <message>
         <source>Enforce C++</source>
-        <translation>Принудительно C++</translation>
+        <translation type="vanished">Принудительно C++</translation>
     </message>
     <message>
         <source>Enforce C</source>
-        <translation>Принудительно C</translation>
+        <translation type="vanished">Принудительно C</translation>
     </message>
     <message>
         <location filename="mainwindow.ui" line="392"/>
@@ -1099,12 +1099,12 @@ Do you want to proceed checking without using any of these project files?</sourc
         <translation type="obsolete">Не удалось загрузить %1. Установленный Cppcheck поврежден. Вы можете использовать ключ --data-dir=&lt;directory&gt; в командной строке, чтобы указать, где расположен этот файл.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Лицензия</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Авторы</translation>
     </message>
@@ -1114,13 +1114,13 @@ Do you want to proceed checking without using any of these project files?</sourc
         <translation type="obsolete">XML файлы версии 2 (*.xml);;XML файлы версии 1 (*.xml);;Текстовые файлы  (*.txt);;CSV файлы (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Сохранить файл с отчетом</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML-файлы (*.xml)</translation>
     </message>
@@ -1188,7 +1188,7 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 Открытые нового XML файла приведет к очистке текущих результатов. Продолжить?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Открыть файл с отчетом</translation>
     </message>
@@ -1209,17 +1209,17 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML файлы версии 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Текстовые файлы (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV файлы(*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
@@ -1236,19 +1236,19 @@ The user interface language has been reset to English. Open the Preferences-dial
 The user interface language has been reset to English. Open the Preferences-dialog to select any of the available languages.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Файлы проекта (*.cppcheck);;Все файлы(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Выберите файл проекта</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Проект:</translation>
     </message>
@@ -1270,12 +1270,12 @@ The user interface language has been reset to English. Open the Preferences-dial
     <message>
         <location filename="mainwindow.cpp" line="570"/>
         <source>Visual Studio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Visual Studio</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="571"/>
         <source>Borland C++ Builder 6</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Borland C++ Builder 6</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="574"/>
@@ -1302,7 +1302,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
 Вы хотите продолжить анализ без использования этих файлов проекта?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1313,7 +1313,7 @@ Do you want to proceed?</source>
 Вы хотите продолжить?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
@@ -1322,37 +1322,37 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 Вы хотите остановить анализ и выйти из Cppcheck?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation>XML файлы (*.xml);;Текстовые файлы (*.txt);;CSV файлы (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation>Директория для сборки &apos;%1&apos; не существует, создать?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation>Невозможно импортировать &apos;%1&apos;, анализ остановлен</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation>Файлы проекта (*.cppcheck)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Выберите имя файла для проекта</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>Файл с проектом не загружен</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1568,22 +1568,22 @@ Options:
         <translation>Положите свои .cfg-файлы в один каталог с файлом проекта. Вы увидите их сверху.</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation>MISRA C 2012</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation>Файл с текстами правил MISRA</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Скопируйте текст из Appendix A &amp;quot;Summary of guidelines&amp;quot; из фала правил MISRA C 2012 pdf в текстовый файл.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -1671,7 +1671,12 @@ Options:
         <translation>Исключить исходные файлы в путях</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation>Внешние инструменты</translation>
     </message>
@@ -1753,32 +1758,32 @@ Options:
         <translation>Дополнения</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation>Стандарты кодирования</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation>Cert</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_sr.ts
+++ b/gui/cppcheck_sr.ts
@@ -402,13 +402,13 @@ Parameters: -l(line) (file)</source>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -998,12 +998,12 @@ Do you want to load this project file instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation type="unfinished">License</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation type="unfinished">Authors</translation>
     </message>
@@ -1012,13 +1012,13 @@ Do you want to load this project file instead?</source>
         <translation type="obsolete">XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation type="unfinished">Save the report file</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation type="unfinished">XML files (*.xml)</translation>
     </message>
@@ -1080,39 +1080,39 @@ This is probably because the settings were changed between the Cppcheck versions
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation type="unfinished">Text files (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1164,7 +1164,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1172,44 +1172,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1363,22 +1363,22 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1501,7 +1501,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1531,32 +1536,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>

--- a/gui/cppcheck_sv.ts
+++ b/gui/cppcheck_sv.ts
@@ -455,13 +455,13 @@ Exempel:
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1121,12 +1121,12 @@ Vill du fortsätta analysen utan att använda någon av dessa projektfiler?</tra
 %2</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>Licens</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>Utvecklare</translation>
     </message>
@@ -1136,13 +1136,13 @@ Vill du fortsätta analysen utan att använda någon av dessa projektfiler?</tra
         <translation type="obsolete">XML filer version 2 (*.xml);;XML filer version 1 (*.xml);;Text filer (*.txt);;CSV filer (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>Spara rapport</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML filer (*.xml)</translation>
     </message>
@@ -1210,7 +1210,7 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 När en ny XML fil öppnas så tas alla nuvarande resultat bort. Vill du fortsätta?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>Öppna rapportfilen</translation>
     </message>
@@ -1239,17 +1239,17 @@ Vill du stoppa analysen och avsluta Cppcheck?</translation>
         <translation type="obsolete">XML filer version 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>Text filer (*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV filer (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
@@ -1266,19 +1266,19 @@ The user interface language has been reset to English. Open the Preferences-dial
 Språket har nollställts till Engelska. Öppna Preferences och välj något av de tillgängliga språken.</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>Projektfiler (*.cppcheck);;Alla filer(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>Välj projektfil</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>Projekt:</translation>
     </message>
@@ -1332,7 +1332,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
 Vill du fortsätta analysen utan att använda någon av dessa projekt filer?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1340,7 +1340,7 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
@@ -1349,37 +1349,37 @@ Do you want to stop the analysis and exit Cppcheck?</source>
 Vill du stoppa analysen och avsluta Cppcheck?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation>XML filer (*.xml);;Text filer (*.txt);;CSV filer (*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation>Build dir &apos;%1&apos; existerar ej, skapa den?</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation>Misslyckades att importera &apos;%1&apos;, analysen stoppas</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation>Projekt filer (*.cppcheck)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>Välj Projektfil</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>Inget projekt laddat</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1615,7 +1615,7 @@ Sökvägar och defines importeras.</translation>
         <translation type="obsolete">Visual Studio</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -1678,22 +1678,27 @@ Sökvägar och defines importeras.</translation>
         <translation>Include sökvägar:</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1804,22 +1809,22 @@ Sökvägar och defines importeras.</translation>
         <translation>Addons</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation>Y2038</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation>Tråd säkerhet</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation>Kodstandarder</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation>Cert</translation>
     </message>
@@ -1832,12 +1837,12 @@ Sökvägar och defines importeras.</translation>
         <translation type="obsolete">Best practice är att använda flera verktyg</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation>Clang analyzer</translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation>Clang-tidy</translation>
     </message>

--- a/gui/cppcheck_zh_CN.ts
+++ b/gui/cppcheck_zh_CN.ts
@@ -431,13 +431,13 @@ Parameters: -l(line) (file)</source>
         <location filename="mainwindow.cpp" line="553"/>
         <location filename="mainwindow.cpp" line="658"/>
         <location filename="mainwindow.cpp" line="680"/>
-        <location filename="mainwindow.cpp" line="1113"/>
-        <location filename="mainwindow.cpp" line="1238"/>
-        <location filename="mainwindow.cpp" line="1359"/>
-        <location filename="mainwindow.cpp" line="1499"/>
-        <location filename="mainwindow.cpp" line="1522"/>
-        <location filename="mainwindow.cpp" line="1593"/>
-        <location filename="mainwindow.cpp" line="1667"/>
+        <location filename="mainwindow.cpp" line="1117"/>
+        <location filename="mainwindow.cpp" line="1242"/>
+        <location filename="mainwindow.cpp" line="1363"/>
+        <location filename="mainwindow.cpp" line="1503"/>
+        <location filename="mainwindow.cpp" line="1526"/>
+        <location filename="mainwindow.cpp" line="1597"/>
+        <location filename="mainwindow.cpp" line="1671"/>
         <source>Cppcheck</source>
         <translation>Cppcheck</translation>
     </message>
@@ -1128,13 +1128,13 @@ Opening a new XML file will clear current results.Do you want to proceed?</sourc
 打开一个新的 XML 文件将会清空当前结果。你要继续吗？</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1129"/>
-        <location filename="mainwindow.cpp" line="1309"/>
+        <location filename="mainwindow.cpp" line="1133"/>
+        <location filename="mainwindow.cpp" line="1313"/>
         <source>XML files (*.xml)</source>
         <translation>XML 文件(*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1131"/>
+        <location filename="mainwindow.cpp" line="1135"/>
         <source>Open the report file</source>
         <translation>打开报告文件</translation>
     </message>
@@ -1147,12 +1147,12 @@ Do you want to stop the checking and exit Cppcheck?</source>
 你是否需要停止检查并退出 Cppcheck？</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1280"/>
+        <location filename="mainwindow.cpp" line="1284"/>
         <source>License</source>
         <translation>许可证</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1287"/>
+        <location filename="mainwindow.cpp" line="1291"/>
         <source>Authors</source>
         <translation>作者</translation>
     </message>
@@ -1162,7 +1162,7 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML 文件版本 2 (*.xml);;XML 文件版本 1 (*.xml);; 文本文件(*.txt);; CSV 文件(*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1302"/>
+        <location filename="mainwindow.cpp" line="1306"/>
         <source>Save the report file</source>
         <translation>保存报告文件</translation>
     </message>
@@ -1175,17 +1175,17 @@ Do you want to stop the checking and exit Cppcheck?</source>
         <translation type="obsolete">XML 文件版本 2 (*.xml)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1313"/>
+        <location filename="mainwindow.cpp" line="1317"/>
         <source>Text files (*.txt)</source>
         <translation>文本文件(*.txt)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1317"/>
+        <location filename="mainwindow.cpp" line="1321"/>
         <source>CSV files (*.csv)</source>
         <translation>CSV 文件(*.csv)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1361"/>
+        <location filename="mainwindow.cpp" line="1365"/>
         <source>Cppcheck - %1</source>
         <translation>Cppcheck - %1</translation>
     </message>
@@ -1202,19 +1202,19 @@ The user interface language has been reset to English. Open the Preferences-dial
 用户界面语言已被重置为英语。打开“首选项”对话框，选择任何可用的语言。</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1407"/>
+        <location filename="mainwindow.cpp" line="1411"/>
         <source>Project files (*.cppcheck);;All files(*.*)</source>
         <translation>项目文件(*.cppcheck);;所有文件(*.*)</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1409"/>
+        <location filename="mainwindow.cpp" line="1413"/>
         <source>Select Project File</source>
         <translation>选择项目文件</translation>
     </message>
     <message>
         <location filename="mainwindow.cpp" line="159"/>
-        <location filename="mainwindow.cpp" line="1437"/>
-        <location filename="mainwindow.cpp" line="1562"/>
+        <location filename="mainwindow.cpp" line="1441"/>
+        <location filename="mainwindow.cpp" line="1566"/>
         <source>Project:</source>
         <translation>项目:</translation>
     </message>
@@ -1266,7 +1266,7 @@ Do you want to proceed analysis without using any of these project files?</sourc
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1114"/>
+        <location filename="mainwindow.cpp" line="1118"/>
         <source>Current results will be cleared.
 
 Opening a new XML file will clear current results.
@@ -1274,44 +1274,44 @@ Do you want to proceed?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1234"/>
+        <location filename="mainwindow.cpp" line="1238"/>
         <source>Analyzer is running.
 
 Do you want to stop the analysis and exit Cppcheck?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1300"/>
+        <location filename="mainwindow.cpp" line="1304"/>
         <source>XML files (*.xml);;Text files (*.txt);;CSV files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1500"/>
+        <location filename="mainwindow.cpp" line="1504"/>
         <source>Build dir &apos;%1&apos; does not exist, create it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1523"/>
+        <location filename="mainwindow.cpp" line="1527"/>
         <source>Failed to import &apos;%1&apos;, analysis is stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1547"/>
+        <location filename="mainwindow.cpp" line="1551"/>
         <source>Project files (*.cppcheck)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1549"/>
+        <location filename="mainwindow.cpp" line="1553"/>
         <source>Select Project Filename</source>
         <translation>选择项目文件名</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1594"/>
+        <location filename="mainwindow.cpp" line="1598"/>
         <source>No project file loaded</source>
         <translation>项目文件未加载</translation>
     </message>
     <message>
-        <location filename="mainwindow.cpp" line="1662"/>
+        <location filename="mainwindow.cpp" line="1666"/>
         <source>The project file
 
 %1
@@ -1487,22 +1487,22 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="597"/>
+        <location filename="projectfiledialog.ui" line="607"/>
         <source>MISRA C 2012</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="606"/>
+        <location filename="projectfiledialog.ui" line="616"/>
         <source>Misra rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="613"/>
+        <location filename="projectfiledialog.ui" line="623"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy/paste the text from Appendix A &amp;quot;Summary of guidelines&amp;quot; from the MISRA C 2012 pdf to a text file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="620"/>
+        <location filename="projectfiledialog.ui" line="630"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1590,7 +1590,12 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="632"/>
+        <location filename="projectfiledialog.ui" line="569"/>
+        <source>Note: Addons require &lt;a href=&quot;https://www.python.org/&quot;&gt;Python&lt;/a&gt; beeing installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="projectfiledialog.ui" line="642"/>
         <source>External tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1672,32 +1677,32 @@ Options:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="569"/>
+        <location filename="projectfiledialog.ui" line="579"/>
         <source>Y2038</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="576"/>
+        <location filename="projectfiledialog.ui" line="586"/>
         <source>Thread safety</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="583"/>
+        <location filename="projectfiledialog.ui" line="593"/>
         <source>Coding standards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="590"/>
+        <location filename="projectfiledialog.ui" line="600"/>
         <source>Cert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="645"/>
+        <location filename="projectfiledialog.ui" line="655"/>
         <source>Clang analyzer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="projectfiledialog.ui" line="638"/>
+        <location filename="projectfiledialog.ui" line="648"/>
         <source>Clang-tidy</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
The Korean language file was missing the "language" attribute, so it was
no longer updated before.
The Russian language file had the attribute "sourcelanguage" set to
"ru_RU" which does not make sense and led to some wrong/strange entries.
The France and Korean translation files were missing the "location"
entries, so the GUI-preview with the translated text was not shown and
there were no references to the source-code.
All these errors are fixed.
For the German file I translated the new hint about addons requiring
Python being installed.