### PR TITLE
Fix cmake in Release mode

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,14 +1,18 @@
-if (NOT USE_MATCHCOMPILER_OPT MATCHES "Off")
-    set(lib_src "${CMAKE_BINARY_DIR}/lib/build/mc_")
-else()
-    set(lib_src "${CMAKE_SOURCE_DIR}/lib/")
-endif()
+set(srcs_lib pathmatch.cpp path.cpp)
+foreach(file ${srcs_lib})
+    if (NOT USE_MATCHCOMPILER_OPT MATCHES "Off")
+        set(src "${CMAKE_BINARY_DIR}/lib/build/mc_${file}")
+        set_source_files_properties(${src} PROPERTIES GENERATED TRUE)
+    else()
+        set(src "${CMAKE_SOURCE_DIR}/lib/${file}")
+    endif()
+    set(srcs_tools ${srcs_tools} ${src})
+endforeach()
 
 add_executable(dmake EXCLUDE_FROM_ALL
         dmake.cpp
         ${CMAKE_SOURCE_DIR}/cli/filelister.cpp
-        ${lib_src}pathmatch.cpp
-        ${lib_src}path.cpp
+        ${srcs_tools}
         ${CMAKE_SOURCE_DIR}/externals/simplecpp/simplecpp
 )
 target_include_directories(dmake PRIVATE ${CMAKE_SOURCE_DIR}/cli ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/externals/simplecpp)


### PR DESCRIPTION
In tools/, it did not understand that some files are generated by
matchcompiler.py.

```
CMake Error at tools/CMakeLists.txt:7 (add_executable):
  Cannot find source file:

    </some/path>/cppcheck/build/lib/build/mc_pathmatch.cpp

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .m .M .mm .h .hh .h++ .hm
  .hpp .hxx .in .txx

CMake Error at tools/CMakeLists.txt:7 (add_executable):
  No SOURCES given to target: dmake

```