### PR TITLE
qt.cfg: #9650: Fix missing configuration for QString.chop()

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -4969,6 +4969,8 @@
       <function name="shrink_to_fit" action="change-internal"/>
       <function name="squeeze" action="change-internal"/>
       <function name="reserve" action="change-internal"/>
+      <function name="chop" action="change"/>
+      <function name="remove" action="change"/>
     </size>
     <access indexOperator="array-like">
       <function name="at" yields="at_index"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -379,7 +379,7 @@ void MacroTest2_test()
 #endif
 }
 
-void validCode(int * pIntPtr)
+void validCode(int * pIntPtr, QString & qstrArg)
 {
     if (QFile::exists("test")) {
     }
@@ -404,6 +404,19 @@ void validCode(int * pIntPtr)
     Q_DECLARE_LOGGING_CATEGORY(logging_category_test);
     QT_FORWARD_DECLARE_CLASS(forwardDeclaredClass);
     QT_FORWARD_DECLARE_STRUCT(forwardDeclaredStruct);
+
+    //#9650
+    QString qstr1(qstrArg);
+    if (qstr1.length() == 1) {
+    } else {
+        qstr1.chop(1);
+        if (qstr1.length() == 1) {}
+    }
+    if (qstr1.length() == 1) {
+    } else {
+        qstr1.remove(1);
+        if (qstr1.length() == 1) {}
+    }
 }
 
 void ignoredReturnValue()


### PR DESCRIPTION
chop() and also remove() change the size of a QString, so they have to
be added in the container configuration accordingly to avoid false
positives.