### PR TITLE
Fix typo in cfg file for Qt

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -2235,7 +2235,7 @@
     <const/>
   </function>
   <!-- QString QString::vasprintf(const char *cformat, va_list ap) // static -->
-  <function name="QString::vsprintf">
+  <function name="QString::vasprintf">
     <noreturn>false</noreturn>
     <returnValue type="QString"/>
     <use-retval/>


### PR DESCRIPTION
As far as I can see this is a typo. The actual definition of vsprintf is directly below.
