### PR TITLE
Valid code for incrementing raw pointer

### DIFF
--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -326,7 +326,10 @@ private:
     void pointer() {
         check("static struct class * ab;\n"
               "int * p;\n"
-              "p++;\n");
+              "\n"
+              "void f() {\n"
+              "    p++;\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
@danmar Could you please evaluate this change?

I looked up the code change history and this test case doesn't quite match the code in the ticket. The code in the ticket is valid and would compile but the code in the test case is invalid (because one cannot randomly increment a pointer outside a function scope) and would not compile with Visual C++. This makes the checker code to not find the increment, so the test doesn't actually test the checker code. The change I propose make the code closer to the ticket code.

Do you have any objections against this change?