### PR TITLE
Fix potential typo: use token.next.linenr instead of token.linenr

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -23,6 +23,7 @@ import os
 import argparse
 import codecs
 import string
+from collections import defaultdict
 
 try:
     from itertools import izip as zip
@@ -1381,7 +1382,7 @@ class MisraChecker:
         # initialization lists and function calls, e.g.:
         # struct S a = {1, 2, 3}, b, c = foo(1, 2), d;
         #                       ^                 ^
-        end_tokens_map = {}
+        end_tokens_map = defaultdict(set)
 
         skip_to = None
         for token in data.tokenlist:
@@ -1399,10 +1400,8 @@ class MisraChecker:
             # Save end tokens from function calls in initialization
             if simpleMatch(token, ') ;'):
                 if (token.isExpandedMacro):
-                    end_tokens_map.setdefault(token.next.linenr, set())
-                    end_tokens_map[token.linenr].add(token.next.column)
+                    end_tokens_map[token.next.linenr].add(token.next.column)
                 else:
-                    end_tokens_map.setdefault(token.linenr, set())
                     end_tokens_map[token.linenr].add(token.column)
             if token.str != ',':
                 continue
@@ -1410,7 +1409,6 @@ class MisraChecker:
                 if token.astParent.str in ('(', '{'):
                     end_token = token.astParent.link
                     if end_token:
-                        end_tokens_map.setdefault(end_token.linenr, set())
                         end_tokens_map[end_token.linenr].add(end_token.column)
                     continue
                 elif token.astParent.str == ',':


### PR DESCRIPTION
After upgrading to latest version of cppcheck, it produced internal errors when using the misra checker (see attached screenshot).
After some investigation, the errors seem to be caused by the misra 12.3 checker function in misra.py.

To me, it looks like there might be a typo: when referencing the end_tokens_map, the linenr of the wrong token seems to be used.
This is fixed by this PR, it removes the internalErrors.

Also, the end_tokens_map is now a defaultdict, to minimize the risk of similar typos in the future and to clean up the code.

![image](https://user-images.githubusercontent.com/37386001/72059889-2e083700-32d3-11ea-940f-ede41c6f05bf.png)
