### PR TITLE
Update cmake_minimum_required VERSION

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 if (BUILD_TESTS)
 
+    cmake_minimum_required(VERSION 3.4) # cmake_policy(SET CMP0064 NEW)
     cmake_policy(SET CMP0064 NEW)
     cmake_policy(SET CMP0057 NEW)
 


### PR DESCRIPTION
When tests are built, the minimum required cmake version is 3.4.
The file test/CMakeLists.txt uses `cmake_policy(SET CMP0064 NEW)`,
which requires cmake 3.4 [1].

[1] https://cmake.org/cmake/help/v3.4/policy/CMP0064.html
