### PR TITLE
Catch preprocessor errors possibly issued during loading files

### DIFF
--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -2426,8 +2426,16 @@ std::map<std::string, simplecpp::TokenList*> simplecpp::load(const simplecpp::To
             continue;
 
         std::ifstream fin(filename.c_str());
-        if (!fin.is_open())
+        if (!fin.is_open()) {
+            if (outputList) {
+                simplecpp::Output err(fileNumbers);
+                err.type = simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND;
+                err.location = Location(fileNumbers);
+                err.msg = "Can not open include file '" + filename + "' that is explicitly included.";
+                outputList->push_back(err);
+            }
             continue;
+        }
 
         TokenList *tokenlist = new TokenList(fin, fileNumbers, filename, outputList);
         if (!tokenlist->front()) {

--- a/externals/simplecpp/simplecpp.h
+++ b/externals/simplecpp/simplecpp.h
@@ -167,7 +167,8 @@ namespace simplecpp {
             INCLUDE_NESTED_TOO_DEEPLY,
             SYNTAX_ERROR,
             PORTABILITY_BACKSLASH,
-            UNHANDLED_CHAR_ERROR
+            UNHANDLED_CHAR_ERROR,
+            EXPLICIT_INCLUDE_NOT_FOUND
         } type;
         Location location;
         std::string msg;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -299,7 +299,11 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             }
         }
 
-        preprocessor.loadFiles(tokens1, files);
+        try {
+            preprocessor.loadFiles(tokens1, files, true);
+        } catch (const simplecpp::Output & o) {
+            return mExitCode;
+        }
 
         if (!mSettings.plistOutput.empty()) {
             std::string filename2;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -275,6 +275,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
             case simplecpp::Output::SYNTAX_ERROR:
             case simplecpp::Output::UNHANDLED_CHAR_ERROR:
+            case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
                 err = true;
                 break;
             case simplecpp::Output::WARNING:
@@ -299,11 +300,8 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             }
         }
 
-        try {
-            preprocessor.loadFiles(tokens1, files, true);
-        } catch (const simplecpp::Output & o) {
+        if (!preprocessor.loadFiles(tokens1, files))
             return mExitCode;
-        }
 
         if (!mSettings.plistOutput.empty()) {
             std::string filename2;

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -559,6 +559,7 @@ static bool hasErrors(const simplecpp::OutputList &outputList)
         case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
         case simplecpp::Output::SYNTAX_ERROR:
         case simplecpp::Output::UNHANDLED_CHAR_ERROR:
+        case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
             return true;
         case simplecpp::Output::WARNING:
         case simplecpp::Output::MISSING_HEADER:
@@ -580,6 +581,7 @@ void Preprocessor::handleErrors(const simplecpp::OutputList& outputList, bool th
             case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
             case simplecpp::Output::SYNTAX_ERROR:
             case simplecpp::Output::UNHANDLED_CHAR_ERROR:
+            case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
                 throw output;
             case simplecpp::Output::WARNING:
             case simplecpp::Output::MISSING_HEADER:
@@ -590,13 +592,14 @@ void Preprocessor::handleErrors(const simplecpp::OutputList& outputList, bool th
     }
 }
 
-void Preprocessor::loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files, bool throwError)
+bool Preprocessor::loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files)
 {
     const simplecpp::DUI dui = createDUI(mSettings, emptyString, files[0]);
 
     simplecpp::OutputList outputList;
     mTokenLists = simplecpp::load(rawtokens, files, dui, &outputList);
-    handleErrors(outputList, throwError);
+    handleErrors(outputList, false);
+    return !hasErrors(outputList);
 }
 
 void Preprocessor::removeComments()
@@ -721,6 +724,7 @@ void Preprocessor::reportOutput(const simplecpp::OutputList &outputList, bool sh
         case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
         case simplecpp::Output::SYNTAX_ERROR:
         case simplecpp::Output::UNHANDLED_CHAR_ERROR:
+        case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
             error(out.location.file(), out.location.line, out.msg);
             break;
         };

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -724,8 +724,10 @@ void Preprocessor::reportOutput(const simplecpp::OutputList &outputList, bool sh
         case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
         case simplecpp::Output::SYNTAX_ERROR:
         case simplecpp::Output::UNHANDLED_CHAR_ERROR:
-        case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
             error(out.location.file(), out.location.line, out.msg);
+            break;
+        case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
+            error(emptyString, 0, out.msg);
             break;
         };
     }

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -98,7 +98,9 @@ public:
 
     std::set<std::string> getConfigs(const simplecpp::TokenList &tokens) const;
 
-    void loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files);
+    void handleErrors(const simplecpp::OutputList &outputList, bool throwError);
+
+    void loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files, bool throwError = false);
 
     void removeComments();
 

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -100,7 +100,7 @@ public:
 
     void handleErrors(const simplecpp::OutputList &outputList, bool throwError);
 
-    void loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files, bool throwError = false);
+    bool loadFiles(const simplecpp::TokenList &rawtokens, std::vector<std::string> &files);
 
     void removeComments();
 


### PR DESCRIPTION
Currently, only errors that are issued during preprocessing are caught.
Related simplecpp issue: danmar/simplecpp#183 simplecpp PR: danmar/simplecpp#184