### PR TITLE
Fixes #9664 - False positive on C++20 designated initialization 

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3115,7 +3115,7 @@ void Tokenizer::setVarIdStructMembers(Token **tok1,
 {
     Token *tok = *tok1;
 
-    if (Token::Match(tok, "%name% = { . %name% =")) {
+    if (Token::Match(tok, "%name% = { . %name% =|{")) {
         const int struct_varid = tok->varId();
         if (struct_varid == 0)
             return;
@@ -3126,7 +3126,7 @@ void Tokenizer::setVarIdStructMembers(Token **tok1,
         while (tok->str() != "}") {
             if (Token::Match(tok, "{|[|("))
                 tok = tok->link();
-            if (Token::Match(tok->previous(), "[,{] . %name% =")) {
+            if (Token::Match(tok->previous(), "[,{] . %name% =|{")) {
                 tok = tok->next();
                 const std::map<std::string, int>::iterator it = members.find(tok->str());
                 if (it == members.end()) {
@@ -9365,7 +9365,7 @@ void Tokenizer::reportUnknownMacros()
         for (const Token *inner = tok->tokAt(2); inner != endTok; inner = inner->next()) {
             if (Token::Match(inner, "[[({]"))
                 inner = inner->link();
-            else if (Token::Match(inner->previous(), "[,(] . %name% ="))
+            else if (Token::Match(inner->previous(), "[,(] . %name% =|{"))
                 unknownMacroError(tok);
         }
     }
@@ -9637,7 +9637,7 @@ void Tokenizer::findGarbageCode() const
         if (Token::simpleMatch(tok, ".") &&
             !Token::simpleMatch(tok->previous(), ".") &&
             !Token::simpleMatch(tok->next(), ".") &&
-            !Token::Match(tok->previous(), "{|, . %name% =|.|[") &&
+            !Token::Match(tok->previous(), "{|, . %name% =|.|[|{") &&
             !Token::Match(tok->previous(), ", . %name%")) {
             if (!Token::Match(tok->previous(), "%name%|)|]|>|}"))
                 syntaxError(tok, tok->strAt(-1) + " " + tok->str() + " " + tok->strAt(1));

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -783,7 +783,7 @@ static void compileTerm(Token *&tok, AST_state& state)
             tok = tok->next();
             if (tok->str() == "<")
                 tok = tok->link()->next();
-            if (Token::Match(tok, "{ . %name% =")) {
+            if (Token::Match(tok, "{ . %name% =|{")) {
                 const int inArrayAssignment = state.inArrayAssignment;
                 state.inArrayAssignment = 1;
                 compileBinOp(tok, state, compileExpression);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7704,6 +7704,7 @@ private:
         ASSERT_EQUALS("xB[1y.z.1={(&=,{={=", testAst("x = { [B] = {1, .y = &(struct s) { .z=1 } } };"));
         ASSERT_EQUALS("xab,c,{=", testAst("x={a,b,(c)};"));
         ASSERT_EQUALS("x0fSa.1=b.2=,c.\"\"=,{(||=", testAst("x = 0 || f(S{.a = 1, .b = 2, .c = \"\" });"));
+        ASSERT_EQUALS("x0fSa.1{=b.2{,c.\"\"=,{(||=", testAst("x = 0 || f(S{.a = { 1 }, .b { 2 }, .c = \"\" });"));
 
         // struct initialization hang
         ASSERT_EQUALS("sbar.1{,{(={= fcmd( forfieldfield++;;(",
@@ -8037,6 +8038,9 @@ private:
 
         // op op
         ASSERT_THROW_EQUALS(tokenizeAndStringify("void f() { dostuff (x==>y); }"), InternalError, "syntax error: == >");
+
+        // Ticket #9664
+        ASSERT_NO_THROW(tokenizeAndStringify("S s = { .x { 2 }, .y[0] { 3 } };"));
     }
 
 

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -2497,6 +2497,13 @@ private:
                       tokenize("void foo() {\n"
                                "  struct ABC abc = {.a=abc.a,.b=abc.b};\n"
                                "}"));
+
+        ASSERT_EQUALS("1: void foo ( ) {\n"
+                      "2: struct ABC abc@1 ; abc@1 = { . a@2 { abc@1 . a@2 } , . b@3 = { abc@1 . b@3 } } ;\n"
+                      "3: }\n",
+                      tokenize("void foo() {\n"
+                               "  struct ABC abc = {.a { abc.a },.b= { abc.b } };\n"
+                               "}"));
     }
 
     void varid_arrayinit() { // #7579 - no variable declaration in rhs


### PR DESCRIPTION
Hey!
As an exercise to learn how the code works I am attempting to fix a defect reported by myself.

The warning was easy to fix in findGarbage, however there are a couple more places where a change was required. 
I did reuse a couple of test scenarios from previous tickets related to designated initializers to make sure they don't occur with this syntax as well.  If that is excessive, I will remove them.

Will be glad for any feedback.

Currently  these examples all produce different AST's:
{ .x = 3 }; 
{ .x = { 3 } }; 
{ .x { 3 } }; 
I had an idea to use a simplification to change case 3 into case 2, but then read in another pull request that you prefer not to use simplifications.