### PR TITLE
Enforcing CppCoreGuideline C.35 on virtual class destructor

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1644,7 +1644,7 @@ void CheckClass::virtualDestructor()
     // * derived class has non-empty destructor (only c++03, in c++11 it's UB see paragraph 3 in [expr.delete])
     // * base class is deleted
     // unless inconclusive in which case:
-    // * A class with any virtual functions should have a destructor that is either public and virtual or else protected and non-virtual
+    // * A class with any virtual functions should have a destructor that is either public and virtual or protected
     const bool printInconclusive = mSettings->inconclusive;
 
     std::list<const Function *> inconclusiveErrors;
@@ -1657,7 +1657,7 @@ void CheckClass::virtualDestructor()
                 const Function *destructor = scope->getDestructor();
                 if (destructor) {
                     if(!((destructor->hasVirtualSpecifier() && destructor->access == AccessControl::Public) ||
-                        (!destructor->hasVirtualSpecifier() && destructor->access == AccessControl::Protected))) {
+                        (destructor->access == AccessControl::Protected))) {
                         for (const Function &func : scope->functionList) {
                             if (func.hasVirtualSpecifier()) {
                                 inconclusiveErrors.push_back(destructor);

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -2699,6 +2699,15 @@ private:
                                "    delete base;\n"
                                "}\n", true);
         ASSERT_EQUALS("[test.cpp:3]: (error) Class 'Base' which is inherited by class 'Derived' does not have a virtual destructor.\n", errout.str());
+        
+        // class Base destructor is not virtual but protected -> no error
+        checkVirtualDestructor("class Base {\n"
+                               "public:\n"
+                               "    virtual void foo(){}\n"
+                               "protected:\n"
+                               "    ~Base(){}\n"
+                               "};\n", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkNoMemset(const char code[]) {


### PR DESCRIPTION
A base class destructor should be either public and virtual, or protected and non-virtual
https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rc-dtor-virtual

Following discussion at: https://sourceforge.net/p/cppcheck/discussion/general/thread/0a321369c3/