### PR TITLE
[posix.cfg] Fix file descriptor params to have proper range value

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -639,11 +639,11 @@
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1" direction="in">
-      <valid>0:</valid>
+      <not-null/>
       <not-uninit/>
     </arg>
     <arg nr="2" direction="in">
-      <not-null/>
+      <valid>0:</valid>
       <not-uninit/>
       <not-bool/>
     </arg>

--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -639,7 +639,7 @@
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1" direction="in">
-      <not-null/>
+      <valid>0:</valid>
       <not-uninit/>
     </arg>
     <arg nr="2" direction="in">
@@ -1323,6 +1323,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="int"/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <valid>0:</valid>
       <not-bool/>
     </arg>
     <arg nr="2" direction="in">
@@ -1332,6 +1333,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     </arg>
     <arg nr="3" direction="in">
       <not-uninit/>
+      <valid>0:</valid>
     </arg>
     <arg nr="4" direction="in">
       <not-null/>
@@ -1346,6 +1348,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <returnValue type="int"/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <valid>0:</valid>
       <not-bool/>
     </arg>
     <arg nr="2" direction="in">


### PR DESCRIPTION
In `posix.cfg` all parameters that are file descriptors should have a proper range value of [0, Max].

(-1 depicts an invalid fd that is returned in case of error from other file handling functions. 0, 1, 2 can be reused if they had been closed previously.)