### PR TITLE
[posix.cfg] Fix fstat family

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -1320,6 +1320,54 @@
       <not-bool/>
     </arg>
   </function>
+  <!-- Note: fstatat64() is a large-file version of the fstatat() function -->
+  <!-- int fstatat64(int dirfd, const char *pathname, struct stat64  *statbuf, int flags); -->
+  <function name="fstatat64">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <returnValue type="int"/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="4" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- int __fxstatat64 (int __ver, int __fildes, const char *__filename, struct stat64 *__stat_buf, int __flag); -->
+  <function name="__fxstatat64">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <returnValue type="int"/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="4" direction="out">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="5" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
   <!-- ########## Resource allocation ########## -->
   <resource>
     <alloc init="true">mkostemp</alloc>

--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -1397,13 +1397,13 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-bool/>
     </arg>
   </function>
-  <!-- int fstat(const char *file_name, struct stat *buf); -->
+  <!-- int fstat(int fd, struct stat *statbuf); -->
   <function name="fstat">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1" direction="in">
-      <not-null/>
+      <valid>0:</valid>
       <not-uninit/>
     </arg>
     <arg nr="2" direction="out">
@@ -1414,13 +1414,13 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   <!-- int fstatat(int dirfd, const char *pathname, struct stat *statbuf, int flags); -->
   <!-- Note: fstatat64() is a large-file version of the fstatat() function as defined in POSIX 1003.1-2008 (ISO/IEC 9945-2009). -->
   <!-- int fstatat64(int dirfd, const char *pathname, struct stat64  *statbuf, int flags); -->
-  <!-- int __fxstatat64(int dirfd, const char *pathname, struct stat64  *statbuf, int flags); -->
-  <function name="fstatat,fstatat64,__fxstatat64">
+  <function name="fstatat,fstatat64">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <valid>0:</valid>
     </arg>
     <arg nr="2" direction="in">
       <not-null/>
@@ -1431,6 +1431,31 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-bool/>
     </arg>
     <arg nr="4" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+  </function>
+  <!-- int __fxstatat64 (int __ver, int __fildes, const char *__filename, struct stat64 *__stat_buf, int __flag); -->
+  <function name="__fxstatat64">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <returnValue type="int"/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+      <valid>0:</valid>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="4" direction="out">
+      <not-null/>
+      <not-bool/>
+    </arg>
+    <arg nr="5" direction="in">
       <not-bool/>
       <not-uninit/>
     </arg>

--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -1412,9 +1412,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     </arg>
   </function>
   <!-- int fstatat(int dirfd, const char *pathname, struct stat *statbuf, int flags); -->
-  <!-- Note: fstatat64() is a large-file version of the fstatat() function as defined in POSIX 1003.1-2008 (ISO/IEC 9945-2009). -->
-  <!-- int fstatat64(int dirfd, const char *pathname, struct stat64  *statbuf, int flags); -->
-  <function name="fstatat,fstatat64">
+  <function name="fstatat">
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="int"/>
@@ -1431,31 +1429,6 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-bool/>
     </arg>
     <arg nr="4" direction="in">
-      <not-bool/>
-      <not-uninit/>
-    </arg>
-  </function>
-  <!-- int __fxstatat64 (int __ver, int __fildes, const char *__filename, struct stat64 *__stat_buf, int __flag); -->
-  <function name="__fxstatat64">
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <returnValue type="int"/>
-    <arg nr="1" direction="in">
-      <not-uninit/>
-    </arg>
-    <arg nr="2" direction="in">
-      <not-uninit/>
-      <valid>0:</valid>
-    </arg>
-    <arg nr="3" direction="in">
-      <not-null/>
-      <not-uninit/>
-    </arg>
-    <arg nr="4" direction="out">
-      <not-null/>
-      <not-bool/>
-    </arg>
-    <arg nr="5" direction="in">
       <not-bool/>
       <not-uninit/>
     </arg>


### PR DESCRIPTION
Parameters of the fstat family function that are file descriptors should have a proper range value of [0, Max].

The signature of `fstat` was wrong, it is different from `stat` (probably a copy paste error in the past).
`__fxstatat64` has different signature than `fstatat64`, that is fixed also.