### PR TITLE
[posix.cfg] Fix ttyname_r typo

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -4239,7 +4239,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <warn severity="portability">Non reentrant function 'ttyname' called. For threadsafe applications it is recommended to use the reentrant replacement function 'ttyname_r'.</warn>
   </function>
   <!-- int ttyname_r(int fd, char *buf, size_t buflen); -->
-  <function name="ttyname">
+  <function name="ttyname_r">
     <use-retval/>
     <returnValue type="int"/>
     <noreturn>false</noreturn>


### PR DESCRIPTION
There is another function with name `ttyname`. Also the comment suggests there is a typo.