### PR TITLE
daca@home client: Require at least Python 3 from now on

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,13 +105,12 @@ matrix:
         - pylint --rcfile=pylintrc_travis addons/*.py
         - pylint --rcfile=pylintrc_travis htmlreport/cppcheck-htmlreport
         - pylint --rcfile=pylintrc_travis htmlreport/*.py
-        - pylint --rcfile=pylintrc_travis --ignore=donate-cpu-server.py tools/*.py
+        - pylint --rcfile=pylintrc_travis --ignore=donate-cpu-server.py --ignore=donate-cpu.py --ignore=donate_cpu_lib.py --ignore=test-my-pr.py tools/*.py
         - python3 -m pylint --rcfile=pylintrc_travis addons/*.py
         - python3 -m pylint --rcfile=pylintrc_travis htmlreport/cppcheck-htmlreport
         - python3 -m pylint --rcfile=pylintrc_travis htmlreport/*.py
         - python3 -m pylint --rcfile=pylintrc_travis tools/*.py
 # check python syntax by compiling some selected scripts
-        - python -m py_compile ./tools/donate-cpu.py
         - python3 -m py_compile ./tools/donate-cpu.py
         - python3 -m py_compile ./tools/donate-cpu-server.py
 # check addons/misc.py

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -103,18 +103,12 @@ for arg in sys.argv[1:]:
 
 if sys.version_info.major < 3:
     print("#" * 80)
-    print("#" * 80)
     print("IMPORTANT")
-    print("Please consider switching to Python 3.")
-    print("")
-    print("We plan to completely drop Python 2 support")
-    print("for the Donate CPU client in the near future.")
-    print("")
-    print("For further information and reporting complaints, ideas, ... see:")
-    print("https://sourceforge.net/p/cppcheck/discussion/development/thread/86813a8a53/")
+    print("Python 2 is no longer supported!")
+    print("Please run the client with Python 3, thanks!")
     print("#" * 80)
-    print("#" * 80)
-    time.sleep(5)
+    time.sleep(2)
+    sys.exit(1)
 
 print('Thank you!')
 if not check_requirements():

--- a/tools/test/run_donate_cpu_client_tests.sh
+++ b/tools/test/run_donate_cpu_client_tests.sh
@@ -23,7 +23,7 @@ ftp://ftp.se.debian.org/debian/pool/main/0/0xffff/0xffff_0.8.orig.tar.gz
 ftp://ftp.se.debian.org/debian/pool/main/a/actionaz/actionaz_3.8.0.orig.tar.gz
 )
 
-for python_exec in "python" "python3"
+for python_exec in "python3"
 do
     for test_package in "${test_packages[@]}"
     do


### PR DESCRIPTION
This makes it possible to implement new features like .tar.xz support
(see https://trac.cppcheck.net/ticket/9508) or aborting endlessly
running analysis via timeout (see
https://sourceforge.net/p/cppcheck/discussion/development/thread/86813a8a53/).