### PR TITLE
Fix AppVeyor issue following reportVerification rename.

### DIFF
--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -498,7 +498,7 @@ void ThreadExecutor::reportInfo(const ErrorLogger::ErrorMessage &msg)
 
 }
 
-void ThreadExecutor::reportVerification(const std::string  &/*str*/)
+void ThreadExecutor::bughuntingReport(const std::string  &/*str*/)
 {
     // TODO
 }
@@ -561,7 +561,7 @@ void ThreadExecutor::reportInfo(const ErrorLogger::ErrorMessage &/*msg*/)
 
 }
 
-void ThreadExecutor::reportVerification(const std::string &/*str*/)
+void ThreadExecutor::bughuntingReport(const std::string &/*str*/)
 {
 }
 


### PR DESCRIPTION
The rename to bughuntingReport was incomplete. Found while investigating the failures with https://github.com/danmar/cppcheck/pull/2496