### PR TITLE
Donate CPU/test-my-pr: Add timeout for the Cppcheck execution

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -22,7 +22,7 @@ import operator
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.1"
+SERVER_VERSION = "1.3.2"
 
 OLD_VERSION = '1.90'
 
@@ -67,6 +67,7 @@ def overviewReport() -> str:
     html = '<html><head><title>daca@home</title></head><body>\n'
     html += '<h1>daca@home</h1>\n'
     html += '<a href="crash.html">Crash report</a><br>\n'
+    html += '<a href="timeout.html">Timeout report</a><br>\n'
     html += '<a href="stale.html">Stale report</a><br>\n'
     html += '<a href="diff.html">Diff report</a><br>\n'
     html += '<a href="head.html">HEAD report</a><br>\n'
@@ -82,7 +83,7 @@ def overviewReport() -> str:
 
 
 def fmt(a: str, b: str, c: str = None, d: str = None, e: str = None, link: bool = True) -> str:
-    column_width = [40, 10, 5, 6, 6, 8]
+    column_width = [40, 10, 5, 7, 7, 8]
     ret = a
     while len(ret) < column_width[0]:
         ret += ' '
@@ -214,6 +215,47 @@ def crashReport(results_path: str) -> str:
         html += '\n'.join(stack_trace['stack_trace']) + '\n\n'
     html += '</pre>\n'
 
+    html += '</body></html>\n'
+    return html
+
+
+def timeoutReport(results_path: str) -> str:
+    html = '<html><head><title>Timeout report</title></head><body>\n'
+    html += '<h1>Timeout report</h1>\n'
+    html += '<pre>\n'
+    html += '<b>' + fmt('Package', 'Date       Time', OLD_VERSION, 'Head', link=False) + '</b>\n'
+    current_year = datetime.date.today().year
+    for filename in sorted(glob.glob(os.path.expanduser(results_path + '/*'))):
+        if not os.path.isfile(filename):
+            continue
+        datestr = ''
+        with open(filename, 'rt') as file_:
+            for line in file_:
+                line = line.strip()
+                if line.startswith('cppcheck: '):
+                    if OLD_VERSION not in line:
+                        # Package results seem to be too old, skip
+                        break
+                    else:
+                        # Current package, parse on
+                        continue
+                if line.startswith(str(current_year) + '-') or line.startswith(str(current_year - 1) + '-'):
+                    datestr = line
+                if line.startswith('count:'):
+                    if line.find('TO!') < 0:
+                        break
+                    package = filename[filename.rfind('/')+1:]
+                    counts = line.strip().split(' ')
+                    c2 = ''
+                    if counts[2] == 'TO!':
+                        c2 = 'Timeout'
+                    c1 = ''
+                    if counts[1] == 'TO!':
+                        c1 = 'Timeout'
+                    html += fmt(package, datestr, c2, c1) + '\n'
+                    break
+
+    html += '</pre>\n'
     html += '</body></html>\n'
     return html
 
@@ -772,6 +814,9 @@ class HttpClientThread(Thread):
                 httpGetResponse(self.connection, html, 'text/html')
             elif url == 'crash.html':
                 html = crashReport(self.resultPath)
+                httpGetResponse(self.connection, html, 'text/html')
+            elif url == 'timeout.html':
+                html = timeoutReport(self.resultPath)
                 httpGetResponse(self.connection, html, 'text/html')
             elif url == 'stale.html':
                 html = staleReport(self.resultPath)

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -172,6 +172,7 @@ while True:
         print("No files to process")
         continue
     crash = False
+    timeout = False
     count = ''
     elapsed_time = ''
     results_to_diff = []
@@ -193,6 +194,10 @@ while True:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)
                 count += ' 0'
+            elif c == RETURN_CODE_TIMEOUT:
+                # Timeout
+                count += ' TO!'
+                timeout = True
             else:
                 crash = True
                 count += ' Crash!'
@@ -220,7 +225,7 @@ while True:
     info_output += 'info messages:\n' + head_info_msg
     if 'head' in cppcheck_versions:
         output += 'head results:\n' + results_to_diff[cppcheck_versions.index('head')]
-    if not crash:
+    if not crash and not timeout:
         output += 'diff:\n' + diff_results(work_path, cppcheck_versions[0], results_to_diff[0], cppcheck_versions[1], results_to_diff[1]) + '\n'
     if package_url:
         print('=========================================================')

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,6 +15,12 @@ import tarfile
 # changes)
 CLIENT_VERSION = "1.1.42"
 
+# Timeout for analysis with Cppcheck in seconds
+CPPCHECK_TIMEOUT = 60 * 60
+
+# Return code that is used to mark a timed out analysis
+RETURN_CODE_TIMEOUT = -999
+
 
 def check_requirements():
     result = True
@@ -249,12 +255,18 @@ def run_command(cmd):
     print(cmd)
     startTime = time.time()
     p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    comm = p.communicate()
+    return_code = RETURN_CODE_TIMEOUT
+    try:
+        comm = p.communicate(timeout=CPPCHECK_TIMEOUT)
+        return_code = p.returncode
+    except subprocess.TimeoutExpired:
+        p.kill()
+        comm = p.communicate()
     stop_time = time.time()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore')
     elapsed_time = stop_time - startTime
-    return p.returncode, stdout, stderr, elapsed_time
+    return return_code, stdout, stderr, elapsed_time
 
 
 def scan_package(work_path, cppcheck_path, jobs, libraries):
@@ -300,6 +312,9 @@ def scan_package(work_path, cppcheck_path, jobs, libraries):
                 else:
                     stacktrace = stdout[last_check_pos:]
         return returncode, stacktrace, '', returncode, options, ''
+    if returncode == RETURN_CODE_TIMEOUT:
+        print('Timeout!')
+        return returncode, stdout, '', elapsed_time, options, ''
     if returncode != 0:
         print('Error!')
         if returncode > 0:

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -13,7 +13,7 @@ import tarfile
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.1.42"
+CLIENT_VERSION = "1.2.0"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 60 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -255,13 +255,13 @@ def run_command(cmd):
     print(cmd)
     startTime = time.time()
     p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    return_code = RETURN_CODE_TIMEOUT
     try:
         comm = p.communicate(timeout=CPPCHECK_TIMEOUT)
         return_code = p.returncode
     except subprocess.TimeoutExpired:
         p.kill()
         comm = p.communicate()
+        return_code = RETURN_CODE_TIMEOUT
     stop_time = time.time()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore')


### PR DESCRIPTION
This adds a timeout of 60 minutes for the Cppcheck analysis.
Timed out results do not count as crash but they are uploaded and
marked with "TO!" in the list of the latest results. No "diff" is
generated for timed out results so they do not add wrong entries to
the "Diff report".
In test-my-pr.py the timed out results are listed separately just like
the crashes.