### PR TITLE
donate_cpu: Fix timeout if multithreaded

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -7,6 +7,7 @@ import sys
 import socket
 import time
 import re
+import signal
 import tarfile
 import shlex
 
@@ -249,12 +250,12 @@ def has_include(path, includes):
 def run_command(cmd):
     print(cmd)
     startTime = time.time()
-    p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=os.setsid)
     try:
         comm = p.communicate(timeout=CPPCHECK_TIMEOUT)
         return_code = p.returncode
     except subprocess.TimeoutExpired:
-        p.kill()
+        os.killpg(os.getpgid(p.pid), signal.SIGTERM)  # Send the signal to all the process groups
         comm = p.communicate()
         return_code = RETURN_CODE_TIMEOUT
     stop_time = time.time()

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.2.2"
+CLIENT_VERSION = "1.2.3"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 60 * 60


### PR DESCRIPTION
Highly inspired by https://stackoverflow.com/a/4791612.

To test, you can run the following command (change `CPPCHECK_TIMEOUT` to 60 or so to avoid waiting for one hour):
```
python donate-cpu.py -j3 --test --package=ftp://ftp.de.debian.org/debian/pool/main/s/skyeye/skyeye_1.2.5.orig.tar.gz
```
When run with `donate-cpu` in the current repo, it does not exit after the timeout has expired.

If someone has a better idea, I'm all for it. This probably needs some testing (according to the python docs, the commands I used are unix only), I've run in on Arch Linux, and it seems to work. Testing on WSL, cygwin, mingw (if donate-cpu runs on these platforms)  would be much appreciated.