### PR TITLE
9575: false positive in fclose

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -785,7 +785,11 @@ const Token * CheckLeakAutoVar::checkTokenInsideExpression(const Token * const t
         if (alloc.type == 0)
             alloc.status = VarInfo::NOALLOC;
         functionCall(tok, openingPar, varInfo, alloc, nullptr);
-        return openingPar;
+        const std::string &returnValue = mSettings->library.returnValue(tok);
+        if (returnValue.compare(0, 3, "arg") == 0)
+            // the function returns one of its argument, we need to process a potential assignment
+            return openingPar;
+        return openingPar->link();
     }
 
     return nullptr;

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -2048,6 +2048,7 @@ private:
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(returnedValue); // #9298
+        TEST_CASE(fclose_false_positive); // #9575
     }
 
     void returnedValue() { // #9298
@@ -2059,6 +2060,12 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
     }
+
+    void fclose_false_positive() { // #9575
+        check("int  f(FILE *fp) { return fclose(fp); }");
+        ASSERT_EQUALS("", errout.str());
+    }
+
 };
 
 REGISTER_TEST(TestLeakAutoVarStrcpy)


### PR DESCRIPTION
Fix false positive introduced by
https://github.com/danmar/cppcheck/commit/0b7649ca9bb51a2f8b587afc2e085bf1d82d1013

Only return the function token from checkTokenInsideExpression when it
might be one the argument (hence keeping a pointer to one of them).
Otherwise, we can directly skip to the token after the function call.