### PR TITLE
misra.py: Fix false negative for rule 20.4

### DIFF
--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -955,6 +955,7 @@ union misra_19_2 { }; // 19.2
 #include "notfound.h" // 20.1
 
 #define int short // 20.4
+#define inline "foo" // no warning in C90 standard
 #undef X  // 20.5
 
 #define M_20_7_1(A)  (A+1) // 20.7


### PR DESCRIPTION
Define different sets of reserved keywords for C90 and C99.

This will fix false negative for compliant example, defined in MISRA document, and close [trac 9506](https://trac.cppcheck.net/ticket/9605).