### PR TITLE
misra.py: Fix R13.4 crash on dumps with AST error

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1420,6 +1420,13 @@ class MisraChecker:
                 continue
             if not token.astParent:
                 continue
+
+            # Broken syntax
+            if not token.astOperand1:
+                continue
+            if not token.astOperand1.previous:
+                continue
+
             if token.astOperand1.str == '[' and token.astOperand1.previous.str in ('{', ','):
                 continue
             if not (token.astParent.str in [',', ';', '{']):


### PR DESCRIPTION
Found while running misra.py over [CoreFreq](https://github.com/cyring/CoreFreq) as follows:
```bash
cppcheck -j4 --template=daca2 language=c --addon=misra.py --addon=cert.py
```

[Complete output](https://gist.github.com/jubnzv/e281ad7618baaa0cd4a47bd30a9e98fa) contains some [AST](https://gist.github.com/jubnzv/e281ad7618baaa0cd4a47bd30a9e98fa#file-corefreq-crash-L76) [errors](https://gist.github.com/jubnzv/e281ad7618baaa0cd4a47bd30a9e98fa#file-corefreq-crash-L69) from Cppcheck that caused misra.py [crash](https://gist.github.com/jubnzv/e281ad7618baaa0cd4a47bd30a9e98fa#file-corefreq-crash-L660). Not sure how to add regression tests for this case.