### PR TITLE
Allow filtering when using --project

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -186,7 +186,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
         if (!ignored.empty())
             std::cout << "cppcheck: Maybe all paths were ignored?" << std::endl;
         return false;
-    } else if (!mSettings->fileFilter.empty()) {
+    } else if (!mSettings->fileFilter.empty() && settings.project.fileSettings.empty()) {
         std::map<std::string, std::size_t> newMap;
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i)
             if (matchglob(mSettings->fileFilter, i->first)) {


### PR DESCRIPTION
Hi,

some time ago I was looking for this feature: https://sourceforge.net/p/cppcheck/discussion/general/thread/08b0400c/
Looks like it is actually almost there. This tiny PR allows filtering (--file-filter) together with project files. 

Thanks for making cppcheck!