### PR TITLE
Ticket 5607: Allow to exclude folders with glob pattern

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -164,7 +164,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
         std::list<ImportProject::FileSettings> newList;
 
         for (const ImportProject::FileSettings &fsetting : settings.project.fileSettings) {
-            if (Suppressions::matchglob(mSettings->fileFilter, fsetting.filename)) {
+            if (matchglob(mSettings->fileFilter, fsetting.filename)) {
                 newList.push_back(fsetting);
             }
         }
@@ -189,7 +189,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
     } else if (!mSettings->fileFilter.empty()) {
         std::map<std::string, std::size_t> newMap;
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i)
-            if (Suppressions::matchglob(mSettings->fileFilter, i->first)) {
+            if (matchglob(mSettings->fileFilter, i->first)) {
                 newMap[i->first] = i->second;
             }
         mFiles = newMap;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -43,6 +43,10 @@ void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
                 ignore = true;
                 break;
             }
+			if (isValidGlobPattern(i) && matchglob(i, it->filename)) {
+			    ignore = true;
+			    break;
+			}
             if (!Path::isAbsolute(i)) {
                 i = mPath + i;
                 if (it->filename.size() > i.size() && it->filename.compare(0,i.size(),i)==0) {

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -43,10 +43,10 @@ void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
                 ignore = true;
                 break;
             }
-			if (isValidGlobPattern(i) && matchglob(i, it->filename)) {
-			    ignore = true;
-			    break;
-			}
+            if (isValidGlobPattern(i) && matchglob(i, it->filename)) {
+                ignore = true;
+                break;
+            }
             if (!Path::isAbsolute(i)) {
                 i = mPath + i;
                 if (it->filename.size() > i.size() && it->filename.compare(0,i.size(),i)==0) {

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -21,6 +21,7 @@
 #include "errorlogger.h"
 #include "mathlib.h"
 #include "path.h"
+#include "utils.h"
 
 #include <tinyxml2.h>
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -26,24 +26,10 @@
 
 #include <algorithm>
 #include <cctype>   // std::isdigit, std::isalnum, etc
-#include <stack>
 #include <sstream>
 #include <utility>
 
 class ErrorLogger;
-
-static bool isValidGlobPattern(const std::string &pattern)
-{
-    for (std::string::const_iterator i = pattern.begin(); i != pattern.end(); ++i) {
-        if (*i == '*' || *i == '?') {
-            std::string::const_iterator j = i + 1;
-            if (j != pattern.end() && (*j == '*' || *j == '?')) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
 
 static bool isAcceptedErrorIdChar(char c)
 {
@@ -353,68 +339,4 @@ std::list<Suppressions::Suppression> Suppressions::getUnmatchedGlobalSuppression
         result.push_back(s);
     }
     return result;
-}
-
-bool Suppressions::matchglob(const std::string &pattern, const std::string &name)
-{
-    const char *p = pattern.c_str();
-    const char *n = name.c_str();
-    std::stack<std::pair<const char *, const char *> > backtrack;
-
-    for (;;) {
-        bool matching = true;
-        while (*p != '\0' && matching) {
-            switch (*p) {
-            case '*':
-                // Step forward until we match the next character after *
-                while (*n != '\0' && *n != p[1]) {
-                    n++;
-                }
-                if (*n != '\0') {
-                    // If this isn't the last possibility, save it for later
-                    backtrack.push(std::make_pair(p, n));
-                }
-                break;
-            case '?':
-                // Any character matches unless we're at the end of the name
-                if (*n != '\0') {
-                    n++;
-                } else {
-                    matching = false;
-                }
-                break;
-            default:
-                // Non-wildcard characters match literally
-                if (*n == *p) {
-                    n++;
-                } else if (*n == '\\' && *p == '/') {
-                    n++;
-                } else if (*n == '/' && *p == '\\') {
-                    n++;
-                } else {
-                    matching = false;
-                }
-                break;
-            }
-            p++;
-        }
-
-        // If we haven't failed matching and we've reached the end of the name, then success
-        if (matching && *n == '\0') {
-            return true;
-        }
-
-        // If there are no other paths to try, then fail
-        if (backtrack.empty()) {
-            return false;
-        }
-
-        // Restore pointers from backtrack stack
-        p = backtrack.top().first;
-        n = backtrack.top().second;
-        backtrack.pop();
-
-        // Advance name pointer by one because the current position didn't work
-        n++;
-    }
 }

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -162,7 +162,6 @@ public:
      */
     std::list<Suppression> getUnmatchedGlobalSuppressions(const bool unusedFunctionChecking) const;
 
-    static bool matchglob(const std::string &pattern, const std::string &name);
 private:
     /** @brief List of error which the user doesn't want to see. */
     std::list<Suppression> mSuppressions;

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -113,83 +113,83 @@ inline static int caseInsensitiveStringCompare(const std::string &lhs, const std
 
 inline static bool isValidGlobPattern(const std::string& pattern)
 {
-	for (std::string::const_iterator i = pattern.begin(); i != pattern.end(); ++i) {
-		if (*i == '*' || *i == '?') {
-			std::string::const_iterator j = i + 1;
-			if (j != pattern.end() && (*j == '*' || *j == '?')) {
-				return false;
-			}
-	}
+    for (std::string::const_iterator i = pattern.begin(); i != pattern.end(); ++i) {
+        if (*i == '*' || *i == '?') {
+            std::string::const_iterator j = i + 1;
+            if (j != pattern.end() && (*j == '*' || *j == '?')) {
+                return false;
+            }
+    }
 }
-	return true;
+    return true;
 }
 
 inline static bool matchglob(const std::string& pattern, const std::string& name)
 {
-	const char* p = pattern.c_str();
-	const char* n = name.c_str();
-	std::stack<std::pair<const char*, const char*> > backtrack;
+    const char* p = pattern.c_str();
+    const char* n = name.c_str();
+    std::stack<std::pair<const char*, const char*> > backtrack;
 
-	for (;;) {
-		bool matching = true;
-		while (*p != '\0' && matching) {
-			switch (*p) {
-			case '*':
-				// Step forward until we match the next character after *
-				while (*n != '\0' && *n != p[1]) {
-					n++;
-				}
-				if (*n != '\0') {
-					// If this isn't the last possibility, save it for later
-					backtrack.push(std::make_pair(p, n));
-				}
-				break;
-			case '?':
-				// Any character matches unless we're at the end of the name
-				if (*n != '\0') {
-					n++;
-				}
-				else {
-					matching = false;
-				}
-				break;
-			default:
-				// Non-wildcard characters match literally
-				if (*n == *p) {
-					n++;
-				}
-				else if (*n == '\\' && *p == '/') {
-					n++;
-				}
-				else if (*n == '/' && *p == '\\') {
-					n++;
-				}
-				else {
-					matching = false;
-				}
-				break;
-			}
-			p++;
-		}
+    for (;;) {
+        bool matching = true;
+        while (*p != '\0' && matching) {
+            switch (*p) {
+            case '*':
+                // Step forward until we match the next character after *
+                while (*n != '\0' && *n != p[1]) {
+                    n++;
+                }
+                if (*n != '\0') {
+                    // If this isn't the last possibility, save it for later
+                    backtrack.push(std::make_pair(p, n));
+                }
+                break;
+            case '?':
+                // Any character matches unless we're at the end of the name
+                if (*n != '\0') {
+                    n++;
+                }
+                else {
+                    matching = false;
+                }
+                break;
+            default:
+                // Non-wildcard characters match literally
+                if (*n == *p) {
+                    n++;
+                }
+                else if (*n == '\\' && *p == '/') {
+                    n++;
+                }
+                else if (*n == '/' && *p == '\\') {
+                    n++;
+                }
+                else {
+                    matching = false;
+                }
+                break;
+            }
+            p++;
+        }
 
-		// If we haven't failed matching and we've reached the end of the name, then success
-		if (matching && *n == '\0') {
-			return true;
-		}
+        // If we haven't failed matching and we've reached the end of the name, then success
+        if (matching && *n == '\0') {
+            return true;
+        }
 
-		// If there are no other paths to try, then fail
-		if (backtrack.empty()) {
-			return false;
-		}
+        // If there are no other paths to try, then fail
+        if (backtrack.empty()) {
+            return false;
+        }
 
-		// Restore pointers from backtrack stack
-		p = backtrack.top().first;
-		n = backtrack.top().second;
-		backtrack.pop();
+        // Restore pointers from backtrack stack
+        p = backtrack.top().first;
+        n = backtrack.top().second;
+        backtrack.pop();
 
-		// Advance name pointer by one because the current position didn't work
-		n++;
-	}
+        // Advance name pointer by one because the current position didn't work
+        n++;
+    }
 }
 
 #define UNUSED(x) (void)(x)

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -25,6 +25,7 @@
 #include <cctype>
 #include <cstddef>
 #include <string>
+#include <stack>
 
 inline bool endsWith(const std::string &str, char c)
 {
@@ -108,6 +109,87 @@ inline static int caseInsensitiveStringCompare(const std::string &lhs, const std
             return (c1 < c2) ? -1 : 1;
     }
     return 0;
+}
+
+inline static bool isValidGlobPattern(const std::string& pattern)
+{
+	for (std::string::const_iterator i = pattern.begin(); i != pattern.end(); ++i) {
+		if (*i == '*' || *i == '?') {
+			std::string::const_iterator j = i + 1;
+			if (j != pattern.end() && (*j == '*' || *j == '?')) {
+				return false;
+			}
+	}
+}
+	return true;
+}
+
+inline static bool matchglob(const std::string& pattern, const std::string& name)
+{
+	const char* p = pattern.c_str();
+	const char* n = name.c_str();
+	std::stack<std::pair<const char*, const char*> > backtrack;
+
+	for (;;) {
+		bool matching = true;
+		while (*p != '\0' && matching) {
+			switch (*p) {
+			case '*':
+				// Step forward until we match the next character after *
+				while (*n != '\0' && *n != p[1]) {
+					n++;
+				}
+				if (*n != '\0') {
+					// If this isn't the last possibility, save it for later
+					backtrack.push(std::make_pair(p, n));
+				}
+				break;
+			case '?':
+				// Any character matches unless we're at the end of the name
+				if (*n != '\0') {
+					n++;
+				}
+				else {
+					matching = false;
+				}
+				break;
+			default:
+				// Non-wildcard characters match literally
+				if (*n == *p) {
+					n++;
+				}
+				else if (*n == '\\' && *p == '/') {
+					n++;
+				}
+				else if (*n == '/' && *p == '\\') {
+					n++;
+				}
+				else {
+					matching = false;
+				}
+				break;
+			}
+			p++;
+		}
+
+		// If we haven't failed matching and we've reached the end of the name, then success
+		if (matching && *n == '\0') {
+			return true;
+		}
+
+		// If there are no other paths to try, then fail
+		if (backtrack.empty()) {
+			return false;
+		}
+
+		// Restore pointers from backtrack stack
+		p = backtrack.top().first;
+		n = backtrack.top().second;
+		backtrack.pop();
+
+		// Advance name pointer by one because the current position didn't work
+		n++;
+	}
 }
 
 #define UNUSED(x) (void)(x)

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -119,8 +119,8 @@ inline static bool isValidGlobPattern(const std::string& pattern)
             if (j != pattern.end() && (*j == '*' || *j == '?')) {
                 return false;
             }
+        }
     }
-}
     return true;
 }
 

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -50,7 +50,7 @@ private:
         TEST_CASE(importCompileCommandsArgumentsSection); // Handle arguments section
         TEST_CASE(importCompileCommandsNoCommandSection); // gracefully handles malformed json
         TEST_CASE(importCppcheckGuiProject);
-		TEST_CASE(ignorePaths);
+        TEST_CASE(ignorePaths);
     }
 
     void setDefines() const {
@@ -187,23 +187,23 @@ private:
         ASSERT_EQUALS("lib/", s.includePaths.front());
     }
 
-	void ignorePaths() {
-		ImportProject::FileSettings fs1, fs2;
-		fs1.filename = "foo/bar";
-		fs2.filename = "qwe/rty";
-		TestImporter project;
-		project.fileSettings = {fs1, fs2};
+    void ignorePaths() {
+        ImportProject::FileSettings fs1, fs2;
+        fs1.filename = "foo/bar";
+        fs2.filename = "qwe/rty";
+        TestImporter project;
+        project.fileSettings = {fs1, fs2};
 
-		project.ignorePaths({"*foo", "bar*"});
-		ASSERT_EQUALS(2, project.fileSettings.size());
+        project.ignorePaths({"*foo", "bar*"});
+        ASSERT_EQUALS(2, project.fileSettings.size());
 
-		project.ignorePaths({"foo/*"});
-		ASSERT_EQUALS(1, project.fileSettings.size());
-		ASSERT_EQUALS("qwe/rty", project.fileSettings.front().filename);
+        project.ignorePaths({"foo/*"});
+        ASSERT_EQUALS(1, project.fileSettings.size());
+        ASSERT_EQUALS("qwe/rty", project.fileSettings.front().filename);
 
-		project.ignorePaths({ "*e/r*" });
-		ASSERT_EQUALS(0, project.fileSettings.size());
-	}
+        project.ignorePaths({ "*e/r*" });
+        ASSERT_EQUALS(0, project.fileSettings.size());
+    }
 };
 
 REGISTER_TEST(TestImportProject)

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -50,6 +50,7 @@ private:
         TEST_CASE(importCompileCommandsArgumentsSection); // Handle arguments section
         TEST_CASE(importCompileCommandsNoCommandSection); // gracefully handles malformed json
         TEST_CASE(importCppcheckGuiProject);
+		TEST_CASE(ignorePaths);
     }
 
     void setDefines() const {
@@ -185,6 +186,24 @@ private:
         ASSERT_EQUALS(1, s.includePaths.size());
         ASSERT_EQUALS("lib/", s.includePaths.front());
     }
