### PR TITLE
avoid false positive unused static const struct member

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1400,6 +1400,8 @@ void CheckUnusedVar::checkStructMemberUsage()
             // Check if the struct member variable is used anywhere in the file
             if (Token::findsimplematch(mTokenizer->tokens(), (". " + var.name()).c_str()))
                 continue;
+            if (Token::findsimplematch(mTokenizer->tokens(), (":: " + var.name()).c_str()))
+                continue;
 
             unusedStructMemberError(var.nameToken(), scope.className, var.name(), scope.type == Scope::eUnion);
         }

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -511,6 +511,17 @@ private:
                                "    ab.b = 0;\n"
                                "}");
         ASSERT_EQUALS("[test.cpp:3]: (style) struct member 'AB::a' is never used.\n", errout.str());
+
+        checkStructMemberUsage("struct A\n"
+            "{\n"
+            "    static const int a = 0;\n"
+            "};\n"
+            "\n"
+            "int foo()\n"
+            "{\n"
+            "    return A::a;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void structmember_sizeof() {


### PR DESCRIPTION
        struct A
            {
                static const int a = 0; //detected as unused member in cppcheck 1.9 release
            };
            
            int foo()
            {
                return A::a; //used here
            }