### PR TITLE
opencv2.cfg: Add types, macros, functions and memory (de)allocation

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -50,7 +50,7 @@
               <optional>
                 <attribute name="realloc-arg"><ref name="ARGNO"/></attribute>
               </optional>
-              <ref name="DATA-NAME"/>
+              <ref name="DATA-EXTNAME-SINGLE"/>
             </element>
             <element name="use"><ref name="DATA-EXTNAME"/></element>
           </choice>
@@ -75,7 +75,7 @@
               <optional>
                 <attribute name="arg"><ref name="ARGNO"/></attribute>
               </optional>
-              <ref name="DATA-NAME"/>
+              <ref name="DATA-EXTNAME-SINGLE"/>
             </element>
             <element name="realloc">
               <optional>
@@ -87,7 +87,7 @@
               <optional>
                 <attribute name="realloc-arg"><ref name="ARGNO"/></attribute>
               </optional>
-              <ref name="DATA-NAME"/>
+              <ref name="DATA-EXTNAME-SINGLE"/>
             </element>
             <element name="use"><ref name="DATA-EXTNAME"/></element>
           </choice>

--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -35,7 +35,7 @@
               <optional>
                 <attribute name="buffer-size"><ref name="DATA-BUFFER-SIZE"/></attribute>
               </optional>
-              <ref name="DATA-NAME"/>
+              <ref name="DATA-EXTNAME-SINGLE"/>
             </element>
             <element name="realloc">
               <optional>
@@ -567,6 +567,12 @@
   <define name="DATA-NAME">
     <data type="string">
       <param name="pattern">[a-zA-Z_][a-zA-Z_0-9]*</param>
+    </data>
+  </define>
+
+  <define name="DATA-EXTNAME-SINGLE">
+    <data type="string">
+      <param name="pattern">[a-zA-Z_][a-zA-Z_0-9:]*</param>
     </data>
   </define>
 

--- a/cfg/opencv2.cfg
+++ b/cfg/opencv2.cfg
@@ -5,7 +5,19 @@
   <!-- The OpenCV library is typically included by '#include <opencv2/*>' or -->
   <!-- '#include "opencv2/*"'. -->
   <!-- ########## OpenCV Types ########## -->
+  <podtype name="cv::int8_t" sign="s" size="1"/>
+  <podtype name="cv::int16_t" sign="s" size="2"/>
+  <podtype name="cv::int32_t" sign="s" size="4"/>
+  <podtype name="cv::int64_t" sign="s" size="8"/>
+  <podtype name="cv::uint8_t" sign="u" size="1"/>
+  <podtype name="cv::uint16_t" sign="u" size="2"/>
+  <podtype name="cv::uint32_t" sign="u" size="4"/>
+  <podtype name="cv::uint64_t" sign="u" size="8"/>
+  <smart-pointer class-name="cv::Ptr"/>
   <!-- ########## OpenCV Macros / Defines ########## -->
+  <define name="CV_ALWAYS_INLINE" value="inline"/>
+  <define name="CV_EXTERN_C" value="extern &quot;C&quot;"/>
+  <define name="CV_OVERRIDE" value="override"/>
   <define name="CV_PI" value="3.1415926535897932384626433832795"/>
   <define name="CV_2PI" value="6.283185307179586476925286766559"/>
   <define name="CV_LOG2" value="0.69314718055994530941723212145818"/>
@@ -22,11 +34,54 @@
   <define name="CV_IS_SUBMAT(flags)" value="((flags) &amp; CV_MAT_SUBMAT_FLAG)"/>
   <define name="MIN(a,b)" value="((a) &gt; (b) ? (b) : (a))"/>
   <define name="MAX(a,b)" value="((a) &lt; (b) ? (b) : (a))"/>
+  <define name="CV_Error(code,msg)" value="cv::error( code, msg, CV_Func, __FILE__, __LINE__ )"/>
+  <define name="CV_Assert(expr)" value="do { if(!!(expr)) ; else cv::error( cv::Error::StsAssert, #expr, CV_Func, __FILE__, __LINE__ ); } while(0)"/>
   <!-- ########## OpenCV containers ########## -->
   <!-- OpenCV containers that are similar to std containers -->
   <container id="cvString" startPattern="cv :: String" inherits="stdString"/>
   <!-- ########## OpenCV Allocation / Deallocation ########## -->
+  <memory>
+    <alloc init="false" buffer-size="malloc">cv::fastMalloc</alloc>
+    <dealloc>cv::fastFree</dealloc>
+  </memory>
   <!-- ########## OpenCV Functions ########## -->
+  <!-- void cv::errorNoReturn	(int _code, const String & _err, const char * _func, const char * _file, int _line) -->
+  <function name="cv::errorNoReturn">
+    <noreturn>true</noreturn>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="4" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="5" direction="in">
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- void cv::fastFree (void *ptr) -->
+  <function name="cv::fastFree">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-uninit indirect="1"/>
+    </arg>
+  </function>
+  <!-- void * cv::fastMalloc (size_t bufSize) -->
+  <function name="cv::fastMalloc">
+    <noreturn>false</noreturn>
+    <returnValue type="void *"/>
+    <use-retval/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+  </function>
   <!-- Mat cv::imread ( const String & filename, int flags = IMREAD_COLOR ) -->
   <function name="cv::imread">
     <noreturn>false</noreturn>

--- a/test/cfg/opencv2.cpp
+++ b/test/cfg/opencv2.cpp
@@ -26,10 +26,20 @@ void validCode(char* argStr)
     cv::String cvStr("Hello");
     cvStr += " World";
     std::cout << cvStr;
+
+    char * pBuf = (char *)cv::fastMalloc(20);
+    cv::fastFree(pBuf);
 }
 
 void ignoredReturnValue()
 {
     // cppcheck-suppress ignoredReturnValue
     cv::imread("42.png");
+}
+
+void memleak()
+{
+    char * pBuf = (char *)cv::fastMalloc(1000);
+    std::cout << pBuf;
+    // cppcheck-suppress memleak
 }


### PR DESCRIPTION
cfg/cppcheck-cfg.rng: Fix that functions in classes can not be specified as allocation functions