### PR TITLE
Show version number in Cppcheck GUI's title bar

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1363,11 +1363,18 @@ void MainWindow::toggleFilterToolBar()
 
 void MainWindow::formatAndSetTitle(const QString &text)
 {
+    QString nameWithVersion = QString("Cppcheck %1").arg(CppCheck::version());
+
+    QString extraVersion = CppCheck::extraVersion();
+    if (!extraVersion.isEmpty()) {
+        nameWithVersion += " (" + extraVersion + ")";
+    }
+
     QString title;
     if (text.isEmpty())
-        title = tr("Cppcheck");
+        title = nameWithVersion;
     else
-        title = QString(tr("Cppcheck - %1")).arg(text);
+        title = QString("%1 - %2").arg(nameWithVersion, text);
     setWindowTitle(title);
 }
 


### PR DESCRIPTION
Since knowing the version number is often important, show it in the title bar.

I don't have a fully functional Qt compilation environment, so this is a half-blindly made patch, which is known to compile, but untested otherwise.