### PR TITLE
Fix #9501: htmlreport: Line number position is shifted

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -43,7 +43,6 @@ h1 {
 
 .error2 {
     background-color: #faa;
-    border: 1px dotted black;
     display: inline-block;
     margin-left: 4px;
 }


### PR DESCRIPTION
The 1 pixel dotted border that is drawn around every Cppcheck error
message adds 2 extra pixels for every line with an error message.
For more than very few error messages in a file, the discrepancy is
clearly visible and line numbering gets wrong.
This commit removes the dotted border as it is not necessary.
The error message is highlighted with a red background and is still
clearly visible.
Ticket: https://trac.cppcheck.net/ticket/9501