+
+	void ignorePaths() {
+		ImportProject::FileSettings fs1, fs2;
+		fs1.filename = "foo/bar";
+		fs2.filename = "qwe/rty";
+		TestImporter project;
+		project.fileSettings = {fs1, fs2};
+
+		project.ignorePaths({"*foo", "bar*"});
+		ASSERT_EQUALS(2, project.fileSettings.size());
+
+		project.ignorePaths({"foo/*"});
+		ASSERT_EQUALS(1, project.fileSettings.size());
+		ASSERT_EQUALS("qwe/rty", project.fileSettings.front().filename);
+
+		project.ignorePaths({ "*e/r*" });
+		ASSERT_EQUALS(0, project.fileSettings.size());
+	}
 };
 
 REGISTER_TEST(TestImportProject)

--- a/test/testrunner.vcxproj
+++ b/test/testrunner.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="testunusedfunctions.cpp" />
     <ClCompile Include="testunusedprivfunc.cpp" />
     <ClCompile Include="testunusedvar.cpp" />
+    <ClCompile Include="testutils.cpp" />
     <ClCompile Include="testvaarg.cpp" />
     <ClCompile Include="testvalueflow.cpp" />
     <ClCompile Include="testvarid.cpp" />

--- a/test/testrunner.vcxproj.filters
+++ b/test/testrunner.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="testexprengine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="testutils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="options.h">

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -66,8 +66,6 @@ private:
 
         TEST_CASE(unusedFunction);
 
