### PR TITLE
Ticket #9569: Do not substitute type aliases within enum definitions.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2040,6 +2040,10 @@ bool Tokenizer::simplifyUsing()
                 continue;
             }
 
+            // skip enum definitions
+            if (tok1->str() == "enum")
+                skipEnumBody(&tok1);
+
             // check for member function and adjust scope
             if (isMemberFunction(tok1)) {
                 if (!scope1.empty())

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -75,6 +75,7 @@ private:
         TEST_CASE(tokenize35);  // #8361
         TEST_CASE(tokenize36);  // #8436
         TEST_CASE(tokenize37);  // #8550
+        TEST_CASE(tokenize38);  // #9569
 
         TEST_CASE(validate);
 
@@ -880,6 +881,12 @@ private:
         const char expS [] = "class name { public: static void init ( ) { } } ; "
                              "void foo ( ) { return name :: init ( ) ; }";
         ASSERT_EQUALS(expS, tokenizeAndStringify(codeS));
+    }
+
+    void tokenize38() { // #9569
+        const char code[] = "using Binary = std::vector<char>; enum Type { Binary };";
+        const char exp[]  = "enum Type { Binary } ;";
+        ASSERT_EQUALS(exp, tokenizeAndStringify(code));
     }
 
     void validate() {


### PR DESCRIPTION
This ticket highlights that we're wrongly substituting type aliases within enum definitions, that should be untouched.

This patch fixes it.