### PR TITLE
Fix #8758 (add syntax error for invalid code)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9439,7 +9439,7 @@ void Tokenizer::findGarbageCode() const
             if (match1 && match2)
                 syntaxError(tok);
         }
-        if (Token::Match(tok, "%comp%|+|-|/|% )|]|}")) {
+        if (Token::Match(tok, "%or%|%oror%|~|^|!|%comp%|+|-|/|% )|]|}")) {
             if (isC())
                 syntaxError(tok, tok->str() + tok->next()->str());
             if (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator"))

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -244,6 +244,7 @@ private:
         TEST_CASE(garbageCode210); // #8762
         TEST_CASE(garbageCode211); // #8764
         TEST_CASE(garbageCode212); // #8765
+        TEST_CASE(garbageCode213); // #8758
 
         TEST_CASE(garbageCodeFuzzerClientMode1); // test cases created with the fuzzer client, mode 1
 
@@ -1659,6 +1660,10 @@ private:
 
     void garbageCode212() { // #8765
         ASSERT_THROW(checkCode("{(){}[]typedef r n00e0[](((n00e0 0((;()))))){(0 typedef n00e0 bre00 n00e0())}[]();typedef n n00e0()[],(bre00)}"), InternalError);
+    }
+
+    void garbageCode213() { // #8758
+        ASSERT_THROW(checkCode("{\"\"[(1||)];}"), InternalError);
     }
 
     void syntaxErrorFirstToken() {


### PR DESCRIPTION
I have run this test-my-pr.py with 978 packages (before getting too bored) and
the only difference is in the package `binkd-1.1a-99`. Both current master and
this change reports a syntax error, but with this change, cppcheck reports that
`!)` is wrong syntax (previously, only the line was reported).