### PR TITLE
Avoid giant C4267 warning in 64-bit Visual C++ build

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3776,6 +3776,15 @@ AccessControl Scope::defaultAccess() const
     }
 }
 
+void Scope::addVariable(const Token *token_, const Token *start_, const Token *end_,
+    AccessControl access_, const Type *type_, const Scope *scope_, const Settings* settings)
+{
+    // keep possible size_t -> int truncation outside emplace_back() to have a single line
+    // C4267 VC++ warning instead of several dozens lines
+    const int varIndex = varlist.size();
+    varlist.emplace_back(token_, start_, end_, varIndex, access_, type_, scope_, settings);
+}
+
 // Get variable list..
 void Scope::getVariableList(const Settings* settings)
 {

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1081,11 +1081,7 @@ public:
 
     void addVariable(const Token *token_, const Token *start_,
                      const Token *end_, AccessControl access_, const Type *type_,
-                     const Scope *scope_, const Settings* settings) {
-        varlist.emplace_back(token_, start_, end_, varlist.size(),
-                             access_,
-                             type_, scope_, settings);
-    }
+                     const Scope *scope_, const Settings* settings);
 
     /** @brief initialize varlist */
     void getVariableList(const Settings* settings);


### PR DESCRIPTION
This is a better implementation of what was discussed in https://github.com/danmar/cppcheck/pull/2384 The code is moved outside header so that users don't need specific warning settings. It can be simplified later if warning settings are changed in the project.

@danmar Daniel, do you like this?