### PR TITLE
Fix #9510: Crash in valueflow.cpp solveExprValues() (division by zero)

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2990,12 +2990,8 @@ static const Token* solveExprValues(const Token* expr, std::list<ValueFlow::Valu
             return solveExprValues(binaryTok, values);
         }
         case '*': {
-            transformIntValues(values, [&](MathLib::bigint x) -> MathLib::bigint {
-                if (intval == 0) {
-                    return 0;
-                } else {
-                    return x / intval;
-                }
+            transformIntValues(values, [&](MathLib::bigint x) {
+                return (intval == 0) ? 0 : x / intval;
             });
             return solveExprValues(binaryTok, values);
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2990,8 +2990,10 @@ static const Token* solveExprValues(const Token* expr, std::list<ValueFlow::Valu
             return solveExprValues(binaryTok, values);
         }
         case '*': {
+            if (intval == 0)
+                break;
             transformIntValues(values, [&](MathLib::bigint x) {
-                return (intval == 0) ? 0 : x / intval;
+                return x / intval;
             });
             return solveExprValues(binaryTok, values);
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2990,8 +2990,12 @@ static const Token* solveExprValues(const Token* expr, std::list<ValueFlow::Valu
             return solveExprValues(binaryTok, values);
         }
         case '*': {
-            transformIntValues(values, [&](MathLib::bigint x) {
-                return x / intval;
+            transformIntValues(values, [&](MathLib::bigint x) -> MathLib::bigint {
+                if (intval == 0) {
+                    return 0;
+                } else {
+                    return x / intval;
+                }
             });
             return solveExprValues(binaryTok, values);
         }

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -130,6 +130,8 @@ private:
         TEST_CASE(valueFlowPointerAliasDeref);
 
         TEST_CASE(valueFlowCrashIncompleteCode);
+
+        TEST_CASE(valueFlowCrash);
     }
 
     static bool isNotTokValue(const ValueFlow::Value &val) {
@@ -4342,6 +4344,15 @@ private:
                "  };\n"
                "}\n";
         valueOfTok(code, "0");
+    }
+
+    void valueFlowCrash() {
+        const char* code;
+
+        code = "void f(int x) {\n"
+               "    if (0 * (x > 2)) {}\n"
+               "}\n";
+        valueOfTok(code, "x");
     }
 };
 


### PR DESCRIPTION
https://trac.cppcheck.net/ticket/9510