### PR TITLE
fix 9296: false negative uninit variable

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1112,6 +1112,9 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, Alloc al
     if (vartok->strAt(1) == "]")
         return true;
 
+    if (vartok->astParent()->tokType() == Token::Type::eBitOp)
+        return true;
+
     return false;
 }
 

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1112,8 +1112,8 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, Alloc al
     if (vartok->strAt(1) == "]")
         return true;
 
-    auto ast_parent = vartok->astParent();
-    if (ast_parent && (ast_parent->tokType() == Token::Type::eBitOp) && (ast_parent->isBinaryOp()))
+    const Token *astParent = vartok->astParent();
+    if (astParent && (astParent->tokType() == Token::Type::eBitOp) && (astParent->isBinaryOp()))
         return true;
 
     return false;

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1112,7 +1112,8 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, Alloc al
     if (vartok->strAt(1) == "]")
         return true;
 
-    if (vartok->astParent() && (vartok->astParent()->tokType() == Token::Type::eBitOp))
+    auto ast_parent = vartok->astParent();
+    if (ast_parent && (ast_parent->tokType() == Token::Type::eBitOp) && (ast_parent->isBinaryOp()))
         return true;
 
     return false;

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1112,7 +1112,7 @@ bool CheckUninitVar::isVariableUsage(const Token *vartok, bool pointer, Alloc al
     if (vartok->strAt(1) == "]")
         return true;
 
-    if (vartok->astParent()->tokType() == Token::Type::eBitOp)
+    if (vartok->astParent() && (vartok->astParent()->tokType() == Token::Type::eBitOp))
         return true;
 
     return false;

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -21,7 +21,6 @@
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
-#include "simplecpp.h"
 
 #include <sstream>
 #include <string>
@@ -706,21 +705,19 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         // Ticket #9296
-        checkUninitVar("int __round_mask(int, int);\n"
-                       "void f(void)\n"
+        checkUninitVar("void f(void)\n"
                        "{\n"
                        "    int x;\n"
                        "    int z = (x) & ~__round_mask(1, 1);\n"
                        "}");
-        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: x\n", errout.str());
 
-        checkUninitVar("int __round_mask(int, int);\n"
-                       "void f(void)\n"
+        checkUninitVar("void f(void)\n"
                        "{\n"
                        "    int x;\n"
                        "    int z = (x) | ~__round_mask(1, 1);\n"
                        "}");
-        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: x\n", errout.str());
 
         checkUninitVar("int __round_mask(int, int);\n"
                        "void f(void)\n"


### PR DESCRIPTION
Fix for [#9296](https://trac.cppcheck.net/ticket/9296)