### PR TITLE
daca2-getpackages.py: Fix #9508: Add support for xz compressed archives

### DIFF
--- a/tools/daca2-getpackages.py
+++ b/tools/daca2-getpackages.py
@@ -121,7 +121,7 @@ def getpackages():
             filenames = []
         elif line.startswith('./pool/main/'):
             path = line[2:-1]
-        elif path and line.endswith(('.orig.tar.gz', '.orig.tar.bz2')):
+        elif path and line.endswith(('.orig.tar.gz', '.orig.tar.bz2', '.orig.tar.xz')):
             filename = line[1 + line.rfind(' '):]
             filenames.append(filename)
 

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -101,11 +101,10 @@ for arg in sys.argv[1:]:
         print('Unhandled argument: ' + arg)
         sys.exit(1)
 
-if sys.version_info.major < 3:
+if sys.version_info.major < 3 or (sys.version_info.major == 3 and sys.version_info.minor < 4):
     print("#" * 80)
     print("IMPORTANT")
-    print("Python 2 is no longer supported!")
-    print("Please run the client with Python 3, thanks!")
+    print("Please run the client with at least Python 3.4, thanks!")
     print("#" * 80)
     time.sleep(2)
     sys.exit(1)


### PR DESCRIPTION
Using .tar.xz packages adds about 4500 additional packages that can be
tested and changes many existing packages where a more recent version
can be used now that is only available as .tar.xz file.

Related ticket: https://trac.cppcheck.net/ticket/9508