### PR TITLE
 bug fix - de-escape double backslashes in file paths of #line directives 

### DIFF
--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -137,6 +137,12 @@ static bool isAlternativeUnaryOp(const simplecpp::Token *tok, const std::string 
             (tok->next && (tok->next->name || tok->next->number)));
 }
 
+static std::string replaceAll(std::string s, const std::string& from, const std::string& to)
+{
+  for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
+    s.replace(pos, from.size(), to);
+  return s;
+}
 
 const std::string simplecpp::Location::emptyFileName;
 
@@ -498,7 +504,7 @@ void simplecpp::TokenList::readfile(std::istream &istr, const std::string &filen
                 } else if (lastline == "# line %num%") {
                     lineDirective(location.fileIndex, std::atol(cback()->str().c_str()), &location);
                 } else if (lastline == "# %num% %str%" || lastline == "# line %num% %str%") {
-                    lineDirective(fileIndex(cback()->str().substr(1U, cback()->str().size() - 2U)),
+                    lineDirective(fileIndex(replaceAll(cback()->str().substr(1U, cback()->str().size() - 2U),"\\\\","\\")),
                                   std::atol(cback()->previous->str().c_str()), &location);
                 }
                 // #endfile

--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -139,9 +139,9 @@ static bool isAlternativeUnaryOp(const simplecpp::Token *tok, const std::string 
 
 static std::string replaceAll(std::string s, const std::string& from, const std::string& to)
 {
-  for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
-    s.replace(pos, from.size(), to);
-  return s;
+    for (size_t pos = s.find(from); pos != std::string::npos; pos = s.find(from, pos + to.size()))
+        s.replace(pos, from.size(), to);
+    return s;
 }
 
 const std::string simplecpp::Location::emptyFileName;


### PR DESCRIPTION
From merged PR danmar/simplecpp#187.