### PR TITLE
Rename constArgument to knownArgument

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3015,7 +3015,7 @@ static bool isVariableExpression(const Token* tok)
     return false;
 }
 
-void CheckOther::checkConstArgument()
+void CheckOther::checkKnownArgument()
 {
     if (!mSettings->isEnabled(Settings::STYLE))
         return;
@@ -3041,12 +3041,12 @@ void CheckOther::checkConstArgument()
                 tok2 = tok2->astOperand2();
             if (isVariableExpression(tok2))
                 continue;
-            constArgumentError(tok, tok->astParent()->previous(), &tok->values().front());
+            knownArgumentError(tok, tok->astParent()->previous(), &tok->values().front());
         }
     }
 }
 
-void CheckOther::constArgumentError(const Token *tok, const Token *ftok, const ValueFlow::Value *value)
+void CheckOther::knownArgumentError(const Token *tok, const Token *ftok, const ValueFlow::Value *value)
 {
     MathLib::bigint intvalue = value ? value->intvalue : 0;
     const std::string expr = tok ? tok->expressionString() : std::string("x");
@@ -3054,7 +3054,7 @@ void CheckOther::constArgumentError(const Token *tok, const Token *ftok, const V
 
     const std::string errmsg = "Argument '" + expr + "' to function " + fun + " is always " + std::to_string(intvalue);
     const ErrorPath errorPath = getErrorPath(tok, value, errmsg);
-    reportError(errorPath, Severity::style, "constArgument", errmsg, CWE570, false);
+    reportError(errorPath, Severity::style, "knownArgument", errmsg, CWE570, false);
 }
 
 void CheckOther::checkComparePointers()

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -86,7 +86,7 @@ public:
         checkOther.checkEvaluationOrder();
         checkOther.checkFuncArgNamesDifferent();
         checkOther.checkShadowVariables();
-        checkOther.checkConstArgument();
+        checkOther.checkKnownArgument();
         checkOther.checkComparePointers();
         checkOther.checkIncompleteStatement();
         checkOther.checkPipeParameterSize();
@@ -211,7 +211,7 @@ public:
     /** @brief %Check for shadow variables. Less noisy than gcc/clang -Wshadow. */
     void checkShadowVariables();
 
-    void checkConstArgument();
+    void checkKnownArgument();
 
     void checkComparePointers();
 
@@ -269,7 +269,7 @@ private:
     void funcArgNamesDifferent(const std::string & functionName, nonneg int index, const Token* declaration, const Token* definition);
     void funcArgOrderDifferent(const std::string & functionName, const Token * declaration, const Token * definition, const std::vector<const Token*> & declarations, const std::vector<const Token*> & definitions);
     void shadowError(const Token *var, const Token *shadowed, std::string type);
-    void constArgumentError(const Token *tok, const Token *ftok, const ValueFlow::Value *value);
+    void knownArgumentError(const Token *tok, const Token *ftok, const ValueFlow::Value *value);
     void comparePointersError(const Token *tok, const ValueFlow::Value *v1, const ValueFlow::Value *v2);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
@@ -335,7 +335,7 @@ private:
         c.shadowError(nullptr, nullptr, "variable");
         c.shadowError(nullptr, nullptr, "function");
         c.shadowError(nullptr, nullptr, "argument");
-        c.constArgumentError(nullptr, nullptr, nullptr);
+        c.knownArgumentError(nullptr, nullptr, nullptr);
         c.comparePointersError(nullptr, nullptr, nullptr);
         c.redundantAssignmentError(nullptr, nullptr, "var", false);
         c.redundantInitializationError(nullptr, nullptr, "var", false);


### PR DESCRIPTION
This will make the name more consistent with other checks(like `knownConditionTrueFalse`). Checks named with `const` usually are for checking when the `const` keywords can be used(like `constParameter` or `constVariable`). 

This also avoids the confusion between the difference of `Argument` vs `Parameter`.