### PR TITLE
misra.py: Fix R12.4 crash on volatile macro argument

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1735,6 +1735,8 @@ class MisraChecker:
             if (not isConstantExpression(token)) or (not isUnsignedInt(token)):
                 continue
             for value in token.values:
+                if value.intvalue is None:
+                    continue
                 if value.intvalue < 0 or value.intvalue > max_uint:
                     self.reportError(token, 12, 4)
                     break

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -473,6 +473,7 @@ void misra_12_3(int a, int b, int c) { // no warning
 
 #define MISRA12_4a 2000000000u
 #define MISRA12_4b 4000000000u
+#define volatile_macro_12_4  (*(volatile U32 *) 0xFFFFFC10u)
 void misra_12_4() {
   uint32_t x;
   bool t;
@@ -481,6 +482,7 @@ void misra_12_4() {
   x = 0u - 1u; // 12.4
   x = t ? 0u : (0u-1u); // 12.4
   x = 556200230913ULL;
+  foo(&volatile_macro_12_4); // no crash
 }
 
 struct misra_13_1_t { int a; int b; };


### PR DESCRIPTION
This will fix crash reported in this thread: https://sourceforge.net/p/cppcheck/discussion/general/thread/0fa96ed286