### PR TITLE
travis: Test matchcompiler with both python2 and python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,8 @@ matrix:
 # check if showtime=top5 works
         - ./tools/test_showtimetop5.sh
 # check matchcompiler
-        - ./tools/test_matchcompiler.py
+        - python2 tools/test_matchcompiler.py
+        - python3 tools/test_matchcompiler.py
 # check --dump
         - ${CPPCHECK} test/testpreprocessor.cpp --dump
         - xmllint --noout test/testpreprocessor.cpp.dump


### PR DESCRIPTION
I'm not sure how long cppcheck needs to support python 2, but I guess it still does so let's make sure it works with both python 2 and 3.