### PR TITLE
cleaned up includes based on include-what-you-use

### DIFF
--- a/gui/codeeditor.h
+++ b/gui/codeeditor.h
@@ -9,8 +9,6 @@
 class CodeEditorStyle;
 class QPaintEvent;
 class QResizeEvent;
-class QSize;
-class QWidget;
 
 class Highlighter : public QSyntaxHighlighter {
     Q_OBJECT

--- a/gui/filelist.cpp
+++ b/gui/filelist.cpp
@@ -20,7 +20,6 @@
 #include <QDir>
 #include <QFileInfo>
 #include "filelist.h"
-#include "path.h"
 #include "pathmatch.h"
 
 QStringList FileList::getDefaultFilters()

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -24,6 +24,7 @@
 #include <QSettings>
 #ifdef _WIN32
 #include <QMessageBox>
+#include "aboutdialog.h"
 #else
 #include <iostream>
 #endif
@@ -31,7 +32,6 @@
 #include "common.h"
 #include "mainwindow.h"
 #include "erroritem.h"
-#include "aboutdialog.h"
 #include "translationhandler.h"
 
 

--- a/gui/mainwindow.h
+++ b/gui/mainwindow.h
@@ -34,7 +34,6 @@ class ThreadHandler;
 class TranslationHandler;
 class ScratchPad;
 class ProjectFile;
-class ErrorItem;
 class QAction;
 
 /// @addtogroup GUI

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -25,13 +25,13 @@
 #include <QDateTime>
 #include <set>
 #include "threadresult.h"
-#include "importproject.h"
 #include "suppressions.h"
 
 class ResultsView;
 class CheckThread;
 class QSettings;
 class Settings;
+class ImportProject;
 
 /// @addtogroup GUI
 /// @{

--- a/gui/xmlreport.h
+++ b/gui/xmlreport.h
@@ -24,7 +24,6 @@
 #include "report.h"
 
 class ErrorItem;
-class QObject;
 
 /// @addtogroup GUI
 /// @{

--- a/lib/check.h
+++ b/lib/check.h
@@ -22,7 +22,7 @@
 //---------------------------------------------------------------------------
 
 #include "config.h"
-#include "token.h"
+#include "errorlogger.h" // for Severity::SeverityType
 #include "tokenize.h"
 
 #include <list>
@@ -42,6 +42,7 @@ namespace ValueFlow {
 
 class Settings;
 class Token;
+class ErrorLogger;
 
 /** Use WRONG_DATA in checkers to mark conditions that check that data is correct */
 #define WRONG_DATA(COND, TOK)  (wrongData((TOK), (COND), #COND))

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -131,7 +131,6 @@
 
 #include "exprengine.h"
 #include "astutils.h"
-#include "path.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "tokenize.h"

--- a/lib/forwardanalyzer.h
+++ b/lib/forwardanalyzer.h
@@ -19,11 +19,11 @@
 #ifndef forwardanalyzerH
 #define forwardanalyzerH
 
-#include "valueptr.h"
 #include <vector>
 
 class Settings;
 class Token;
+template <class T> class ValuePtr;
 
 struct ForwardAnalyzer {
     struct Action {

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1577,7 +1577,7 @@ void Token::printValueFlow(bool xml, std::ostream &out) const
                 case ValueFlow::Value::ValueKind::Possible:
                     out << "possible ";
                     break;
-                };
+                }
             }
             if (tok->mImpl->mValues->size() > 1U)
                 out << '{';

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -91,6 +91,7 @@
 #include "token.h"
 #include "tokenlist.h"
 #include "utils.h"
+#include "valueptr.h"
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
If we could extract `Severity` from `errorlogger.h` we could get rid of that include in `check.h`. According to `ClangBuildAnalyzer` it is the heaviest include during compilation.