### PR TITLE
Fix #9584: Limit stack trace depth in daca@home crash page

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -8,12 +8,13 @@ import socket
 import time
 import re
 import tarfile
+import shlex
 
 
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.2.0"
+CLIENT_VERSION = "1.2.1"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 60 * 60
@@ -254,7 +255,7 @@ def has_include(path, includes):
 def run_command(cmd):
     print(cmd)
     startTime = time.time()
-    p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
         comm = p.communicate(timeout=CPPCHECK_TIMEOUT)
         return_code = p.returncode
@@ -302,7 +303,7 @@ def scan_package(work_path, cppcheck_path, jobs, libraries):
         stacktrace = ''
         if cppcheck_path == 'cppcheck':
             # re-run within gdb to get a stacktrace
-            cmd = 'gdb --batch --eval-command=run --eval-command=bt --return-child-result --args ' + cppcheck_cmd + " -j1"
+            cmd = 'gdb --batch --eval-command=run --eval-command="bt 50" --return-child-result --args ' + cppcheck_cmd + " -j1"
             dummy, stdout, stderr, elapsed_time = run_command(cmd)
             gdb_pos = stdout.find(" received signal")
             if not gdb_pos == -1:


### PR DESCRIPTION
This limits the backtrace to a maximum of 50 entries.
Trac ticket: https://trac.cppcheck.net/ticket/9584