### PR TITLE
Improve isSameExpression for same valued literals with followvar

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -593,16 +593,16 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
     // Follow variable
     if (followVar && tok1->str() != tok2->str() && (Token::Match(tok1, "%var%") || Token::Match(tok2, "%var%"))) {
         const Token * varTok1 = followVariableExpression(tok1, cpp, tok2);
-        if (varTok1->str() == tok2->str()) {
+        if ((varTok1->str() == tok2->str()) || isSameConstantValue(macro, varTok1, tok2)) {
             followVariableExpressionError(tok1, varTok1, errors);
             return isSameExpression(cpp, macro, varTok1, tok2, library, true, followVar, errors);
         }
         const Token * varTok2 = followVariableExpression(tok2, cpp, tok1);
-        if (tok1->str() == varTok2->str()) {
+        if ((tok1->str() == varTok2->str()) || isSameConstantValue(macro, tok1, varTok2)) {
             followVariableExpressionError(tok2, varTok2, errors);
             return isSameExpression(cpp, macro, tok1, varTok2, library, true, followVar, errors);
         }
-        if (varTok1->str() == varTok2->str()) {
+        if ((varTok1->str() == varTok2->str()) || isSameConstantValue(macro, varTok1, varTok2)) {
             followVariableExpressionError(tok1, varTok1, errors);
             followVariableExpressionError(tok2, varTok2, errors);
             return isSameExpression(cpp, macro, varTok1, varTok2, library, true, followVar, errors);

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -142,9 +142,10 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
+        tokenizer.simplifyTokens1("");
         const Token * const tok1 = Token::findsimplematch(tokenizer.tokens(), tokStr1);
         const Token * const tok2 = Token::findsimplematch(tok1->next(), tokStr2);
-        return ::isSameExpression(false, false, tok1, tok2, library, false, false, nullptr);
+        return ::isSameExpression(false, false, tok1, tok2, library, false, true, nullptr);
     }
 
     void isSameExpression() {
@@ -161,6 +162,9 @@ private:
         ASSERT_EQUALS(true,  isSameExpression("(1 + x) < (x + 1);", "+", "+"));
         ASSERT_EQUALS(false, isSameExpression("(1.0l + x) < (1.0 + x);", "+", "+"));
         ASSERT_EQUALS(true,  isSameExpression("(0.0 + x) < (x + 0x0p+0);", "+", "+"));
+        ASSERT_EQUALS(true,  isSameExpression("void f() {double y = 1e1; (x + y) < (x + 10.0); } ", "+", "+"));
+        ASSERT_EQUALS(true,  isSameExpression("void f() {double y = 1e1; (x + 10.0) < (y + x); } ", "+", "+"));
+        ASSERT_EQUALS(true,  isSameExpression("void f() {double y = 1e1; double z = 10.0; (x + y) < (x + z); } ", "+", "+"));
     }
 
     bool isVariableChanged(const char code[], const char startPattern[], const char endPattern[]) {


### PR DESCRIPTION
It allows (for example) cppcheck to detect that the lhs and the rhs are
the same in the following example:

	double g()
	{
        	double a = 1e1
	        return a & 10.0;
	}