### PR TITLE
a new method to declare inline suppress which is more readable and more convenient.

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -81,15 +81,19 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
     std::list<Suppressions::Suppression> inlineSuppressions;
     for (const simplecpp::Token *tok = tokens.cfront(); tok; tok = tok->next) {
         if (tok->comment) {
-            Suppressions::Suppression s;
-            std::string errmsg;
-            if (!s.parseComment(tok->str(), &errmsg))
-                continue;
-            if (!errmsg.empty())
-                bad->push_back(BadInlineSuppression(tok->location, errmsg));
-            if (!s.errorId.empty())
-                inlineSuppressions.push_back(s);
-            continue;
+			int nextStartIndex = 0;
+			while (nextStartIndex>= 0) {
+                Suppressions::Suppression s;
+                std::string errmsg;
+				nextStartIndex = s.parseComment(tok->str(), nextStartIndex, &errmsg);
+                if (nextStartIndex < 0)
+                    break;
+                if (!errmsg.empty())
+                    bad->push_back(BadInlineSuppression(tok->location, errmsg));
+                if (!s.errorId.empty())
+                    inlineSuppressions.push_back(s);
+			}
+			continue;
         }
 
         if (inlineSuppressions.empty())
@@ -110,7 +114,7 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
         // Add the suppressions.
         for (Suppressions::Suppression &suppr : inlineSuppressions) {
             suppr.fileName = relativeFilename;
-            suppr.lineNumber = tok->location.line;
+            suppr.lineNumber = tok->location.line-2;
             mSettings.nomsg.addSuppression(suppr);
         }
         inlineSuppressions.clear();

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -78,14 +78,12 @@ namespace {
 
 static void parseCommentToken(const simplecpp::Token *tok, std::list<Suppressions::Suppression> &inlineSuppressions, std::list<BadInlineSuppression> *bad)
 {
-    static Suppressions suppressions;
-
-    size_t position=tok->str().find("cppcheck-suppress");
+    const std::size_t position=tok->str().find("cppcheck-suppress");
     if (position != std::string::npos) {
         if ((tok->str().length() > position+17) && (tok->str()[position+17] == '[')) {  //multi suppress format
             std::string errmsg;
             std::vector<Suppressions::Suppression> ss;
-            ss = suppressions.parseMultiSuppressComment(tok->str(), &errmsg);
+            ss = Suppressions::parseMultiSuppressComment(tok->str(), &errmsg);
 
             if (!errmsg.empty())
                 bad->push_back(BadInlineSuppression(tok->location, errmsg));

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -114,7 +114,7 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
         // Add the suppressions.
         for (Suppressions::Suppression &suppr : inlineSuppressions) {
             suppr.fileName = relativeFilename;
-            suppr.lineNumber = tok->location.line-2;
+            suppr.lineNumber = tok->location.line-1;
             mSettings.nomsg.addSuppression(suppr);
         }
         inlineSuppressions.clear();

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -81,18 +81,14 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
     std::list<Suppressions::Suppression> inlineSuppressions;
     for (const simplecpp::Token *tok = tokens.cfront(); tok; tok = tok->next) {
         if (tok->comment) {
-            int nextStartIndex = 0;
-            while (nextStartIndex>= 0) {
-                Suppressions::Suppression s;
-                std::string errmsg;
-                nextStartIndex = s.parseComment(tok->str(), nextStartIndex, &errmsg);
-                if (nextStartIndex < 0)
-                    break;
-                if (!errmsg.empty())
-                    bad->push_back(BadInlineSuppression(tok->location, errmsg));
-                if (!s.errorId.empty())
-                    inlineSuppressions.push_back(s);
-            }
+            Suppressions::Suppression s;
+            std::string errmsg;
+            if (!s.parseComment(tok->str(), &errmsg))
+                continue;
+            if (!errmsg.empty())
+                bad->push_back(BadInlineSuppression(tok->location, errmsg));
+            if (!s.errorId.empty())
+                inlineSuppressions.push_back(s);
             continue;
         }
 

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -81,19 +81,19 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
     std::list<Suppressions::Suppression> inlineSuppressions;
     for (const simplecpp::Token *tok = tokens.cfront(); tok; tok = tok->next) {
         if (tok->comment) {
-			int nextStartIndex = 0;
-			while (nextStartIndex>= 0) {
+            int nextStartIndex = 0;
+            while (nextStartIndex>= 0) {
                 Suppressions::Suppression s;
                 std::string errmsg;
-				nextStartIndex = s.parseComment(tok->str(), nextStartIndex, &errmsg);
+                nextStartIndex = s.parseComment(tok->str(), nextStartIndex, &errmsg);
                 if (nextStartIndex < 0)
                     break;
                 if (!errmsg.empty())
                     bad->push_back(BadInlineSuppression(tok->location, errmsg));
                 if (!s.errorId.empty())
                     inlineSuppressions.push_back(s);
-			}
-			continue;
+            }
+            continue;
         }
 
         if (inlineSuppressions.empty())

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -110,7 +110,7 @@ static void inlineSuppressions(const simplecpp::TokenList &tokens, Settings &mSe
         // Add the suppressions.
         for (Suppressions::Suppression &suppr : inlineSuppressions) {
             suppr.fileName = relativeFilename;
-            suppr.lineNumber = tok->location.line-1;
+            suppr.lineNumber = tok->location.line;
             mSettings.nomsg.addSuppression(suppr);
         }
         inlineSuppressions.clear();

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -182,39 +182,39 @@ void Suppressions::ErrorMessage::setFileName(const std::string &s)
 
 int Suppressions::Suppression::parseComment(std::string comment, unsigned int startIndex, std::string *errorMessage)
 {
-	if (comment.size() < 2)
-		return -1;
+    if (comment.size() < 2)
+        return -1;
 
-	size_t suppress_position = comment.find("cppcheck-suppress", startIndex);
-	if (suppress_position == std::string::npos)
-		return -1;
+    size_t suppress_position = comment.find("cppcheck-suppress", startIndex);
+    if (suppress_position == std::string::npos)
+        return -1;
 
-	std::istringstream iss(comment.substr(suppress_position));
-	std::string suppress_word;
-	iss >> suppress_word;
+    std::istringstream iss(comment.substr(suppress_position));
+    std::string suppress_word;
+    iss >> suppress_word;
 
-	//there must has a ':' after cppcheck-suppress, and ':' must not adjoins '@'
-	if (suppress_word.length()<=18 || suppress_word[17]!=':' || suppress_word[18]=='@') {
+    //there must has a ':' after cppcheck-suppress, and ':' must not adjoins '@'
+    if (suppress_word.length()<=18 || suppress_word[17]!=':' || suppress_word[18]=='@') {
         if (errorMessage && errorMessage->empty())
             *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
-		return suppress_position+suppress_word.length();
-	}
+        return suppress_position+suppress_word.length();
+    }
 
-	//'@' is optional
-	size_t symbol_position = suppress_word.find("@");
-	if (symbol_position == std::string::npos) {    //no need parse symbol name
-		errorId = suppress_word.substr(18);
-	}
-	else {                                  //need parse symbol name
-	    //if '@' exist, there must has symbol after '@'
-	    if (suppress_word.length()<=symbol_position+1) {
+    //'@' is optional
+    size_t symbol_position = suppress_word.find("@");
+    if (symbol_position == std::string::npos) {    //no need parse symbol name
+        errorId = suppress_word.substr(18);
+    }
+    else {                                  //need parse symbol name
+        //if '@' exist, there must has symbol after '@'
+        if (suppress_word.length()<=symbol_position+1) {
             if (errorMessage && errorMessage->empty())
                 *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
-			return suppress_position+suppress_word.length();
-	    }
-		errorId = suppress_word.substr(18, symbol_position-18);
-		symbolName = suppress_word.substr(symbol_position+1);
-	}
+            return suppress_position+suppress_word.length();
+        }
+        errorId = suppress_word.substr(18, symbol_position-18);
+        symbolName = suppress_word.substr(symbol_position+1);
+    }
 
     return suppress_position+suppress_word.length();
 }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -118,12 +118,12 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     if (comment.size() < 2)
         return suppressions;
 
-    size_t suppress_position = comment.find("cppcheck-suppress");
+    const std::size_t suppress_position = comment.find("cppcheck-suppress");
     if (suppress_position == std::string::npos)
         return suppressions;
 
-    size_t start_position = comment.find("[", suppress_position);
-    size_t end_position = comment.find("]", suppress_position);
+    const std::size_t start_position = comment.find("[", suppress_position);
+    const std::size_t end_position = comment.find("]", suppress_position);
     if (   start_position == std::string::npos 
         || end_position == std::string::npos 
         || start_position != suppress_position+17 //there must be no space before "["
@@ -135,22 +135,23 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     }
 
     //extract supressions
-    size_t current_comma_position = 0;
-    std::string suppression_word;
+    std::size_t current_comma_position = 0;
     //multi_suppressions_word maybe "[errorId1, errorId2 symbolName=arr", who just has left bracket
     std::string multi_suppressions_word = comment.substr(start_position, end_position-start_position);
     do
     {
+        std::string suppression_word;
+
         //single suppression word
-        size_t previou_comma_position=current_comma_position;
-        current_comma_position=multi_suppressions_word.find(",", previou_comma_position+1);  //find "," after previous comma
+        const std::size_t previous_comma_position=current_comma_position;
+        current_comma_position=multi_suppressions_word.find(",", previous_comma_position+1);  //find "," after previous comma
         if (current_comma_position == std::string::npos)
         {
-            suppression_word = multi_suppressions_word.substr(previou_comma_position+1);
+            suppression_word = multi_suppressions_word.substr(previous_comma_position+1);
         }
         else
         {
-            suppression_word = multi_suppressions_word.substr(previou_comma_position+1, current_comma_position-previou_comma_position-1);
+            suppression_word = multi_suppressions_word.substr(previous_comma_position+1, current_comma_position-previous_comma_position-1);
         }
 
         //parse single suppression word

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -112,6 +112,13 @@ std::string Suppressions::parseXmlFile(const char *filename)
     return "";
 }
 
+std::vector<Suppressions::Suppression> Suppressions::parseComment(std::string comment, std::string *errorMessageconst)
+{
+    std::vector<Suppression> suppressions;
+
+    return suppressions;
+}
+
 std::string Suppressions::addSuppressionLine(const std::string &line)
 {
     std::istringstream lineStream(line);

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -122,12 +122,11 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     if (suppress_position == std::string::npos)
         return suppressions;
 
-    //legal format is "cppcheck-suppress[errorId, errorId symbolName=arr]"
     size_t start_position = comment.find("[", suppress_position);
     size_t end_position = comment.find("]", suppress_position);
     if (   start_position == std::string::npos 
         || end_position == std::string::npos 
-        || start_position != suppress_position+17 //between "cppcheck-suppress" and "[" there must no space
+        || start_position != suppress_position+17 //there must be no space before "["
         || start_position >= end_position)
     {
         if (errorMessage && errorMessage->empty())
@@ -136,7 +135,6 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     }
 
     //extract supressions
-    size_t previou_comma_position = 0;
     size_t current_comma_position = 0;
     std::string suppression_word;
     //multi_suppressions_word maybe "[errorId1, errorId2 symbolName=arr", who just has left bracket
@@ -144,7 +142,7 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     do
     {
         //single suppression word
-        previou_comma_position=current_comma_position;
+        size_t previou_comma_position=current_comma_position;
         current_comma_position=multi_suppressions_word.find(",", previou_comma_position+1);  //find "," after previous comma
         if (current_comma_position == std::string::npos)
         {

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -118,9 +118,15 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     if (comment.size() < 2)
         return suppressions;
 
-    const std::size_t suppress_position = comment.find("cppcheck-suppress");
+    const std::size_t first_non_blank_position = comment.find_first_not_of(" \t\n", 2);
+    const std::size_t suppress_position = comment.find("cppcheck-suppress", 2);
     if (suppress_position == std::string::npos)
         return suppressions;
+    if (suppress_position != first_non_blank_position) {
+        if (errorMessage && errorMessage->empty())
+            *errorMessage = "Bad multi suppression '" + comment + "'. there shouldn't have non-blank character before cppcheck-suppress";
+        return suppressions;
+    }
 
     const std::size_t start_position = comment.find("[", suppress_position);
     const std::size_t end_position = comment.find("]", suppress_position);

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -127,7 +127,7 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     size_t end_position = comment.find("]", suppress_position);
     if (   start_position == std::string::npos 
         || end_position == std::string::npos 
-        || start_position != suppress_position+1 //between "cppcheck-suppress" and "[" there must no space
+        || start_position != suppress_position+17 //between "cppcheck-suppress" and "[" there must no space
         || start_position >= end_position)
     {
         if (errorMessage && errorMessage->empty())
@@ -139,7 +139,8 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(s
     size_t previou_comma_position = 0;
     size_t current_comma_position = 0;
     std::string suppression_word;
-    std::string multi_suppressions_word = comment.substr(start_position+1, end_position-start_position-1);
+    //multi_suppressions_word maybe "[errorId1, errorId2 symbolName=arr", who just has left bracket
+    std::string multi_suppressions_word = comment.substr(start_position, end_position-start_position);
     do
     {
         //single suppression word

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -180,40 +180,45 @@ void Suppressions::ErrorMessage::setFileName(const std::string &s)
     mFileName = Path::simplifyPath(s);
 }
 
-bool Suppressions::Suppression::parseComment(std::string comment, std::string *errorMessage)
+int Suppressions::Suppression::parseComment(std::string comment, unsigned int startIndex, std::string *errorMessage)
 {
-    if (comment.size() < 2)
-        return false;
+	size_t position;
 
-    if (comment.find(';') != std::string::npos)
-        comment.erase(comment.find(';'));
+	if (comment.size() < 2)
+		return -1;
 
-    if (comment.find("//", 2) != std::string::npos)
-        comment.erase(comment.find("//",2));
+	position = comment.find("cppcheck-suppress", startIndex);
+	if (position == std::string::npos)
+		return -1;
 
-    if (comment.compare(comment.size() - 2, 2, "*/") == 0)
-        comment.erase(comment.size() - 2, 2);
+	std::istringstream iss(comment.substr(position));
+	std::string suppress_word;
+	iss >> suppress_word;
 
-    std::istringstream iss(comment.substr(2));
-    std::string word;
-    iss >> word;
-    if (word != "cppcheck-suppress")
-        return false;
-    iss >> errorId;
-    if (!iss)
-        return false;
-    while (iss) {
-        iss >> word;
-        if (!iss)
-            break;
-        if (word.find_first_not_of("+-*/%#;") == std::string::npos)
-            break;
-        if (word.compare(0,11,"symbolName=")==0)
-            symbolName = word.substr(11);
-        else if (errorMessage && errorMessage->empty())
-            *errorMessage = "Bad suppression attribute '" + word + "'. You can write comments in the comment after a ; or //. Valid suppression attributes; symbolName=sym";
-    }
-    return true;
+	//there must has a ':' after cppcheck-suppress, and ':' must not adjoins '@'
+	if (suppress_word.length()<=18 || suppress_word[17]!=':' || suppress_word[18]=='@') {
+        if (errorMessage && errorMessage->empty())
+            *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
+		return startIndex+suppress_word.length();
+	}
+
+	//'@' is optional
+	position = suppress_word.find("@");
+	if (position == std::string::npos) {    //no need parse symbol name
+		errorId = suppress_word.substr(18);
+	}
+	else {                                  //need parse symbol name
+	    //if '@' exist, there must has symbol after '@'
+	    if (suppress_word.length()<=position+1) {
+            if (errorMessage && errorMessage->empty())
+                *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
+			return startIndex+suppress_word.length();
+	    }
+		errorId = suppress_word.substr(18, position-18);
+		symbolName = suppress_word.substr(position+1);
+	}
+
+    return startIndex+suppress_word.length();
 }
 
 bool Suppressions::Suppression::isSuppressed(const Suppressions::ErrorMessage &errmsg) const

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -182,16 +182,14 @@ void Suppressions::ErrorMessage::setFileName(const std::string &s)
 
 int Suppressions::Suppression::parseComment(std::string comment, unsigned int startIndex, std::string *errorMessage)
 {
-	size_t position;
-
 	if (comment.size() < 2)
 		return -1;
 
-	position = comment.find("cppcheck-suppress", startIndex);
-	if (position == std::string::npos)
+	size_t suppress_position = comment.find("cppcheck-suppress", startIndex);
+	if (suppress_position == std::string::npos)
 		return -1;
 
-	std::istringstream iss(comment.substr(position));
+	std::istringstream iss(comment.substr(suppress_position));
 	std::string suppress_word;
 	iss >> suppress_word;
 
@@ -199,26 +197,26 @@ int Suppressions::Suppression::parseComment(std::string comment, unsigned int st
 	if (suppress_word.length()<=18 || suppress_word[17]!=':' || suppress_word[18]=='@') {
         if (errorMessage && errorMessage->empty())
             *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
-		return startIndex+suppress_word.length();
+		return suppress_position+suppress_word.length();
 	}
 
 	//'@' is optional
-	position = suppress_word.find("@");
-	if (position == std::string::npos) {    //no need parse symbol name
+	size_t symbol_position = suppress_word.find("@");
+	if (symbol_position == std::string::npos) {    //no need parse symbol name
 		errorId = suppress_word.substr(18);
 	}
 	else {                                  //need parse symbol name
 	    //if '@' exist, there must has symbol after '@'
-	    if (suppress_word.length()<=position+1) {
+	    if (suppress_word.length()<=symbol_position+1) {
             if (errorMessage && errorMessage->empty())
                 *errorMessage = "Bad suppression attribute '" + suppress_word + "'. legal format is cppcheck-suppress:errorId or cppcheck-suppress:errorId@symbol";
-			return startIndex+suppress_word.length();
+			return suppress_position+suppress_word.length();
 	    }
-		errorId = suppress_word.substr(18, position-18);
-		symbolName = suppress_word.substr(position+1);
+		errorId = suppress_word.substr(18, symbol_position-18);
+		symbolName = suppress_word.substr(symbol_position+1);
 	}
 
-    return startIndex+suppress_word.length();
+    return suppress_position+suppress_word.length();
 }
 
 bool Suppressions::Suppression::isSuppressed(const Suppressions::ErrorMessage &errmsg) const

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -78,11 +78,10 @@ public:
         /**
          * Parse inline suppression in comment
          * @param comment the full comment text
-         * @param startIndex start position to find "cppcheck-suppress"
          * @param errorMessage output parameter for error message (wrong suppression attribute)
-         * @return next search start position of "cppcheck-suppress", -1 means has not find "cppcheck-suppress"
+         * @return true if it is a inline comment.
          */
-        int parseComment(std::string comment, unsigned int startIndex, std::string *errorMessage);
+        bool parseComment(std::string comment, std::string *errorMessage);
 
         bool isSuppressed(const ErrorMessage &errmsg) const;
 

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -122,7 +122,7 @@ public:
      * @param errorMessage output parameter for error message (wrong suppression attribute)
      * @return empty vector if something wrong.
      */
-    std::vector<Suppression> parseMultiSuppressComment(std::string comment, std::string *errorMessageconst);
+    std::vector<Suppression> parseMultiSuppressComment(std::string comment, std::string *errorMessage);
 
     /**
      * @brief Don't show the given error.

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -26,6 +26,7 @@
 #include <list>
 #include <set>
 #include <string>
+#include <vector>
 
 /// @addtogroup Core
 /// @{
@@ -114,6 +115,14 @@ public:
      * @return error message. empty upon success
      */
     std::string parseXmlFile(const char *filename);
+
+    /**
+     * Parse multi inline suppression in comment
+     * @param comment the full comment text
+     * @param errorMessage output parameter for error message (wrong suppression attribute)
+     * @return empty vector if it is a inline comment.
+     */
+    std::vector<Suppression> parseComment(std::string comment, std::string *errorMessageconst);
 
     /**
      * @brief Don't show the given error.

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -120,7 +120,7 @@ public:
      * Parse multi inline suppression in comment
      * @param comment the full comment text
      * @param errorMessage output parameter for error message (wrong suppression attribute)
-     * @return empty vector if it is a inline comment.
+     * @return empty vector if something wrong.
      */
     std::vector<Suppression> parseComment(std::string comment, std::string *errorMessageconst);
 

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -78,10 +78,11 @@ public:
         /**
          * Parse inline suppression in comment
          * @param comment the full comment text
+         * @param startIndex start position to find "cppcheck-suppress"
          * @param errorMessage output parameter for error message (wrong suppression attribute)
-         * @return true if it is a inline comment.
+         * @return next search start position of "cppcheck-suppress", -1 means has not find "cppcheck-suppress"
          */
-        bool parseComment(std::string comment, std::string *errorMessage);
+        int parseComment(std::string comment, unsigned int startIndex, std::string *errorMessage);
 
         bool isSuppressed(const ErrorMessage &errmsg) const;
 

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -122,7 +122,7 @@ public:
      * @param errorMessage output parameter for error message (wrong suppression attribute)
      * @return empty vector if something wrong.
      */
-    std::vector<Suppression> parseComment(std::string comment, std::string *errorMessageconst);
+    std::vector<Suppression> parseMultiSuppressComment(std::string comment, std::string *errorMessageconst);
 
     /**
      * @brief Don't show the given error.

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -122,7 +122,7 @@ public:
      * @param errorMessage output parameter for error message (wrong suppression attribute)
      * @return empty vector if something wrong.
      */
-    std::vector<Suppression> parseMultiSuppressComment(std::string comment, std::string *errorMessage);
+    static std::vector<Suppression> parseMultiSuppressComment(std::string comment, std::string *errorMessage);
 
     /**
      * @brief Don't show the given error.

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -54,6 +54,9 @@ private:
         TEST_CASE(inlinesuppress_symbolname);
         TEST_CASE(inlinesuppress_comment);
 
+        TEST_CASE(multi_inlinesuppress);
+        TEST_CASE(multi_inlinesuppress_comment);
+
         TEST_CASE(globalSuppressions); // Testing that global suppressions work (#8515)
 
         TEST_CASE(inlinesuppress_unusedFunction); // #4210 - unusedFunction
@@ -465,6 +468,103 @@ private:
         ASSERT_EQUALS("", errMsg);
         ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc -- some comment", &errMsg));
         ASSERT_EQUALS("", errMsg);
+    }
+
+    void multi_inlinesuppress() {
+        Suppressions ss;
+        std::vector<Suppressions::Suppression> suppressions;
+        std::string errMsg;
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId]", &errMsg);
+        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS("errorId", suppressions[0].errorId);
+        ASSERT_EQUALS("", suppressions[0].symbolName);
+        ASSERT_EQUALS("", errMsg);
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId symbolName=arr]", &errMsg);
+        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS("errorId", suppressions[0].errorId);
+        ASSERT_EQUALS("arr", suppressions[0].symbolName);
+        ASSERT_EQUALS("", errMsg);
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId symbolName=]", &errMsg);
+        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS("errorId", suppressions[0].errorId);
+        ASSERT_EQUALS("", suppressions[0].symbolName);
+        ASSERT_EQUALS("", errMsg);
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS("errorId1", suppressions[0].errorId);
+        ASSERT_EQUALS("", suppressions[0].symbolName);
+        ASSERT_EQUALS("errorId2", suppressions[1].errorId);
+        ASSERT_EQUALS("arr", suppressions[1].symbolName);
+        ASSERT_EQUALS("", errMsg);
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress [errorId]", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[]", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress errorId", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1 errorId2 symbolName=arr]", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbol=arr]", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbolName]", &errMsg);
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
+    }
+
+    void multi_inlinesuppress_comment() {
+        Suppressions ss;
+        std::vector<Suppressions::Suppression> suppressions;
+        std::string errMsg;
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("//cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(true, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("//some text cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(true, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("//cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(true, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("//some text cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(true, errMsg.empty());
     }
 
     void globalSuppressions() { // Testing that Cppcheck::useGlobalSuppressions works (#8515)

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -329,6 +329,14 @@ private:
         // suppress uninitvar inline
         (this->*check)("void f() {\n"
                        "    int a;\n"
+                       "    a++;// cppcheck-suppress uninitvar\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
                        "    /* cppcheck-suppress uninitvar */\n"
                        "    a++;\n"
                        "}\n",
@@ -341,6 +349,69 @@ private:
                        "    /* cppcheck-suppress uninitvar */\n"
                        "\n"
                        "    a++;\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    a++;/* cppcheck-suppress uninitvar */\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    // cppcheck-suppress[uninitvar]\n"
+                       "    a++;\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    // cppcheck-suppress[uninitvar]\n"
+                       "    a++;\n"
+                       "\n"
+                       "    a++;\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    a++;// cppcheck-suppress[uninitvar]\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    /* cppcheck-suppress[uninitvar]*/\n"
+                       "    a++;\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    /* cppcheck-suppress[uninitvar]*/\n"
+                       "\n"
+                       "    a++;\n"
+                       "}\n",
+                       "");
+        ASSERT_EQUALS("", errout.str());
+
+        // suppress uninitvar inline
+        (this->*check)("void f() {\n"
+                       "    int a;\n"
+                       "    a++;/* cppcheck-suppress[uninitvar]*/\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -563,6 +634,11 @@ private:
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//some text cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
+        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(true, errMsg.empty());
+
+        errMsg = "";
+        suppressions=ss.parseMultiSuppressComment("/*cppcheck-suppress[errorId1, errorId2 symbolName=arr]*/", &errMsg);
         ASSERT_EQUALS(2, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
     }

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -307,8 +307,7 @@ private:
         // suppress uninitvar inline
         (this->*check)("void f() {\n"
                        "    int a;\n"
-                       "    // cppcheck-suppress uninitvar\n"
-                       "    a++;\n"
+                       "    a++;// cppcheck-suppress:uninitvar\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -316,9 +315,8 @@ private:
         // suppress uninitvar inline
         (this->*check)("void f() {\n"
                        "    int a;\n"
-                       "    // cppcheck-suppress uninitvar\n"
+                       "    a++;// cppcheck-suppress:uninitvar\n"
                        "\n"
-                       "    a++;\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -326,8 +324,7 @@ private:
         // suppress uninitvar inline
         (this->*check)("void f() {\n"
                        "    int a;\n"
-                       "    /* cppcheck-suppress uninitvar */\n"
-                       "    a++;\n"
+                       "    a++;/* cppcheck-suppress:uninitvar */\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -335,9 +332,8 @@ private:
         // suppress uninitvar inline
         (this->*check)("void f() {\n"
                        "    int a;\n"
-                       "    /* cppcheck-suppress uninitvar */\n"
+                       "    a++;/* cppcheck-suppress:uninitvar */\n"
                        "\n"
-                       "    a++;\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -348,8 +344,7 @@ private:
                        "        foo\n"
                        "    }"
                        "    int a;\n"
-                       "    // cppcheck-suppress uninitvar\n"
-                       "    a++;\n"
+                       "    a++;// cppcheck-suppress:uninitvar\n"
                        "}",
                        "");
         ASSERT_EQUALS("", errout.str());
@@ -357,8 +352,7 @@ private:
         // suppress uninitvar inline, without error present
         (this->*check)("void f() {\n"
                        "    int a;\n"
-                       "    // cppcheck-suppress uninitvar\n"
-                       "    b++;\n"
+                       "    b++;// cppcheck-suppress:uninitvar\n"
                        "}\n",
                        "");
         ASSERT_EQUALS("[test.cpp:4]: (information) Unmatched suppression: uninitvar\n", errout.str());
@@ -425,15 +419,41 @@ private:
     void inlinesuppress() {
         Suppressions::Suppression s;
         std::string msg;
-        ASSERT_EQUALS(false, s.parseComment("/* some text */", &msg));
-        ASSERT_EQUALS(false, s.parseComment("/* cppcheck-suppress */", &msg));
+        msg.clear();
+        ASSERT_EQUALS(-1, s.parseComment("/* some text */", 0, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+		
+        msg.clear();
+        ASSERT_EQUALS(20, s.parseComment("/* cppcheck-suppress */", 0, &msg));
+        ASSERT_EQUALS(false, msg.empty());
 
         msg.clear();
-        ASSERT_EQUALS(true, s.parseComment("/* cppcheck-suppress id */", &msg));
-        ASSERT_EQUALS("", msg);
+        ASSERT_EQUALS(21, s.parseComment("/* cppcheck-suppress: */", 0, &msg));
+        ASSERT_EQUALS(false, msg.empty());
 
-        ASSERT_EQUALS(true, s.parseComment("/* cppcheck-suppress id some text */", &msg));
-        ASSERT_EQUALS("Bad suppression attribute 'some'. You can write comments in the comment after a ; or //. Valid suppression attributes; symbolName=sym", msg);
+        msg.clear();
+        ASSERT_EQUALS(28, s.parseComment("/* cppcheck-suppress:errorId */", 0, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(29, s.parseComment("/* cppcheck-suppress:errorId@ */", 0, &msg));
+        ASSERT_EQUALS(false, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(35, s.parseComment("/* cppcheck-suppress:errorId@symbol */", 0, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(28, s.parseComment("/* cppcheck-suppress:errorId cppcheck-suppress:errorId@symbol */", 0, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(61, s.parseComment("/* cppcheck-suppress:errorId cppcheck-suppress:errorId@symbol */", 28, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(-1, s.parseComment("/* cppcheck-suppress:errorId cppcheck-suppress:errorId@symbol */", 61, &msg));
+        ASSERT_EQUALS(true, msg.empty());
     }
 
     void inlinesuppress_symbolname() {
@@ -441,16 +461,14 @@ private:
 
         checkSuppression("void f() {\n"
                          "    int a;\n"
-                         "    /* cppcheck-suppress uninitvar symbolName=a */\n"
-                         "    a++;\n"
+                         "    a++;/* cppcheck-suppress:uninitvar@a */\n"
                          "}\n",
                          "");
         ASSERT_EQUALS("", errout.str());
 
         checkSuppression("void f() {\n"
                          "    int a,b;\n"
-                         "    /* cppcheck-suppress uninitvar symbolName=b */\n"
-                         "    a++; b++;\n"
+                         "    a++; b++;/* cppcheck-suppress:uninitvar@b */\n"
                          "}\n",
                          "");
         ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: a\n", errout.str());
@@ -458,13 +476,19 @@ private:
 
     void inlinesuppress_comment() {
         Suppressions::Suppression s;
-        std::string errMsg;
-        ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc ; some comment", &errMsg));
-        ASSERT_EQUALS("", errMsg);
-        ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc // some comment", &errMsg));
-        ASSERT_EQUALS("", errMsg);
-        ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc -- some comment", &errMsg));
-        ASSERT_EQUALS("", errMsg);
+        std::string msg;
+
+        msg.clear();
+        ASSERT_EQUALS(38, s.parseComment("/* some text cppcheck-suppress:errorId some text cppcheck-suppress:errorId@symbol some text */", 0, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(81, s.parseComment("/* some text cppcheck-suppress:errorId some text cppcheck-suppress:errorId@symbol some text */", 38, &msg));
+        ASSERT_EQUALS(true, msg.empty());
+
+        msg.clear();
+        ASSERT_EQUALS(-1, s.parseComment("/* some text cppcheck-suppress:errorId some text cppcheck-suppress:errorId@symbol some text */", 81, &msg));
+        ASSERT_EQUALS(true, msg.empty());
     }
 
     void globalSuppressions() { // Testing that Cppcheck::useGlobalSuppressions works (#8515)
@@ -511,10 +535,8 @@ private:
         const char code[] =
             "struct Point\n"
             "{\n"
-            "    // cppcheck-suppress unusedStructMember\n"
-            "    int x;\n"
-            "    // cppcheck-suppress unusedStructMember\n"
-            "    int y;\n"
+            "    int x;// cppcheck-suppress:unusedStructMember\n"
+            "    int y;// cppcheck-suppress:unusedStructMember\n"
             "};";
         cppCheck.check("/somewhere/test.cpp", code);
         ASSERT_EQUALS("",errout.str());
@@ -533,8 +555,7 @@ private:
         files["test.cpp"] = "double result(0.0);\n"
                             "_asm\n"
                             "{\n"
-                            "   // cppcheck-suppress syntaxError\n"
-                            "   push  EAX               ; save EAX for callers \n"
+                            "   push  EAX               ; save EAX for callers // cppcheck-suppress:syntaxError\n"
                             "   mov   EAX,Real10        ; get the address pointed to by Real10\n"
                             "   fld   TBYTE PTR [EAX]   ; load an extended real (10 bytes)\n"
                             "   fstp  QWORD PTR result  ; store a double (8 bytes)\n"

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -622,20 +622,22 @@ private:
         ASSERT_EQUALS(2, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
 
+        //error, shouldn't have "some text" at beginning
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//some text cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
-        ASSERT_EQUALS(true, errMsg.empty());
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
         ASSERT_EQUALS(2, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
 
+        //error, shouldn't have "some text" at beginning
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//some text cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
-        ASSERT_EQUALS(true, errMsg.empty());
+        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("/*cppcheck-suppress[errorId1, errorId2 symbolName=arr]*/", &errMsg);


### PR DESCRIPTION
The old method to declare inline suppress may affect the code readability, especially when I use inline suppresses in big project, It's really a hell. I found the main reason is that every inline suppress need occupy one line, It disorganized the origin code. for example:
![image](https://user-images.githubusercontent.com/8264304/74247460-087eab00-4d21-11ea-8aaa-9f3ec6b52536.png)

Now I give a new method to declare many inline suppress In the same line with the error code. It's format just like: "cppcheck-suppress:errorId@symbol", and you can write many suppress in one line, the  part of "@symbol" can be ignored, also you can use common comment around them arbitrarily. for example:
![image](https://user-images.githubusercontent.com/8264304/74247488-16343080-4d21-11ea-9971-18ed5786e489.png)

the suppress comment above has the same effect with old method, but It's more readable. 
