### PR TITLE
Fix false positives in knownConditionTrueFalse when using expressions with const variables

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -205,7 +205,7 @@ bool isLikelyStreamRead(bool cpp, const Token *op);
 
 bool isCPPCast(const Token* tok);
 
-bool isConstVarExpression(const Token *tok);
+bool isConstVarExpression(const Token *tok, const char * skipMatch = nullptr);
 
 const Variable *getLHSVariable(const Token *tok);
 

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1378,6 +1378,8 @@ void CheckCondition::alwaysTrueFalse()
                 continue;
             if (Token::Match(tok, "%comp%") && isSameExpression(mTokenizer->isCPP(), true, tok->astOperand1(), tok->astOperand2(), mSettings->library, true, true))
                 continue;
+            if (isConstVarExpression(tok, "[|(|&|+|-|*|/|%|^|>>|<<"))
+                continue;
 
             const bool constIfWhileExpression =
                 tok->astParent() && Token::Match(tok->astTop()->astOperand1(), "if|while") && !tok->astTop()->astOperand1()->isConstexpr() &&

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3000,6 +3000,9 @@ static bool isVariableExpression(const Token* tok)
     if (Token::simpleMatch(tok, "."))
         return isVariableExpression(tok->astOperand1()) &&
                isVariableExpression(tok->astOperand2());
+    if (Token::simpleMatch(tok, "["))
+        return isVariableExpression(tok->astOperand1()) &&
+               tok->astOperand2() && tok->astOperand2()->hasKnownIntValue();
     return false;
 }
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3329,6 +3329,24 @@ private:
               "        return;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("int f(int a, int b) {\n"
+              "    static const int x = 10;\n"
+              "    return x == 1 ? a : b;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("const bool x = false;\n"
+              "void f() {\n"
+              "    if (x) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("const bool x = false;\n"
+              "void f() {\n"
+              "    if (!x) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void alwaysTrueInfer() {


### PR DESCRIPTION
This fixes the FPs in this case:

```cpp
int f(int a, int b) {
    static const int x = 10;
    return x == 1 ? a : b;
}
```

And in this case:

```cpp
const bool x = false;
void f() {
    if (x) {}
}
```