### PR TITLE
CMake correction to "fixed OSS-Fuzz builds and added CMake targets" (…

### DIFF
--- a/oss-fuzz/CMakeLists.txt
+++ b/oss-fuzz/CMakeLists.txt
@@ -1,10 +1,12 @@
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_executable(fuzz-client EXCLUDE_FROM_ALL
             main.cpp
-            type2.cpp)
+            type2.cpp
+            $<TARGET_OBJECTS:simplecpp_objs_sanitized>
+            $<TARGET_OBJECTS:tinyxml_objs_sanitized>
+            $<TARGET_OBJECTS:lib_objs_sanitized>)
     target_include_directories(fuzz-client PRIVATE ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/externals/simplecpp ${CMAKE_SOURCE_DIR}/externals/tinyxml ${CMAKE_SOURCE_DIR}/externals)
     target_compile_options(fuzz-client PRIVATE -fsanitize=fuzzer)
-    target_link_libraries(fuzz-client PRIVATE simplecpp_objs_sanitized tinyxml_objs_sanitized lib_objs_sanitized)
     # requires CMake >= 3.13
     #target_link_options(fuzz-client PRIVATE -fsanitize=address -fsanitize=fuzzer)
     target_link_libraries(fuzz-client PRIVATE -fsanitize=address -fsanitize=fuzzer)


### PR DESCRIPTION
…28cd5d7)

The pull request fixes the following errors produced in combination with clang by oss-fuzz/CMakeLists.txt introduced with 28cd5d7:

CMake Error at oss-fuzz/CMakeLists.txt:7 (target_link_libraries):
  Target "simplecpp_objs_sanitized" of type OBJECT_LIBRARY may not be linked
  into another target.  One may link only to STATIC or SHARED libraries, or
  to executables with the ENABLE_EXPORTS property set.


CMake Error at oss-fuzz/CMakeLists.txt:7 (target_link_libraries):
  Target "tinyxml_objs_sanitized" of type OBJECT_LIBRARY may not be linked
  into another target.  One may link only to STATIC or SHARED libraries, or
  to executables with the ENABLE_EXPORTS property set.


CMake Error at oss-fuzz/CMakeLists.txt:7 (target_link_libraries):
  Target "lib_objs_sanitized" of type OBJECT_LIBRARY may not be linked into
  another target.  One may link only to STATIC or SHARED libraries, or to
  executables with the ENABLE_EXPORTS property set.
