### PR TITLE
errorlogger.cpp: Handle empty file-name like "*" (unmatchedSuppression)

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -564,7 +564,7 @@ bool ErrorLogger::reportUnmatchedSuppressions(const std::list<Suppressions::Supp
         bool suppressed = false;
         for (const Suppressions::Suppression &s2 : unmatched) {
             if (s2.errorId == "unmatchedSuppression") {
-                if ((s2.fileName == "*" || s2.fileName == s.fileName) &&
+                if ((s2.fileName.empty() || s2.fileName == "*" || s2.fileName == s.fileName) &&
                     (s2.lineNumber == Suppressions::Suppression::NO_LINE || s2.lineNumber == s.lineNumber)) {
                     suppressed = true;
                     break;

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -325,6 +325,14 @@ private:
         reportUnmatchedSuppressions(suppressions);
         ASSERT_EQUALS("", errout.str());
 
+        // suppress all unmatchedSuppression (corresponds to "--suppress=unmatchedSuppression")
+        errout.str("");
+        suppressions.clear();
+        suppressions.emplace_back("abc", "a.c", 10U);
+        suppressions.emplace_back("unmatchedSuppression", "", Suppressions::Suppression::NO_LINE);
+        reportUnmatchedSuppressions(suppressions);
+        ASSERT_EQUALS("", errout.str());
+
         // suppress all unmatchedSuppression in a.c
         errout.str("");
         suppressions.clear();


### PR DESCRIPTION
Using "--suppress=unmatchedSuppression" did not suppress the error-id in
all files, one needed to specify `"*"` as file-name. This commit also
allows empty file-names to suppress "unmatchedSuppression", not only "*"
or the exact file-name.
The manual uses the following example for suppressions specified in a
file:
```
// suppress all uninitvar errors in all files
uninitvar
```

This example suggests that no "*" has to be used to get suppression in
all files. I think that the command line parameter should work in the
same way.