### PR TITLE
Fix crash in addons/test/test-misra.py

### DIFF
--- a/addons/test/util.py
+++ b/addons/test/util.py
@@ -13,7 +13,7 @@ def find_cppcheck_binary():
         if os.path.exists(location):
             break
     else:
-        raise RuntimeError("Could not fine cppcheck binary")
+        raise RuntimeError("Could not find cppcheck binary")
 
     return location
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3457,6 +3457,8 @@ static bool isDecayedPointer(const Token *tok)
 {
     if (!tok)
         return false;
+    if (!tok->astParent())
+        return false;
     if (astIsPointer(tok->astParent()) && !Token::simpleMatch(tok->astParent(), "return"))
         return true;
     if (tok->astParent()->isConstOp())


### PR DESCRIPTION
```
    ./bin/cppcheck --dump --quiet ../addons/test/misra/misra-test.c
    AddressSanitizer:DEADLYSIGNAL
    =================================================================
    ==15993==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000040 (pc 0x55f6a7e19b53 bp 0x7ffd72146250 sp 0x7ffd72146240 T0)
    ==15993==The signal is caused by a READ memory access.
    ==15993==Hint: address points to the zero page.
        #0 0x55f6a7e19b52 in Token::isArithmeticalOp() const ../lib/token.h:418
        #1 0x55f6a7e19aa5 in Token::isConstOp() const ../lib/token.h:408
        #2 0x55f6a860a032 in isDecayedPointer ../lib/valueflow.cpp:3462
        #3 0x55f6a860c27e in valueFlowLifetime ../lib/valueflow.cpp:3574
        #4 0x55f6a8634aba in ValueFlow::setValues(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) ../lib/valueflow.cpp:6127
        #5 0x55f6a84de5dc in Tokenizer::simplifyTokens1(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../lib/tokenize.cpp:2349
        #6 0x55f6a8122aa3 in CppCheck::checkFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::istream&) ../lib/cppcheck.cpp:727
        #7 0x55f6a81192b7 in CppCheck::check(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ../lib/cppcheck.cpp:407
        #8 0x55f6a7d37270 in CppCheckExecutor::check_internal(CppCheck&, int, char const* const*) ../cli/cppcheckexecutor.cpp:920
        #9 0x55f6a7d3366c in CppCheckExecutor::check(int, char const* const*) ../cli/cppcheckexecutor.cpp:231
        #10 0x55f6a871ebef in main ../cli/main.cpp:95
        #11 0x7fe03286409a in __libc_start_main ../csu/libc-start.c:308

```
