### PR TITLE
[windows] cannot run test-misra (binary not found)

### DIFF
--- a/addons/test/util.py
+++ b/addons/test/util.py
@@ -1,9 +1,25 @@
 # Helpers for pytest tests
 import subprocess
 import json
+import os
+
+
+def find_cppcheck_binary():
+    possible_locations = [
+        "./cppcheck",
+        r".\bin\cppcheck.exe",
+    ]
+    for location in possible_locations:
+        if os.path.exists(location):
+            break
+    else:
+        raise RuntimeError("Could not fine cppcheck binary")
+
+    return location
 
 def dump_create(fpath, *argv):
-    cmd = ["./cppcheck", "--dump", "--quiet", fpath] + list(argv)
+    cppcheck_binary = find_cppcheck_binary()
+    cmd = [cppcheck_binary, "--dump", "--quiet", fpath] + list(argv)
     p = subprocess.Popen(cmd)
     p.communicate()
     if p.returncode != 0:


### PR DESCRIPTION
Hi,

for reasons that are out of my control I need to run tests in a windows environment.

    set PYTHONPATH=addons
    python -m pytest addons/test/test-misra.py

This fails because `cppcheck` can't be found, when I compile cppcheck with visual studio. the release binary via `MSBuild cppcheck.sln /p:Configuration=Release /p:Platform=x64 /p:PlatformToolset=v142` it's found under `bin`.

Would this change be ok?