### PR TITLE
Fixed #7159 (wrong handling of function parameters)

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3428,8 +3428,12 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
 
     // count default arguments
     for (const Token* tok = argDef->next(); tok && tok != argDef->link(); tok = tok->next()) {
-        if (tok->str() == "=")
+        if (tok->str() == "=") {
             initArgCount++;
+            if (tok->strAt(1) == "[") {
+                tok = findLambdaEndToken(tok->next());
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Please do not merge it yet - the testcase is overcomplicated and can be simplified to expose the same behavior.

The repro in https://trac.cppcheck.net/ticket/7159 exposes the following situation:
1. argCount() yields 1 and initializedArgCount() yields 2 which makes no sense
2. and therefore minArgCount() does unsigned subtraction "1-2" which overflows (defined behavior)
3. result of step 3 is then implicitly converted into signed int which is implementation defined and yields "-1" for many popular implementations
4. "-1" is returned by a function which has "nonneg" annotation
5. minArgCount() yields a value which is negative which makes no sense

So it looks like it should better be addressed. I'm not sure this fix doesn't break anything else.
