### PR TITLE
New check: catch block is not empty

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -302,3 +302,21 @@ void CheckExceptionSafety::unhandledExceptionSpecification()
     }
 }
 
+//---------------------------------------------------------------------------
+//    try {} catch (anything) {/*nothing*/} <- Exception should be handled
+//---------------------------------------------------------------------------
+void CheckExceptionSafety::emptyCatchBlock()
+{
+    if (!mSettings->isEnabled(Settings::STYLE))
+        return;
+
+    const SymbolDatabase* const symbolDatabase = mTokenizer->getSymbolDatabase();
+
+    for (const Scope &scope : symbolDatabase->scopeList) {
+        if (scope.type != Scope::eCatch)
+            continue;
+
+        if (scope.bodyStart->next() == scope.bodyEnd)
+            emptyCatchBlockError(scope.bodyStart);
+    }
+}

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -36,6 +36,7 @@ class Settings;
 // CWE ID used:
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 static const struct CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
+static const struct CWE CWE1069(1069U); // Empty Exception Block
 
 
 /// @addtogroup Checks
@@ -72,6 +73,7 @@ public:
         checkExceptionSafety.checkCatchExceptionByValue();
         checkExceptionSafety.nothrowThrows();
         checkExceptionSafety.unhandledExceptionSpecification();
+        checkExceptionSafety.emptyCatchBlock();
     }
 
     /** Don't throw exceptions in destructors */
@@ -91,6 +93,8 @@ public:
 
     /** @brief %Check for unhandled exception specification */
     void unhandledExceptionSpecification();
+
+    void emptyCatchBlock();
 
 private:
     /** Don't throw exceptions in destructors */
@@ -135,6 +139,13 @@ private:
                     "Either use a try/catch around the function call, or add a exception specification for " + funcname + "() also.", CWE703, true);
     }
 
+    void emptyCatchBlockError(const Token * const tok) {
+        reportError(tok, Severity::style,
+                    "emptyCatchBlock", "Empty catch block swallow an error condition and then continuing execution.\n"
+                    "It could prevent the software from running reliably and might introduce a vulnerability."
+                    "Also using exceptions as control flow considered as antipattern.", CWE1069, false);
+    }
+
     /** Generate all possible errors (for --errorlist) */
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckExceptionSafety c(nullptr, settings, errorLogger);
@@ -144,6 +155,7 @@ private:
         c.catchExceptionByValueError(nullptr);
         c.noexceptThrowError(nullptr);
         c.unhandledExceptionSpecificationError(nullptr, nullptr, "funcname");
+        c.emptyCatchBlockError(nullptr);
     }
 
     /** Short description of class (for --doc) */
@@ -159,7 +171,8 @@ private:
                "- Throwing a copy of a caught exception instead of rethrowing the original exception\n"
                "- Exception caught by value instead of by reference\n"
                "- Throwing exception in noexcept, nothrow(), __attribute__((nothrow)) or __declspec(nothrow) function\n"
-               "- Unhandled exception specification when calling function foo()\n";
+               "- Unhandled exception specification when calling function foo()\n"
+               "- Empty catch block swallow an error condition\n";
     }
 };
 /// @}

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -100,7 +100,7 @@ private:
                // style
                "- unused variable\n"
                "- allocated but unused variable\n"
-               "- unred variable\n"
+               "- unread variable\n"
                "- unassigned variable\n"
                "- unused struct member\n";
     }

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -51,6 +51,7 @@ private:
         TEST_CASE(nothrowAttributeThrow);
         TEST_CASE(nothrowAttributeThrow2); // #5703
         TEST_CASE(nothrowDeclspecThrow);
+        TEST_CASE(emptyCatchBlock);
     }
 
     void check(const char code[], bool inconclusive = false) {
@@ -91,6 +92,7 @@ private:
               "        try {\n"
               "            throw e;\n"
               "        } catch (...) {\n"
+              "            f();"
               "        }\n"
               "    }\n"
               "}");
