### PR TITLE
Avoid some additional memleakOnRealloc false positives

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -551,7 +551,9 @@ void CheckMemoryLeakInFunction::checkReallocUsage()
 
                 // Check that another copy of the pointer wasn't saved earlier in the function
                 if (Token::findmatch(scope->bodyStart, "%name% = %varid% ;", tok, tok->varId()) ||
-                    Token::findmatch(scope->bodyStart, "[{};] %varid% = %name% [;=]", tok, tok->varId()))
+                    Token::findmatch(scope->bodyStart, "[{};] %varid% = %name% [;=]", tok, tok->varId()) ||
+                    Token::findmatch(scope->bodyStart, "[{};] %varid% = * %name% [;=]", tok, tok->varId()) ||
+                    Token::findmatch(scope->bodyStart, "[{};] %varid% = %name% . %name% [;=]", tok, tok->varId()))
                     continue;
 
                 const Token* tokEndRealloc = reallocTok->linkAt(1);

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -551,9 +551,7 @@ void CheckMemoryLeakInFunction::checkReallocUsage()
 
                 // Check that another copy of the pointer wasn't saved earlier in the function
                 if (Token::findmatch(scope->bodyStart, "%name% = %varid% ;", tok, tok->varId()) ||
-                    Token::findmatch(scope->bodyStart, "[{};] %varid% = %name% [;=]", tok, tok->varId()) ||
-                    Token::findmatch(scope->bodyStart, "[{};] %varid% = * %name% [;=]", tok, tok->varId()) ||
-                    Token::findmatch(scope->bodyStart, "[{};] %varid% = %name% . %name% [;=]", tok, tok->varId()))
+                    Token::findmatch(scope->bodyStart, "[{};] %varid% = *| %name% .| %name%| [;=]", tok, tok->varId()))
                     continue;
 
                 const Token* tokEndRealloc = reallocTok->linkAt(1);

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -172,6 +172,9 @@ private:
         TEST_CASE(realloc18);
         TEST_CASE(realloc19);
         TEST_CASE(realloc20);
+        TEST_CASE(realloc21);
+        TEST_CASE(realloc22);
+        TEST_CASE(realloc23);
         TEST_CASE(reallocarray1);
     }
 
@@ -376,6 +379,39 @@ private:
               "{\n"
               "    void *a = malloc(sizeof(a));\n"
               "    a = realloc((a) + 1, sizeof(a) * 2);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void realloc21() {
+        check("char *foo(char *bs0)\n"
+              "{\n"
+              "    char *bs = bs0;\n"
+              "    bs = realloc(bs, 100);\n"
+              "    if (bs == NULL) return bs0;\n"
+              "    return bs;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void realloc22() {
+        check("void foo(char **bsp)\n"
+              "{\n"
+              "    char *bs = *bsp;\n"
+              "    bs = realloc(bs, 100);\n"
+              "    if (bs == NULL) return;\n"
+              "    *bsp = bs;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void realloc23() {
+        check("void foo(struct ABC *s)\n"
+              "{\n"
+              "    uint32_t *cigar = s->cigar;\n"
+              "    if (!(cigar = realloc(cigar, 100 * sizeof(*cigar))))\n"
+              "        return;\n"
+              "    s->cigar = cigar;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
`checkReallocUsage()` already contains code to suppress the _Common realloc mistake: 'bs' nulled but not freed upon failure [memleakOnRealloc]_ error message when the pointer has been previously copied from another variable (hence there is an additional copy of the original pointer value) within the same function, as so:

```c
char *foo(char *bs0)
{
    char *bs = bs0;
    bs = realloc(bs, 100);
    if (bs == NULL) return bs0;
    return bs;
}
```

We were getting false positives in similar code because the initial assignment was of the form
`bs = *bsptr` or `bs = structptr->my_bs` rather than the RHS being a simple identifier. This patch extends the suppression code to recognise those two patterns (and I guess `bs = mystruct.my_bs`) as also meaning that there is an existing variable containing the exact same original pointer value.