### PR TITLE
Fix 9546: properly check that the bound is the size

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -869,7 +869,11 @@ void CheckStl::stlOutOfBounds()
         for (const Token *cond : conds) {
             const Token *vartok;
             const Token *containerToken;
-            if (Token::Match(cond, "<= %var% . %name% ( )") && Token::Match(cond->astOperand1(), "%var%")) {
+            // check in the ast that cond is of the form "%var% <= %var% . %name% ( )"
+            if (cond->str() == "<=" && Token::Match(cond->astOperand1(), "%var%") &&
+                cond->astOperand2()->str() == "(" && cond->astOperand2()->astOperand1()->str() == "." &&
+                Token::Match(cond->astOperand2()->astOperand1()->astOperand1(), "%var%") &&
+                Token::Match(cond->astOperand2()->astOperand1()->astOperand2(), "%name%")) {
                 vartok = cond->astOperand1();
                 containerToken = cond->next();
             } else {

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -1425,6 +1425,13 @@ private:
               "    for (B b : D()) {}\n" // Don't crash on range-based for-loop
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("void foo(std::vector<int> foo) {\n"
+              "    for (unsigned int ii = 0; ii <= foo.size() + 1; ++ii) {\n"
+              "       foo.at(ii) = 0;\n"
+              "    }\n"
+              "}");
+        TODO_ASSERT_EQUALS("[test.cpp:3]: (error) When ii==foo.size(), foo.at(ii) is out of bounds.\n", "", errout.str());
     }
 
     void STLSizeNoErr() {
@@ -1474,6 +1481,15 @@ private:
                   "    int i = x;"
                   "    for (int i = 5; i <= data.size(); i++)\n"
                   "        data[i] = 0;\n"
+                  "}");
+            ASSERT_EQUALS("", errout.str());
+        }
+
+        {
+            check("void foo(std::vector<int> foo) {\n"
+                  "    for (unsigned int ii = 0; ii <= foo.size() - 1; ++ii) {\n"
+                  "       foo.at(ii) = 0;\n"
+                  "    }\n"
                   "}");
             ASSERT_EQUALS("", errout.str());
         }


### PR DESCRIPTION
Previously, as the check was done on the token and not on the ast,
`i <= v.size()` and `i <= v.size() - 2` would both raise the same
warning.

This patch fixes this, but this mean the check is only done when the
condition if `i <= v.size()`. Any other (more complex) condition is
ignore, and so we have false negative for instance with
 `i <= v.size() + 1`.