### PR TITLE
cmake/compileroptions.cmake: Fix missing stack options under Cygwin

### DIFF
--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -125,6 +125,10 @@ if (MSVC)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /STACK:8000000")
 endif()
 
+if (CYGWIN)
+    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wl,--stack,8388608")
+endif()
+
 include(cmake/dynamic_analyzer_options.cmake    REQUIRED)
 
 # Add user supplied extra options (optimization, etc...)


### PR DESCRIPTION
testrunner fails with SEGFAULT when built with cmake under Cygwin.
This fix adds a compiler option to increase the stack size in the same
way as it is already done in the Makefile.