### PR TITLE
Ticket #9572: Properly detect designated initializers.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9469,7 +9469,7 @@ void Tokenizer::findGarbageCode() const
         if (Token::simpleMatch(tok, ".") &&
             !Token::simpleMatch(tok->previous(), ".") &&
             !Token::simpleMatch(tok->next(), ".") &&
-            !Token::Match(tok->previous(), "{|, . %name% [=.]") &&
+            !Token::Match(tok->previous(), "{|, . %name% =|.|[") &&
             !Token::Match(tok->previous(), ", . %name%")) {
             if (!Token::Match(tok->previous(), "%name%|)|]|>|}"))
                 syntaxError(tok, tok->strAt(-1) + " " + tok->str() + " " + tok->strAt(1));

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7968,6 +7968,12 @@ private:
         ASSERT_NO_THROW(tokenizeAndStringify("S s = { .ab.a=2, .ab.b=3 };"));
 
         ASSERT_NO_THROW(tokenizeAndStringify("extern \"C\" typedef void FUNC();"));
+
+        // Ticket #9572
+        ASSERT_NO_THROW(tokenizeAndStringify("struct poc { "
+                                             "  struct { int d; } port[1]; "
+                                             "}; "
+                                             "struct poc p = { .port[0] = {.d = 3} };"));
     }
 
 


### PR DESCRIPTION
This patch fixes the detection of designated initializers in ``Tokenizer::findGarbageCode``.