### PR TITLE
Fix #9574: htmlreport: Defect ID column not scrollable anymore

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -91,7 +91,7 @@ div.verbose div.content {
     text-align: left;
     width: 150px;
     /*height: 75%;*/
-    position: fixed;
+    /*position: fixed;*/
     overflow: auto;
     z-index: 1;
 }
@@ -103,7 +103,7 @@ div.verbose div.content {
     text-align: left;
     width: 300px;
     /*height: 75%;*/
-    position: fixed;
+    /*position: fixed;*/
     overflow: auto;
     z-index: 1;
 }
@@ -133,7 +133,7 @@ div.verbose div.content {
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
     box-sizing: content-box;
-    float: left;
+    /*float: left;*/
     margin: 5px;
     margin-left: 10px;
     padding: 0 10px 10px 10px;
@@ -146,7 +146,7 @@ div.verbose div.content {
     -webkit-box-sizing: content-box;
     -moz-box-sizing: content-box;
     box-sizing: content-box;
-    float: left;
+    /*float: left;*/
     margin: 5px;
     margin-left: 10px;
     padding: 0 10px 10px 10px;


### PR DESCRIPTION
This removes the fixed position setting for the menu on the left. Thus
it scrolls up and down like the rest of the page. The disadvantage is
that the menu is not available everywhere on the page, but IMHO it is
more important to have a working page where nothing overlaps or is
unreachable.
Ticket: https://trac.cppcheck.net/ticket/9574