### PR TITLE
test-my-pr: Allow work_path to be relative

### DIFF
--- a/tools/test-my-pr.py
+++ b/tools/test-my-pr.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
 
     print(args)
 
-    work_path = args.work_path
+    work_path = os.path.abspath(args.work_path)
     if not os.path.exists(work_path):
         os.makedirs(work_path)
     master_dir = os.path.join(work_path, 'cppcheck')


### PR DESCRIPTION
Previously, calling test-my-pr with a relative work-path resulted in a
crash when trying to create the result file (due to the change of
current working directory).
