### PR TITLE
Travis: make logs less noisy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,18 +183,18 @@ matrix:
         - travis_retry sudo apt-get update -qq
         - travis_retry sudo apt-get install libxml2-utils libpcre3
       script:
-        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
+        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck check -j 2 -s
         - make clean
-        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
+        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck check -j 2 -s
 # check if cppcheck builds on osx
     - name: "make osx"
       os: osx
       before_install:
         - true
       script:
-        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}"  make cppcheck testrunner -j 2 -s
+        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}"  make cppcheck check -j 2 -s
         - make clean
-        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
+        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck check -j 2 -s
 
 script:
 # fail the entire job as soon as one of the subcommands exits non-zero to save time and resources

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,17 +51,17 @@ matrix:
     - name: "undefined behaviour sanitizers"
       compiler: gcc
       script:
-        - CXXFLAGS="-fsanitize=undefined -fno-sanitize-recover=all -Og -g3" make cppcheck test checkcfg -j 2
+        - CXXFLAGS="-fsanitize=undefined -fno-sanitize-recover=all -Og -g3" make cppcheck check checkcfg -j 2 -s
 # -fsanitize=address
     - name: "address sanitizers"
       compiler: gcc
       script:
-         - CXXFLAGS="-fsanitize=address -Og -g3" make cppcheck test checkcfg -j 2
+         - CXXFLAGS="-fsanitize=address -Og -g3" make cppcheck check checkcfg -j 2 -s
 # check a lot of stuff that only needs to be checked in a single configuration
     - name: "misc"
       compiler: clang
       script:
-        - make -j 2
+        - make -j 2 -s
 # run extra tests
         - tools/generate_and_run_more_tests.sh
 # check for missing CWE entries
@@ -183,18 +183,18 @@ matrix:
         - travis_retry sudo apt-get update -qq
         - travis_retry sudo apt-get install libxml2-utils libpcre3
       script:
-        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2
+        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
         - make clean
-        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2
+        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
 # check if cppcheck builds on osx
     - name: "make osx"
       os: osx
       before_install:
         - true
       script:
-        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}"  make cppcheck testrunner -j 2
+        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}"  make cppcheck testrunner -j 2 -s
         - make clean
-        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2
+        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck testrunner -j 2 -s
 
 script:
 # fail the entire job as soon as one of the subcommands exits non-zero to save time and resources
@@ -204,13 +204,13 @@ script:
 # check with TEST_MATHLIB_VALUE enabled
   - touch lib/mathlib.cpp test/testmathlib.cpp
   - echo $CXXFLAGS
-  - make -s test -j2 CPPFLAGS=-DTEST_MATHLIB_VALUE
+  - make -s check -j2 CPPFLAGS=-DTEST_MATHLIB_VALUE
   - touch lib/mathlib.cpp test/testmathlib.cpp
 # syntax checking of cppcheck source code with -DNONNEG
   - ls lib/*.cpp | xargs -n 1 -P 2 g++ -fsyntax-only -std=c++0x -Ilib -Iexternals -Iexternals/simplecpp -Iexternals/tinyxml -DNONNEG
 # compile cppcheck, default build
   - echo $CXXFLAGS
-  - make -s test -j2
+  - make -s check -j2
 # compile gui
   - cd gui
   - qmake
@@ -237,7 +237,7 @@ script:
   - cd ../
 # Build gui/test
   - cd gui/test/projectfile
-  - qmake && make && ./test-projectfile
+  - qmake && make -s -j2 && ./test-projectfile
   - cd -
 # Build triage
   - cd ./tools/triage


### PR DESCRIPTION
Make more compilation silent, and use `make check` instead of `make test` to avoid printing every single test case.

Also, run tests on osx and Ubuntu Trusty (previously, testrunner was only compiled).