### PR TITLE
Fix processing of for loop iteration expression in FwdAnalysis

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1958,7 +1958,7 @@ bool FwdAnalysis::unusedValue(const Token *expr, const Token *startToken, const 
         return false;
     mWhat = What::UnusedValue;
     Result result = check(expr, startToken, endToken);
-    return (result.type == FwdAnalysis::Result::Type::NONE || result.type == FwdAnalysis::Result::Type::RETURN) && !possiblyAliased(expr, startToken);
+    return (result.type == FwdAnalysis::Result::Type::NONE || result.type == FwdAnalysis::Result::Type::RETURN || result.type == FwdAnalysis::Result::Type::WRITE) && !possiblyAliased(expr, startToken);
 }
 
 std::vector<FwdAnalysis::KnownAndToken> FwdAnalysis::valueFlow(const Token *expr, const Token *startToken, const Token *endToken)

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -268,6 +268,9 @@ private:
     struct Result check(const Token *expr, const Token *startToken, const Token *endToken);
     struct Result checkRecursive(const Token *expr, const Token *startToken, const Token *endToken, const std::set<int> &exprVarIds, bool local, bool inInnerClass, int depth=0);
 
+
+    struct Result checkForLoop(const Token *expr, const Token *forToken, const std::set<int> &exprVarIds, bool local, bool inInnerClass, int depth);
+
     // Is expression a l-value global data?
     bool isGlobalData(const Token *expr) const;
 

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -853,7 +853,7 @@ bool CheckBufferOverrun::analyseWholeProgram1(const CTU::FileInfo *ctu, const st
 
     const char *errorId = nullptr;
     std::string errmsg;
-    CWE cwe(0);
+    CWE cwe;
 
     if (type == 1) {
         errorId = "ctuArrayIndex";

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -133,6 +133,9 @@ private:
     Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
     bool analyseWholeProgram1(const CTU::FileInfo *ctu, const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger);
 
+    void reportArrayOOBOver(const std::list<ErrorLogger::ErrorMessage::FileLocation> &locationList,const CTU::FileInfo::FunctionCall *functionCall,const CTU::FileInfo::UnsafeUsage &unsafeUsage, ErrorLogger &errorLogger);
+    void reportArrayOOBUnder(const std::list<ErrorLogger::ErrorMessage::FileLocation> &locationList, const CTU::FileInfo::UnsafeUsage &unsafeUsage, ErrorLogger &errorLogger);
+    void reportOOBPointer(const std::list<ErrorLogger::ErrorMessage::FileLocation> &locationList,const CTU::FileInfo::FunctionCall *functionCall,const CTU::FileInfo::UnsafeUsage &unsafeUsage, ErrorLogger &errorLogger);
 
     static std::string myName() {
         return "Bounds checking";

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -346,7 +346,8 @@ Variables::VariableUsage *Variables::find(unsigned int varid)
     return nullptr;
 }
 
-static bool replacementNeeded(const Variables::VariableUsage *var1, const Scope *scope){
+static bool replacementNeeded(const Variables::VariableUsage *var1, const Scope *scope)
+{
     // pointerArray => don't replace
     if (var1->mType == Variables::pointerArray)
         return false;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -112,7 +112,7 @@ void ImportProject::FileSettings::setDefines(std::string defs)
 static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std::string, cppcheck::stricmp> &variables)
 {
     std::set<std::string, cppcheck::stricmp> expanded;
-    std::string::size_type start = 0;
+    std::string::size_type start;
     while ((start = s.find("$(")) != std::string::npos) {
         const std::string::size_type end = s.find(')',start);
         if (end == std::string::npos)

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -699,14 +699,13 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
                 else if (argnodename == "valid") {
                     // Validate the validation expression
                     const char *p = argnode->GetText();
-                    bool error = false;
                     bool range = false;
                     bool has_dot = false;
 
                     if (!p)
                         return Error(BAD_ATTRIBUTE_VALUE, "\"\"");
 
-                    error = *p == '.';
+                    bool error = *p == '.';
                     for (; *p; p++) {
                         if (std::isdigit(*p))
                             error |= (*(p+1) == '-');

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -950,7 +950,7 @@ void TemplateSimplifier::getTemplateInstantiations()
                             if (it1 != mTemplateDeclarations.end()) {
                                 // insert using namespace into token stream
                                 std::string::size_type offset = 0;
-                                std::string::size_type pos = 0;
+                                std::string::size_type pos;
                                 while ((pos = nameSpace.substr(offset).find(' ')) != std::string::npos) {
                                     qualificationTok->insertToken(nameSpace.substr(offset, pos), "", true);
                                     offset = offset + pos + 1;
@@ -1470,9 +1470,9 @@ void TemplateSimplifier::addNamespace(const TokenAndName &templateDeclaration, c
     const bool insert = tokStart != tok;
 
     std::string::size_type start = 0;
-    std::string::size_type end = 0;
     bool inTemplate = false;
     int level = 0;
+    std::string::size_type end;
     while ((end = templateDeclaration.scope().find(" ", start)) != std::string::npos) {
         std::string token = templateDeclaration.scope().substr(start, end - start);
         // done if scopes overlap

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5920,7 +5920,7 @@ bool Tokenizer::simplifyConditions()
                     const std::string& op1(tok->next()->str());
                     const std::string& op2(tok->strAt(3));
 
-                    bool eq = false;
+                    bool eq;
                     if (MathLib::isInt(op1) && MathLib::isInt(op2))
                         eq = (MathLib::toLongNumber(op1) == MathLib::toLongNumber(op2));
                     else {

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -115,7 +115,7 @@ void TokenList::addtoken(std::string str, const nonneg int lineno, const nonneg 
     // If token contains # characters, split it up
     if (split) {
         size_t begin = 0;
-        size_t end = 0;
+        size_t end;
         while ((end = str.find("##", begin)) != std::string::npos) {
             addtoken(str.substr(begin, end - begin), lineno, fileno, false);
             addtoken("##", lineno, fileno, false);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1004,7 +1004,7 @@ static Token * valueFlowSetConstantValue(Token *tok, const Settings *settings, b
                 setTokenValue(const_cast<Token *>(tok->next()), value, settings);
             }
         } else if (tok2->tokType() == Token::eChar) {
-            nonneg int sz = 0;
+            nonneg int sz;
             if (cpp && settings->standards.cpp >= Standards::CPP20 && tok2->isUtf8())
                 sz = 1;
             else if (tok2->isUtf16())
@@ -1153,7 +1153,7 @@ static void valueFlowArrayBool(TokenList *tokenlist)
         if (tok->hasKnownIntValue())
             continue;
         const Variable *var = nullptr;
-        bool known = false;
+        bool known;
         std::list<ValueFlow::Value>::const_iterator val =
             std::find_if(tok->values().begin(), tok->values().end(), std::mem_fn(&ValueFlow::Value::isTokValue));
         if (val == tok->values().end()) {

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -431,6 +431,7 @@ void timet_h(struct timespec* ptp1)
 
 void dl(const char* libname, const char* func)
 {
+    // cppcheck-suppress unreadVariable
     void* lib = dlopen(libname, RTLD_NOW);
     // cppcheck-suppress redundantInitialization
     // cppcheck-suppress resourceLeak

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -67,7 +67,9 @@ void nullPointer__get_daylight(int *h)
 void validCode()
 {
     DWORD dwordInit = 0;
+    // cppcheck-suppress unreadVariable
     WORD wordInit = 0;
+    // cppcheck-suppress unreadVariable
     BYTE byteInit = 0;
 
     // Valid Semaphore usage, no leaks, valid arguments
@@ -189,11 +191,13 @@ void validCode()
     }
     WSACleanup();
 
+    // cppcheck-suppress unreadVariable
     wordInit = MAKEWORD(1, 2);
     // cppcheck-suppress redundantAssignment
     dwordInit = MAKELONG(1, 2);
     // cppcheck-suppress redundantAssignment
     wordInit = LOWORD(dwordInit);
+    // cppcheck-suppress unreadVariable
     byteInit = LOBYTE(wordInit);
     wordInit = HIWORD(dwordInit);
     // cppcheck-suppress redundantAssignment

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6680,6 +6680,15 @@ private:
                       "test.cpp:3:note:s is overwritten\n",
                       errout.str());
 
+        check("void g(int a);\n"
+              "void f(int a) {\n"
+              "    int i = a;\n"
+              "    for(int j = 0; j < 10; ++j, i = j) {\n"
+              "        g(i);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
         check("void f() {\n"
               "    int *p = NULL;\n"
               "    p = dostuff();\n"

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -742,7 +742,7 @@ private:
 
         functionVariableUsage("void foo()\n"
                               "{\n"
-                              "    int i = 0,code=10;\n"
+                              "    int i ,code=10;\n"
                               "    for(i = 0; i < 10; i++) {\n"
                               "        std::cout<<code<<std::endl;\n"
                               "        code += 2;\n"
@@ -752,7 +752,7 @@ private:
 
         functionVariableUsage("void foo()\n"
                               "{\n"
-                              "    int i = 0,code=10,d=10;\n"
+                              "    int i,code=10,d=10;\n"
                               "    for(i = 0; i < 10; i++) {\n"
                               "        std::cout<<code<<std::endl;\n"
                               "        code += 2;\n"
@@ -765,7 +765,7 @@ private:
 
         functionVariableUsage("void foo()\n"
                               "{\n"
-                              "    int i = 0,code=10,d=10;\n"
+                              "    int i,code=10,d=10;\n"
                               "    for(i = 0; i < 10; i++) {\n"
                               "        std::cout<<code<<std::endl;\n"
                               "        code += 2;\n"
@@ -777,7 +777,7 @@ private:
 
         functionVariableUsage("void foo()\n"
                               "{\n"
-                              "    int i = 0,code=10,d=10;\n"
+                              "    int i,code=10,d=10;\n"
                               "    for(i = 0; i < 10; i++) {\n"
                               "        std::cout<<code<<std::endl;\n"
                               "        code += 2;\n"
@@ -791,7 +791,7 @@ private:
 
         functionVariableUsage("void foo()\n"
                               "{\n"
-                              "    int i = 0,a=10,b=20;\n"
+                              "    int i,a=10,b=20;\n"
                               "    for(i = 0; i < 10; i++) {\n"
                               "        std::cout<<a<<std::endl;\n"
                               "        int tmp=a;\n"
@@ -1607,7 +1607,8 @@ private:
                               "    data->info = k;\n"
                               "    line_start = ptr;\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:10]: (style) Variable 'line_start' is assigned a value that is never used.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:8]: (style) Variable 'line_start' is assigned a value that is never used.\n"
+                      "[test.cpp:10]: (style) Variable 'line_start' is assigned a value that is never used.\n", errout.str());
     }
 
     void localvar18() { // ticket #1723
@@ -1843,7 +1844,7 @@ private:
                               "    int a = 0;\n"
                               "    bar(a=2);\n"
                               "}");
-        TODO_ASSERT_EQUALS("error", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'a' is assigned a value that is never used.\n", errout.str());
 
         functionVariableUsage("void bar(int);\n"
                               "int foo() {\n"
@@ -2813,7 +2814,8 @@ private:
                               "    srcdata = vdata;\n"
                               "    b(srcdata);\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (style) Unused variable: buf\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:6]: (style) Variable 'srcdata' is assigned a value that is never used.\n"
+                      "[test.cpp:3]: (style) Unused variable: buf\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -2825,7 +2827,7 @@ private:
                               "    srcdata = buf;\n"
                               "    b(srcdata);\n"
                               "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:6]: (style) Variable 'srcdata' is assigned a value that is never used.\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -2881,7 +2883,8 @@ private:
                               "    srcdata = vdata;\n"
                               "    b(srcdata);\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (style) Unused variable: buf\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:7]: (style) Variable 'srcdata' is assigned a value that is never used.\n"
+                      "[test.cpp:3]: (style) Unused variable: buf\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -2894,7 +2897,8 @@ private:
                               "    srcdata = buf;\n"
                               "    b(srcdata);\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:5]: (style) Unused variable: vdata\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:7]: (style) Variable 'srcdata' is assigned a value that is never used.\n"
+                      "[test.cpp:5]: (style) Unused variable: vdata\n", errout.str());
     }
 
     void localvaralias7() { // ticket 1732
@@ -2947,7 +2951,7 @@ private:
                               "    }\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:15]: (style) Variable 'pb' is assigned a value that is never used.\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -2970,7 +2974,9 @@ private:
                               "    }\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:15]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:16]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:17]: (style) Variable 'pb' is assigned a value that is never used.\n", errout.str());
 
 
         functionVariableUsage("void foo()\n"
@@ -2989,7 +2995,10 @@ private:
                               "    pb = b4;\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (style) Unused variable: b1\n"
+        ASSERT_EQUALS("[test.cpp:9]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:11]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:13]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:3]: (style) Unused variable: b1\n"
                       "[test.cpp:4]: (style) Unused variable: b2\n"
                       "[test.cpp:5]: (style) Unused variable: b3\n", errout.str());
 
@@ -3039,7 +3048,7 @@ private:
                               "    }\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:17]: (style) Variable 'pb' is assigned a value that is never used.\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -3066,7 +3075,9 @@ private:
                               "    }\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:17]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:18]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:19]: (style) Variable 'pb' is assigned a value that is never used.\n", errout.str());
 
         functionVariableUsage("void foo()\n"
                               "{\n"
@@ -3088,7 +3099,10 @@ private:
                               "    pb = b4;\n"
                               "    b(pb);\n"
                               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (style) Unused variable: b1\n"
+        ASSERT_EQUALS("[test.cpp:9]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:12]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:15]: (style) Variable 'pb' is assigned a value that is never used.\n"
+                      "[test.cpp:3]: (style) Unused variable: b1\n"
                       "[test.cpp:4]: (style) Unused variable: b2\n"
                       "[test.cpp:5]: (style) Unused variable: b3\n", errout.str());
     }


### PR DESCRIPTION
The for loop iteration expression was processed following the flow of
token as well as during the looping.
It should not be processed with the flow of token, but only during the
looping.

This commit adds the facility to parse `for (InitStatement; Condition; IterationExpression)`
and skip the iteration expression.

This fixes false positives, for instance, in the added test, we used to
have the following warning:
```
test.cpp:4:style:Redundant initialization for 'i'. The initialized value is overwritten before it is read.\n
test.cpp:3:note:i is initialized\n
test.cpp:4:note:i is overwritten\n
```