@@ -360,7 +362,7 @@ private:
               "void myCatchingFoo() {\n"
               "  try {\n"
               "    myThrowingFoo();\n"
-              "  } catch(MyException &) {}\n"
+              "  } catch(MyException &) {f();}\n"
               "}\n", true);
         ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:1]: (style, inconclusive) Unhandled exception specification when calling function myThrowingFoo().\n", errout.str());
     }
@@ -405,6 +407,18 @@ private:
         // avoid false positives
         check("const char *func() __attribute((nothrow)); void func1() { return 0; }\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void emptyCatchBlock() {
+        check("void f() {\n"
+              "    try {\n"
+              "        bar();\n"
+              "    } catch(MyException &) {\n"
+              "    } catch (...) {\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (style) Empty catch block swallow an error condition and then continuing execution.\n"
+                      "[test.cpp:5]: (style) Empty catch block swallow an error condition and then continuing execution.\n", errout.str());
     }
 };
 

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -104,10 +104,10 @@ extern std::ostringstream output;
 #define ASSERT_EQUALS_WITHOUT_LINENUMBERS( EXPECTED , ACTUAL )  assertEqualsWithoutLineNumbers(__FILE__, __LINE__, EXPECTED, ACTUAL)
 #define ASSERT_EQUALS_DOUBLE( EXPECTED , ACTUAL, TOLERANCE )  assertEqualsDouble(__FILE__, __LINE__, EXPECTED, ACTUAL, TOLERANCE)
 #define ASSERT_EQUALS_MSG( EXPECTED , ACTUAL, MSG )  assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL, MSG)
-#define ASSERT_THROW( CMD, EXCEPTION ) try { CMD ; assertThrowFail(__FILE__, __LINE__); } catch (const EXCEPTION&) { } catch (...) { assertThrowFail(__FILE__, __LINE__); }
+#define ASSERT_THROW( CMD, EXCEPTION ) try { CMD ; assertThrowFail(__FILE__, __LINE__); } catch (const EXCEPTION&) { ; } catch (...) { assertThrowFail(__FILE__, __LINE__); }
 #define ASSERT_THROW_EQUALS( CMD, EXCEPTION, EXPECTED ) try { CMD ; assertThrowFail(__FILE__, __LINE__); } catch (const EXCEPTION&e) { assertEquals(__FILE__, __LINE__, EXPECTED, e.errorMessage); } catch (...) { assertThrowFail(__FILE__, __LINE__); }
 #define ASSERT_NO_THROW( CMD ) try { CMD ; } catch (...) { assertNoThrowFail(__FILE__, __LINE__); }
-#define TODO_ASSERT_THROW( CMD, EXCEPTION ) try { CMD ; } catch (const EXCEPTION&) { } catch (...) { assertThrow(__FILE__, __LINE__); }
+#define TODO_ASSERT_THROW( CMD, EXCEPTION ) try { CMD ; } catch (const EXCEPTION&) { ; } catch (...) { assertThrow(__FILE__, __LINE__); }
 #define TODO_ASSERT( CONDITION ) { const bool condition=(CONDITION); todoAssertEquals(__FILE__, __LINE__, true, false, condition); }
 #define TODO_ASSERT_EQUALS( WANTED , CURRENT , ACTUAL ) todoAssertEquals(__FILE__, __LINE__, WANTED, CURRENT, ACTUAL)
 #define EXPECT_EQ( EXPECTED, ACTUAL ) assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL)


### PR DESCRIPTION
Using empty catch block mostly is not a good practice according to [CWE-1069](https://cwe.mitre.org/data/definitions/1069.html). Also using exception for a control flow purposes: e.g. break several nested loops or return value from function also is not good approach(the second one is hard to check automatically).

This problem is more common for java/c# and at least 1 proprietary static analyzer has such check for it
SO [discussions](https://stackoverflow.com/q/1234343/2230159)

Also typo fix in lib/checkunusedvar.h