### PR TITLE
daca2-getpackages.py: Fix semver sorting and getting latest package

### DIFF
--- a/tools/daca2-getpackages.py
+++ b/tools/daca2-getpackages.py
@@ -41,8 +41,12 @@ def wget(filepath):
 def latestvername(names):
     if len(names) == 1:
         return names[0]
-    names.sort(cmp=semver.cmp, key=lambda x: x[x.index(
-        '_')+1:x.index('.orig.tar')-x.index('_')+1])
+    try:
+        names.sort(cmp=semver.compare, key=lambda x: x[x.index('_')+1:x.index('.orig.tar')])
+    except ValueError:
+        # semver.compare() throws an exception if the version is not formatted
+        # like it is required by semver. For example 0.8 is not valid.
+        pass
     return names[-1]
 
 


### PR DESCRIPTION
There were two issues:
1. The version was not correctly extracted out of the filename. When
extracting a sub-string in Python one has to specify start index and
end index instead of start index and length.
2. The function `semver.cmp()` does nothing useful. Instead the function
`semver.compare()` must be called when two version should be compared.
See https://github.com/python-semver/python-semver/issues/117#issuecomment-479188221

Because `semver.compare()` now really compares the versions it is
possible that an exception is thrown if a version is not in the semver
version format. In such cases the sorting is aborted and the last
filename in the array is returned. This is often but not always already
the latest version from what I have seen.