### PR TITLE
[visual studio] problem: missing MSVCRversionnumber.DLL on target machine

### DIFF
--- a/cli/cli.vcxproj
+++ b/cli/cli.vcxproj
@@ -336,7 +336,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>CPPCHECKLIB_IMPORT;NDEBUG;WIN32;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level4</WarningLevel>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>

--- a/lib/cppcheck.vcxproj
+++ b/lib/cppcheck.vcxproj
@@ -487,7 +487,7 @@ xcopy "$(SolutionDir)platforms" "$(OutDir)platforms" /E /I /D /Y</Command>
       <AdditionalIncludeDirectories>..\externals;..\externals\simplecpp;..\externals\tinyxml;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4018;4244;4251;4389;4482;4512;4701</DisableSpecificWarnings>
       <PreprocessorDefinitions>CPPCHECKLIB_EXPORT;TINYXML2_EXPORT;SIMPLECPP_EXPORT;NDEBUG;WIN32;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>
       </DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/test/testrunner.vcxproj
+++ b/test/testrunner.vcxproj
@@ -274,7 +274,7 @@
       <BufferSecurityCheck>false</BufferSecurityCheck>
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>CPPCHECKLIB_IMPORT;SIMPLECPP_IMPORT;NDEBUG;WIN32;_CRT_SECURE_NO_WARNINGS;WIN32_LEAN_AND_MEAN;_WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level4</WarningLevel>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>


### PR DESCRIPTION
Problem: opening the `sln` compliling and running `cppcheck.exe` works fine but when moving this exe to other machines you depend on that dll being available on that machine.
 
If I understand the docs correctly, this could be solved comiling with /MT or installing the needed dll on the target machine.

From the docs:

https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=vs-2019

> /MD Causes the application to use the multithread-specific and
>     DLL-specific version of the run-time library. Defines _MT and _DLL
>     and causes the compiler to place the library name MSVCRT.lib into
>     the .obj file. 
>     Applications compiled with this option are statically linked to
>     MSVCRT.lib. This library provides a layer of code that enables the
>     linker to resolve external references. The actual working code is
>     contained in MSVCRversionnumber.DLL, which must be available at run
>     time to applications linked with MSVCRT.lib.
> 
> /MT Causes the application to use the multithread, static version of the
>     run-time library. Defines _MT and causes the compiler to place the
>     library name LIBCMT.lib into the .obj file so that the linker will
>     use LIBCMT.lib to resolve external symbols.

Would you be ok with changing the defaults for `RuntimeLibrary`, or are there any drawbacks I am not aware (binary size,...)?.

PS.: I could have asked this in the forum but I thought it would be easier to discuss on the changes and running the tests on them.