### PR TITLE
donate_cpu_lib: Fix python 3 crash if fail to get package

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -129,7 +129,7 @@ def get_packages_count(server_address):
 
 def get_package(server_address, package_index = None):
     print('Connecting to server to get assigned work..')
-    package = None
+    package = b''
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect(server_address)
@@ -140,7 +140,7 @@ def get_package(server_address, package_index = None):
             sock.send(request.encode())
         package = sock.recv(256)
     except socket.error:
-        package = b''
+        pass
     sock.close()
     return package.decode('utf-8')
 

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -140,7 +140,7 @@ def get_package(server_address, package_index = None):
             sock.send(request.encode())
         package = sock.recv(256)
     except socket.error:
-        package = ''
+        package = b''
     sock.close()
     return package.decode('utf-8')
 


### PR DESCRIPTION
Decoding a string is not allowed in python 3 (in python 2 it works).
If fetching the package fails, assign an empty byte string instead to
avoid crashing.

When this happes, previously there was a crash of the running script.
Now it will cause `donate_cpu` do wait 30 seconds before retrying, while
`test-my-pr` will exit cleanly. I saw this when trying to run `test-my-pr`
(more than once), probably due to shaky connection, perhaps `test-my-pr`
should also wait and retry at least a couple of times before exiting?