### PR TITLE
Remove .dump file after plugins execution

### DIFF
--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -20,6 +20,7 @@
 #include <QString>
 #include <QDebug>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -338,6 +339,10 @@ void CheckThread::runAddonsAndTools(const ImportProject::FileSettings *fileSetti
             }
             parseAddonErrors(output, addon);
         }
+    }
+
+    if (!dumpFile.isEmpty()) {
+        QFile::remove(dumpFile);
     }
 }
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -46,6 +46,7 @@
 #include <vector>
 #include <memory>
 #include <iostream> // <- TEMPORARY
+#include <cstdio>
 
 #ifdef HAVE_RULES
 #define PCRE_STATIC
@@ -283,7 +284,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             case simplecpp::Output::PORTABILITY_BACKSLASH:
                 err = false;
                 break;
-            };
+            }
 
             if (err) {
                 const ErrorLogger::ErrorMessage::FileLocation loc1(output.location.file(), output.location.line, output.location.col);
@@ -659,6 +660,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                     reportErr(errmsg);
                 }
             }
+            std::remove(dumpFile.c_str());
         }
 
     } catch (const std::runtime_error &e) {


### PR DESCRIPTION
Hello

We discussed in pr #2153 issue with extra huge .dump files. You proposed to remove it when they have been used. This humble change should add such functionality.