-        TEST_CASE(matchglob);
-
         TEST_CASE(suppressingSyntaxErrorAndExitCode);
     }
 
@@ -590,23 +588,6 @@ private:
         ASSERT_EQUALS(0, checkSuppression("void f() {}", "unusedFunction"));
     }
 
-    void matchglob() {
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("x*", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*z", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "yz"));
-        //ASSERT_EQUALS(false, Suppressions::matchglob("*y*", "abc"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*", "x/y/z"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("*/y/z", "x/y/z"));
-
-        //ASSERT_EQUALS(false, Suppressions::matchglob("?", "xyz"));
-        //ASSERT_EQUALS(false, Suppressions::matchglob("x?", "xyz"));
-        //ASSERT_EQUALS(false, Suppressions::matchglob("?z", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("?y?", "xyz"));
-        //ASSERT_EQUALS(true, Suppressions::matchglob("?/?/?", "x/y/z"));
-    }
-
     void suppressingSyntaxErrorAndExitCode() {
         std::map<std::string, std::string> files;
         files["test.cpp"] = "fi if;";
@@ -640,4 +621,4 @@ private:
 
 };
 
-//REGISTER_TEST(TestSuppressions)
+REGISTER_TEST(TestSuppressions)

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -591,20 +591,20 @@ private:
     }
 
     void matchglob() {
-        ASSERT_EQUALS(true, Suppressions::matchglob("*", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("x*", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("*z", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "yz"));
-        ASSERT_EQUALS(false, Suppressions::matchglob("*y*", "abc"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("*", "x/y/z"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("*/y/z", "x/y/z"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("x*", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*z", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*y*", "yz"));
+        //ASSERT_EQUALS(false, Suppressions::matchglob("*y*", "abc"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*", "x/y/z"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("*/y/z", "x/y/z"));
 
-        ASSERT_EQUALS(false, Suppressions::matchglob("?", "xyz"));
-        ASSERT_EQUALS(false, Suppressions::matchglob("x?", "xyz"));
-        ASSERT_EQUALS(false, Suppressions::matchglob("?z", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("?y?", "xyz"));
-        ASSERT_EQUALS(true, Suppressions::matchglob("?/?/?", "x/y/z"));
+        //ASSERT_EQUALS(false, Suppressions::matchglob("?", "xyz"));
+        //ASSERT_EQUALS(false, Suppressions::matchglob("x?", "xyz"));
+        //ASSERT_EQUALS(false, Suppressions::matchglob("?z", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("?y?", "xyz"));
+        //ASSERT_EQUALS(true, Suppressions::matchglob("?/?/?", "x/y/z"));
     }
 
     void suppressingSyntaxErrorAndExitCode() {
@@ -640,4 +640,4 @@ private:
 
 };
 
-REGISTER_TEST(TestSuppressions)
+//REGISTER_TEST(TestSuppressions)

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -1,0 +1,72 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2019 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "testsuite.h"
+#include "utils.h"
+
+class TestUtils : public TestFixture {
+public:
+	TestUtils() : TestFixture("TestUtils") {
+	}
+
+private:
+	void run() OVERRIDE {
+		TEST_CASE(isValidGlobPattern);
+		TEST_CASE(matchglob);
+	}
+
+	void isValidGlobPattern() {
+		ASSERT_EQUALS(true, ::isValidGlobPattern("*"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("*x"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("x*"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("*/x/*"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("x/*/z"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("**"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("**x"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("x**"));
+
+		ASSERT_EQUALS(true, ::isValidGlobPattern("?"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("?x"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("x?"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("?/x/?"));
+		ASSERT_EQUALS(true, ::isValidGlobPattern("x/?/z"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("??"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("??x"));
+		ASSERT_EQUALS(false, ::isValidGlobPattern("x??"));
+	}
+
+	void matchglob() {
+		ASSERT_EQUALS(true, ::matchglob("*", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("x*", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("*z", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("*y*", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("*y*", "yz"));
+		ASSERT_EQUALS(false, ::matchglob("*y*", "abc"));
+		ASSERT_EQUALS(true, ::matchglob("*", "x/y/z"));
+		ASSERT_EQUALS(true, ::matchglob("*/y/z", "x/y/z"));
+
+		ASSERT_EQUALS(false, ::matchglob("?", "xyz"));
+		ASSERT_EQUALS(false, ::matchglob("x?", "xyz"));
+		ASSERT_EQUALS(false, ::matchglob("?z", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("?y?", "xyz"));
+		ASSERT_EQUALS(true, ::matchglob("?/?/?", "x/y/z"));
+	}
+};
+
+REGISTER_TEST(TestUtils)

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -22,51 +22,51 @@
 
 class TestUtils : public TestFixture {
 public:
-	TestUtils() : TestFixture("TestUtils") {
-	}
+    TestUtils() : TestFixture("TestUtils") {
+    }
 
 private:
-	void run() OVERRIDE {
-		TEST_CASE(isValidGlobPattern);
-		TEST_CASE(matchglob);
-	}
+    void run() OVERRIDE {
+        TEST_CASE(isValidGlobPattern);
+        TEST_CASE(matchglob);
+    }
 
-	void isValidGlobPattern() {
-		ASSERT_EQUALS(true, ::isValidGlobPattern("*"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("*x"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("x*"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("*/x/*"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("x/*/z"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("**"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("**x"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("x**"));
+    void isValidGlobPattern() {
+        ASSERT_EQUALS(true, ::isValidGlobPattern("*"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("*x"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x*"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("*/x/*"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x/*/z"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("**"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("**x"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("x**"));
 
-		ASSERT_EQUALS(true, ::isValidGlobPattern("?"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("?x"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("x?"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("?/x/?"));
-		ASSERT_EQUALS(true, ::isValidGlobPattern("x/?/z"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("??"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("??x"));
-		ASSERT_EQUALS(false, ::isValidGlobPattern("x??"));
-	}
+        ASSERT_EQUALS(true, ::isValidGlobPattern("?"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("?x"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x?"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("?/x/?"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x/?/z"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("??"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("??x"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("x??"));
+    }
 
-	void matchglob() {
-		ASSERT_EQUALS(true, ::matchglob("*", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("x*", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("*z", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("*y*", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("*y*", "yz"));
-		ASSERT_EQUALS(false, ::matchglob("*y*", "abc"));
-		ASSERT_EQUALS(true, ::matchglob("*", "x/y/z"));
-		ASSERT_EQUALS(true, ::matchglob("*/y/z", "x/y/z"));
+    void matchglob() {
+        ASSERT_EQUALS(true, ::matchglob("*", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("x*", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("*z", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("*y*", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("*y*", "yz"));
+        ASSERT_EQUALS(false, ::matchglob("*y*", "abc"));
+        ASSERT_EQUALS(true, ::matchglob("*", "x/y/z"));
+        ASSERT_EQUALS(true, ::matchglob("*/y/z", "x/y/z"));
 
-		ASSERT_EQUALS(false, ::matchglob("?", "xyz"));
-		ASSERT_EQUALS(false, ::matchglob("x?", "xyz"));
-		ASSERT_EQUALS(false, ::matchglob("?z", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("?y?", "xyz"));
-		ASSERT_EQUALS(true, ::matchglob("?/?/?", "x/y/z"));
-	}
+        ASSERT_EQUALS(false, ::matchglob("?", "xyz"));
+        ASSERT_EQUALS(false, ::matchglob("x?", "xyz"));
+        ASSERT_EQUALS(false, ::matchglob("?z", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("?y?", "xyz"));
+        ASSERT_EQUALS(true, ::matchglob("?/?/?", "x/y/z"));
+    }
 };
 
 REGISTER_TEST(TestUtils)


### PR DESCRIPTION
Ticket 5607: https://trac.cppcheck.net/ticket/5607

Now it is possible to ignore paths with glob:
`cppcheck -i*autogen\*`

Glob pattern matching already been implemented in the Suppression class as a static method. I moved implementation to Utils.