### PR TITLE
misra.py: Fix R5.4 false positives with C99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,9 @@ matrix:
         - cd ../../
 # check addons/misra.py
         - cd addons/test
-        - ${CPPCHECK} --dump misra/misra-test.c
+        # We'll force C89 standard to enable an additional verification for
+        # rules 5.4 and 5.5 which have standard-dependent options.
+        - ${CPPCHECK} --dump misra/misra-test.c --std=c89
         - python3 ../misra.py -verify misra/misra-test.c.dump
         - ${CPPCHECK} --dump misra/misra-test.cpp
         - python3 ../misra.py -verify misra/misra-test.cpp.dump

--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -656,7 +656,7 @@ class Configuration:
     functions = []
     variables = []
     valueflow = []
-    standards = []
+    standards = None
 
     def __init__(self, name):
         self.name = name
@@ -666,7 +666,7 @@ class Configuration:
         self.functions = []
         self.variables = []
         self.valueflow = []
-        self.standards = []
+        self.standards = Standards()
 
     def set_tokens_links(self):
         """Set next/previous links between tokens."""
@@ -762,10 +762,18 @@ class Standards:
         posix        If Posix was used
     """
 
-    def __init__(self, standardsnode):
-        self.c = standardsnode.find("c").get("version")
-        self.cpp = standardsnode.find("cpp").get("version")
-        self.posix = standardsnode.find("posix") is not None
+    c = ""
+    cpp = ""
+    posix = False
+
+    def set_c(self, node):
+        self.c = node.get("version")
+
+    def set_cpp(self, node):
+        self.cpp = node.get("version")
+
+    def set_posix(self, node):
+        self.posix = node.get("posix") is not None
 
     def __repr__(self):
         attrs = ["c", "cpp", "posix"]
@@ -896,11 +904,15 @@ class CppcheckData:
                     cfg = None
                     cfg_arguments = []
 
-            # Parse nested elemenets of configuration node
+            # Parse standards
             elif node.tag == "standards" and event == 'start':
                 continue
-            elif node.tag == "standards" and event == 'end':
-                cfg.standards = Standards(node)
+            elif node.tag == 'c' and event == 'start':
+                cfg.standards.set_c(node)
+            elif node.tag == 'cpp' and event == 'start':
+                cfg.standards.set_cpp(node)
+            elif node.tag == 'posix' and event == 'start':
+                cfg.standards.set_posix(node)
 
             # Parse directives list
             elif node.tag == 'directive' and event == 'start':

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -806,10 +806,10 @@ class MisraChecker:
         )
 
     def get_num_significant_naming_chars(self, cfg):
-        if cfg.standards and cfg.standards.c == "c99":
-            return 63
-        else:
+        if cfg.standards and cfg.standards.c == "c89":
             return 31
+        else:
+            return 63
 
     def misra_2_7(self, data):
         for func in data.functions:


### PR DESCRIPTION
Fix false positives with rule 5.4 with C99 standard.

See: [trac 9592](https://trac.cppcheck.net/ticket/9592).