### PR TITLE
add command line option to select single project configuration of loaded solution

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -575,7 +575,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 mSettings->checkAllConfigurations = false; // Can be overridden with --max-configs or --force
                 const std::string projectFile = argv[i]+10;
                 ImportProject::Type projType = mSettings->project.import(projectFile, mSettings);
-                mSettings->project.mType = projType;
+                mSettings->project.projectType = projType;
                 if (projType == ImportProject::Type::CPPCHECK_GUI) {
                     mPathNames = mSettings->project.guiProject.pathNames;
                     for (const std::string &lib : mSettings->project.guiProject.libraries)
@@ -633,7 +633,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             // --project-configuration
             else if (std::strncmp(argv[i], "--project-configuration=", 24) == 0) {
                 mVSConfig = argv[i] + 24;
-                if (!mVSConfig.empty() && (mSettings->project.mType == ImportProject::Type::VS_SLN || mSettings->project.mType == ImportProject::Type::VS_VCXPROJ))
+                if (!mVSConfig.empty() && (mSettings->project.projectType == ImportProject::Type::VS_SLN || mSettings->project.projectType == ImportProject::Type::VS_VCXPROJ))
                     mSettings->project.ignoreOtherConfigs(mVSConfig);
             }
 

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -631,8 +631,8 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             }
 
             // --project-configuration
-            else if (std::strncmp(argv[i], "--project-configuration", 23) == 0) {
-                mVSConfig = argv[i] + 8;
+            else if (std::strncmp(argv[i], "--project-configuration=", 24) == 0) {
+                mVSConfig = argv[i] + 24;
                 if (!mVSConfig.empty() && (mSettings->project.mType == ImportProject::Type::VS_SLN || mSettings->project.mType == ImportProject::Type::VS_VCXPROJ))
                     mSettings->project.ignoreOtherConfigs(mVSConfig);
             }

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -575,6 +575,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 mSettings->checkAllConfigurations = false; // Can be overridden with --max-configs or --force
                 const std::string projectFile = argv[i]+10;
                 ImportProject::Type projType = mSettings->project.import(projectFile, mSettings);
+                mSettings->project.mType = projType;
                 if (projType == ImportProject::Type::CPPCHECK_GUI) {
                     mPathNames = mSettings->project.guiProject.pathNames;
                     for (const std::string &lib : mSettings->project.guiProject.libraries)
@@ -627,6 +628,13 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printMessage("cppcheck: Failed to load project '" + projectFile + "'. The format is unknown.");
                     return false;
                 }
+            }
+
+            // --project-configuration
+            else if (std::strncmp(argv[i], "--project-configuration", 23) == 0) {
+                mVSConfig = argv[i] + 8;
+                if (!mVSConfig.empty() && (mSettings->project.mType == ImportProject::Type::VS_SLN || mSettings->project.mType == ImportProject::Type::VS_VCXPROJ))
+                    mSettings->project.ignoreOtherConfigs(mVSConfig);
             }
 
             // Report progress
@@ -1108,6 +1116,11 @@ void CmdLineParser::printHelp()
               "                         or Borland C++ Builder 6 (*.bpr). The files to analyse,\n"
               "                         include paths, defines, platform and undefines in\n"
               "                         the specified file will be used.\n"
+              "    --project-configuration=<config>\n"
+              "                         If used together with a Visual Studio Solution (*.sln)\n"
+              "                         or Visual Studio Project (*.vcxproj) you can limit\n"
+              "                         the configuration cppcheck should check.\n"
+              "                         For example: ""--project-configuration=Release|Win32"""
               "    --max-configs=<limit>\n"
               "                         Maximum number of configurations to check in a file\n"
               "                         before skipping it. Default is '12'. If used together\n"

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -114,6 +114,7 @@ private:
     bool mShowVersion;
     bool mShowErrorMessages;
     bool mExitAfterPrint;
+    std::string mVSConfig;
 };
 
 /// @}

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -34,6 +34,11 @@
 #include <sstream>
 
 
+ImportProject::ImportProject()
+{
+    projectType = Type::UNKNOWN;
+}
+
 void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
 {
     for (std::list<FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -81,6 +81,7 @@ public:
         void setIncludePaths(const std::string &basepath, const std::list<std::string> &in, std::map<std::string, std::string, cppcheck::stricmp> &variables);
     };
     std::list<FileSettings> fileSettings;
+    Type mType;
 
     void selectOneVsConfig(cppcheck::Platform::PlatformType platform);
 

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -81,7 +81,9 @@ public:
         void setIncludePaths(const std::string &basepath, const std::list<std::string> &in, std::map<std::string, std::string, cppcheck::stricmp> &variables);
     };
     std::list<FileSettings> fileSettings;
-    Type mType;
+    Type projectType;
+
+    ImportProject();
 
     void selectOneVsConfig(cppcheck::Platform::PlatformType platform);
 

--- a/man/manual.md
+++ b/man/manual.md
@@ -179,6 +179,11 @@ Running Cppcheck on a Visual Studio project:
 
     cppcheck --project=foobar.vcxproj
 
+Both options will analyze all available configurations in the project(s).
+Limiting on a single configuration:
+
+    cppcheck --project=foobar.sln "--project-configuration=Release|Win32"
+
 In the `Cppcheck GUI` you have the choice to only analyze a single debug configuration. If you want to use this choice on the command line then create a `Cppcheck GUI` project with this activated and then import the GUI project file on the command line.
 
 To ignore certain folders in the project you can use `-i`. This will skip analysis of source files in the `foo` folder.


### PR DESCRIPTION
In #1795 a command line option was introduced, but the PR was not completed.
Here is the change again, limited to command line access.
Thanks to @fuzzelhjb providing base implementation.

Maybe missing:
- [ ] check whether --project is active and provided before --project-configuration
