### PR TITLE
gtk.cfg/cppcheck-cfg.rng: Add Gtk utility functions, enhance RNG file

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -123,7 +123,7 @@
               <optional>
                 <attribute name="type">
                   <data type="string">
-                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*([ ]?[*&amp;])*</param>
+                    <param name="pattern">([a-zA-Z_][a-zA-Z_0-9]*[ ])*([a-zA-Z_][a-zA-Z_0-9]*::)*([a-zA-Z_][a-zA-Z_0-9]*([ ]?[*&amp;])*)+</param>
                   </data>
                 </attribute>
               </optional>

--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -2575,9 +2575,18 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- const gchar * g_basename (const gchar *file_name); -->
   <function name="g_basename">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
+    <warn severity="style" reason="Obsolete" alternatives="g_path_get_basename">g_basename has been deprecated since version 2.2 and should not be used in newly-written code. Use g_path_get_basename() instead, but notice that g_path_get_basename() allocates new memory for the returned string, unlike this function which returns a pointer into the argument.</warn>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_bit_lock">
     <leak-ignore/>
@@ -2789,6 +2798,18 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- gchar * g_dirname (const gchar *file_name); -->
+  <function name="g_dirname">
+    <noreturn>false</noreturn>
+    <returnValue type="gchar *"/>
+    <use-retval/>
+    <warn severity="style" reason="Obsolete" alternatives="g_path_get_dirname">g_dirname is deprecated and should not be used in newly-written code. Use g_path_get_dirname() instead.</warn>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <function name="g_dngettext">
     <leak-ignore/>
     <noreturn>false</noreturn>
@@ -2874,6 +2895,12 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- gchar * g_get_current_dir (void); -->
+  <function name="g_get_current_dir">
+    <noreturn>false</noreturn>
+    <returnValue type="gchar *"/>
+    <use-retval/>
+  </function>
   <function name="g_get_current_time">
     <leak-ignore/>
     <noreturn>false</noreturn>
@@ -2910,17 +2937,26 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- const gchar * const * g_get_system_config_dirs (void); -->
   <function name="g_get_system_config_dirs">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *const *"/>
+    <use-retval/>
   </function>
+  <!-- const gchar * const * g_get_system_data_dirs (void); -->
   <function name="g_get_system_data_dirs">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *const *"/>
+    <use-retval/>
   </function>
+  <!-- const gchar * g_get_tmp_dir (void); -->
   <function name="g_get_tmp_dir">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
   </function>
   <function name="g_get_user_cache_dir">
     <leak-ignore/>
@@ -2946,9 +2982,17 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- const gchar * g_getenv (const gchar *variable); -->
   <function name="g_getenv">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_hash_table_add">
     <leak-ignore/>
@@ -3154,9 +3198,15 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- void g_nullify_pointer (gpointer *nullify_location); -->
   <function name="g_nullify_pointer">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1" direction="out">
+      <not-null/>
+      <not-bool/>
+    </arg>
   </function>
   <!-- void g_object_add_weak_pointer (GObject *object, gpointer *weak_pointer_location); -->
   <function name="g_object_add_weak_pointer">
@@ -3475,13 +3525,51 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- gchar * g_path_get_basename (const gchar *file_name); -->
+  <function name="g_path_get_basename">
+    <noreturn>false</noreturn>
+    <returnValue type="gchar *"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- gchar * g_path_get_dirname (const gchar *file_name); -->
+  <function name="g_path_get_dirname">
+    <noreturn>false</noreturn>
+    <returnValue type="gchar *"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- gboolean g_path_is_absolute (const gchar *file_name); -->
   <function name="g_path_is_absolute">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="gboolean"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
+  <!-- const gchar * g_path_skip_root (const gchar *file_name); -->
   <function name="g_path_skip_root">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="const gchar *"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_pattern_match">
     <leak-ignore/>
@@ -3773,9 +3861,22 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- gboolean g_setenv (const gchar *variable, const gchar *value, gboolean overwrite); -->
   <function name="g_setenv">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="gboolean"/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-uninit/>
+    </arg>
   </function>
   <function name="g_shell_error_quark">
     <leak-ignore/>
@@ -4572,9 +4673,16 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <!-- void g_unsetenv (const gchar *variable); -->
   <function name="g_unsetenv">
     <leak-ignore/>
     <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <not-bool/>
+    </arg>
   </function>
   <function name="g_usleep">
     <leak-ignore/>


### PR DESCRIPTION
This adds/fixes some miscellaneous Gtk/Glib utility functions.
Reference:
https://developer.gnome.org/glib/stable/glib-Miscellaneous-Utility-Functions.html
For specifying pointers to pointers as return value types the
cppcheck-cfg.rng has been enhanced to allow this.