### PR TITLE
gtk.cfg: Fix syntax errors and false positives

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -161,6 +161,12 @@
   <define name="NC_(context, string)" value="(string)"/>
   <define name="g_assert(expr)" value="assert(expr)"/>
   <define name="g_assert_not_reached()" value="assert(NULL)"/>
+  <define name="g_assert_true(expr)" value="g_assert(expr)"/>
+  <define name="g_assert_cmpstr(s1, cmp, s2)" value="g_assert_true(g_strcmp0 ((s1), (s2)) cmp 0)"/>
+  <define name="g_assert_cmpint(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
+  <define name="g_assert_cmpuint(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
+  <define name="g_assert_cmphex(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
+  <define name="g_assert_cmpfloat(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
   <define name="g_signal_connect(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, (GConnectFlags) 0)"/>
   <define name="g_signal_connect_after(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, G_CONNECT_AFTER)"/>
   <define name="g_signal_connect_swapped(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, G_CONNECT_SWAPPED)"/>
@@ -881,8 +887,19 @@
       <not-bool/>
     </arg>
   </function>
+  <!-- gboolean g_hash_table_replace (GHashTable *hash_table, gpointer key, gpointer value); -->
   <function name="g_hash_table_replace">
     <noreturn>false</noreturn>
+    <arg nr="1" direction="inout">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+    </arg>
+    <arg nr="3">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <!-- GList * g_list_append (GList *list, gpointer data); -->
   <function name="g_list_append">
@@ -5246,9 +5263,16 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- void g_hash_table_iter_replace (GHashTableIter *iter, gpointer value); -->
   <function name="g_hash_table_iter_replace">
-    <leak-ignore/>
     <noreturn>false</noreturn>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
+    <arg nr="2">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_hash_table_iter_steal">
     <leak-ignore/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -11,8 +11,11 @@
 #include <glib.h>
 
 
-void validCode(int argInt)
+void validCode(int argInt, GHashTableIter * hash_table_iter, GHashTable * hash_table)
 {
+    g_assert_cmpint(4 + 1, >=, 5);
+    g_assert_cmpstr("test", ==, "test");
+
     // if G_UNLIKELY is not defined this results in a syntax error
     if G_UNLIKELY(argInt == 1) {
     } else if (G_UNLIKELY(argInt == 2)) {
@@ -59,6 +62,10 @@ void validCode(int argInt)
         gsize result_val = 1;
         g_once_init_leave(&init_val, result_val);
     }
+
+    g_hash_table_iter_replace(hash_table_iter, g_strdup("test"));
+    g_hash_table_insert(hash_table, g_strdup("key"), g_strdup("value"));
+    g_hash_table_replace(hash_table, g_strdup("key"), g_strdup("value"));
 }
 
 void g_malloc_test()


### PR DESCRIPTION
A missing definition for g_assert_cmp*() causes syntax errors if code
like g_assert_cmpint(a, ==, b); is encountered.
The function g_hash_table_iter_replace() does not have to be marked
with leak-ignore since the memory could be freed later if corresponding
functions are present in the GHashTable. Since we can not know if this
is the case we have to assume that the memory is freed to avoid false
positives. The same is true for g_hash_table_insert() and
g_hash_table_replace().