### PR TITLE
Disable warnings causing too much noise

### DIFF
--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -45,7 +45,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wcast-qual")                # Cast for removing type qualifiers
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wno-conversion")            # Implicit conversions that may alter a value
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wfloat-equal")              # Floating values used in equality comparisons
-    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Winline")                   # If a inline declared function couldn't be inlined
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wmissing-declarations")     # If a global function is defined without a previous declaration
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Wmissing-format-attribute") # 
     set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -Woverloaded-virtual")       # when a function declaration hides virtual functions from a base class


### PR DESCRIPTION
I had this warning disabled locally for quite a while now since it is just too noisy and not helpful at all. The Makefile also doesn't contain this. Has a different author since I came across this while looking at the patches which Debian has applied - see https://packages.debian.org/sid/cppcheck and http://deb.debian.org/debian/pool/main/c/cppcheck/cppcheck_1.90-4.debian.tar.xz