### PR TITLE
Fix crash 9492: Crash in FwdAnalysis::checkRecursive() (condTok is nullptr)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2473,7 +2473,7 @@ void Tokenizer::combineOperators()
         } else if (tok->str() == "->") {
             // If the preceding sequence is "( & %name% )", replace it by "%name%"
             Token *t = tok->tokAt(-4);
-            if (Token::Match(t, "( & %name% )")) {
+            if (Token::Match(t, "( & %name% )") && !Token::simpleMatch(t->previous(), ">")) {
                 t->deleteThis();
                 t->deleteThis();
                 t->deleteNext();
@@ -9471,7 +9471,7 @@ void Tokenizer::findGarbageCode() const
     // Code must end with } ; ) NAME
     if (!Token::Match(list.back(), "%name%|;|}|)"))
         syntaxError(list.back());
-    if (list.back()->str() == ")" && !Token::Match(list.back()->link()->previous(), "%name% ("))
+    if (list.back()->str() == ")" && !Token::Match(list.back()->link()->previous(), "%name%|> ("))
         syntaxError(list.back());
     for (const Token *end = list.back(); end && end->isName(); end = end->previous()) {
         if (Token::Match(end, "void|char|short|int|long|float|double|const|volatile|static|inline|struct|class|enum|union|template|sizeof|case|break|continue|typedef"))

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1461,6 +1461,12 @@ void TokenList::validateAst() const
             if (!tok->astOperand1() || !tok->astOperand2())
                 throw InternalError(tok, "Syntax Error: AST broken, binary operator '" + tok->str() + "' doesn't have two operands.", InternalError::AST);
         }
+
+        // Check control blocks
+        if (Token::Match(tok->previous(), "if|while|for|switch (")) {
+            if (!tok->astOperand1() || !tok->astOperand2())
+                throw InternalError(tok, "Syntax Error: AST broken, '" + tok->previous()->str() + "' doesn't have two operands.", InternalError::AST);
+        }
     }
 }
 

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1465,7 +1465,10 @@ void TokenList::validateAst() const
         // Check control blocks
         if (Token::Match(tok->previous(), "if|while|for|switch (")) {
             if (!tok->astOperand1() || !tok->astOperand2())
-                throw InternalError(tok, "Syntax Error: AST broken, '" + tok->previous()->str() + "' doesn't have two operands.", InternalError::AST);
+                throw InternalError(tok,
+                                    "Syntax Error: AST broken, '" + tok->previous()->str() +
+                                        "' doesn't have two operands.",
+                                    InternalError::AST);
         }
     }
 }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -2421,8 +2421,9 @@ private:
 
         // #3714 - segmentation fault for syntax error
         ASSERT_THROW(check("void f() {\n"
-              "    if (()) { }\n"
-              "}"), InternalError);
+                           "    if (()) { }\n"
+                           "}"),
+                     InternalError);
 
         // #3865
         check("void f() {\n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -2420,9 +2420,9 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         // #3714 - segmentation fault for syntax error
-        check("void f() {\n"
+        ASSERT_THROW(check("void f() {\n"
               "    if (()) { }\n"
-              "}");
+              "}"), InternalError);
 
         // #3865
         check("void f() {\n"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -471,6 +471,7 @@ private:
         TEST_CASE(checkTemplates);
         TEST_CASE(checkNamespaces);
         TEST_CASE(checkLambdas);
+        TEST_CASE(checkIfCppCast);
 
         // #9052
         TEST_CASE(noCrash1);
@@ -946,6 +947,7 @@ private:
         ASSERT_EQUALS("; __published: ;", tokenizeAndStringify(";__published:;", false));
         ASSERT_EQUALS("a . public : ;", tokenizeAndStringify("a.public:;", false));
         ASSERT_EQUALS("void f ( x & = 2 ) ;", tokenizeAndStringify("void f(x &= 2);", false));
+        ASSERT_EQUALS("const_cast < a * > ( & e )", tokenizeAndStringify("const_cast<a*>(&e)", false));
     }
 
     void concatenateNegativeNumber() {
@@ -8077,6 +8079,20 @@ private:
                                              "    auto b = [this, a] {};\n"
                                              "  }\n"
                                              "};\n"))
+    }
+    void checkIfCppCast() {
+        ASSERT_NO_THROW(tokenizeAndStringify("struct a {\n"
+                                             "  int b();\n"
+                                             "};\n"
+                                             "struct c {\n"
+                                             "  bool d() const;\n"
+                                             "  a e;\n"
+                                             "};\n"
+                                             "bool c::d() const {\n"
+                                             "  int f = 0;\n"
+                                             "  if (!const_cast<a *>(&e)->b()) {}\n"
+                                             "  return f;\n"
+                                             "}\n"))
     }
 
     void noCrash1() {


### PR DESCRIPTION
The underling problem is that we simplified `const_cast<a*>(&e)` to `const_cast<a*> e` which causes ast to be wrong. 

I have also made it such that the statements like `if`, `while`, `for`, and `switch` that are missing the ast nodes become a syntax error so we can try to catch more of these cases in the future.

It would be nice if we could add a check such that certain angle brackets are always linked(such as after `template` or a C++ cast), but I didn't add such validation in this PR.