### PR TITLE
CI builds now supporting RULES

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -31,15 +31,15 @@ jobs:
 
       - name: Build cppcheck
         run: |
-          make -j2 USE_Z3=yes
+          make -j2 USE_Z3=yes HAVE_RULES=yes
 
       - name: Build test
         run: |
-          make -j2 testrunner USE_Z3=yes
+          make -j2 testrunner USE_Z3=yes HAVE_RULES=yes
 
       - name: Test
         run: |
-          make -j2 check USE_Z3=yes
+          make -j2 check USE_Z3=yes HAVE_RULES=yes
 
       - name: Validate
         run: |

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-      fail-fast: true
+      fail-fast: false # not worthwhile...
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -67,13 +67,13 @@ jobs:
           del Build\gui\cppcheck-gui.pdb
           
       - name: Build x64 debug configuration using MSBuild
-        run: msbuild -m cppcheck.sln /p:Configuration=Debug /p:Platform=x64
+        run: msbuild -m cppcheck.sln /p:Configuration=Debug-PCRE /p:Platform=x64
 
       - name: Run Debug test
         run: .\bin\debug\testrunner.exe
 
       - name: Build x64 release configuration using MSBuild
-        run: msbuild -m cppcheck.sln /p:Configuration=Release /p:Platform=x64
+        run: msbuild -m cppcheck.sln /p:Configuration=Release-PCRE /p:Platform=x64
 
       - name: Run Release test
         run: .\bin\testrunner.exe

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -39,7 +39,7 @@ jobs:
           dir x64
           dir x64\Release
           copy pcre.h ..\externals
-          copy Release\pcre.lib ..\externals
+          copy Release\pcre.lib ..\externals\pcre64.lib
 
       - name: Install Z3 library
         run: |

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -86,6 +86,16 @@ jobs:
       - uses: actions/upload-artifact@v2-preview
         with:
           name: cppcheck_gui
+          path: ./**/cfg/*.cfg
+        
+      - uses: actions/upload-artifact@v2-preview
+        with:
+          name: cppcheck_gui
+          path: ./**/platforms/*.xml  
+          
+      - uses: actions/upload-artifact@v2-preview
+        with:
+          name: cppcheck_gui
           path: externals\z3\bin\*.dll
         
       - uses: actions/upload-artifact@v2-preview

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -26,13 +26,27 @@ jobs:
 
       - name: Setup msbuild.exe
         uses: microsoft/setup-msbuild@v1.0.0
-      
+                  
+      - name: Install PCRE
+        run: |
+          curl -fsSL https://ftp.pcre.org/pub/pcre/pcre-8.44.zip -o pcre-8.44.zip
+          7z x pcre-8.44.zip
+          cd pcre-8.44
+          cmake . -G "Visual Studio 16 2019" -A x64
+          msbuild -m PCRE.sln /p:Configuration=Release /p:Platform=x64
+          dir
+          dir Release
+          dir x64
+          dir x64\Release
+          copy pcre.h ..\externals
+          copy Release\pcre.lib ..\externals
+
       - name: Install Z3 library
         run: |
           curl -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-win.zip -o z3-4.8.7-win.zip
           7z x z3-4.8.7-win.zip -oexternals -r -y
           move externals\z3-4.8.7-x64-win externals\z3
-          
+
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
 
@@ -51,14 +65,15 @@ jobs:
           dir Build\gui
           del Build\gui\cppcheck-gui.ilk
           del Build\gui\cppcheck-gui.pdb
+          
       - name: Build x64 debug configuration using MSBuild
-        run: msbuild -m cppcheck.sln /p:Configuration=Debug
+        run: msbuild -m cppcheck.sln /p:Configuration=Debug /p:Platform=x64
 
       - name: Run Debug test
         run: .\bin\debug\testrunner.exe
 
       - name: Build x64 release configuration using MSBuild
-        run: msbuild -m cppcheck.sln /p:Configuration=Release
+        run: msbuild -m cppcheck.sln /p:Configuration=Release /p:Platform=x64
 
       - name: Run Release test
         run: .\bin\testrunner.exe


### PR DESCRIPTION
For Windows PCRE had to be built. On ubuntu and macos the pre-installed library is being used.