### PR TITLE
Update dependency TinyXML2 to version v8.0.0 with PR#811

### DIFF
--- a/externals/tinyxml/tinyxml2.cpp
+++ b/externals/tinyxml/tinyxml2.cpp
@@ -2623,21 +2623,32 @@ namespace tinyxml2 {
     }
 
 
-    void XMLPrinter::OpenElement(const char* name, bool compactMode)
+    void XMLPrinter::PrepareForNewNode(bool compactMode)
     {
         SealElementIfJustOpened();
-        _stack.Push(name);
-
-        if (_textDepth < 0 && !_firstElement && !compactMode) {
+        if (compactMode) {
+            return;
+        }
+        if (_firstElement) {
+            PrintSpace(_depth);
+        } else if (_textDepth < 0) {
             Putc('\n');
             PrintSpace(_depth);
         }
+
+        _firstElement = false;
+    }
+
+
+    void XMLPrinter::OpenElement(const char* name, bool compactMode)
+    {
+        PrepareForNewNode(compactMode);
+        _stack.Push(name);
 
         Write("<");
         Write(name);
 
         _elementJustOpened = true;
-        _firstElement = false;
         ++_depth;
     }
 
@@ -2811,13 +2822,7 @@ namespace tinyxml2 {
 
     void XMLPrinter::PushComment(const char* comment)
     {
-        SealElementIfJustOpened();
-        if (_textDepth < 0 && !_firstElement && !_compactMode) {
-            Putc('\n');
-            PrintSpace(_depth);
-        }
-        _firstElement = false;
-
+        PrepareForNewNode(_compactMode);
         Write("<!--");
         Write(comment);
         Write("-->");
@@ -2826,13 +2831,7 @@ namespace tinyxml2 {
 
     void XMLPrinter::PushDeclaration(const char* value)
     {
-        SealElementIfJustOpened();
-        if (_textDepth < 0 && !_firstElement && !_compactMode) {
-            Putc('\n');
-            PrintSpace(_depth);
-        }
-        _firstElement = false;
-
+        PrepareForNewNode(_compactMode);
         Write("<?");
         Write(value);
         Write("?>");
@@ -2841,13 +2840,7 @@ namespace tinyxml2 {
 
     void XMLPrinter::PushUnknown(const char* value)
     {
-        SealElementIfJustOpened();
-        if (_textDepth < 0 && !_firstElement && !_compactMode) {
-            Putc('\n');
-            PrintSpace(_depth);
-        }
-        _firstElement = false;
-
+        PrepareForNewNode(_compactMode);
         Write("<!");
         Write(value);
         Putc('>');

--- a/externals/tinyxml/tinyxml2.cpp
+++ b/externals/tinyxml/tinyxml2.cpp
@@ -23,7 +23,7 @@ distribution.
 
 #include "tinyxml2.h"
 
-#include <new>		// yes, this one new style header, is in the Android SDK.
+#include <new>      // yes, this one new style header, is in the Android SDK.
 #if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)
 #   include <stddef.h>
 #   include <stdarg.h>
@@ -33,2773 +33,2884 @@ distribution.
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
-	// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
-	/*int _snprintf_s(
-	   char *buffer,
-	   size_t sizeOfBuffer,
-	   size_t count,
-	   const char *format [,
-		  argument] ...
-	);*/
-	static inline int TIXML_SNPRINTF( char* buffer, size_t size, const char* format, ... )
-	{
-		va_list va;
-		va_start( va, format );
-		int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
-		va_end( va );
-		return result;
-	}
+// Microsoft Visual Studio, version 2005 and higher. Not WinCE.
+/*int _snprintf_s(
+   char *buffer,
+   size_t sizeOfBuffer,
+   size_t count,
+   const char *format [,
+      argument] ...
+);*/
+static inline int TIXML_SNPRINTF(char* buffer, size_t size, const char* format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    const int result = vsnprintf_s(buffer, size, _TRUNCATE, format, va);
+    va_end(va);
+    return result;
+}
 
-	static inline int TIXML_VSNPRINTF( char* buffer, size_t size, const char* format, va_list va )
-	{
-		int result = vsnprintf_s( buffer, size, _TRUNCATE, format, va );
-		return result;
-	}
+static inline int TIXML_VSNPRINTF(char* buffer, size_t size, const char* format, va_list va)
+{
+    const int result = vsnprintf_s(buffer, size, _TRUNCATE, format, va);
+    return result;
+}
 
-	#define TIXML_VSCPRINTF	_vscprintf
-	#define TIXML_SSCANF	sscanf_s
+#define TIXML_VSCPRINTF _vscprintf
+#define TIXML_SSCANF    sscanf_s
 #elif defined _MSC_VER
-	// Microsoft Visual Studio 2003 and earlier or WinCE
-	#define TIXML_SNPRINTF	_snprintf
-	#define TIXML_VSNPRINTF _vsnprintf
-	#define TIXML_SSCANF	sscanf
-	#if (_MSC_VER < 1400 ) && (!defined WINCE)
-		// Microsoft Visual Studio 2003 and not WinCE.
-		#define TIXML_VSCPRINTF   _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
-	#else
-		// Microsoft Visual Studio 2003 and earlier or WinCE.
-		static inline int TIXML_VSCPRINTF( const char* format, va_list va )
-		{
-			int len = 512;
-			for (;;) {
-				len = len*2;
-				char* str = new char[len]();
-				const int required = _vsnprintf(str, len, format, va);
-				delete[] str;
-				if ( required != -1 ) {
-					TIXMLASSERT( required >= 0 );
-					len = required;
-					break;
-				}
-			}
-			TIXMLASSERT( len >= 0 );
-			return len;
-		}
-	#endif
+// Microsoft Visual Studio 2003 and earlier or WinCE
+#define TIXML_SNPRINTF  _snprintf
+#define TIXML_VSNPRINTF _vsnprintf
+#define TIXML_SSCANF    sscanf
+#if (_MSC_VER < 1400 ) && (!defined WINCE)
+// Microsoft Visual Studio 2003 and not WinCE.
+#define TIXML_VSCPRINTF   _vscprintf // VS2003's C runtime has this, but VC6 C runtime or WinCE SDK doesn't have.
 #else
-	// GCC version 3 and higher
-	//#warning( "Using sn* functions." )
-	#define TIXML_SNPRINTF	snprintf
-	#define TIXML_VSNPRINTF	vsnprintf
-	static inline int TIXML_VSCPRINTF( const char* format, va_list va )
-	{
-		int len = vsnprintf( 0, 0, format, va );
-		TIXMLASSERT( len >= 0 );
-		return len;
-	}
-	#define TIXML_SSCANF   sscanf
+// Microsoft Visual Studio 2003 and earlier or WinCE.
+static inline int TIXML_VSCPRINTF(const char* format, va_list va)
+{
+    int len = 512;
+    for (;;) {
+        len = len*2;
+        char* str = new char[len]();
+        const int required = _vsnprintf(str, len, format, va);
+        delete[] str;
+        if (required != -1) {
+            TIXMLASSERT(required >= 0);
+            len = required;
+            break;
+        }
+    }
+    TIXMLASSERT(len >= 0);
+    return len;
+}
+#endif
+#else
+// GCC version 3 and higher
+//#warning( "Using sn* functions." )
+#define TIXML_SNPRINTF  snprintf
+#define TIXML_VSNPRINTF vsnprintf
+static inline int TIXML_VSCPRINTF(const char* format, va_list va)
+{
+    int len = vsnprintf(0, 0, format, va);
+    TIXMLASSERT(len >= 0);
+    return len;
+}
+#define TIXML_SSCANF   sscanf
+#endif
+
+#if defined(_WIN64)
+#define TIXML_FSEEK _fseeki64
+#define TIXML_FTELL _ftelli64
+#elif defined(__APPLE__) || (__FreeBSD__)
+#define TIXML_FSEEK fseeko
+#define TIXML_FTELL ftello
+#elif defined(__unix__) && defined(__x86_64__)
+#define TIXML_FSEEK fseeko64
+#define TIXML_FTELL ftello64
+#else
+#define TIXML_FSEEK fseek
+#define TIXML_FTELL ftell
 #endif
 
 
-static const char LINE_FEED				= (char)0x0a;			// all line endings are normalized to LF
+static const char LINE_FEED             = static_cast<char>(0x0a);          // all line endings are normalized to LF
 static const char LF = LINE_FEED;
-static const char CARRIAGE_RETURN		= (char)0x0d;			// CR gets filtered out
+static const char CARRIAGE_RETURN       = static_cast<char>(0x0d);          // CR gets filtered out
 static const char CR = CARRIAGE_RETURN;
-static const char SINGLE_QUOTE			= '\'';
-static const char DOUBLE_QUOTE			= '\"';
+static const char SINGLE_QUOTE          = '\'';
+static const char DOUBLE_QUOTE          = '\"';
 
 // Bunch of unicode info at:
-//		http://www.unicode.org/faq/utf_bom.html
-//	ef bb bf (Microsoft "lead bytes") - designates UTF-8
+//      http://www.unicode.org/faq/utf_bom.html
+//  ef bb bf (Microsoft "lead bytes") - designates UTF-8
 
 static const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
 static const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
 static const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
 
-namespace tinyxml2
-{
+namespace tinyxml2 {
 
-struct Entity {
-    const char* pattern;
-    int length;
-    char value;
-};
+    struct Entity {
+        const char* pattern;
+        int length;
+        char value;
+    };
 
-static const int NUM_ENTITIES = 5;
-static const Entity entities[NUM_ENTITIES] = {
-    { "quot", 4,	DOUBLE_QUOTE },
-    { "amp", 3,		'&'  },
-    { "apos", 4,	SINGLE_QUOTE },
-    { "lt",	2, 		'<'	 },
-    { "gt",	2,		'>'	 }
-};
-
-
-StrPair::~StrPair()
-{
-    Reset();
-}
+    static const int NUM_ENTITIES = 5;
+    static const Entity entities[NUM_ENTITIES] = {
+        { "quot", 4,    DOUBLE_QUOTE },
+        { "amp", 3,     '&'  },
+        { "apos", 4,    SINGLE_QUOTE },
+        { "lt", 2,      '<'  },
+        { "gt", 2,      '>'  }
+    };
 
 
-void StrPair::TransferTo( StrPair* other )
-{
-    if ( this == other ) {
-        return;
+    StrPair::~StrPair()
+    {
+        Reset();
     }
-    // This in effect implements the assignment operator by "moving"
-    // ownership (as in auto_ptr).
-
-    TIXMLASSERT( other != 0 );
-    TIXMLASSERT( other->_flags == 0 );
-    TIXMLASSERT( other->_start == 0 );
-    TIXMLASSERT( other->_end == 0 );
-
-    other->Reset();
-
-    other->_flags = _flags;
-    other->_start = _start;
-    other->_end = _end;
-
-    _flags = 0;
-    _start = 0;
-    _end = 0;
-}
 
 
-void StrPair::Reset()
-{
-    if ( _flags & NEEDS_DELETE ) {
-        delete [] _start;
-    }
-    _flags = 0;
-    _start = 0;
-    _end = 0;
-}
-
-
-void StrPair::SetStr( const char* str, int flags )
-{
-    TIXMLASSERT( str );
-    Reset();
-    size_t len = strlen( str );
-    TIXMLASSERT( _start == 0 );
-    _start = new char[ len+1 ];
-    memcpy( _start, str, len+1 );
-    _end = _start + len;
-    _flags = flags | NEEDS_DELETE;
-}
-
-
-char* StrPair::ParseText( char* p, const char* endTag, int strFlags, int* curLineNumPtr )
-{
-    TIXMLASSERT( p );
-    TIXMLASSERT( endTag && *endTag );
-	TIXMLASSERT(curLineNumPtr);
-
-    char* start = p;
-    char  endChar = *endTag;
-    size_t length = strlen( endTag );
-
-    // Inner loop of text parsing.
-    while ( *p ) {
-        if ( *p == endChar && strncmp( p, endTag, length ) == 0 ) {
-            Set( start, p, strFlags );
-            return p + length;
-        } else if (*p == '\n') {
-            ++(*curLineNumPtr);
+    void StrPair::TransferTo(StrPair* other)
+    {
+        if (this == other) {
+            return;
         }
-        ++p;
-        TIXMLASSERT( p );
-    }
-    return 0;
-}
+        // This in effect implements the assignment operator by "moving"
+        // ownership (as in auto_ptr).
 
+        TIXMLASSERT(other != 0);
+        TIXMLASSERT(other->_flags == 0);
+        TIXMLASSERT(other->_start == 0);
+        TIXMLASSERT(other->_end == 0);
 
-char* StrPair::ParseName( char* p )
-{
-    if ( !p || !(*p) ) {
-        return 0;
-    }
-    if ( !XMLUtil::IsNameStartChar( *p ) ) {
-        return 0;
-    }
+        other->Reset();
 
-    char* const start = p;
-    ++p;
-    while ( *p && XMLUtil::IsNameChar( *p ) ) {
-        ++p;
+        other->_flags = _flags;
+        other->_start = _start;
+        other->_end = _end;
+
+        _flags = 0;
+        _start = 0;
+        _end = 0;
     }
 
-    Set( start, p, 0 );
-    return p;
-}
+
+    void StrPair::Reset()
+    {
+        if (_flags & NEEDS_DELETE) {
+            delete [] _start;
+        }
+        _flags = 0;
+        _start = 0;
+        _end = 0;
+    }
 
 
-void StrPair::CollapseWhitespace()
-{
-    // Adjusting _start would cause undefined behavior on delete[]
-    TIXMLASSERT( ( _flags & NEEDS_DELETE ) == 0 );
-    // Trim leading space.
-    _start = XMLUtil::SkipWhiteSpace( _start, 0 );
+    void StrPair::SetStr(const char* str, int flags)
+    {
+        TIXMLASSERT(str);
+        Reset();
+        size_t len = strlen(str);
+        TIXMLASSERT(_start == 0);
+        _start = new char[ len+1 ];
+        memcpy(_start, str, len+1);
+        _end = _start + len;
+        _flags = flags | NEEDS_DELETE;
+    }
 
-    if ( *_start ) {
-        const char* p = _start;	// the read pointer
-        char* q = _start;	// the write pointer
 
-        while( *p ) {
-            if ( XMLUtil::IsWhiteSpace( *p )) {
-                p = XMLUtil::SkipWhiteSpace( p, 0 );
-                if ( *p == 0 ) {
-                    break;    // don't write to q; this trims the trailing space.
-                }
-                *q = ' ';
-                ++q;
+    char* StrPair::ParseText(char* p, const char* endTag, int strFlags, int* curLineNumPtr)
+    {
+        TIXMLASSERT(p);
+        TIXMLASSERT(endTag && *endTag);
+        TIXMLASSERT(curLineNumPtr);
+
+        char* start = p;
+        const char  endChar = *endTag;
+        size_t length = strlen(endTag);
+
+        // Inner loop of text parsing.
+        while (*p) {
+            if (*p == endChar && strncmp(p, endTag, length) == 0) {
+                Set(start, p, strFlags);
+                return p + length;
+            } else if (*p == '\n') {
+                ++(*curLineNumPtr);
             }
-            *q = *p;
-            ++q;
+            ++p;
+            TIXMLASSERT(p);
+        }
+        return 0;
+    }
+
+
+    char* StrPair::ParseName(char* p)
+    {
+        if (!p || !(*p)) {
+            return 0;
+        }
+        if (!XMLUtil::IsNameStartChar(*p)) {
+            return 0;
+        }
+
+        char* const start = p;
+        ++p;
+        while (*p && XMLUtil::IsNameChar(*p)) {
             ++p;
         }
-        *q = 0;
+
+        Set(start, p, 0);
+        return p;
     }
-}
 
 
-const char* StrPair::GetStr()
-{
-    TIXMLASSERT( _start );
-    TIXMLASSERT( _end );
-    if ( _flags & NEEDS_FLUSH ) {
-        *_end = 0;
-        _flags ^= NEEDS_FLUSH;
+    void StrPair::CollapseWhitespace()
+    {
+        // Adjusting _start would cause undefined behavior on delete[]
+        TIXMLASSERT((_flags & NEEDS_DELETE) == 0);
+        // Trim leading space.
+        _start = XMLUtil::SkipWhiteSpace(_start, 0);
 
-        if ( _flags ) {
-            const char* p = _start;	// the read pointer
-            char* q = _start;	// the write pointer
+        if (*_start) {
+            const char* p = _start; // the read pointer
+            char* q = _start;   // the write pointer
 
-            while( p < _end ) {
-                if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR ) {
-                    // CR-LF pair becomes LF
-                    // CR alone becomes LF
-                    // LF-CR becomes LF
-                    if ( *(p+1) == LF ) {
-                        p += 2;
+            while (*p) {
+                if (XMLUtil::IsWhiteSpace(*p)) {
+                    p = XMLUtil::SkipWhiteSpace(p, 0);
+                    if (*p == 0) {
+                        break;    // don't write to q; this trims the trailing space.
                     }
-                    else {
-                        ++p;
-                    }
-                    *q = LF;
+                    *q = ' ';
                     ++q;
                 }
-                else if ( (_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF ) {
-                    if ( *(p+1) == CR ) {
-                        p += 2;
-                    }
-                    else {
-                        ++p;
-                    }
-                    *q = LF;
-                    ++q;
-                }
-                else if ( (_flags & NEEDS_ENTITY_PROCESSING) && *p == '&' ) {
-                    // Entities handled by tinyXML2:
-                    // - special entities in the entity table [in/out]
-                    // - numeric character reference [in]
-                    //   &#20013; or &#x4e2d;
-
-                    if ( *(p+1) == '#' ) {
-                        const int buflen = 10;
-                        char buf[buflen] = { 0 };
-                        int len = 0;
-                        char* adjusted = const_cast<char*>( XMLUtil::GetCharacterRef( p, buf, &len ) );
-                        if ( adjusted == 0 ) {
-                            *q = *p;
-                            ++p;
-                            ++q;
-                        }
-                        else {
-                            TIXMLASSERT( 0 <= len && len <= buflen );
-                            TIXMLASSERT( q + len <= adjusted );
-                            p = adjusted;
-                            memcpy( q, buf, len );
-                            q += len;
-                        }
-                    }
-                    else {
-                        bool entityFound = false;
-                        for( int i = 0; i < NUM_ENTITIES; ++i ) {
-                            const Entity& entity = entities[i];
-                            if ( strncmp( p + 1, entity.pattern, entity.length ) == 0
-                                    && *( p + entity.length + 1 ) == ';' ) {
-                                // Found an entity - convert.
-                                *q = entity.value;
-                                ++q;
-                                p += entity.length + 2;
-                                entityFound = true;
-                                break;
-                            }
-                        }
-                        if ( !entityFound ) {
-                            // fixme: treat as error?
-                            ++p;
-                            ++q;
-                        }
-                    }
-                }
-                else {
-                    *q = *p;
-                    ++p;
-                    ++q;
-                }
+                *q = *p;
+                ++q;
+                ++p;
             }
             *q = 0;
         }
-        // The loop below has plenty going on, and this
-        // is a less useful mode. Break it out.
-        if ( _flags & NEEDS_WHITESPACE_COLLAPSING ) {
-            CollapseWhitespace();
-        }
-        _flags = (_flags & NEEDS_DELETE);
     }
-    TIXMLASSERT( _start );
-    return _start;
-}
+
+
+    const char* StrPair::GetStr()
+    {
+        TIXMLASSERT(_start);
+        TIXMLASSERT(_end);
+        if (_flags & NEEDS_FLUSH) {
+            *_end = 0;
+            _flags ^= NEEDS_FLUSH;
+
+            if (_flags) {
+                const char* p = _start; // the read pointer
+                char* q = _start;   // the write pointer
+
+                while (p < _end) {
+                    if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == CR) {
+                        // CR-LF pair becomes LF
+                        // CR alone becomes LF
+                        // LF-CR becomes LF
+                        if (*(p+1) == LF) {
+                            p += 2;
+                        } else {
+                            ++p;
+                        }
+                        *q = LF;
+                        ++q;
+                    } else if ((_flags & NEEDS_NEWLINE_NORMALIZATION) && *p == LF) {
+                        if (*(p+1) == CR) {
+                            p += 2;
+                        } else {
+                            ++p;
+                        }
+                        *q = LF;
+                        ++q;
+                    } else if ((_flags & NEEDS_ENTITY_PROCESSING) && *p == '&') {
+                        // Entities handled by tinyXML2:
+                        // - special entities in the entity table [in/out]
+                        // - numeric character reference [in]
+                        //   &#20013; or &#x4e2d;
+
+                        if (*(p+1) == '#') {
+                            const int buflen = 10;
+                            char buf[buflen] = { 0 };
+                            int len = 0;
+                            const char* adjusted = const_cast<char*>(XMLUtil::GetCharacterRef(p, buf, &len));
+                            if (adjusted == 0) {
+                                *q = *p;
+                                ++p;
+                                ++q;
+                            } else {
+                                TIXMLASSERT(0 <= len && len <= buflen);
+                                TIXMLASSERT(q + len <= adjusted);
+                                p = adjusted;
+                                memcpy(q, buf, len);
+                                q += len;
+                            }
+                        } else {
+                            bool entityFound = false;
+                            for (int i = 0; i < NUM_ENTITIES; ++i) {
+                                const Entity& entity = entities[i];
+                                if (strncmp(p + 1, entity.pattern, entity.length) == 0
+                                    && *(p + entity.length + 1) == ';') {
+                                    // Found an entity - convert.
+                                    *q = entity.value;
+                                    ++q;
+                                    p += entity.length + 2;
+                                    entityFound = true;
+                                    break;
+                                }
+                            }
+                            if (!entityFound) {
+                                // fixme: treat as error?
+                                ++p;
+                                ++q;
+                            }
+                        }
+                    } else {
+                        *q = *p;
+                        ++p;
+                        ++q;
+                    }
+                }
+                *q = 0;
+            }
+            // The loop below has plenty going on, and this
+            // is a less useful mode. Break it out.
+            if (_flags & NEEDS_WHITESPACE_COLLAPSING) {
+                CollapseWhitespace();
+            }
+            _flags = (_flags & NEEDS_DELETE);
+        }
+        TIXMLASSERT(_start);
+        return _start;
+    }
 
 
 
 
 // --------- XMLUtil ----------- //
 
-const char* XMLUtil::writeBoolTrue  = "true";
-const char* XMLUtil::writeBoolFalse = "false";
+    const char* XMLUtil::writeBoolTrue  = "true";
+    const char* XMLUtil::writeBoolFalse = "false";
 
-void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
-{
-	static const char* defTrue  = "true";
-	static const char* defFalse = "false";
+    void XMLUtil::SetBoolSerialization(const char* writeTrue, const char* writeFalse)
+    {
+        static const char* defTrue  = "true";
+        static const char* defFalse = "false";
 
-	writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
-	writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
-}
+        writeBoolTrue = (writeTrue) ? writeTrue : defTrue;
+        writeBoolFalse = (writeFalse) ? writeFalse : defFalse;
+    }
 
 
-const char* XMLUtil::ReadBOM( const char* p, bool* bom )
-{
-    TIXMLASSERT( p );
-    TIXMLASSERT( bom );
-    *bom = false;
-    const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
-    // Check for BOM:
-    if (    *(pu+0) == TIXML_UTF_LEAD_0
+    const char* XMLUtil::ReadBOM(const char* p, bool* bom)
+    {
+        TIXMLASSERT(p);
+        TIXMLASSERT(bom);
+        *bom = false;
+        const unsigned char* pu = reinterpret_cast<const unsigned char*>(p);
+        // Check for BOM:
+        if (*(pu+0) == TIXML_UTF_LEAD_0
             && *(pu+1) == TIXML_UTF_LEAD_1
-            && *(pu+2) == TIXML_UTF_LEAD_2 ) {
-        *bom = true;
-        p += 3;
-    }
-    TIXMLASSERT( p );
-    return p;
-}
-
-
-void XMLUtil::ConvertUTF32ToUTF8( unsigned long input, char* output, int* length )
-{
-    const unsigned long BYTE_MASK = 0xBF;
-    const unsigned long BYTE_MARK = 0x80;
-    const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
-
-    if (input < 0x80) {
-        *length = 1;
-    }
-    else if ( input < 0x800 ) {
-        *length = 2;
-    }
-    else if ( input < 0x10000 ) {
-        *length = 3;
-    }
-    else if ( input < 0x200000 ) {
-        *length = 4;
-    }
-    else {
-        *length = 0;    // This code won't convert this correctly anyway.
-        return;
-    }
-
-    output += *length;
-
-    // Scary scary fall throughs are annotated with carefully designed comments
-    // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
-    switch (*length) {
-        case 4:
-            --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 3:
-            --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 2:
-            --output;
-            *output = (char)((input | BYTE_MARK) & BYTE_MASK);
-            input >>= 6;
-            //fall through
-        case 1:
-            --output;
-            *output = (char)(input | FIRST_BYTE_MARK[*length]);
-            break;
-        default:
-            TIXMLASSERT( false );
-    }
-}
-
-
-const char* XMLUtil::GetCharacterRef( const char* p, char* value, int* length )
-{
-    // Presume an entity, and pull it out.
-    *length = 0;
-
-    if ( *(p+1) == '#' && *(p+2) ) {
-        unsigned long ucs = 0;
-        TIXMLASSERT( sizeof( ucs ) >= 4 );
-        ptrdiff_t delta = 0;
-        unsigned mult = 1;
-        static const char SEMICOLON = ';';
-
-        if ( *(p+2) == 'x' ) {
-            // Hexadecimal.
-            const char* q = p+3;
-            if ( !(*q) ) {
-                return 0;
-            }
-
-            q = strchr( q, SEMICOLON );
-
-            if ( !q ) {
-                return 0;
-            }
-            TIXMLASSERT( *q == SEMICOLON );
-
-            delta = q-p;
-            --q;
-
-            while ( *q != 'x' ) {
-                unsigned int digit = 0;
-
-                if ( *q >= '0' && *q <= '9' ) {
-                    digit = *q - '0';
-                }
-                else if ( *q >= 'a' && *q <= 'f' ) {
-                    digit = *q - 'a' + 10;
-                }
-                else if ( *q >= 'A' && *q <= 'F' ) {
-                    digit = *q - 'A' + 10;
-                }
-                else {
-                    return 0;
-                }
-                TIXMLASSERT( digit < 16 );
-                TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
-                const unsigned int digitScaled = mult * digit;
-                TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
-                ucs += digitScaled;
-                TIXMLASSERT( mult <= UINT_MAX / 16 );
-                mult *= 16;
-                --q;
-            }
+            && *(pu+2) == TIXML_UTF_LEAD_2) {
+            *bom = true;
+            p += 3;
         }
-        else {
-            // Decimal.
-            const char* q = p+2;
-            if ( !(*q) ) {
-                return 0;
-            }
-
-            q = strchr( q, SEMICOLON );
-
-            if ( !q ) {
-                return 0;
-            }
-            TIXMLASSERT( *q == SEMICOLON );
-
-            delta = q-p;
-            --q;
-
-            while ( *q != '#' ) {
-                if ( *q >= '0' && *q <= '9' ) {
-                    const unsigned int digit = *q - '0';
-                    TIXMLASSERT( digit < 10 );
-                    TIXMLASSERT( digit == 0 || mult <= UINT_MAX / digit );
-                    const unsigned int digitScaled = mult * digit;
-                    TIXMLASSERT( ucs <= ULONG_MAX - digitScaled );
-                    ucs += digitScaled;
-                }
-                else {
-                    return 0;
-                }
-                TIXMLASSERT( mult <= UINT_MAX / 10 );
-                mult *= 10;
-                --q;
-            }
-        }
-        // convert the UCS to UTF-8
-        ConvertUTF32ToUTF8( ucs, value, length );
-        return p + delta + 1;
-    }
-    return p+1;
-}
-
-
-void XMLUtil::ToStr( int v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%d", v );
-}
-
-
-void XMLUtil::ToStr( unsigned v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%u", v );
-}
-
-
-void XMLUtil::ToStr( bool v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
-}
-
-/*
-	ToStr() of a number is a very tricky topic.
-	https://github.com/leethomason/tinyxml2/issues/106
-*/
-void XMLUtil::ToStr( float v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%.8g", v );
-}
-
-
-void XMLUtil::ToStr( double v, char* buffer, int bufferSize )
-{
-    TIXML_SNPRINTF( buffer, bufferSize, "%.17g", v );
-}
-
-
-void XMLUtil::ToStr(int64_t v, char* buffer, int bufferSize)
-{
-	// horrible syntax trick to make the compiler happy about %lld
-	TIXML_SNPRINTF(buffer, bufferSize, "%lld", (long long)v);
-}
-
-
-bool XMLUtil::ToInt( const char* str, int* value )
-{
-    if ( TIXML_SSCANF( str, "%d", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-bool XMLUtil::ToUnsigned( const char* str, unsigned *value )
-{
-    if ( TIXML_SSCANF( str, "%u", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-bool XMLUtil::ToBool( const char* str, bool* value )
-{
-    int ival = 0;
-    if ( ToInt( str, &ival )) {
-        *value = (ival==0) ? false : true;
-        return true;
-    }
-    if ( StringEqual( str, "true" ) ) {
-        *value = true;
-        return true;
-    }
-    else if ( StringEqual( str, "false" ) ) {
-        *value = false;
-        return true;
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToFloat( const char* str, float* value )
-{
-    if ( TIXML_SSCANF( str, "%f", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToDouble( const char* str, double* value )
-{
-    if ( TIXML_SSCANF( str, "%lf", value ) == 1 ) {
-        return true;
-    }
-    return false;
-}
-
-
-bool XMLUtil::ToInt64(const char* str, int64_t* value)
-{
-	long long v = 0;	// horrible syntax trick to make the compiler happy about %lld
-	if (TIXML_SSCANF(str, "%lld", &v) == 1) {
-		*value = (int64_t)v;
-		return true;
-	}
-	return false;
-}
-
-
-char* XMLDocument::Identify( char* p, XMLNode** node )
-{
-    TIXMLASSERT( node );
-    TIXMLASSERT( p );
-    char* const start = p;
-    int const startLine = _parseCurLineNum;
-    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
-    if( !*p ) {
-        *node = 0;
-        TIXMLASSERT( p );
+        TIXMLASSERT(p);
         return p;
     }
 
-    // These strings define the matching patterns:
-    static const char* xmlHeader		= { "<?" };
-    static const char* commentHeader	= { "<!--" };
-    static const char* cdataHeader		= { "<![CDATA[" };
-    static const char* dtdHeader		= { "<!" };
-    static const char* elementHeader	= { "<" };	// and a header for everything else; check last.
 
-    static const int xmlHeaderLen		= 2;
-    static const int commentHeaderLen	= 4;
-    static const int cdataHeaderLen		= 9;
-    static const int dtdHeaderLen		= 2;
-    static const int elementHeaderLen	= 1;
+    void XMLUtil::ConvertUTF32ToUTF8(unsigned long input, char* output, int* length)
+    {
+        const unsigned long BYTE_MASK = 0xBF;
+        const unsigned long BYTE_MARK = 0x80;
+        const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
-    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLUnknown ) );		// use same memory pool
-    TIXMLASSERT( sizeof( XMLComment ) == sizeof( XMLDeclaration ) );	// use same memory pool
-    XMLNode* returnNode = 0;
-    if ( XMLUtil::StringEqual( p, xmlHeader, xmlHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += xmlHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, commentHeader, commentHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLComment>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += commentHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, cdataHeader, cdataHeaderLen ) ) {
-        XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
-        returnNode = text;
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += cdataHeaderLen;
-        text->SetCData( true );
-    }
-    else if ( XMLUtil::StringEqual( p, dtdHeader, dtdHeaderLen ) ) {
-        returnNode = CreateUnlinkedNode<XMLUnknown>( _commentPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += dtdHeaderLen;
-    }
-    else if ( XMLUtil::StringEqual( p, elementHeader, elementHeaderLen ) ) {
-        returnNode =  CreateUnlinkedNode<XMLElement>( _elementPool );
-        returnNode->_parseLineNum = _parseCurLineNum;
-        p += elementHeaderLen;
-    }
-    else {
-        returnNode = CreateUnlinkedNode<XMLText>( _textPool );
-        returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
-        p = start;	// Back it up, all the text counts.
-        _parseCurLineNum = startLine;
-    }
+        if (input < 0x80) {
+            *length = 1;
+        } else if (input < 0x800) {
+            *length = 2;
+        } else if (input < 0x10000) {
+            *length = 3;
+        } else if (input < 0x200000) {
+            *length = 4;
+        } else {
+            *length = 0;    // This code won't convert this correctly anyway.
+            return;
+        }
 
-    TIXMLASSERT( returnNode );
-    TIXMLASSERT( p );
-    *node = returnNode;
-    return p;
-}
+        output += *length;
 
-
-bool XMLDocument::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    if ( visitor->VisitEnter( *this ) ) {
-        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
-            if ( !node->Accept( visitor ) ) {
-                break;
-            }
+        // Scary scary fall throughs are annotated with carefully designed comments
+        // to suppress compiler warnings such as -Wimplicit-fallthrough in gcc
+        switch (*length) {
+        case 4:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        //fall through
+        case 3:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        //fall through
+        case 2:
+            --output;
+            *output = static_cast<char>((input | BYTE_MARK) & BYTE_MASK);
+            input >>= 6;
+        //fall through
+        case 1:
+            --output;
+            *output = static_cast<char>(input | FIRST_BYTE_MARK[*length]);
+            break;
+        default:
+            TIXMLASSERT(false);
         }
     }
-    return visitor->VisitExit( *this );
-}
+
+
+    const char* XMLUtil::GetCharacterRef(const char* p, char* value, int* length)
+    {
+        // Presume an entity, and pull it out.
+        *length = 0;
+
+        if (*(p+1) == '#' && *(p+2)) {
+            unsigned long ucs = 0;
+            TIXMLASSERT(sizeof(ucs) >= 4);
+            ptrdiff_t delta = 0;
+            unsigned mult = 1;
+            static const char SEMICOLON = ';';
+
+            if (*(p+2) == 'x') {
+                // Hexadecimal.
+                const char* q = p+3;
+                if (!(*q)) {
+                    return 0;
+                }
+
+                q = strchr(q, SEMICOLON);
+
+                if (!q) {
+                    return 0;
+                }
+                TIXMLASSERT(*q == SEMICOLON);
+
+                delta = q-p;
+                --q;
+
+                while (*q != 'x') {
+                    unsigned int digit = 0;
+
+                    if (*q >= '0' && *q <= '9') {
+                        digit = *q - '0';
+                    } else if (*q >= 'a' && *q <= 'f') {
+                        digit = *q - 'a' + 10;
+                    } else if (*q >= 'A' && *q <= 'F') {
+                        digit = *q - 'A' + 10;
+                    } else {
+                        return 0;
+                    }
+                    TIXMLASSERT(digit < 16);
+                    TIXMLASSERT(digit == 0 || mult <= UINT_MAX / digit);
+                    const unsigned int digitScaled = mult * digit;
+                    TIXMLASSERT(ucs <= ULONG_MAX - digitScaled);
+                    ucs += digitScaled;
+                    TIXMLASSERT(mult <= UINT_MAX / 16);
+                    mult *= 16;
+                    --q;
+                }
+            } else {
+                // Decimal.
+                const char* q = p+2;
+                if (!(*q)) {
+                    return 0;
+                }
+
+                q = strchr(q, SEMICOLON);
+
+                if (!q) {
+                    return 0;
+                }
+                TIXMLASSERT(*q == SEMICOLON);
+
+                delta = q-p;
+                --q;
+
+                while (*q != '#') {
+                    if (*q >= '0' && *q <= '9') {
+                        const unsigned int digit = *q - '0';
+                        TIXMLASSERT(digit < 10);
+                        TIXMLASSERT(digit == 0 || mult <= UINT_MAX / digit);
+                        const unsigned int digitScaled = mult * digit;
+                        TIXMLASSERT(ucs <= ULONG_MAX - digitScaled);
+                        ucs += digitScaled;
+                    } else {
+                        return 0;
+                    }
+                    TIXMLASSERT(mult <= UINT_MAX / 10);
+                    mult *= 10;
+                    --q;
+                }
+            }
+            // convert the UCS to UTF-8
+            ConvertUTF32ToUTF8(ucs, value, length);
+            return p + delta + 1;
+        }
+        return p+1;
+    }
+
+
+    void XMLUtil::ToStr(int v, char* buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%d", v);
+    }
+
+
+    void XMLUtil::ToStr(unsigned v, char* buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%u", v);
+    }
+
+
+    void XMLUtil::ToStr(bool v, char* buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%s", v ? writeBoolTrue : writeBoolFalse);
+    }
+
+    /*
+        ToStr() of a number is a very tricky topic.
+        https://github.com/leethomason/tinyxml2/issues/106
+    */
+    void XMLUtil::ToStr(float v, char* buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%.8g", v);
+    }
+
+
+    void XMLUtil::ToStr(double v, char* buffer, int bufferSize)
+    {
+        TIXML_SNPRINTF(buffer, bufferSize, "%.17g", v);
+    }
+
+
+    void XMLUtil::ToStr(int64_t v, char* buffer, int bufferSize)
+    {
+        // horrible syntax trick to make the compiler happy about %lld
+        TIXML_SNPRINTF(buffer, bufferSize, "%lld", static_cast<long long>(v));
+    }
+
+    void XMLUtil::ToStr(uint64_t v, char* buffer, int bufferSize)
+    {
+        // horrible syntax trick to make the compiler happy about %llu
+        TIXML_SNPRINTF(buffer, bufferSize, "%llu", (long long)v);
+    }
+
+    bool XMLUtil::ToInt(const char* str, int* value)
+    {
+        if (TIXML_SSCANF(str, "%d", value) == 1) {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToUnsigned(const char* str, unsigned *value)
+    {
+        if (TIXML_SSCANF(str, "%u", value) == 1) {
+            return true;
+        }
+        return false;
+    }
+
+    bool XMLUtil::ToBool(const char* str, bool* value)
+    {
+        int ival = 0;
+        if (ToInt(str, &ival)) {
+            *value = (ival==0) ? false : true;
+            return true;
+        }
+        static const char* TRUE_VALS[] = { "true", "True", "TRUE", 0 };
+        static const char* FALSE_VALS[] = { "false", "False", "FALSE", 0 };
+
+        for (int i = 0; TRUE_VALS[i]; ++i) {
+            if (StringEqual(str, TRUE_VALS[i])) {
+                *value = true;
+                return true;
+            }
+        }
+        for (int i = 0; FALSE_VALS[i]; ++i) {
+            if (StringEqual(str, FALSE_VALS[i])) {
+                *value = false;
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    bool XMLUtil::ToFloat(const char* str, float* value)
+    {
+        if (TIXML_SSCANF(str, "%f", value) == 1) {
+            return true;
+        }
+        return false;
+    }
+
+
+    bool XMLUtil::ToDouble(const char* str, double* value)
+    {
+        if (TIXML_SSCANF(str, "%lf", value) == 1) {
+            return true;
+        }
+        return false;
+    }
+
+
+    bool XMLUtil::ToInt64(const char* str, int64_t* value)
+    {
+        long long v = 0;    // horrible syntax trick to make the compiler happy about %lld
+        if (TIXML_SSCANF(str, "%lld", &v) == 1) {
+            *value = static_cast<int64_t>(v);
+            return true;
+        }
+        return false;
+    }
+
+
+    bool XMLUtil::ToUnsigned64(const char* str, uint64_t* value)
+    {
+        unsigned long long v = 0;   // horrible syntax trick to make the compiler happy about %llu
+        if (TIXML_SSCANF(str, "%llu", &v) == 1) {
+            *value = (uint64_t)v;
+            return true;
+        }
+        return false;
+    }
+
+
+    char* XMLDocument::Identify(char* p, XMLNode** node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(p);
+        char* const start = p;
+        int const startLine = _parseCurLineNum;
+        p = XMLUtil::SkipWhiteSpace(p, &_parseCurLineNum);
+        if (!*p) {
+            *node = 0;
+            TIXMLASSERT(p);
+            return p;
+        }
+
+        // These strings define the matching patterns:
+        static const char* xmlHeader        = { "<?" };
+        static const char* commentHeader    = { "<!--" };
+        static const char* cdataHeader      = { "<![CDATA[" };
+        static const char* dtdHeader        = { "<!" };
+        static const char* elementHeader    = { "<" };  // and a header for everything else; check last.
+
+        static const int xmlHeaderLen       = 2;
+        static const int commentHeaderLen   = 4;
+        static const int cdataHeaderLen     = 9;
+        static const int dtdHeaderLen       = 2;
+        static const int elementHeaderLen   = 1;
+
+        TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLUnknown));             // use same memory pool
+        TIXMLASSERT(sizeof(XMLComment) == sizeof(XMLDeclaration));         // use same memory pool
+        XMLNode* returnNode = 0;
+        if (XMLUtil::StringEqual(p, xmlHeader, xmlHeaderLen)) {
+            returnNode = CreateUnlinkedNode<XMLDeclaration>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += xmlHeaderLen;
+        } else if (XMLUtil::StringEqual(p, commentHeader, commentHeaderLen)) {
+            returnNode = CreateUnlinkedNode<XMLComment>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += commentHeaderLen;
+        } else if (XMLUtil::StringEqual(p, cdataHeader, cdataHeaderLen)) {
+            XMLText* text = CreateUnlinkedNode<XMLText>(_textPool);
+            returnNode = text;
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += cdataHeaderLen;
+            text->SetCData(true);
+        } else if (XMLUtil::StringEqual(p, dtdHeader, dtdHeaderLen)) {
+            returnNode = CreateUnlinkedNode<XMLUnknown>(_commentPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += dtdHeaderLen;
+        } else if (XMLUtil::StringEqual(p, elementHeader, elementHeaderLen)) {
+            returnNode =  CreateUnlinkedNode<XMLElement>(_elementPool);
+            returnNode->_parseLineNum = _parseCurLineNum;
+            p += elementHeaderLen;
+        } else {
+            returnNode = CreateUnlinkedNode<XMLText>(_textPool);
+            returnNode->_parseLineNum = _parseCurLineNum; // Report line of first non-whitespace character
+            p = start;  // Back it up, all the text counts.
+            _parseCurLineNum = startLine;
+        }
+
+        TIXMLASSERT(returnNode);
+        TIXMLASSERT(p);
+        *node = returnNode;
+        return p;
+    }
+
+
+    bool XMLDocument::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        if (visitor->VisitEnter(*this)) {
+            for (const XMLNode* node=FirstChild(); node; node=node->NextSibling()) {
+                if (!node->Accept(visitor)) {
+                    break;
+                }
+            }
+        }
+        return visitor->VisitExit(*this);
+    }
 
 
 // --------- XMLNode ----------- //
 
-XMLNode::XMLNode( XMLDocument* doc ) :
-    _document( doc ),
-    _parent( 0 ),
-    _value(),
-    _parseLineNum( 0 ),
-    _firstChild( 0 ), _lastChild( 0 ),
-    _prev( 0 ), _next( 0 ),
-	_userData( 0 ),
-    _memPool( 0 )
-{
-}
-
-
-XMLNode::~XMLNode()
-{
-    DeleteChildren();
-    if ( _parent ) {
-        _parent->Unlink( this );
-    }
-}
-
-const char* XMLNode::Value() const
-{
-    // Edge case: XMLDocuments don't have a Value. Return null.
-    if ( this->ToDocument() )
-        return 0;
-    return _value.GetStr();
-}
-
-void XMLNode::SetValue( const char* str, bool staticMem )
-{
-    if ( staticMem ) {
-        _value.SetInternedStr( str );
-    }
-    else {
-        _value.SetStr( str );
-    }
-}
-
-XMLNode* XMLNode::DeepClone(XMLDocument* target) const
-{
-	XMLNode* clone = this->ShallowClone(target);
-	if (!clone) return 0;
-
-	for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
-		XMLNode* childClone = child->DeepClone(target);
-		TIXMLASSERT(childClone);
-		clone->InsertEndChild(childClone);
-	}
-	return clone;
-}
-
-void XMLNode::DeleteChildren()
-{
-    while( _firstChild ) {
-        TIXMLASSERT( _lastChild );
-        DeleteChild( _firstChild );
-    }
-    _firstChild = _lastChild = 0;
-}
-
-
-void XMLNode::Unlink( XMLNode* child )
-{
-    TIXMLASSERT( child );
-    TIXMLASSERT( child->_document == _document );
-    TIXMLASSERT( child->_parent == this );
-    if ( child == _firstChild ) {
-        _firstChild = _firstChild->_next;
-    }
-    if ( child == _lastChild ) {
-        _lastChild = _lastChild->_prev;
+    XMLNode::XMLNode(XMLDocument* doc) :
+        _document(doc),
+        _parent(0),
+        _value(),
+        _parseLineNum(0),
+        _firstChild(0), _lastChild(0),
+        _prev(0), _next(0),
+        _userData(0),
+        _memPool(0)
+    {
     }
 
-    if ( child->_prev ) {
-        child->_prev->_next = child->_next;
-    }
-    if ( child->_next ) {
-        child->_next->_prev = child->_prev;
-    }
-	child->_next = 0;
-	child->_prev = 0;
-	child->_parent = 0;
-}
 
-
-void XMLNode::DeleteChild( XMLNode* node )
-{
-    TIXMLASSERT( node );
-    TIXMLASSERT( node->_document == _document );
-    TIXMLASSERT( node->_parent == this );
-    Unlink( node );
-	TIXMLASSERT(node->_prev == 0);
-	TIXMLASSERT(node->_next == 0);
-	TIXMLASSERT(node->_parent == 0);
-    DeleteNode( node );
-}
-
-
-XMLNode* XMLNode::InsertEndChild( XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
-    }
-    InsertChildPreamble( addThis );
-
-    if ( _lastChild ) {
-        TIXMLASSERT( _firstChild );
-        TIXMLASSERT( _lastChild->_next == 0 );
-        _lastChild->_next = addThis;
-        addThis->_prev = _lastChild;
-        _lastChild = addThis;
-
-        addThis->_next = 0;
-    }
-    else {
-        TIXMLASSERT( _firstChild == 0 );
-        _firstChild = _lastChild = addThis;
-
-        addThis->_prev = 0;
-        addThis->_next = 0;
-    }
-    addThis->_parent = this;
-    return addThis;
-}
-
-
-XMLNode* XMLNode::InsertFirstChild( XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
-    }
-    InsertChildPreamble( addThis );
-
-    if ( _firstChild ) {
-        TIXMLASSERT( _lastChild );
-        TIXMLASSERT( _firstChild->_prev == 0 );
-
-        _firstChild->_prev = addThis;
-        addThis->_next = _firstChild;
-        _firstChild = addThis;
-
-        addThis->_prev = 0;
-    }
-    else {
-        TIXMLASSERT( _lastChild == 0 );
-        _firstChild = _lastChild = addThis;
-
-        addThis->_prev = 0;
-        addThis->_next = 0;
-    }
-    addThis->_parent = this;
-    return addThis;
-}
-
-
-XMLNode* XMLNode::InsertAfterChild( XMLNode* afterThis, XMLNode* addThis )
-{
-    TIXMLASSERT( addThis );
-    if ( addThis->_document != _document ) {
-        TIXMLASSERT( false );
-        return 0;
+    XMLNode::~XMLNode()
+    {
+        DeleteChildren();
+        if (_parent) {
+            _parent->Unlink(this);
+        }
     }
 
-    TIXMLASSERT( afterThis );
-
-    if ( afterThis->_parent != this ) {
-        TIXMLASSERT( false );
-        return 0;
+    const char* XMLNode::Value() const
+    {
+        // Edge case: XMLDocuments don't have a Value. Return null.
+        if (this->ToDocument())
+            return 0;
+        return _value.GetStr();
     }
-    if ( afterThis == addThis ) {
-        // Current state: BeforeThis -> AddThis -> OneAfterAddThis
-        // Now AddThis must disappear from it's location and then
-        // reappear between BeforeThis and OneAfterAddThis.
-        // So just leave it where it is.
+
+    void XMLNode::SetValue(const char* str, bool staticMem)
+    {
+        if (staticMem) {
+            _value.SetInternedStr(str);
+        } else {
+            _value.SetStr(str);
+        }
+    }
+
+    XMLNode* XMLNode::DeepClone(XMLDocument* target) const
+    {
+        XMLNode* clone = this->ShallowClone(target);
+        if (!clone) return 0;
+
+        for (const XMLNode* child = this->FirstChild(); child; child = child->NextSibling()) {
+            XMLNode* childClone = child->DeepClone(target);
+            TIXMLASSERT(childClone);
+            clone->InsertEndChild(childClone);
+        }
+        return clone;
+    }
+
+    void XMLNode::DeleteChildren()
+    {
+        while (_firstChild) {
+            TIXMLASSERT(_lastChild);
+            DeleteChild(_firstChild);
+        }
+        _firstChild = _lastChild = 0;
+    }
+
+
+    void XMLNode::Unlink(XMLNode* child)
+    {
+        TIXMLASSERT(child);
+        TIXMLASSERT(child->_document == _document);
+        TIXMLASSERT(child->_parent == this);
+        if (child == _firstChild) {
+            _firstChild = _firstChild->_next;
+        }
+        if (child == _lastChild) {
+            _lastChild = _lastChild->_prev;
+        }
+
+        if (child->_prev) {
+            child->_prev->_next = child->_next;
+        }
+        if (child->_next) {
+            child->_next->_prev = child->_prev;
+        }
+        child->_next = 0;
+        child->_prev = 0;
+        child->_parent = 0;
+    }
+
+
+    void XMLNode::DeleteChild(XMLNode* node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_document == _document);
+        TIXMLASSERT(node->_parent == this);
+        Unlink(node);
+        TIXMLASSERT(node->_prev == 0);
+        TIXMLASSERT(node->_next == 0);
+        TIXMLASSERT(node->_parent == 0);
+        DeleteNode(node);
+    }
+
+
+    XMLNode* XMLNode::InsertEndChild(XMLNode* addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document) {
+            TIXMLASSERT(false);
+            return 0;
+        }
+        InsertChildPreamble(addThis);
+
+        if (_lastChild) {
+            TIXMLASSERT(_firstChild);
+            TIXMLASSERT(_lastChild->_next == 0);
+            _lastChild->_next = addThis;
+            addThis->_prev = _lastChild;
+            _lastChild = addThis;
+
+            addThis->_next = 0;
+        } else {
+            TIXMLASSERT(_firstChild == 0);
+            _firstChild = _lastChild = addThis;
+
+            addThis->_prev = 0;
+            addThis->_next = 0;
+        }
+        addThis->_parent = this;
         return addThis;
     }
 
-    if ( afterThis->_next == 0 ) {
-        // The last node or the only node.
-        return InsertEndChild( addThis );
+
+    XMLNode* XMLNode::InsertFirstChild(XMLNode* addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document) {
+            TIXMLASSERT(false);
+            return 0;
+        }
+        InsertChildPreamble(addThis);
+
+        if (_firstChild) {
+            TIXMLASSERT(_lastChild);
+            TIXMLASSERT(_firstChild->_prev == 0);
+
+            _firstChild->_prev = addThis;
+            addThis->_next = _firstChild;
+            _firstChild = addThis;
+
+            addThis->_prev = 0;
+        } else {
+            TIXMLASSERT(_lastChild == 0);
+            _firstChild = _lastChild = addThis;
+
+            addThis->_prev = 0;
+            addThis->_next = 0;
+        }
+        addThis->_parent = this;
+        return addThis;
     }
-    InsertChildPreamble( addThis );
-    addThis->_prev = afterThis;
-    addThis->_next = afterThis->_next;
-    afterThis->_next->_prev = addThis;
-    afterThis->_next = addThis;
-    addThis->_parent = this;
-    return addThis;
-}
 
 
-
-
-const XMLElement* XMLNode::FirstChildElement( const char* name ) const
-{
-    for( const XMLNode* node = _firstChild; node; node = node->_next ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
+    XMLNode* XMLNode::InsertAfterChild(XMLNode* afterThis, XMLNode* addThis)
+    {
+        TIXMLASSERT(addThis);
+        if (addThis->_document != _document) {
+            TIXMLASSERT(false);
+            return 0;
         }
+
+        TIXMLASSERT(afterThis);
+
+        if (afterThis->_parent != this) {
+            TIXMLASSERT(false);
+            return 0;
+        }
+        if (afterThis == addThis) {
+            // Current state: BeforeThis -> AddThis -> OneAfterAddThis
+            // Now AddThis must disappear from it's location and then
+            // reappear between BeforeThis and OneAfterAddThis.
+            // So just leave it where it is.
+            return addThis;
+        }
+
+        if (afterThis->_next == 0) {
+            // The last node or the only node.
+            return InsertEndChild(addThis);
+        }
+        InsertChildPreamble(addThis);
+        addThis->_prev = afterThis;
+        addThis->_next = afterThis->_next;
+        afterThis->_next->_prev = addThis;
+        afterThis->_next = addThis;
+        addThis->_parent = this;
+        return addThis;
     }
-    return 0;
-}
 
 
-const XMLElement* XMLNode::LastChildElement( const char* name ) const
-{
-    for( const XMLNode* node = _lastChild; node; node = node->_prev ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
-        }
-    }
-    return 0;
-}
 
 
-const XMLElement* XMLNode::NextSiblingElement( const char* name ) const
-{
-    for( const XMLNode* node = _next; node; node = node->_next ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
-        }
-    }
-    return 0;
-}
-
-
-const XMLElement* XMLNode::PreviousSiblingElement( const char* name ) const
-{
-    for( const XMLNode* node = _prev; node; node = node->_prev ) {
-        const XMLElement* element = node->ToElementWithName( name );
-        if ( element ) {
-            return element;
-        }
-    }
-    return 0;
-}
-
-
-char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
-{
-    // This is a recursive method, but thinking about it "at the current level"
-    // it is a pretty simple flat list:
-    //		<foo/>
-    //		<!-- comment -->
-    //
-    // With a special case:
-    //		<foo>
-    //		</foo>
-    //		<!-- comment -->
-    //
-    // Where the closing element (/foo) *must* be the next thing after the opening
-    // element, and the names must match. BUT the tricky bit is that the closing
-    // element will be read by the child.
-    //
-    // 'endTag' is the end tag for this node, it is returned by a call to a child.
-    // 'parentEnd' is the end tag for the parent, which is filled in and returned.
-
-    while( p && *p ) {
-        XMLNode* node = 0;
-
-        p = _document->Identify( p, &node );
-        TIXMLASSERT( p );
-        if ( node == 0 ) {
-            break;
-        }
-
-        int initialLineNum = node->_parseLineNum;
-
-        StrPair endTag;
-        p = node->ParseDeep( p, &endTag, curLineNumPtr );
-        if ( !p ) {
-            DeleteNode( node );
-            if ( !_document->Error() ) {
-                _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
-            }
-            break;
-        }
-
-        XMLDeclaration* decl = node->ToDeclaration();
-        if ( decl ) {
-            // Declarations are only allowed at document level
-            bool wellLocated = ( ToDocument() != 0 );
-            if ( wellLocated ) {
-                // Multiple declarations are allowed but all declarations
-                // must occur before anything else
-                for ( const XMLNode* existingNode = _document->FirstChild(); existingNode; existingNode = existingNode->NextSibling() ) {
-                    if ( !existingNode->ToDeclaration() ) {
-                        wellLocated = false;
-                        break;
-                    }
-                }
-            }
-            if ( !wellLocated ) {
-                _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
-                DeleteNode( node );
-                break;
+    const XMLElement* XMLNode::FirstChildElement(const char* name) const
+    {
+        for (const XMLNode* node = _firstChild; node; node = node->_next) {
+            const XMLElement* element = node->ToElementWithName(name);
+            if (element) {
+                return element;
             }
         }
-
-        XMLElement* ele = node->ToElement();
-        if ( ele ) {
-            // We read the end tag. Return it to the parent.
-            if ( ele->ClosingType() == XMLElement::CLOSING ) {
-                if ( parentEndTag ) {
-                    ele->_value.TransferTo( parentEndTag );
-                }
-                node->_memPool->SetTracked();   // created and then immediately deleted.
-                DeleteNode( node );
-                return p;
-            }
-
-            // Handle an end tag returned to this level.
-            // And handle a bunch of annoying errors.
-            bool mismatch = false;
-            if ( endTag.Empty() ) {
-                if ( ele->ClosingType() == XMLElement::OPEN ) {
-                    mismatch = true;
-                }
-            }
-            else {
-                if ( ele->ClosingType() != XMLElement::OPEN ) {
-                    mismatch = true;
-                }
-                else if ( !XMLUtil::StringEqual( endTag.GetStr(), ele->Name() ) ) {
-                    mismatch = true;
-                }
-            }
-            if ( mismatch ) {
-                _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
-                DeleteNode( node );
-                break;
-            }
-        }
-        InsertEndChild( node );
-    }
-    return 0;
-}
-
-/*static*/ void XMLNode::DeleteNode( XMLNode* node )
-{
-    if ( node == 0 ) {
-        return;
-    }
-	TIXMLASSERT(node->_document);
-	if (!node->ToDocument()) {
-		node->_document->MarkInUse(node);
-	}
-
-    MemPool* pool = node->_memPool;
-    node->~XMLNode();
-    pool->Free( node );
-}
-
-void XMLNode::InsertChildPreamble( XMLNode* insertThis ) const
-{
-    TIXMLASSERT( insertThis );
-    TIXMLASSERT( insertThis->_document == _document );
-
-	if (insertThis->_parent) {
-        insertThis->_parent->Unlink( insertThis );
-	}
-	else {
-		insertThis->_document->MarkInUse(insertThis);
-        insertThis->_memPool->SetTracked();
-	}
-}
-
-const XMLElement* XMLNode::ToElementWithName( const char* name ) const
-{
-    const XMLElement* element = this->ToElement();
-    if ( element == 0 ) {
         return 0;
     }
-    if ( name == 0 ) {
-        return element;
+
+
+    const XMLElement* XMLNode::LastChildElement(const char* name) const
+    {
+        for (const XMLNode* node = _lastChild; node; node = node->_prev) {
+            const XMLElement* element = node->ToElementWithName(name);
+            if (element) {
+                return element;
+            }
+        }
+        return 0;
     }
-    if ( XMLUtil::StringEqual( element->Name(), name ) ) {
-       return element;
+
+
+    const XMLElement* XMLNode::NextSiblingElement(const char* name) const
+    {
+        for (const XMLNode* node = _next; node; node = node->_next) {
+            const XMLElement* element = node->ToElementWithName(name);
+            if (element) {
+                return element;
+            }
+        }
+        return 0;
     }
-    return 0;
-}
+
+
+    const XMLElement* XMLNode::PreviousSiblingElement(const char* name) const
+    {
+        for (const XMLNode* node = _prev; node; node = node->_prev) {
+            const XMLElement* element = node->ToElementWithName(name);
+            if (element) {
+                return element;
+            }
+        }
+        return 0;
+    }
+
+
+    char* XMLNode::ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr)
+    {
+        // This is a recursive method, but thinking about it "at the current level"
+        // it is a pretty simple flat list:
+        //      <foo/>
+        //      <!-- comment -->
+        //
+        // With a special case:
+        //      <foo>
+        //      </foo>
+        //      <!-- comment -->
+        //
+        // Where the closing element (/foo) *must* be the next thing after the opening
+        // element, and the names must match. BUT the tricky bit is that the closing
+        // element will be read by the child.
+        //
+        // 'endTag' is the end tag for this node, it is returned by a call to a child.
+        // 'parentEnd' is the end tag for the parent, which is filled in and returned.
+
+        XMLDocument::DepthTracker tracker(_document);
+        if (_document->Error())
+            return 0;
+
+        while (p && *p) {
+            XMLNode* node = 0;
+
+            p = _document->Identify(p, &node);
+            TIXMLASSERT(p);
+            if (node == 0) {
+                break;
+            }
+
+            const int initialLineNum = node->_parseLineNum;
+
+            StrPair endTag;
+            p = node->ParseDeep(p, &endTag, curLineNumPtr);
+            if (!p) {
+                DeleteNode(node);
+                if (!_document->Error()) {
+                    _document->SetError(XML_ERROR_PARSING, initialLineNum, 0);
+                }
+                break;
+            }
+
+            const XMLDeclaration* const decl = node->ToDeclaration();
+            if (decl) {
+                // Declarations are only allowed at document level
+                //
+                // Multiple declarations are allowed but all declarations
+                // must occur before anything else.
+                //
+                // Optimized due to a security test case. If the first node is
+                // a declaration, and the last node is a declaration, then only
+                // declarations have so far been added.
+                bool wellLocated = false;
+
+                if (ToDocument()) {
+                    if (FirstChild()) {
+                        wellLocated =
+                            FirstChild() &&
+                            FirstChild()->ToDeclaration() &&
+                            LastChild() &&
+                            LastChild()->ToDeclaration();
+                    } else {
+                        wellLocated = true;
+                    }
+                }
+                if (!wellLocated) {
+                    _document->SetError(XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
+                    DeleteNode(node);
+                    break;
+                }
+            }
+
+            XMLElement* ele = node->ToElement();
+            if (ele) {
+                // We read the end tag. Return it to the parent.
+                if (ele->ClosingType() == XMLElement::CLOSING) {
+                    if (parentEndTag) {
+                        ele->_value.TransferTo(parentEndTag);
+                    }
+                    node->_memPool->SetTracked();   // created and then immediately deleted.
+                    DeleteNode(node);
+                    return p;
+                }
+
+                // Handle an end tag returned to this level.
+                // And handle a bunch of annoying errors.
+                bool mismatch = false;
+                if (endTag.Empty()) {
+                    if (ele->ClosingType() == XMLElement::OPEN) {
+                        mismatch = true;
+                    }
+                } else {
+                    if (ele->ClosingType() != XMLElement::OPEN) {
+                        mismatch = true;
+                    } else if (!XMLUtil::StringEqual(endTag.GetStr(), ele->Name())) {
+                        mismatch = true;
+                    }
+                }
+                if (mismatch) {
+                    _document->SetError(XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
+                    DeleteNode(node);
+                    break;
+                }
+            }
+            InsertEndChild(node);
+        }
+        return 0;
+    }
+
+    /*static*/ void XMLNode::DeleteNode(XMLNode* node)
+    {
+        if (node == 0) {
+            return;
+        }
+        TIXMLASSERT(node->_document);
+        if (!node->ToDocument()) {
+            node->_document->MarkInUse(node);
+        }
+
+        MemPool* pool = node->_memPool;
+        node->~XMLNode();
+        pool->Free(node);
+    }
+
+    void XMLNode::InsertChildPreamble(XMLNode* insertThis) const
+    {
+        TIXMLASSERT(insertThis);
+        TIXMLASSERT(insertThis->_document == _document);
+
+        if (insertThis->_parent) {
+            insertThis->_parent->Unlink(insertThis);
+        } else {
+            insertThis->_document->MarkInUse(insertThis);
+            insertThis->_memPool->SetTracked();
+        }
+    }
+
+    const XMLElement* XMLNode::ToElementWithName(const char* name) const
+    {
+        const XMLElement* element = this->ToElement();
+        if (element == 0) {
+            return 0;
+        }
+        if (name == 0) {
+            return element;
+        }
+        if (XMLUtil::StringEqual(element->Name(), name)) {
+            return element;
+        }
+        return 0;
+    }
 
 // --------- XMLText ---------- //
-char* XMLText::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    if ( this->CData() ) {
-        p = _value.ParseText( p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-        if ( !p ) {
-            _document->SetError( XML_ERROR_PARSING_CDATA, _parseLineNum, 0 );
+    char* XMLText::ParseDeep(char* p, StrPair*, int* curLineNumPtr)
+    {
+        if (this->CData()) {
+            p = _value.ParseText(p, "]]>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+            if (!p) {
+                _document->SetError(XML_ERROR_PARSING_CDATA, _parseLineNum, 0);
+            }
+            return p;
+        } else {
+            int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
+            if (_document->WhitespaceMode() == COLLAPSE_WHITESPACE) {
+                flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
+            }
+
+            p = _value.ParseText(p, "<", flags, curLineNumPtr);
+            if (p && *p) {
+                return p-1;
+            }
+            if (!p) {
+                _document->SetError(XML_ERROR_PARSING_TEXT, _parseLineNum, 0);
+            }
         }
-        return p;
+        return 0;
     }
-    else {
-        int flags = _document->ProcessEntities() ? StrPair::TEXT_ELEMENT : StrPair::TEXT_ELEMENT_LEAVE_ENTITIES;
-        if ( _document->WhitespaceMode() == COLLAPSE_WHITESPACE ) {
-            flags |= StrPair::NEEDS_WHITESPACE_COLLAPSING;
-        }
 
-        p = _value.ParseText( p, "<", flags, curLineNumPtr );
-        if ( p && *p ) {
-            return p-1;
+
+    XMLNode* XMLText::ShallowClone(XMLDocument* doc) const
+    {
+        if (!doc) {
+            doc = _document;
         }
-        if ( !p ) {
-            _document->SetError( XML_ERROR_PARSING_TEXT, _parseLineNum, 0 );
-        }
+        XMLText* text = doc->NewText(Value());   // fixme: this will always allocate memory. Intern?
+        text->SetCData(this->CData());
+        return text;
     }
-    return 0;
-}
 
 
-XMLNode* XMLText::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
+    bool XMLText::ShallowEqual(const XMLNode* compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLText* text = compare->ToText();
+        return (text && XMLUtil::StringEqual(text->Value(), Value()));
     }
-    XMLText* text = doc->NewText( Value() );	// fixme: this will always allocate memory. Intern?
-    text->SetCData( this->CData() );
-    return text;
-}
 
 
-bool XMLText::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLText* text = compare->ToText();
-    return ( text && XMLUtil::StringEqual( text->Value(), Value() ) );
-}
-
-
-bool XMLText::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
+    bool XMLText::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
 
 
 // --------- XMLComment ---------- //
 
-XMLComment::XMLComment( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLComment::~XMLComment()
-{
-}
-
-
-char* XMLComment::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Comment parses as text.
-    p = _value.ParseText( p, "-->", StrPair::COMMENT, curLineNumPtr );
-    if ( p == 0 ) {
-        _document->SetError( XML_ERROR_PARSING_COMMENT, _parseLineNum, 0 );
+    XMLComment::XMLComment(XMLDocument* doc) : XMLNode(doc)
+    {
     }
-    return p;
-}
 
 
-XMLNode* XMLComment::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
+    XMLComment::~XMLComment()
+    {
     }
-    XMLComment* comment = doc->NewComment( Value() );	// fixme: this will always allocate memory. Intern?
-    return comment;
-}
 
 
-bool XMLComment::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLComment* comment = compare->ToComment();
-    return ( comment && XMLUtil::StringEqual( comment->Value(), Value() ));
-}
+    char* XMLComment::ParseDeep(char* p, StrPair*, int* curLineNumPtr)
+    {
+        // Comment parses as text.
+        p = _value.ParseText(p, "-->", StrPair::COMMENT, curLineNumPtr);
+        if (p == 0) {
+            _document->SetError(XML_ERROR_PARSING_COMMENT, _parseLineNum, 0);
+        }
+        return p;
+    }
 
 
-bool XMLComment::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
+    XMLNode* XMLComment::ShallowClone(XMLDocument* doc) const
+    {
+        if (!doc) {
+            doc = _document;
+        }
+        XMLComment* comment = doc->NewComment(Value());      // fixme: this will always allocate memory. Intern?
+        return comment;
+    }
+
+
+    bool XMLComment::ShallowEqual(const XMLNode* compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLComment* comment = compare->ToComment();
+        return (comment && XMLUtil::StringEqual(comment->Value(), Value()));
+    }
+
+
+    bool XMLComment::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
 
 
 // --------- XMLDeclaration ---------- //
 
-XMLDeclaration::XMLDeclaration( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLDeclaration::~XMLDeclaration()
-{
-    //printf( "~XMLDeclaration\n" );
-}
-
-
-char* XMLDeclaration::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Declaration parses as text.
-    p = _value.ParseText( p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-    if ( p == 0 ) {
-        _document->SetError( XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0 );
-    }
-    return p;
-}
-
-
-XMLNode* XMLDeclaration::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLDeclaration* dec = doc->NewDeclaration( Value() );	// fixme: this will always allocate memory. Intern?
-    return dec;
-}
-
-
-bool XMLDeclaration::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLDeclaration* declaration = compare->ToDeclaration();
-    return ( declaration && XMLUtil::StringEqual( declaration->Value(), Value() ));
-}
-
-
-
-bool XMLDeclaration::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-// --------- XMLUnknown ---------- //
-
-XMLUnknown::XMLUnknown( XMLDocument* doc ) : XMLNode( doc )
-{
-}
-
-
-XMLUnknown::~XMLUnknown()
-{
-}
-
-
-char* XMLUnknown::ParseDeep( char* p, StrPair*, int* curLineNumPtr )
-{
-    // Unknown parses as text.
-    p = _value.ParseText( p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr );
-    if ( !p ) {
-        _document->SetError( XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0 );
-    }
-    return p;
-}
-
-
-XMLNode* XMLUnknown::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
-    }
-    XMLUnknown* text = doc->NewUnknown( Value() );	// fixme: this will always allocate memory. Intern?
-    return text;
-}
-
-
-bool XMLUnknown::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLUnknown* unknown = compare->ToUnknown();
-    return ( unknown && XMLUtil::StringEqual( unknown->Value(), Value() ));
-}
-
-
-bool XMLUnknown::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    return visitor->Visit( *this );
-}
-
-// --------- XMLAttribute ---------- //
-
-const char* XMLAttribute::Name() const
-{
-    return _name.GetStr();
-}
-
-const char* XMLAttribute::Value() const
-{
-    return _value.GetStr();
-}
-
-char* XMLAttribute::ParseDeep( char* p, bool processEntities, int* curLineNumPtr )
-{
-    // Parse using the name rules: bug fix, was using ParseText before
-    p = _name.ParseName( p );
-    if ( !p || !*p ) {
-        return 0;
+    XMLDeclaration::XMLDeclaration(XMLDocument* doc) : XMLNode(doc)
+    {
     }
 
-    // Skip white space before =
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-    if ( *p != '=' ) {
-        return 0;
+
+    XMLDeclaration::~XMLDeclaration()
+    {
+        //printf( "~XMLDeclaration\n" );
     }
 
-    ++p;	// move up to opening quote
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-    if ( *p != '\"' && *p != '\'' ) {
-        return 0;
-    }
 
-    char endTag[2] = { *p, 0 };
-    ++p;	// move past opening quote
-
-    p = _value.ParseText( p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES, curLineNumPtr );
-    return p;
-}
-
-
-void XMLAttribute::SetName( const char* n )
-{
-    _name.SetStr( n );
-}
-
-
-XMLError XMLAttribute::QueryIntValue( int* value ) const
-{
-    if ( XMLUtil::ToInt( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryUnsignedValue( unsigned int* value ) const
-{
-    if ( XMLUtil::ToUnsigned( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryInt64Value(int64_t* value) const
-{
-	if (XMLUtil::ToInt64(Value(), value)) {
-		return XML_SUCCESS;
-	}
-	return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryBoolValue( bool* value ) const
-{
-    if ( XMLUtil::ToBool( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryFloatValue( float* value ) const
-{
-    if ( XMLUtil::ToFloat( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-XMLError XMLAttribute::QueryDoubleValue( double* value ) const
-{
-    if ( XMLUtil::ToDouble( Value(), value )) {
-        return XML_SUCCESS;
-    }
-    return XML_WRONG_ATTRIBUTE_TYPE;
-}
-
-
-void XMLAttribute::SetAttribute( const char* v )
-{
-    _value.SetStr( v );
-}
-
-
-void XMLAttribute::SetAttribute( int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-void XMLAttribute::SetAttribute( unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-void XMLAttribute::SetAttribute(int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	_value.SetStr(buf);
-}
-
-
-
-void XMLAttribute::SetAttribute( bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-void XMLAttribute::SetAttribute( double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-void XMLAttribute::SetAttribute( float v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    _value.SetStr( buf );
-}
-
-
-// --------- XMLElement ---------- //
-XMLElement::XMLElement( XMLDocument* doc ) : XMLNode( doc ),
-    _closingType( OPEN ),
-    _rootAttribute( 0 )
-{
-}
-
-
-XMLElement::~XMLElement()
-{
-    while( _rootAttribute ) {
-        XMLAttribute* next = _rootAttribute->_next;
-        DeleteAttribute( _rootAttribute );
-        _rootAttribute = next;
-    }
-}
-
-
-const XMLAttribute* XMLElement::FindAttribute( const char* name ) const
-{
-    for( XMLAttribute* a = _rootAttribute; a; a = a->_next ) {
-        if ( XMLUtil::StringEqual( a->Name(), name ) ) {
-            return a;
+    char* XMLDeclaration::ParseDeep(char* p, StrPair*, int* curLineNumPtr)
+    {
+        // Declaration parses as text.
+        p = _value.ParseText(p, "?>", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+        if (p == 0) {
+            _document->SetError(XML_ERROR_PARSING_DECLARATION, _parseLineNum, 0);
         }
-    }
-    return 0;
-}
-
-
-const char* XMLElement::Attribute( const char* name, const char* value ) const
-{
-    const XMLAttribute* a = FindAttribute( name );
-    if ( !a ) {
-        return 0;
-    }
-    if ( !value || XMLUtil::StringEqual( a->Value(), value )) {
-        return a->Value();
-    }
-    return 0;
-}
-
-int XMLElement::IntAttribute(const char* name, int defaultValue) const
-{
-	int i = defaultValue;
-	QueryIntAttribute(name, &i);
-	return i;
-}
-
-unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
-{
-	unsigned i = defaultValue;
-	QueryUnsignedAttribute(name, &i);
-	return i;
-}
-
-int64_t XMLElement::Int64Attribute(const char* name, int64_t defaultValue) const
-{
-	int64_t i = defaultValue;
-	QueryInt64Attribute(name, &i);
-	return i;
-}
-
-bool XMLElement::BoolAttribute(const char* name, bool defaultValue) const
-{
-	bool b = defaultValue;
-	QueryBoolAttribute(name, &b);
-	return b;
-}
-
-double XMLElement::DoubleAttribute(const char* name, double defaultValue) const
-{
-	double d = defaultValue;
-	QueryDoubleAttribute(name, &d);
-	return d;
-}
-
-float XMLElement::FloatAttribute(const char* name, float defaultValue) const
-{
-	float f = defaultValue;
-	QueryFloatAttribute(name, &f);
-	return f;
-}
-
-const char* XMLElement::GetText() const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        return FirstChild()->Value();
-    }
-    return 0;
-}
-
-
-void	XMLElement::SetText( const char* inText )
-{
-	if ( FirstChild() && FirstChild()->ToText() )
-		FirstChild()->SetValue( inText );
-	else {
-		XMLText*	theText = GetDocument()->NewText( inText );
-		InsertFirstChild( theText );
-	}
-}
-
-
-void XMLElement::SetText( int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText(int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	SetText(buf);
-}
-
-
-void XMLElement::SetText( bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( float v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-void XMLElement::SetText( double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    SetText( buf );
-}
-
-
-XMLError XMLElement::QueryIntText( int* ival ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToInt( t, ival ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryUnsignedText( unsigned* uval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToUnsigned( t, uval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryInt64Text(int64_t* ival) const
-{
-	if (FirstChild() && FirstChild()->ToText()) {
-		const char* t = FirstChild()->Value();
-		if (XMLUtil::ToInt64(t, ival)) {
-			return XML_SUCCESS;
-		}
-		return XML_CAN_NOT_CONVERT_TEXT;
-	}
-	return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryBoolText( bool* bval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToBool( t, bval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryDoubleText( double* dval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToDouble( t, dval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-
-XMLError XMLElement::QueryFloatText( float* fval ) const
-{
-    if ( FirstChild() && FirstChild()->ToText() ) {
-        const char* t = FirstChild()->Value();
-        if ( XMLUtil::ToFloat( t, fval ) ) {
-            return XML_SUCCESS;
-        }
-        return XML_CAN_NOT_CONVERT_TEXT;
-    }
-    return XML_NO_TEXT_NODE;
-}
-
-int XMLElement::IntText(int defaultValue) const
-{
-	int i = defaultValue;
-	QueryIntText(&i);
-	return i;
-}
-
-unsigned XMLElement::UnsignedText(unsigned defaultValue) const
-{
-	unsigned i = defaultValue;
-	QueryUnsignedText(&i);
-	return i;
-}
-
-int64_t XMLElement::Int64Text(int64_t defaultValue) const
-{
-	int64_t i = defaultValue;
-	QueryInt64Text(&i);
-	return i;
-}
-
-bool XMLElement::BoolText(bool defaultValue) const
-{
-	bool b = defaultValue;
-	QueryBoolText(&b);
-	return b;
-}
-
-double XMLElement::DoubleText(double defaultValue) const
-{
-	double d = defaultValue;
-	QueryDoubleText(&d);
-	return d;
-}
-
-float XMLElement::FloatText(float defaultValue) const
-{
-	float f = defaultValue;
-	QueryFloatText(&f);
-	return f;
-}
-
-
-XMLAttribute* XMLElement::FindOrCreateAttribute( const char* name )
-{
-    XMLAttribute* last = 0;
-    XMLAttribute* attrib = 0;
-    for( attrib = _rootAttribute;
-            attrib;
-            last = attrib, attrib = attrib->_next ) {
-        if ( XMLUtil::StringEqual( attrib->Name(), name ) ) {
-            break;
-        }
-    }
-    if ( !attrib ) {
-        attrib = CreateAttribute();
-        TIXMLASSERT( attrib );
-        if ( last ) {
-            TIXMLASSERT( last->_next == 0 );
-            last->_next = attrib;
-        }
-        else {
-            TIXMLASSERT( _rootAttribute == 0 );
-            _rootAttribute = attrib;
-        }
-        attrib->SetName( name );
-    }
-    return attrib;
-}
-
-
-void XMLElement::DeleteAttribute( const char* name )
-{
-    XMLAttribute* prev = 0;
-    for( XMLAttribute* a=_rootAttribute; a; a=a->_next ) {
-        if ( XMLUtil::StringEqual( name, a->Name() ) ) {
-            if ( prev ) {
-                prev->_next = a->_next;
-            }
-            else {
-                _rootAttribute = a->_next;
-            }
-            DeleteAttribute( a );
-            break;
-        }
-        prev = a;
-    }
-}
-
-
-char* XMLElement::ParseAttributes( char* p, int* curLineNumPtr )
-{
-    XMLAttribute* prevAttribute = 0;
-
-    // Read the attributes.
-    while( p ) {
-        p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-        if ( !(*p) ) {
-            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name() );
-            return 0;
-        }
-
-        // attribute.
-        if (XMLUtil::IsNameStartChar( *p ) ) {
-            XMLAttribute* attrib = CreateAttribute();
-            TIXMLASSERT( attrib );
-            attrib->_parseLineNum = _document->_parseCurLineNum;
-
-            int attrLineNum = attrib->_parseLineNum;
-
-            p = attrib->ParseDeep( p, _document->ProcessEntities(), curLineNumPtr );
-            if ( !p || Attribute( attrib->Name() ) ) {
-                DeleteAttribute( attrib );
-                _document->SetError( XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name() );
-                return 0;
-            }
-            // There is a minor bug here: if the attribute in the source xml
-            // document is duplicated, it will not be detected and the
-            // attribute will be doubly added. However, tracking the 'prevAttribute'
-            // avoids re-scanning the attribute list. Preferring performance for
-            // now, may reconsider in the future.
-            if ( prevAttribute ) {
-                TIXMLASSERT( prevAttribute->_next == 0 );
-                prevAttribute->_next = attrib;
-            }
-            else {
-                TIXMLASSERT( _rootAttribute == 0 );
-                _rootAttribute = attrib;
-            }
-            prevAttribute = attrib;
-        }
-        // end of the tag
-        else if ( *p == '>' ) {
-            ++p;
-            break;
-        }
-        // end of the tag
-        else if ( *p == '/' && *(p+1) == '>' ) {
-            _closingType = CLOSED;
-            return p+2;	// done; sealed element.
-        }
-        else {
-            _document->SetError( XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0 );
-            return 0;
-        }
-    }
-    return p;
-}
-
-void XMLElement::DeleteAttribute( XMLAttribute* attribute )
-{
-    if ( attribute == 0 ) {
-        return;
-    }
-    MemPool* pool = attribute->_memPool;
-    attribute->~XMLAttribute();
-    pool->Free( attribute );
-}
-
-XMLAttribute* XMLElement::CreateAttribute()
-{
-    TIXMLASSERT( sizeof( XMLAttribute ) == _document->_attributePool.ItemSize() );
-    XMLAttribute* attrib = new (_document->_attributePool.Alloc() ) XMLAttribute();
-    TIXMLASSERT( attrib );
-    attrib->_memPool = &_document->_attributePool;
-    attrib->_memPool->SetTracked();
-    return attrib;
-}
-
-//
-//	<ele></ele>
-//	<ele>foo<b>bar</b></ele>
-//
-char* XMLElement::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
-{
-    // Read the element name.
-    p = XMLUtil::SkipWhiteSpace( p, curLineNumPtr );
-
-    // The closing element is the </element> form. It is
-    // parsed just like a regular element then deleted from
-    // the DOM.
-    if ( *p == '/' ) {
-        _closingType = CLOSING;
-        ++p;
-    }
-
-    p = _value.ParseName( p );
-    if ( _value.Empty() ) {
-        return 0;
-    }
-
-    p = ParseAttributes( p, curLineNumPtr );
-    if ( !p || !*p || _closingType != OPEN ) {
         return p;
     }
 
-    p = XMLNode::ParseDeep( p, parentEndTag, curLineNumPtr );
-    return p;
-}
 
-
-
-XMLNode* XMLElement::ShallowClone( XMLDocument* doc ) const
-{
-    if ( !doc ) {
-        doc = _document;
+    XMLNode* XMLDeclaration::ShallowClone(XMLDocument* doc) const
+    {
+        if (!doc) {
+            doc = _document;
+        }
+        XMLDeclaration* dec = doc->NewDeclaration(Value());      // fixme: this will always allocate memory. Intern?
+        return dec;
     }
-    XMLElement* element = doc->NewElement( Value() );					// fixme: this will always allocate memory. Intern?
-    for( const XMLAttribute* a=FirstAttribute(); a; a=a->Next() ) {
-        element->SetAttribute( a->Name(), a->Value() );					// fixme: this will always allocate memory. Intern?
+
+
+    bool XMLDeclaration::ShallowEqual(const XMLNode* compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLDeclaration* declaration = compare->ToDeclaration();
+        return (declaration && XMLUtil::StringEqual(declaration->Value(), Value()));
     }
-    return element;
-}
 
 
-bool XMLElement::ShallowEqual( const XMLNode* compare ) const
-{
-    TIXMLASSERT( compare );
-    const XMLElement* other = compare->ToElement();
-    if ( other && XMLUtil::StringEqual( other->Name(), Name() )) {
 
-        const XMLAttribute* a=FirstAttribute();
-        const XMLAttribute* b=other->FirstAttribute();
+    bool XMLDeclaration::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
 
-        while ( a && b ) {
-            if ( !XMLUtil::StringEqual( a->Value(), b->Value() ) ) {
-                return false;
+// --------- XMLUnknown ---------- //
+
+    XMLUnknown::XMLUnknown(XMLDocument* doc) : XMLNode(doc)
+    {
+    }
+
+
+    XMLUnknown::~XMLUnknown()
+    {
+    }
+
+
+    char* XMLUnknown::ParseDeep(char* p, StrPair*, int* curLineNumPtr)
+    {
+        // Unknown parses as text.
+        p = _value.ParseText(p, ">", StrPair::NEEDS_NEWLINE_NORMALIZATION, curLineNumPtr);
+        if (!p) {
+            _document->SetError(XML_ERROR_PARSING_UNKNOWN, _parseLineNum, 0);
+        }
+        return p;
+    }
+
+
+    XMLNode* XMLUnknown::ShallowClone(XMLDocument* doc) const
+    {
+        if (!doc) {
+            doc = _document;
+        }
+        XMLUnknown* text = doc->NewUnknown(Value());     // fixme: this will always allocate memory. Intern?
+        return text;
+    }
+
+
+    bool XMLUnknown::ShallowEqual(const XMLNode* compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLUnknown* unknown = compare->ToUnknown();
+        return (unknown && XMLUtil::StringEqual(unknown->Value(), Value()));
+    }
+
+
+    bool XMLUnknown::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        return visitor->Visit(*this);
+    }
+
+// --------- XMLAttribute ---------- //
+
+    const char* XMLAttribute::Name() const
+    {
+        return _name.GetStr();
+    }
+
+    const char* XMLAttribute::Value() const
+    {
+        return _value.GetStr();
+    }
+
+    char* XMLAttribute::ParseDeep(char* p, bool processEntities, int* curLineNumPtr)
+    {
+        // Parse using the name rules: bug fix, was using ParseText before
+        p = _name.ParseName(p);
+        if (!p || !*p) {
+            return 0;
+        }
+
+        // Skip white space before =
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+        if (*p != '=') {
+            return 0;
+        }
+
+        ++p;    // move up to opening quote
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+        if (*p != '\"' && *p != '\'') {
+            return 0;
+        }
+
+        const char endTag[2] = { *p, 0 };
+        ++p;    // move past opening quote
+
+        p = _value.ParseText(p, endTag, processEntities ? StrPair::ATTRIBUTE_VALUE : StrPair::ATTRIBUTE_VALUE_LEAVE_ENTITIES, curLineNumPtr);
+        return p;
+    }
+
+
+    void XMLAttribute::SetName(const char* n)
+    {
+        _name.SetStr(n);
+    }
+
+
+    XMLError XMLAttribute::QueryIntValue(int* value) const
+    {
+        if (XMLUtil::ToInt(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryUnsignedValue(unsigned int* value) const
+    {
+        if (XMLUtil::ToUnsigned(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryInt64Value(int64_t* value) const
+    {
+        if (XMLUtil::ToInt64(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryUnsigned64Value(uint64_t* value) const
+    {
+        if (XMLUtil::ToUnsigned64(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryBoolValue(bool* value) const
+    {
+        if (XMLUtil::ToBool(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryFloatValue(float* value) const
+    {
+        if (XMLUtil::ToFloat(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    XMLError XMLAttribute::QueryDoubleValue(double* value) const
+    {
+        if (XMLUtil::ToDouble(Value(), value)) {
+            return XML_SUCCESS;
+        }
+        return XML_WRONG_ATTRIBUTE_TYPE;
+    }
+
+
+    void XMLAttribute::SetAttribute(const char* v)
+    {
+        _value.SetStr(v);
+    }
+
+
+    void XMLAttribute::SetAttribute(int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+
+    void XMLAttribute::SetAttribute(unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+
+    void XMLAttribute::SetAttribute(int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+
+    void XMLAttribute::SetAttribute(bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+    void XMLAttribute::SetAttribute(float v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        _value.SetStr(buf);
+    }
+
+
+// --------- XMLElement ---------- //
+    XMLElement::XMLElement(XMLDocument* doc) : XMLNode(doc),
+        _closingType(OPEN),
+        _rootAttribute(0)
+    {
+    }
+
+
+    XMLElement::~XMLElement()
+    {
+        while (_rootAttribute) {
+            XMLAttribute* next = _rootAttribute->_next;
+            DeleteAttribute(_rootAttribute);
+            _rootAttribute = next;
+        }
+    }
+
+
+    const XMLAttribute* XMLElement::FindAttribute(const char* name) const
+    {
+        for (XMLAttribute* a = _rootAttribute; a; a = a->_next) {
+            if (XMLUtil::StringEqual(a->Name(), name)) {
+                return a;
             }
-            a = a->Next();
-            b = b->Next();
         }
-        if ( a || b ) {
-            // different count
-            return false;
-        }
-        return true;
+        return 0;
     }
-    return false;
-}
 
 
-bool XMLElement::Accept( XMLVisitor* visitor ) const
-{
-    TIXMLASSERT( visitor );
-    if ( visitor->VisitEnter( *this, _rootAttribute ) ) {
-        for ( const XMLNode* node=FirstChild(); node; node=node->NextSibling() ) {
-            if ( !node->Accept( visitor ) ) {
+    const char* XMLElement::Attribute(const char* name, const char* value) const
+    {
+        const XMLAttribute* a = FindAttribute(name);
+        if (!a) {
+            return 0;
+        }
+        if (!value || XMLUtil::StringEqual(a->Value(), value)) {
+            return a->Value();
+        }
+        return 0;
+    }
+
+    int XMLElement::IntAttribute(const char* name, int defaultValue) const
+    {
+        int i = defaultValue;
+        QueryIntAttribute(name, &i);
+        return i;
+    }
+
+    unsigned XMLElement::UnsignedAttribute(const char* name, unsigned defaultValue) const
+    {
+        unsigned i = defaultValue;
+        QueryUnsignedAttribute(name, &i);
+        return i;
+    }
+
+    int64_t XMLElement::Int64Attribute(const char* name, int64_t defaultValue) const
+    {
+        int64_t i = defaultValue;
+        QueryInt64Attribute(name, &i);
+        return i;
+    }
+
+    uint64_t XMLElement::Unsigned64Attribute(const char* name, uint64_t defaultValue) const
+    {
+        uint64_t i = defaultValue;
+        QueryUnsigned64Attribute(name, &i);
+        return i;
+    }
+
+    bool XMLElement::BoolAttribute(const char* name, bool defaultValue) const
+    {
+        bool b = defaultValue;
+        QueryBoolAttribute(name, &b);
+        return b;
+    }
+
+    double XMLElement::DoubleAttribute(const char* name, double defaultValue) const
+    {
+        double d = defaultValue;
+        QueryDoubleAttribute(name, &d);
+        return d;
+    }
+
+    float XMLElement::FloatAttribute(const char* name, float defaultValue) const
+    {
+        float f = defaultValue;
+        QueryFloatAttribute(name, &f);
+        return f;
+    }
+
+    const char* XMLElement::GetText() const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            return FirstChild()->Value();
+        }
+        return 0;
+    }
+
+
+    void    XMLElement::SetText(const char* inText)
+    {
+        if (FirstChild() && FirstChild()->ToText())
+            FirstChild()->SetValue(inText);
+        else {
+            XMLText*    theText = GetDocument()->NewText(inText);
+            InsertFirstChild(theText);
+        }
+    }
+
+
+    void XMLElement::SetText(int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    void XMLElement::SetText(unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    void XMLElement::SetText(int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+    void XMLElement::SetText(uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    void XMLElement::SetText(bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    void XMLElement::SetText(float v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    void XMLElement::SetText(double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        SetText(buf);
+    }
+
+
+    XMLError XMLElement::QueryIntText(int* ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToInt(t, ival)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryUnsignedText(unsigned* uval) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToUnsigned(t, uval)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryInt64Text(int64_t* ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToInt64(t, ival)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryUnsigned64Text(uint64_t* ival) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToUnsigned64(t, ival)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryBoolText(bool* bval) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToBool(t, bval)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryDoubleText(double* dval) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToDouble(t, dval)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+
+    XMLError XMLElement::QueryFloatText(float* fval) const
+    {
+        if (FirstChild() && FirstChild()->ToText()) {
+            const char* t = FirstChild()->Value();
+            if (XMLUtil::ToFloat(t, fval)) {
+                return XML_SUCCESS;
+            }
+            return XML_CAN_NOT_CONVERT_TEXT;
+        }
+        return XML_NO_TEXT_NODE;
+    }
+
+    int XMLElement::IntText(int defaultValue) const
+    {
+        int i = defaultValue;
+        QueryIntText(&i);
+        return i;
+    }
+
+    unsigned XMLElement::UnsignedText(unsigned defaultValue) const
+    {
+        unsigned i = defaultValue;
+        QueryUnsignedText(&i);
+        return i;
+    }
+
+    int64_t XMLElement::Int64Text(int64_t defaultValue) const
+    {
+        int64_t i = defaultValue;
+        QueryInt64Text(&i);
+        return i;
+    }
+
+    uint64_t XMLElement::Unsigned64Text(uint64_t defaultValue) const
+    {
+        uint64_t i = defaultValue;
+        QueryUnsigned64Text(&i);
+        return i;
+    }
+
+    bool XMLElement::BoolText(bool defaultValue) const
+    {
+        bool b = defaultValue;
+        QueryBoolText(&b);
+        return b;
+    }
+
+    double XMLElement::DoubleText(double defaultValue) const
+    {
+        double d = defaultValue;
+        QueryDoubleText(&d);
+        return d;
+    }
+
+    float XMLElement::FloatText(float defaultValue) const
+    {
+        float f = defaultValue;
+        QueryFloatText(&f);
+        return f;
+    }
+
+
+    XMLAttribute* XMLElement::FindOrCreateAttribute(const char* name)
+    {
+        XMLAttribute* last = 0;
+        XMLAttribute* attrib = 0;
+        for (attrib = _rootAttribute;
+             attrib;
+             last = attrib, attrib = attrib->_next) {
+            if (XMLUtil::StringEqual(attrib->Name(), name)) {
                 break;
             }
         }
+        if (!attrib) {
+            attrib = CreateAttribute();
+            TIXMLASSERT(attrib);
+            if (last) {
+                TIXMLASSERT(last->_next == 0);
+                last->_next = attrib;
+            } else {
+                TIXMLASSERT(_rootAttribute == 0);
+                _rootAttribute = attrib;
+            }
+            attrib->SetName(name);
+        }
+        return attrib;
     }
-    return visitor->VisitExit( *this );
-}
+
+
+    void XMLElement::DeleteAttribute(const char* name)
+    {
+        XMLAttribute* prev = 0;
+        for (XMLAttribute* a=_rootAttribute; a; a=a->_next) {
+            if (XMLUtil::StringEqual(name, a->Name())) {
+                if (prev) {
+                    prev->_next = a->_next;
+                } else {
+                    _rootAttribute = a->_next;
+                }
+                DeleteAttribute(a);
+                break;
+            }
+            prev = a;
+        }
+    }
+
+
+    char* XMLElement::ParseAttributes(char* p, int* curLineNumPtr)
+    {
+        XMLAttribute* prevAttribute = 0;
+
+        // Read the attributes.
+        while (p) {
+            p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+            if (!(*p)) {
+                _document->SetError(XML_ERROR_PARSING_ELEMENT, _parseLineNum, "XMLElement name=%s", Name());
+                return 0;
+            }
+
+            // attribute.
+            if (XMLUtil::IsNameStartChar(*p)) {
+                XMLAttribute* attrib = CreateAttribute();
+                TIXMLASSERT(attrib);
+                attrib->_parseLineNum = _document->_parseCurLineNum;
+
+                const int attrLineNum = attrib->_parseLineNum;
+
+                p = attrib->ParseDeep(p, _document->ProcessEntities(), curLineNumPtr);
+                if (!p || Attribute(attrib->Name())) {
+                    DeleteAttribute(attrib);
+                    _document->SetError(XML_ERROR_PARSING_ATTRIBUTE, attrLineNum, "XMLElement name=%s", Name());
+                    return 0;
+                }
+                // There is a minor bug here: if the attribute in the source xml
+                // document is duplicated, it will not be detected and the
+                // attribute will be doubly added. However, tracking the 'prevAttribute'
+                // avoids re-scanning the attribute list. Preferring performance for
+                // now, may reconsider in the future.
+                if (prevAttribute) {
+                    TIXMLASSERT(prevAttribute->_next == 0);
+                    prevAttribute->_next = attrib;
+                } else {
+                    TIXMLASSERT(_rootAttribute == 0);
+                    _rootAttribute = attrib;
+                }
+                prevAttribute = attrib;
+            }
+            // end of the tag
+            else if (*p == '>') {
+                ++p;
+                break;
+            }
+            // end of the tag
+            else if (*p == '/' && *(p+1) == '>') {
+                _closingType = CLOSED;
+                return p+2; // done; sealed element.
+            } else {
+                _document->SetError(XML_ERROR_PARSING_ELEMENT, _parseLineNum, 0);
+                return 0;
+            }
+        }
+        return p;
+    }
+
+    void XMLElement::DeleteAttribute(XMLAttribute* attribute)
+    {
+        if (attribute == 0) {
+            return;
+        }
+        MemPool* pool = attribute->_memPool;
+        attribute->~XMLAttribute();
+        pool->Free(attribute);
+    }
+
+    XMLAttribute* XMLElement::CreateAttribute()
+    {
+        TIXMLASSERT(sizeof(XMLAttribute) == _document->_attributePool.ItemSize());
+        XMLAttribute* attrib = new (_document->_attributePool.Alloc()) XMLAttribute();
+        TIXMLASSERT(attrib);
+        attrib->_memPool = &_document->_attributePool;
+        attrib->_memPool->SetTracked();
+        return attrib;
+    }
+
+
+    XMLElement* XMLElement::InsertNewChildElement(const char* name)
+    {
+        XMLElement* node = _document->NewElement(name);
+        return InsertEndChild(node) ? node : 0;
+    }
+
+    XMLComment* XMLElement::InsertNewComment(const char* comment)
+    {
+        XMLComment* node = _document->NewComment(comment);
+        return InsertEndChild(node) ? node : 0;
+    }
+
+    XMLText* XMLElement::InsertNewText(const char* text)
+    {
+        XMLText* node = _document->NewText(text);
+        return InsertEndChild(node) ? node : 0;
+    }
+
+    XMLDeclaration* XMLElement::InsertNewDeclaration(const char* text)
+    {
+        XMLDeclaration* node = _document->NewDeclaration(text);
+        return InsertEndChild(node) ? node : 0;
+    }
+
+    XMLUnknown* XMLElement::InsertNewUnknown(const char* text)
+    {
+        XMLUnknown* node = _document->NewUnknown(text);
+        return InsertEndChild(node) ? node : 0;
+    }
+
+
+
+//
+//  <ele></ele>
+//  <ele>foo<b>bar</b></ele>
+//
+    char* XMLElement::ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr)
+    {
+        // Read the element name.
+        p = XMLUtil::SkipWhiteSpace(p, curLineNumPtr);
+
+        // The closing element is the </element> form. It is
+        // parsed just like a regular element then deleted from
+        // the DOM.
+        if (*p == '/') {
+            _closingType = CLOSING;
+            ++p;
+        }
+
+        p = _value.ParseName(p);
+        if (_value.Empty()) {
+            return 0;
+        }
+
+        p = ParseAttributes(p, curLineNumPtr);
+        if (!p || !*p || _closingType != OPEN) {
+            return p;
+        }
+
+        p = XMLNode::ParseDeep(p, parentEndTag, curLineNumPtr);
+        return p;
+    }
+
+
+
+    XMLNode* XMLElement::ShallowClone(XMLDocument* doc) const
+    {
+        if (!doc) {
+            doc = _document;
+        }
+        XMLElement* element = doc->NewElement(Value());                      // fixme: this will always allocate memory. Intern?
+        for (const XMLAttribute* a=FirstAttribute(); a; a=a->Next()) {
+            element->SetAttribute(a->Name(), a->Value());                    // fixme: this will always allocate memory. Intern?
+        }
+        return element;
+    }
+
+
+    bool XMLElement::ShallowEqual(const XMLNode* compare) const
+    {
+        TIXMLASSERT(compare);
+        const XMLElement* other = compare->ToElement();
+        if (other && XMLUtil::StringEqual(other->Name(), Name())) {
+
+            const XMLAttribute* a=FirstAttribute();
+            const XMLAttribute* b=other->FirstAttribute();
+
+            while (a && b) {
+                if (!XMLUtil::StringEqual(a->Value(), b->Value())) {
+                    return false;
+                }
+                a = a->Next();
+                b = b->Next();
+            }
+            if (a || b) {
+                // different count
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+
+    bool XMLElement::Accept(XMLVisitor* visitor) const
+    {
+        TIXMLASSERT(visitor);
+        if (visitor->VisitEnter(*this, _rootAttribute)) {
+            for (const XMLNode* node=FirstChild(); node; node=node->NextSibling()) {
+                if (!node->Accept(visitor)) {
+                    break;
+                }
+            }
+        }
+        return visitor->VisitExit(*this);
+    }
 
 
 // --------- XMLDocument ----------- //
 
 // Warning: List must match 'enum XMLError'
-const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
-    "XML_SUCCESS",
-    "XML_NO_ATTRIBUTE",
-    "XML_WRONG_ATTRIBUTE_TYPE",
-    "XML_ERROR_FILE_NOT_FOUND",
-    "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
-    "XML_ERROR_FILE_READ_ERROR",
-    "UNUSED_XML_ERROR_ELEMENT_MISMATCH",
-    "XML_ERROR_PARSING_ELEMENT",
-    "XML_ERROR_PARSING_ATTRIBUTE",
-    "UNUSED_XML_ERROR_IDENTIFYING_TAG",
-    "XML_ERROR_PARSING_TEXT",
-    "XML_ERROR_PARSING_CDATA",
-    "XML_ERROR_PARSING_COMMENT",
-    "XML_ERROR_PARSING_DECLARATION",
-    "XML_ERROR_PARSING_UNKNOWN",
-    "XML_ERROR_EMPTY_DOCUMENT",
-    "XML_ERROR_MISMATCHED_ELEMENT",
-    "XML_ERROR_PARSING",
-    "XML_CAN_NOT_CONVERT_TEXT",
-    "XML_NO_TEXT_NODE"
-};
+    const char* XMLDocument::_errorNames[XML_ERROR_COUNT] = {
+        "XML_SUCCESS",
+        "XML_NO_ATTRIBUTE",
+        "XML_WRONG_ATTRIBUTE_TYPE",
+        "XML_ERROR_FILE_NOT_FOUND",
+        "XML_ERROR_FILE_COULD_NOT_BE_OPENED",
+        "XML_ERROR_FILE_READ_ERROR",
+        "XML_ERROR_PARSING_ELEMENT",
+        "XML_ERROR_PARSING_ATTRIBUTE",
+        "XML_ERROR_PARSING_TEXT",
+        "XML_ERROR_PARSING_CDATA",
+        "XML_ERROR_PARSING_COMMENT",
+        "XML_ERROR_PARSING_DECLARATION",
+        "XML_ERROR_PARSING_UNKNOWN",
+        "XML_ERROR_EMPTY_DOCUMENT",
+        "XML_ERROR_MISMATCHED_ELEMENT",
+        "XML_ERROR_PARSING",
+        "XML_CAN_NOT_CONVERT_TEXT",
+        "XML_NO_TEXT_NODE",
+        "XML_ELEMENT_DEPTH_EXCEEDED"
+    };
 
 
-XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
-    XMLNode( 0 ),
-    _writeBOM( false ),
-    _processEntities( processEntities ),
-    _errorID(XML_SUCCESS),
-    _whitespaceMode( whitespaceMode ),
-    _errorStr(),
-    _errorLineNum( 0 ),
-    _charBuffer( 0 ),
-    _parseCurLineNum( 0 ),
-    _unlinked(),
-    _elementPool(),
-    _attributePool(),
-    _textPool(),
-    _commentPool()
-{
-    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
-    _document = this;
-}
+    XMLDocument::XMLDocument(bool processEntities, Whitespace whitespaceMode) :
+        XMLNode(0),
+        _writeBOM(false),
+        _processEntities(processEntities),
+        _errorID(XML_SUCCESS),
+        _whitespaceMode(whitespaceMode),
+        _errorStr(),
+        _errorLineNum(0),
+        _charBuffer(0),
+        _parseCurLineNum(0),
+        _parsingDepth(0),
+        _unlinked(),
+        _elementPool(),
+        _attributePool(),
+        _textPool(),
+        _commentPool()
+    {
+        // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
+        _document = this;
+    }
 
 
-XMLDocument::~XMLDocument()
-{
-    Clear();
-}
+    XMLDocument::~XMLDocument()
+    {
+        Clear();
+    }
 
 
-void XMLDocument::MarkInUse(XMLNode* node)
-{
-	TIXMLASSERT(node);
-	TIXMLASSERT(node->_parent == 0);
+    void XMLDocument::MarkInUse(const XMLNode* const node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_parent == 0);
 
-	for (int i = 0; i < _unlinked.Size(); ++i) {
-		if (node == _unlinked[i]) {
-			_unlinked.SwapRemove(i);
-			break;
-		}
-	}
-}
+        for (int i = 0; i < _unlinked.Size(); ++i) {
+            if (node == _unlinked[i]) {
+                _unlinked.SwapRemove(i);
+                break;
+            }
+        }
+    }
 
-void XMLDocument::Clear()
-{
-    DeleteChildren();
-	while( _unlinked.Size()) {
-		DeleteNode(_unlinked[0]);	// Will remove from _unlinked as part of delete.
-	}
+    void XMLDocument::Clear()
+    {
+        DeleteChildren();
+        while (_unlinked.Size()) {
+            DeleteNode(_unlinked[0]);   // Will remove from _unlinked as part of delete.
+        }
 
 #ifdef TINYXML2_DEBUG
-    const bool hadError = Error();
+        const bool hadError = Error();
 #endif
-    ClearError();
+        ClearError();
 
-    delete [] _charBuffer;
-    _charBuffer = 0;
+        delete [] _charBuffer;
+        _charBuffer = 0;
+        _parsingDepth = 0;
 
 #if 0
-    _textPool.Trace( "text" );
-    _elementPool.Trace( "element" );
-    _commentPool.Trace( "comment" );
-    _attributePool.Trace( "attribute" );
+        _textPool.Trace("text");
+        _elementPool.Trace("element");
+        _commentPool.Trace("comment");
+        _attributePool.Trace("attribute");
 #endif
 
 #ifdef TINYXML2_DEBUG
-    if ( !hadError ) {
-        TIXMLASSERT( _elementPool.CurrentAllocs()   == _elementPool.Untracked() );
-        TIXMLASSERT( _attributePool.CurrentAllocs() == _attributePool.Untracked() );
-        TIXMLASSERT( _textPool.CurrentAllocs()      == _textPool.Untracked() );
-        TIXMLASSERT( _commentPool.CurrentAllocs()   == _commentPool.Untracked() );
-    }
+        if (!hadError) {
+            TIXMLASSERT(_elementPool.CurrentAllocs()   == _elementPool.Untracked());
+            TIXMLASSERT(_attributePool.CurrentAllocs() == _attributePool.Untracked());
+            TIXMLASSERT(_textPool.CurrentAllocs()      == _textPool.Untracked());
+            TIXMLASSERT(_commentPool.CurrentAllocs()   == _commentPool.Untracked());
+        }
 #endif
-}
-
-
-void XMLDocument::DeepCopy(XMLDocument* target) const
-{
-	TIXMLASSERT(target);
-    if (target == this) {
-        return; // technically success - a no-op.
     }
 
-	target->Clear();
-	for (const XMLNode* node = this->FirstChild(); node; node = node->NextSibling()) {
-		target->InsertEndChild(node->DeepClone(target));
-	}
-}
 
-XMLElement* XMLDocument::NewElement( const char* name )
-{
-    XMLElement* ele = CreateUnlinkedNode<XMLElement>( _elementPool );
-    ele->SetName( name );
-    return ele;
-}
+    void XMLDocument::DeepCopy(XMLDocument* target) const
+    {
+        TIXMLASSERT(target);
+        if (target == this) {
+            return; // technically success - a no-op.
+        }
 
+        target->Clear();
+        for (const XMLNode* node = this->FirstChild(); node; node = node->NextSibling()) {
+            target->InsertEndChild(node->DeepClone(target));
+        }
+    }
 
-XMLComment* XMLDocument::NewComment( const char* str )
-{
-    XMLComment* comment = CreateUnlinkedNode<XMLComment>( _commentPool );
-    comment->SetValue( str );
-    return comment;
-}
-
-
-XMLText* XMLDocument::NewText( const char* str )
-{
-    XMLText* text = CreateUnlinkedNode<XMLText>( _textPool );
-    text->SetValue( str );
-    return text;
-}
+    XMLElement* XMLDocument::NewElement(const char* name)
+    {
+        XMLElement* ele = CreateUnlinkedNode<XMLElement>(_elementPool);
+        ele->SetName(name);
+        return ele;
+    }
 
 
-XMLDeclaration* XMLDocument::NewDeclaration( const char* str )
-{
-    XMLDeclaration* dec = CreateUnlinkedNode<XMLDeclaration>( _commentPool );
-    dec->SetValue( str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"" );
-    return dec;
-}
+    XMLComment* XMLDocument::NewComment(const char* str)
+    {
+        XMLComment* comment = CreateUnlinkedNode<XMLComment>(_commentPool);
+        comment->SetValue(str);
+        return comment;
+    }
 
 
-XMLUnknown* XMLDocument::NewUnknown( const char* str )
-{
-    XMLUnknown* unk = CreateUnlinkedNode<XMLUnknown>( _commentPool );
-    unk->SetValue( str );
-    return unk;
-}
+    XMLText* XMLDocument::NewText(const char* str)
+    {
+        XMLText* text = CreateUnlinkedNode<XMLText>(_textPool);
+        text->SetValue(str);
+        return text;
+    }
 
-static FILE* callfopen( const char* filepath, const char* mode )
-{
-    TIXMLASSERT( filepath );
-    TIXMLASSERT( mode );
+
+    XMLDeclaration* XMLDocument::NewDeclaration(const char* str)
+    {
+        XMLDeclaration* dec = CreateUnlinkedNode<XMLDeclaration>(_commentPool);
+        dec->SetValue(str ? str : "xml version=\"1.0\" encoding=\"UTF-8\"");
+        return dec;
+    }
+
+
+    XMLUnknown* XMLDocument::NewUnknown(const char* str)
+    {
+        XMLUnknown* unk = CreateUnlinkedNode<XMLUnknown>(_commentPool);
+        unk->SetValue(str);
+        return unk;
+    }
+
+    static FILE* callfopen(const char* filepath, const char* mode)
+    {
+        TIXMLASSERT(filepath);
+        TIXMLASSERT(mode);
 #if defined(_MSC_VER) && (_MSC_VER >= 1400 ) && (!defined WINCE)
-    FILE* fp = 0;
-    errno_t err = fopen_s( &fp, filepath, mode );
-    if ( err ) {
-        return 0;
-    }
+        FILE* fp = 0;
+        const errno_t err = fopen_s(&fp, filepath, mode);
+        if (err) {
+            return 0;
+        }
 #else
-    FILE* fp = fopen( filepath, mode );
+        FILE* fp = fopen(filepath, mode);
 #endif
-    return fp;
-}
-
-void XMLDocument::DeleteNode( XMLNode* node )	{
-    TIXMLASSERT( node );
-    TIXMLASSERT(node->_document == this );
-    if (node->_parent) {
-        node->_parent->DeleteChild( node );
+        return fp;
     }
-    else {
-        // Isn't in the tree.
-        // Use the parent delete.
-        // Also, we need to mark it tracked: we 'know'
-        // it was never used.
-        node->_memPool->SetTracked();
-        // Call the static XMLNode version:
-        XMLNode::DeleteNode(node);
+
+    void XMLDocument::DeleteNode(XMLNode* node)
+    {
+        TIXMLASSERT(node);
+        TIXMLASSERT(node->_document == this);
+        if (node->_parent) {
+            node->_parent->DeleteChild(node);
+        } else {
+            // Isn't in the tree.
+            // Use the parent delete.
+            // Also, we need to mark it tracked: we 'know'
+            // it was never used.
+            node->_memPool->SetTracked();
+            // Call the static XMLNode version:
+            XMLNode::DeleteNode(node);
+        }
     }
-}
 
 
-XMLError XMLDocument::LoadFile( const char* filename )
-{
-    if ( !filename ) {
-        TIXMLASSERT( false );
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
+    XMLError XMLDocument::LoadFile(const char* filename)
+    {
+        if (!filename) {
+            TIXMLASSERT(false);
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>");
+            return _errorID;
+        }
+
+        Clear();
+        FILE* fp = callfopen(filename, "rb");
+        if (!fp) {
+            SetError(XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename);
+            return _errorID;
+        }
+        LoadFile(fp);
+        fclose(fp);
         return _errorID;
     }
 
-    Clear();
-    FILE* fp = callfopen( filename, "rb" );
-    if ( !fp ) {
-        SetError( XML_ERROR_FILE_NOT_FOUND, 0, "filename=%s", filename );
+    XMLError XMLDocument::LoadFile(FILE* fp)
+    {
+        Clear();
+
+        TIXML_FSEEK(fp, 0, SEEK_SET);
+        if (fgetc(fp) == EOF && ferror(fp) != 0) {
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        TIXML_FSEEK(fp, 0, SEEK_END);
+
+        unsigned long long filelength;
+        {
+            const long long fileLengthSigned = TIXML_FTELL(fp);
+            TIXML_FSEEK(fp, 0, SEEK_SET);
+            if (fileLengthSigned == -1L) {
+                SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+                return _errorID;
+            }
+            TIXMLASSERT(fileLengthSigned >= 0);
+            filelength = static_cast<unsigned long long>(fileLengthSigned);
+        }
+
+        const size_t maxSizeT = static_cast<size_t>(-1);
+        // We'll do the comparison as an unsigned long long, because that's guaranteed to be at
+        // least 8 bytes, even on a 32-bit platform.
+        if (filelength >= static_cast<unsigned long long>(maxSizeT)) {
+            // Cannot handle files which won't fit in buffer together with null terminator
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        if (filelength == 0) {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return _errorID;
+        }
+
+        const size_t size = static_cast<size_t>(filelength);
+        TIXMLASSERT(_charBuffer == 0);
+        _charBuffer = new char[size+1];
+        const size_t read = fread(_charBuffer, 1, size, fp);
+        if (read != size) {
+            SetError(XML_ERROR_FILE_READ_ERROR, 0, 0);
+            return _errorID;
+        }
+
+        _charBuffer[size] = 0;
+
+        Parse();
         return _errorID;
     }
-    LoadFile( fp );
-    fclose( fp );
-    return _errorID;
-}
 
-// This is likely overengineered template art to have a check that unsigned long value incremented
-// by one still fits into size_t. If size_t type is larger than unsigned long type
-// (x86_64-w64-mingw32 target) then the check is redundant and gcc and clang emit
-// -Wtype-limits warning. This piece makes the compiler select code with a check when a check
-// is useful and code with no check when a check is redundant depending on how size_t and unsigned long
-// types sizes relate to each other.
-template
-<bool = (sizeof(unsigned long) >= sizeof(size_t))>
-struct LongFitsIntoSizeTMinusOne {
-    static bool Fits( unsigned long value )
+
+    XMLError XMLDocument::SaveFile(const char* filename, bool compact)
     {
-        return value < (size_t)-1;
+        if (!filename) {
+            TIXMLASSERT(false);
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>");
+            return _errorID;
+        }
+
+        FILE* fp = callfopen(filename, "w");
+        if (!fp) {
+            SetError(XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename);
+            return _errorID;
+        }
+        SaveFile(fp, compact);
+        fclose(fp);
+        return _errorID;
     }
-};
 
-template <>
-struct LongFitsIntoSizeTMinusOne<false> {
-    static bool Fits( unsigned long )
+
+    XMLError XMLDocument::SaveFile(FILE* fp, bool compact)
     {
+        // Clear any error from the last save, otherwise it will get reported
+        // for *this* call.
+        ClearError();
+        XMLPrinter stream(fp, compact);
+        Print(&stream);
+        return _errorID;
+    }
+
+
+    XMLError XMLDocument::Parse(const char* p, size_t len)
+    {
+        Clear();
+
+        if (len == 0 || !p || !*p) {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return _errorID;
+        }
+        if (len == static_cast<size_t>(-1)) {
+            len = strlen(p);
+        }
+        TIXMLASSERT(_charBuffer == 0);
+        _charBuffer = new char[ len+1 ];
+        memcpy(_charBuffer, p, len);
+        _charBuffer[len] = 0;
+
+        Parse();
+        if (Error()) {
+            // clean up now essentially dangling memory.
+            // and the parse fail can put objects in the
+            // pools that are dead and inaccessible.
+            DeleteChildren();
+            _elementPool.Clear();
+            _attributePool.Clear();
+            _textPool.Clear();
+            _commentPool.Clear();
+        }
+        return _errorID;
+    }
+
+
+    void XMLDocument::Print(XMLPrinter* streamer) const
+    {
+        if (streamer) {
+            Accept(streamer);
+        } else {
+            XMLPrinter stdoutStreamer(stdout);
+            Accept(&stdoutStreamer);
+        }
+    }
+
+
+    void XMLDocument::SetError(XMLError error, int lineNum, const char* format, ...)
+    {
+        TIXMLASSERT(error >= 0 && error < XML_ERROR_COUNT);
+        _errorID = error;
+        _errorLineNum = lineNum;
+        _errorStr.Reset();
+
+        const size_t BUFFER_SIZE = 1000;
+        char* buffer = new char[BUFFER_SIZE];
+
+        TIXMLASSERT(sizeof(error) <= sizeof(int));
+        TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
+
+        if (format) {
+            size_t len = strlen(buffer);
+            TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
+            len = strlen(buffer);
+
+            va_list va;
+            va_start(va, format);
+            TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
+            va_end(va);
+        }
+        _errorStr.SetStr(buffer);
+        delete[] buffer;
+    }
+
+
+    /*static*/ const char* XMLDocument::ErrorIDToName(XMLError errorID)
+    {
+        TIXMLASSERT(errorID >= 0 && errorID < XML_ERROR_COUNT);
+        const char* errorName = _errorNames[errorID];
+        TIXMLASSERT(errorName && errorName[0]);
+        return errorName;
+    }
+
+    const char* XMLDocument::ErrorStr() const
+    {
+        return _errorStr.Empty() ? "" : _errorStr.GetStr();
+    }
+
+
+    void XMLDocument::PrintError() const
+    {
+        printf("%s\n", ErrorStr());
+    }
+
+    const char* XMLDocument::ErrorName() const
+    {
+        return ErrorIDToName(_errorID);
+    }
+
+    void XMLDocument::Parse()
+    {
+        TIXMLASSERT(NoChildren());   // Clear() must have been called previously
+        TIXMLASSERT(_charBuffer);
+        _parseCurLineNum = 1;
+        _parseLineNum = 1;
+        char* p = _charBuffer;
+        p = XMLUtil::SkipWhiteSpace(p, &_parseCurLineNum);
+        p = const_cast<char*>(XMLUtil::ReadBOM(p, &_writeBOM));
+        if (!*p) {
+            SetError(XML_ERROR_EMPTY_DOCUMENT, 0, 0);
+            return;
+        }
+        ParseDeep(p, 0, &_parseCurLineNum);
+    }
+
+    void XMLDocument::PushDepth()
+    {
+        _parsingDepth++;
+        if (_parsingDepth == TINYXML2_MAX_ELEMENT_DEPTH) {
+            SetError(XML_ELEMENT_DEPTH_EXCEEDED, _parseCurLineNum, "Element nesting is too deep.");
+        }
+    }
+
+    void XMLDocument::PopDepth()
+    {
+        TIXMLASSERT(_parsingDepth > 0);
+        --_parsingDepth;
+    }
+
+    XMLPrinter::XMLPrinter(FILE* file, bool compact, int depth) :
+        _elementJustOpened(false),
+        _stack(),
+        _firstElement(true),
+        _fp(file),
+        _depth(depth),
+        _textDepth(-1),
+        _processEntities(true),
+        _compactMode(compact),
+        _buffer()
+    {
+        for (int i=0; i<ENTITY_RANGE; ++i) {
+            _entityFlag[i] = false;
+            _restrictedEntityFlag[i] = false;
+        }
+        for (int i=0; i<NUM_ENTITIES; ++i) {
+            const char entityValue = entities[i].value;
+            const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
+            TIXMLASSERT(flagIndex < ENTITY_RANGE);
+            _entityFlag[flagIndex] = true;
+        }
+        _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
+        _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
+        _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;  // not required, but consistency is nice
+        _buffer.Push(0);
+    }
+
+
+    void XMLPrinter::Print(const char* format, ...)
+    {
+        va_list     va;
+        va_start(va, format);
+
+        if (_fp) {
+            vfprintf(_fp, format, va);
+        } else {
+            const int len = TIXML_VSCPRINTF(format, va);
+            // Close out and re-start the va-args
+            va_end(va);
+            TIXMLASSERT(len >= 0);
+            va_start(va, format);
+            TIXMLASSERT(_buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0);
+            char* p = _buffer.PushArr(len) - 1;      // back up over the null terminator.
+            TIXML_VSNPRINTF(p, len+1, format, va);
+        }
+        va_end(va);
+    }
+
+
+    void XMLPrinter::Write(const char* data, size_t size)
+    {
+        if (_fp) {
+            fwrite(data, sizeof(char), size, _fp);
+        } else {
+            char* p = _buffer.PushArr(static_cast<int>(size)) - 1;     // back up over the null terminator.
+            memcpy(p, data, size);
+            p[size] = 0;
+        }
+    }
+
+
+    void XMLPrinter::Putc(char ch)
+    {
+        if (_fp) {
+            fputc(ch, _fp);
+        } else {
+            char* p = _buffer.PushArr(sizeof(char)) - 1;     // back up over the null terminator.
+            p[0] = ch;
+            p[1] = 0;
+        }
+    }
+
+
+    void XMLPrinter::PrintSpace(int depth)
+    {
+        for (int i=0; i<depth; ++i) {
+            Write("    ");
+        }
+    }
+
+
+    void XMLPrinter::PrintString(const char* p, bool restricted)
+    {
+        // Look for runs of bytes between entities to print.
+        const char* q = p;
+
+        if (_processEntities) {
+            const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
+            while (*q) {
+                TIXMLASSERT(p <= q);
+                // Remember, char is sometimes signed. (How many times has that bitten me?)
+                if (*q > 0 && *q < ENTITY_RANGE) {
+                    // Check for entities. If one is found, flush
+                    // the stream up until the entity, write the
+                    // entity, and keep looking.
+                    if (flag[static_cast<unsigned char>(*q)]) {
+                        while (p < q) {
+                            const size_t delta = q - p;
+                            const int toPrint = (INT_MAX < delta) ? INT_MAX : static_cast<int>(delta);
+                            Write(p, toPrint);
+                            p += toPrint;
+                        }
+                        bool entityPatternPrinted = false;
+                        for (int i=0; i<NUM_ENTITIES; ++i) {
+                            if (entities[i].value == *q) {
+                                Putc('&');
+                                Write(entities[i].pattern, entities[i].length);
+                                Putc(';');
+                                entityPatternPrinted = true;
+                                break;
+                            }
+                        }
+                        if (!entityPatternPrinted) {
+                            // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
+                            TIXMLASSERT(false);
+                        }
+                        ++p;
+                    }
+                }
+                ++q;
+                TIXMLASSERT(p <= q);
+            }
+            // Flush the remaining string. This will be the entire
+            // string if an entity wasn't found.
+            if (p < q) {
+                const size_t delta = q - p;
+                const int toPrint = (INT_MAX < delta) ? INT_MAX : static_cast<int>(delta);
+                Write(p, toPrint);
+            }
+        } else {
+            Write(p);
+        }
+    }
+
+
+    void XMLPrinter::PushHeader(bool writeBOM, bool writeDec)
+    {
+        if (writeBOM) {
+            static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
+            Write(reinterpret_cast< const char* >(bom));
+        }
+        if (writeDec) {
+            PushDeclaration("xml version=\"1.0\"");
+        }
+    }
+
+
+    void XMLPrinter::OpenElement(const char* name, bool compactMode)
+    {
+        SealElementIfJustOpened();
+        _stack.Push(name);
+
+        if (_textDepth < 0 && !_firstElement && !compactMode) {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+
+        Write("<");
+        Write(name);
+
+        _elementJustOpened = true;
+        _firstElement = false;
+        ++_depth;
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, const char* value)
+    {
+        TIXMLASSERT(_elementJustOpened);
+        Putc(' ');
+        Write(name);
+        Write("=\"");
+        PrintString(value, false);
+        Putc('\"');
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, int v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, unsigned v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, int64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, uint64_t v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, bool v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::PushAttribute(const char* name, double v)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(v, buf, BUF_SIZE);
+        PushAttribute(name, buf);
+    }
+
+
+    void XMLPrinter::CloseElement(bool compactMode)
+    {
+        --_depth;
+        const char* name = _stack.Pop();
+
+        if (_elementJustOpened) {
+            Write("/>");
+        } else {
+            if (_textDepth < 0 && !compactMode) {
+                Putc('\n');
+                PrintSpace(_depth);
+            }
+            Write("</");
+            Write(name);
+            Write(">");
+        }
+
+        if (_textDepth == _depth) {
+            _textDepth = -1;
+        }
+        if (_depth == 0 && !compactMode) {
+            Putc('\n');
+        }
+        _elementJustOpened = false;
+    }
+
+
+    void XMLPrinter::SealElementIfJustOpened()
+    {
+        if (!_elementJustOpened) {
+            return;
+        }
+        _elementJustOpened = false;
+        Putc('>');
+    }
+
+
+    void XMLPrinter::PushText(const char* text, bool cdata)
+    {
+        _textDepth = _depth-1;
+
+        SealElementIfJustOpened();
+        if (cdata) {
+            Write("<![CDATA[");
+            Write(text);
+            Write("]]>");
+        } else {
+            PrintString(text, true);
+        }
+    }
+
+
+    void XMLPrinter::PushText(int64_t value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(uint64_t value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(int value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(unsigned value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(bool value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(float value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushText(double value)
+    {
+        char buf[BUF_SIZE];
+        XMLUtil::ToStr(value, buf, BUF_SIZE);
+        PushText(buf, false);
+    }
+
+
+    void XMLPrinter::PushComment(const char* comment)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode) {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<!--");
+        Write(comment);
+        Write("-->");
+    }
+
+
+    void XMLPrinter::PushDeclaration(const char* value)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode) {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<?");
+        Write(value);
+        Write("?>");
+    }
+
+
+    void XMLPrinter::PushUnknown(const char* value)
+    {
+        SealElementIfJustOpened();
+        if (_textDepth < 0 && !_firstElement && !_compactMode) {
+            Putc('\n');
+            PrintSpace(_depth);
+        }
+        _firstElement = false;
+
+        Write("<!");
+        Write(value);
+        Putc('>');
+    }
+
+
+    bool XMLPrinter::VisitEnter(const XMLDocument& doc)
+    {
+        _processEntities = doc.ProcessEntities();
+        if (doc.HasBOM()) {
+            PushHeader(true, false);
+        }
         return true;
     }
-};
-
-XMLError XMLDocument::LoadFile( FILE* fp )
-{
-    Clear();
-
-    fseek( fp, 0, SEEK_SET );
-    if ( fgetc( fp ) == EOF && ferror( fp ) != 0 ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    fseek( fp, 0, SEEK_END );
-    const long filelength = ftell( fp );
-    fseek( fp, 0, SEEK_SET );
-    if ( filelength == -1L ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-    TIXMLASSERT( filelength >= 0 );
-
-    if ( !LongFitsIntoSizeTMinusOne<>::Fits( filelength ) ) {
-        // Cannot handle files which won't fit in buffer together with null terminator
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    if ( filelength == 0 ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return _errorID;
-    }
-
-    const size_t size = filelength;
-    TIXMLASSERT( _charBuffer == 0 );
-    _charBuffer = new char[size+1];
-    size_t read = fread( _charBuffer, 1, size, fp );
-    if ( read != size ) {
-        SetError( XML_ERROR_FILE_READ_ERROR, 0, 0 );
-        return _errorID;
-    }
-
-    _charBuffer[size] = 0;
-
-    Parse();
-    return _errorID;
-}
 
 
-XMLError XMLDocument::SaveFile( const char* filename, bool compact )
-{
-    if ( !filename ) {
-        TIXMLASSERT( false );
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=<null>" );
-        return _errorID;
-    }
-
-    FILE* fp = callfopen( filename, "w" );
-    if ( !fp ) {
-        SetError( XML_ERROR_FILE_COULD_NOT_BE_OPENED, 0, "filename=%s", filename );
-        return _errorID;
-    }
-    SaveFile(fp, compact);
-    fclose( fp );
-    return _errorID;
-}
-
-
-XMLError XMLDocument::SaveFile( FILE* fp, bool compact )
-{
-    // Clear any error from the last save, otherwise it will get reported
-    // for *this* call.
-    ClearError();
-    XMLPrinter stream( fp, compact );
-    Print( &stream );
-    return _errorID;
-}
-
-
-XMLError XMLDocument::Parse( const char* p, size_t len )
-{
-    Clear();
-
-    if ( len == 0 || !p || !*p ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return _errorID;
-    }
-    if ( len == (size_t)(-1) ) {
-        len = strlen( p );
-    }
-    TIXMLASSERT( _charBuffer == 0 );
-    _charBuffer = new char[ len+1 ];
-    memcpy( _charBuffer, p, len );
-    _charBuffer[len] = 0;
-
-    Parse();
-    if ( Error() ) {
-        // clean up now essentially dangling memory.
-        // and the parse fail can put objects in the
-        // pools that are dead and inaccessible.
-        DeleteChildren();
-        _elementPool.Clear();
-        _attributePool.Clear();
-        _textPool.Clear();
-        _commentPool.Clear();
-    }
-    return _errorID;
-}
-
-
-void XMLDocument::Print( XMLPrinter* streamer ) const
-{
-    if ( streamer ) {
-        Accept( streamer );
-    }
-    else {
-        XMLPrinter stdoutStreamer( stdout );
-        Accept( &stdoutStreamer );
-    }
-}
-
-
-void XMLDocument::SetError( XMLError error, int lineNum, const char* format, ... )
-{
-    TIXMLASSERT( error >= 0 && error < XML_ERROR_COUNT );
-    _errorID = error;
-    _errorLineNum = lineNum;
-	_errorStr.Reset();
-
-    size_t BUFFER_SIZE = 1000;
-    char* buffer = new char[BUFFER_SIZE];
-
-    TIXML_SNPRINTF(buffer, BUFFER_SIZE, "Error=%s ErrorID=%d (0x%x) Line number=%d", ErrorIDToName(error), int(error), int(error), lineNum);
-
-	if (format) {
-		size_t len = strlen(buffer);
-		TIXML_SNPRINTF(buffer + len, BUFFER_SIZE - len, ": ");
-		len = strlen(buffer);
-
-		va_list va;
-		va_start(va, format);
-		TIXML_VSNPRINTF(buffer + len, BUFFER_SIZE - len, format, va);
-		va_end(va);
-	}
-	_errorStr.SetStr(buffer);
-	delete[] buffer;
-}
-
-
-/*static*/ const char* XMLDocument::ErrorIDToName(XMLError errorID)
-{
-	TIXMLASSERT( errorID >= 0 && errorID < XML_ERROR_COUNT );
-    const char* errorName = _errorNames[errorID];
-    TIXMLASSERT( errorName && errorName[0] );
-    return errorName;
-}
-
-const char* XMLDocument::ErrorStr() const
-{
-	return _errorStr.Empty() ? "" : _errorStr.GetStr();
-}
-
-
-void XMLDocument::PrintError() const
-{
-    printf("%s\n", ErrorStr());
-}
-
-const char* XMLDocument::ErrorName() const
-{
-    return ErrorIDToName(_errorID);
-}
-
-void XMLDocument::Parse()
-{
-    TIXMLASSERT( NoChildren() ); // Clear() must have been called previously
-    TIXMLASSERT( _charBuffer );
-    _parseCurLineNum = 1;
-    _parseLineNum = 1;
-    char* p = _charBuffer;
-    p = XMLUtil::SkipWhiteSpace( p, &_parseCurLineNum );
-    p = const_cast<char*>( XMLUtil::ReadBOM( p, &_writeBOM ) );
-    if ( !*p ) {
-        SetError( XML_ERROR_EMPTY_DOCUMENT, 0, 0 );
-        return;
-    }
-    ParseDeep(p, 0, &_parseCurLineNum );
-}
-
-XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
-    _elementJustOpened( false ),
-    _stack(),
-    _firstElement( true ),
-    _fp( file ),
-    _depth( depth ),
-    _textDepth( -1 ),
-    _processEntities( true ),
-    _compactMode( compact ),
-    _buffer()
-{
-    for( int i=0; i<ENTITY_RANGE; ++i ) {
-        _entityFlag[i] = false;
-        _restrictedEntityFlag[i] = false;
-    }
-    for( int i=0; i<NUM_ENTITIES; ++i ) {
-        const char entityValue = entities[i].value;
-        const unsigned char flagIndex = (unsigned char)entityValue;
-        TIXMLASSERT( flagIndex < ENTITY_RANGE );
-        _entityFlag[flagIndex] = true;
-    }
-    _restrictedEntityFlag[(unsigned char)'&'] = true;
-    _restrictedEntityFlag[(unsigned char)'<'] = true;
-    _restrictedEntityFlag[(unsigned char)'>'] = true;	// not required, but consistency is nice
-    _buffer.Push( 0 );
-}
-
-
-void XMLPrinter::Print( const char* format, ... )
-{
-    va_list     va;
-    va_start( va, format );
-
-    if ( _fp ) {
-        vfprintf( _fp, format, va );
-    }
-    else {
-        const int len = TIXML_VSCPRINTF( format, va );
-        // Close out and re-start the va-args
-        va_end( va );
-        TIXMLASSERT( len >= 0 );
-        va_start( va, format );
-        TIXMLASSERT( _buffer.Size() > 0 && _buffer[_buffer.Size() - 1] == 0 );
-        char* p = _buffer.PushArr( len ) - 1;	// back up over the null terminator.
-		TIXML_VSNPRINTF( p, len+1, format, va );
-    }
-    va_end( va );
-}
-
-
-void XMLPrinter::Write( const char* data, size_t size )
-{
-    if ( _fp ) {
-        fwrite ( data , sizeof(char), size, _fp);
-    }
-    else {
-        char* p = _buffer.PushArr( static_cast<int>(size) ) - 1;   // back up over the null terminator.
-        memcpy( p, data, size );
-        p[size] = 0;
-    }
-}
-
-
-void XMLPrinter::Putc( char ch )
-{
-    if ( _fp ) {
-        fputc ( ch, _fp);
-    }
-    else {
-        char* p = _buffer.PushArr( sizeof(char) ) - 1;   // back up over the null terminator.
-        p[0] = ch;
-        p[1] = 0;
-    }
-}
-
-
-void XMLPrinter::PrintSpace( int depth )
-{
-    for( int i=0; i<depth; ++i ) {
-        Write( "    " );
-    }
-}
-
-
-void XMLPrinter::PrintString( const char* p, bool restricted )
-{
-    // Look for runs of bytes between entities to print.
-    const char* q = p;
-
-    if ( _processEntities ) {
-        const bool* flag = restricted ? _restrictedEntityFlag : _entityFlag;
-        while ( *q ) {
-            TIXMLASSERT( p <= q );
-            // Remember, char is sometimes signed. (How many times has that bitten me?)
-            if ( *q > 0 && *q < ENTITY_RANGE ) {
-                // Check for entities. If one is found, flush
-                // the stream up until the entity, write the
-                // entity, and keep looking.
-                if ( flag[(unsigned char)(*q)] ) {
-                    while ( p < q ) {
-                        const size_t delta = q - p;
-                        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
-                        Write( p, toPrint );
-                        p += toPrint;
-                    }
-                    bool entityPatternPrinted = false;
-                    for( int i=0; i<NUM_ENTITIES; ++i ) {
-                        if ( entities[i].value == *q ) {
-                            Putc( '&' );
-                            Write( entities[i].pattern, entities[i].length );
-                            Putc( ';' );
-                            entityPatternPrinted = true;
-                            break;
-                        }
-                    }
-                    if ( !entityPatternPrinted ) {
-                        // TIXMLASSERT( entityPatternPrinted ) causes gcc -Wunused-but-set-variable in release
-                        TIXMLASSERT( false );
-                    }
-                    ++p;
-                }
-            }
-            ++q;
-            TIXMLASSERT( p <= q );
+    bool XMLPrinter::VisitEnter(const XMLElement& element, const XMLAttribute* attribute)
+    {
+        const XMLElement* parentElem = 0;
+        if (element.Parent()) {
+            parentElem = element.Parent()->ToElement();
         }
-    }
-    // Flush the remaining string. This will be the entire
-    // string if an entity wasn't found.
-    TIXMLASSERT( p <= q );
-    if ( !_processEntities || ( p < q ) ) {
-        const size_t delta = q - p;
-        const int toPrint = ( INT_MAX < delta ) ? INT_MAX : (int)delta;
-        Write( p, toPrint );
-    }
-}
-
-
-void XMLPrinter::PushHeader( bool writeBOM, bool writeDec )
-{
-    if ( writeBOM ) {
-        static const unsigned char bom[] = { TIXML_UTF_LEAD_0, TIXML_UTF_LEAD_1, TIXML_UTF_LEAD_2, 0 };
-        Write( reinterpret_cast< const char* >( bom ) );
-    }
-    if ( writeDec ) {
-        PushDeclaration( "xml version=\"1.0\"" );
-    }
-}
-
-
-void XMLPrinter::OpenElement( const char* name, bool compactMode )
-{
-    SealElementIfJustOpened();
-    _stack.Push( name );
-
-    if ( _textDepth < 0 && !_firstElement && !compactMode ) {
-        Putc( '\n' );
-    }
-    if ( !compactMode ) {
-        PrintSpace( _depth );
-    }
-
-    Write ( "<" );
-    Write ( name );
-
-    _elementJustOpened = true;
-    _firstElement = false;
-    ++_depth;
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, const char* value )
-{
-    TIXMLASSERT( _elementJustOpened );
-    Putc ( ' ' );
-    Write( name );
-    Write( "=\"" );
-    PrintString( value, false );
-    Putc ( '\"' );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, int v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, unsigned v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute(const char* name, int64_t v)
-{
-	char buf[BUF_SIZE];
-	XMLUtil::ToStr(v, buf, BUF_SIZE);
-	PushAttribute(name, buf);
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, bool v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::PushAttribute( const char* name, double v )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( v, buf, BUF_SIZE );
-    PushAttribute( name, buf );
-}
-
-
-void XMLPrinter::CloseElement( bool compactMode )
-{
-    --_depth;
-    const char* name = _stack.Pop();
-
-    if ( _elementJustOpened ) {
-        Write( "/>" );
-    }
-    else {
-        if ( _textDepth < 0 && !compactMode) {
-            Putc( '\n' );
-            PrintSpace( _depth );
+        const bool compactMode = parentElem ? CompactMode(*parentElem) : _compactMode;
+        OpenElement(element.Name(), compactMode);
+        while (attribute) {
+            PushAttribute(attribute->Name(), attribute->Value());
+            attribute = attribute->Next();
         }
-        Write ( "</" );
-        Write ( name );
-        Write ( ">" );
+        return true;
     }
 
-    if ( _textDepth == _depth ) {
-        _textDepth = -1;
+
+    bool XMLPrinter::VisitExit(const XMLElement& element)
+    {
+        CloseElement(CompactMode(element));
+        return true;
     }
-    if ( _depth == 0 && !compactMode) {
-        Putc( '\n' );
+
+
+    bool XMLPrinter::Visit(const XMLText& text)
+    {
+        PushText(text.Value(), text.CData());
+        return true;
     }
-    _elementJustOpened = false;
-}
 
 
-void XMLPrinter::SealElementIfJustOpened()
-{
-    if ( !_elementJustOpened ) {
-        return;
+    bool XMLPrinter::Visit(const XMLComment& comment)
+    {
+        PushComment(comment.Value());
+        return true;
     }
-    _elementJustOpened = false;
-    Putc( '>' );
-}
 
-
-void XMLPrinter::PushText( const char* text, bool cdata )
-{
-    _textDepth = _depth-1;
-
-    SealElementIfJustOpened();
-    if ( cdata ) {
-        Write( "<![CDATA[" );
-        Write( text );
-        Write( "]]>" );
+    bool XMLPrinter::Visit(const XMLDeclaration& declaration)
+    {
+        PushDeclaration(declaration.Value());
+        return true;
     }
-    else {
-        PrintString( text, true );
+
+
+    bool XMLPrinter::Visit(const XMLUnknown& unknown)
+    {
+        PushUnknown(unknown.Value());
+        return true;
     }
-}
-
-void XMLPrinter::PushText( int64_t value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-void XMLPrinter::PushText( int value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( unsigned value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( bool value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( float value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushText( double value )
-{
-    char buf[BUF_SIZE];
-    XMLUtil::ToStr( value, buf, BUF_SIZE );
-    PushText( buf, false );
-}
-
-
-void XMLPrinter::PushComment( const char* comment )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<!--" );
-    Write( comment );
-    Write( "-->" );
-}
-
-
-void XMLPrinter::PushDeclaration( const char* value )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<?" );
-    Write( value );
-    Write( "?>" );
-}
-
-
-void XMLPrinter::PushUnknown( const char* value )
-{
-    SealElementIfJustOpened();
-    if ( _textDepth < 0 && !_firstElement && !_compactMode) {
-        Putc( '\n' );
-        PrintSpace( _depth );
-    }
-    _firstElement = false;
-
-    Write( "<!" );
-    Write( value );
-    Putc( '>' );
-}
-
-
-bool XMLPrinter::VisitEnter( const XMLDocument& doc )
-{
-    _processEntities = doc.ProcessEntities();
-    if ( doc.HasBOM() ) {
-        PushHeader( true, false );
-    }
-    return true;
-}
-
-
-bool XMLPrinter::VisitEnter( const XMLElement& element, const XMLAttribute* attribute )
-{
-    const XMLElement* parentElem = 0;
-    if ( element.Parent() ) {
-        parentElem = element.Parent()->ToElement();
-    }
-    const bool compactMode = parentElem ? CompactMode( *parentElem ) : _compactMode;
-    OpenElement( element.Name(), compactMode );
-    while ( attribute ) {
-        PushAttribute( attribute->Name(), attribute->Value() );
-        attribute = attribute->Next();
-    }
-    return true;
-}
-
-
-bool XMLPrinter::VisitExit( const XMLElement& element )
-{
-    CloseElement( CompactMode(element) );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLText& text )
-{
-    PushText( text.Value(), text.CData() );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLComment& comment )
-{
-    PushComment( comment.Value() );
-    return true;
-}
-
-bool XMLPrinter::Visit( const XMLDeclaration& declaration )
-{
-    PushDeclaration( declaration.Value() );
-    return true;
-}
-
-
-bool XMLPrinter::Visit( const XMLUnknown& unknown )
-{
-    PushUnknown( unknown.Value() );
-    return true;
-}
 
 }   // namespace tinyxml2

--- a/externals/tinyxml/tinyxml2.h
+++ b/externals/tinyxml/tinyxml2.h
@@ -2324,6 +2324,11 @@ namespace tinyxml2 {
         DynArray< const char*, 10 > _stack;
 
     private:
+        /**
+          Prepares to write a new node. This includes sealing an element that was
+          just opened, and writing any whitespace necessary if not in compact mode.
+        */
+        void PrepareForNewNode(bool compactMode);
         void PrintString(const char*, bool restrictedEntitySet);     // prints out, after detecting entities.
 
         bool _firstElement;

--- a/externals/tinyxml/tinyxml2.h
+++ b/externals/tinyxml/tinyxml2.h
@@ -30,9 +30,9 @@ distribution.
 #   include <stdio.h>
 #   include <stdlib.h>
 #   include <string.h>
-#	if defined(__PS3__)
-#		include <stddef.h>
-#	endif
+#   if defined(__PS3__)
+#       include <stddef.h>
+#   endif
 #else
 #   include <cctype>
 #   include <climits>
@@ -46,7 +46,7 @@ distribution.
    TODO: intern strings instead of allocation.
 */
 /*
-	gcc:
+    gcc:
         g++ -Wall -DTINYXML2_DEBUG tinyxml2.cpp xmltest.cpp -o gccxmltest.exe
 
     Formatting, Artistic Style:
@@ -96,2189 +96,2259 @@ distribution.
 
 
 /* Versioning, past 1.0.14:
-	http://semver.org/
+    http://semver.org/
 */
-static const int TIXML2_MAJOR_VERSION = 6;
-static const int TIXML2_MINOR_VERSION = 1;
+static const int TIXML2_MAJOR_VERSION = 8;
+static const int TIXML2_MINOR_VERSION = 0;
 static const int TIXML2_PATCH_VERSION = 0;
 
-#define TINYXML2_MAJOR_VERSION 6
-#define TINYXML2_MINOR_VERSION 1
+#define TINYXML2_MAJOR_VERSION 8
+#define TINYXML2_MINOR_VERSION 0
 #define TINYXML2_PATCH_VERSION 0
 
-namespace tinyxml2
-{
-class XMLDocument;
-class XMLElement;
-class XMLAttribute;
-class XMLComment;
-class XMLText;
-class XMLDeclaration;
-class XMLUnknown;
-class XMLPrinter;
+// A fixed element depth limit is problematic. There needs to be a
+// limit to avoid a stack overflow. However, that limit varies per
+// system, and the capacity of the stack. On the other hand, it's a trivial
+// attack that can result from ill, malicious, or even correctly formed XML,
+// so there needs to be a limit in place.
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
 
-/*
-	A class that wraps strings. Normally stores the start and end
-	pointers into the XML file itself, and will apply normalization
-	and entity translation if actually read. Can also store (and memory
-	manage) a traditional char[]
-*/
-class StrPair
-{
-public:
-    enum {
-        NEEDS_ENTITY_PROCESSING			= 0x01,
-        NEEDS_NEWLINE_NORMALIZATION		= 0x02,
-        NEEDS_WHITESPACE_COLLAPSING     = 0x04,
+namespace tinyxml2 {
+    class XMLDocument;
+    class XMLElement;
+    class XMLAttribute;
+    class XMLComment;
+    class XMLText;
+    class XMLDeclaration;
+    class XMLUnknown;
+    class XMLPrinter;
 
-        TEXT_ELEMENT		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
-        TEXT_ELEMENT_LEAVE_ENTITIES		= NEEDS_NEWLINE_NORMALIZATION,
-        ATTRIBUTE_NAME		            = 0,
-        ATTRIBUTE_VALUE		            = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
-        ATTRIBUTE_VALUE_LEAVE_ENTITIES  = NEEDS_NEWLINE_NORMALIZATION,
-        COMMENT							= NEEDS_NEWLINE_NORMALIZATION
-    };
+    /*
+        A class that wraps strings. Normally stores the start and end
+        pointers into the XML file itself, and will apply normalization
+        and entity translation if actually read. Can also store (and memory
+        manage) a traditional char[]
 
-    StrPair() : _flags( 0 ), _start( 0 ), _end( 0 ) {}
-    ~StrPair();
+        Isn't clear why TINYXML2_LIB is needed; but seems to fix #719
+    */
+    class TINYXML2_LIB StrPair {
+    public:
+        enum {
+            NEEDS_ENTITY_PROCESSING         = 0x01,
+            NEEDS_NEWLINE_NORMALIZATION     = 0x02,
+            NEEDS_WHITESPACE_COLLAPSING     = 0x04,
 
-    void Set( char* start, char* end, int flags ) {
-        TIXMLASSERT( start );
-        TIXMLASSERT( end );
-        Reset();
-        _start  = start;
-        _end    = end;
-        _flags  = flags | NEEDS_FLUSH;
-    }
+            TEXT_ELEMENT                    = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+            TEXT_ELEMENT_LEAVE_ENTITIES     = NEEDS_NEWLINE_NORMALIZATION,
+            ATTRIBUTE_NAME                  = 0,
+            ATTRIBUTE_VALUE                 = NEEDS_ENTITY_PROCESSING | NEEDS_NEWLINE_NORMALIZATION,
+            ATTRIBUTE_VALUE_LEAVE_ENTITIES  = NEEDS_NEWLINE_NORMALIZATION,
+            COMMENT                         = NEEDS_NEWLINE_NORMALIZATION
+        };
 
-    const char* GetStr();
+        StrPair() : _flags(0), _start(0), _end(0) {}
+        ~StrPair();
 
-    bool Empty() const {
-        return _start == _end;
-    }
-
-    void SetInternedStr( const char* str ) {
-        Reset();
-        _start = const_cast<char*>(str);
-    }
-
-    void SetStr( const char* str, int flags=0 );
-
-    char* ParseText( char* in, const char* endTag, int strFlags, int* curLineNumPtr );
-    char* ParseName( char* in );
-
-    void TransferTo( StrPair* other );
-	void Reset();
-
-private:
-    void CollapseWhitespace();
-
-    enum {
-        NEEDS_FLUSH = 0x100,
-        NEEDS_DELETE = 0x200
-    };
-
-    int     _flags;
-    char*   _start;
-    char*   _end;
-
-    StrPair( const StrPair& other );	// not supported
-    void operator=( StrPair& other );	// not supported, use TransferTo()
-};
-
-
-/*
-	A dynamic array of Plain Old Data. Doesn't support constructors, etc.
-	Has a small initial memory pool, so that low or no usage will not
-	cause a call to new/delete
-*/
-template <class T, int INITIAL_SIZE>
-class DynArray
-{
-public:
-    DynArray() :
-        _mem( _pool ),
-        _allocated( INITIAL_SIZE ),
-        _size( 0 )
-    {
-    }
-
-    ~DynArray() {
-        if ( _mem != _pool ) {
-            delete [] _mem;
+        void Set(char* start, char* end, int flags) {
+            TIXMLASSERT(start);
+            TIXMLASSERT(end);
+            Reset();
+            _start  = start;
+            _end    = end;
+            _flags  = flags | NEEDS_FLUSH;
         }
-    }
 
-    void Clear() {
-        _size = 0;
-    }
+        const char* GetStr();
 
-    void Push( T t ) {
-        TIXMLASSERT( _size < INT_MAX );
-        EnsureCapacity( _size+1 );
-        _mem[_size] = t;
-        ++_size;
-    }
+        bool Empty() const {
+            return _start == _end;
+        }
 
-    T* PushArr( int count ) {
-        TIXMLASSERT( count >= 0 );
-        TIXMLASSERT( _size <= INT_MAX - count );
-        EnsureCapacity( _size+count );
-        T* ret = &_mem[_size];
-        _size += count;
-        return ret;
-    }
+        void SetInternedStr(const char* str) {
+            Reset();
+            _start = const_cast<char*>(str);
+        }
 
-    T Pop() {
-        TIXMLASSERT( _size > 0 );
-        --_size;
-        return _mem[_size];
-    }
+        void SetStr(const char* str, int flags=0);
 
-    void PopArr( int count ) {
-        TIXMLASSERT( _size >= count );
-        _size -= count;
-    }
+        char* ParseText(char* in, const char* endTag, int strFlags, int* curLineNumPtr);
+        char* ParseName(char* in);
 
-    bool Empty() const					{
-        return _size == 0;
-    }
+        void TransferTo(StrPair* other);
+        void Reset();
 
-    T& operator[](int i)				{
-        TIXMLASSERT( i>= 0 && i < _size );
-        return _mem[i];
-    }
+    private:
+        void CollapseWhitespace();
 
-    const T& operator[](int i) const	{
-        TIXMLASSERT( i>= 0 && i < _size );
-        return _mem[i];
-    }
+        enum {
+            NEEDS_FLUSH = 0x100,
+            NEEDS_DELETE = 0x200
+        };
 
-    const T& PeekTop() const            {
-        TIXMLASSERT( _size > 0 );
-        return _mem[ _size - 1];
-    }
+        int     _flags;
+        char*   _start;
+        char*   _end;
 
-    int Size() const					{
-        TIXMLASSERT( _size >= 0 );
-        return _size;
-    }
+        StrPair(const StrPair& other);   // not supported
+        void operator=(const StrPair& other);    // not supported, use TransferTo()
+    };
 
-    int Capacity() const				{
-        TIXMLASSERT( _allocated >= INITIAL_SIZE );
-        return _allocated;
-    }
 
-	void SwapRemove(int i) {
-		TIXMLASSERT(i >= 0 && i < _size);
-		TIXMLASSERT(_size > 0);
-		_mem[i] = _mem[_size - 1];
-		--_size;
-	}
+    /*
+        A dynamic array of Plain Old Data. Doesn't support constructors, etc.
+        Has a small initial memory pool, so that low or no usage will not
+        cause a call to new/delete
+    */
+    template <class T, int INITIAL_SIZE>
+    class DynArray {
+    public:
+        DynArray() :
+            _mem(_pool),
+            _allocated(INITIAL_SIZE),
+            _size(0) {
+        }
 
-    const T* Mem() const				{
-        TIXMLASSERT( _mem );
-        return _mem;
-    }
-
-    T* Mem()							{
-        TIXMLASSERT( _mem );
-        return _mem;
-    }
-
-private:
-    DynArray( const DynArray& ); // not supported
-    void operator=( const DynArray& ); // not supported
-
-    void EnsureCapacity( int cap ) {
-        TIXMLASSERT( cap > 0 );
-        if ( cap > _allocated ) {
-            TIXMLASSERT( cap <= INT_MAX / 2 );
-            int newAllocated = cap * 2;
-            T* newMem = new T[newAllocated];
-            TIXMLASSERT( newAllocated >= _size );
-            memcpy( newMem, _mem, sizeof(T)*_size );	// warning: not using constructors, only works for PODs
-            if ( _mem != _pool ) {
+        ~DynArray() {
+            if (_mem != _pool) {
                 delete [] _mem;
             }
-            _mem = newMem;
-            _allocated = newAllocated;
         }
-    }
 
-    T*  _mem;
-    T   _pool[INITIAL_SIZE];
-    int _allocated;		// objects allocated
-    int _size;			// number objects in use
-};
-
-
-/*
-	Parent virtual class of a pool for fast allocation
-	and deallocation of objects.
-*/
-class MemPool
-{
-public:
-    MemPool() {}
-    virtual ~MemPool() {}
-
-    virtual int ItemSize() const = 0;
-    virtual void* Alloc() = 0;
-    virtual void Free( void* ) = 0;
-    virtual void SetTracked() = 0;
-    virtual void Clear() = 0;
-};
-
-
-/*
-	Template child class to create pools of the correct type.
-*/
-template< int ITEM_SIZE >
-class MemPoolT : public MemPool
-{
-public:
-    MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)	{}
-    ~MemPoolT() {
-        Clear();
-    }
-    
-    void Clear() {
-        // Delete the blocks.
-        while( !_blockPtrs.Empty()) {
-            Block* lastBlock = _blockPtrs.Pop();
-            delete lastBlock;
+        void Clear() {
+            _size = 0;
         }
-        _root = 0;
-        _currentAllocs = 0;
-        _nAllocs = 0;
-        _maxAllocs = 0;
-        _nUntracked = 0;
-    }
 
-    virtual int ItemSize() const	{
-        return ITEM_SIZE;
-    }
-    int CurrentAllocs() const		{
-        return _currentAllocs;
-    }
+        void Push(T t) {
+            TIXMLASSERT(_size < INT_MAX);
+            EnsureCapacity(_size+1);
+            _mem[_size] = t;
+            ++_size;
+        }
 
-    virtual void* Alloc() {
-        if ( !_root ) {
-            // Need a new block.
-            Block* block = new Block();
-            _blockPtrs.Push( block );
+        T* PushArr(int count) {
+            TIXMLASSERT(count >= 0);
+            TIXMLASSERT(_size <= INT_MAX - count);
+            EnsureCapacity(_size+count);
+            T* ret = &_mem[_size];
+            _size += count;
+            return ret;
+        }
 
-            Item* blockItems = block->items;
-            for( int i = 0; i < ITEMS_PER_BLOCK - 1; ++i ) {
-                blockItems[i].next = &(blockItems[i + 1]);
+        T Pop() {
+            TIXMLASSERT(_size > 0);
+            --_size;
+            return _mem[_size];
+        }
+
+        void PopArr(int count) {
+            TIXMLASSERT(_size >= count);
+            _size -= count;
+        }
+
+        bool Empty() const                  {
+            return _size == 0;
+        }
+
+        T& operator[](int i)                {
+            TIXMLASSERT(i>= 0 && i < _size);
+            return _mem[i];
+        }
+
+        const T& operator[](int i) const    {
+            TIXMLASSERT(i>= 0 && i < _size);
+            return _mem[i];
+        }
+
+        const T& PeekTop() const            {
+            TIXMLASSERT(_size > 0);
+            return _mem[ _size - 1];
+        }
+
+        int Size() const                    {
+            TIXMLASSERT(_size >= 0);
+            return _size;
+        }
+
+        int Capacity() const                {
+            TIXMLASSERT(_allocated >= INITIAL_SIZE);
+            return _allocated;
+        }
+
+        void SwapRemove(int i) {
+            TIXMLASSERT(i >= 0 && i < _size);
+            TIXMLASSERT(_size > 0);
+            _mem[i] = _mem[_size - 1];
+            --_size;
+        }
+
+        const T* Mem() const                {
+            TIXMLASSERT(_mem);
+            return _mem;
+        }
+
+        T* Mem() {
+            TIXMLASSERT(_mem);
+            return _mem;
+        }
+
+    private:
+        DynArray(const DynArray&);   // not supported
+        void operator=(const DynArray&);   // not supported
+
+        void EnsureCapacity(int cap) {
+            TIXMLASSERT(cap > 0);
+            if (cap > _allocated) {
+                TIXMLASSERT(cap <= INT_MAX / 2);
+                const int newAllocated = cap * 2;
+                T* newMem = new T[newAllocated];
+                TIXMLASSERT(newAllocated >= _size);
+                memcpy(newMem, _mem, sizeof(T)*_size);   // warning: not using constructors, only works for PODs
+                if (_mem != _pool) {
+                    delete [] _mem;
+                }
+                _mem = newMem;
+                _allocated = newAllocated;
             }
-            blockItems[ITEMS_PER_BLOCK - 1].next = 0;
-            _root = blockItems;
         }
-        Item* const result = _root;
-        TIXMLASSERT( result != 0 );
-        _root = _root->next;
 
-        ++_currentAllocs;
-        if ( _currentAllocs > _maxAllocs ) {
-            _maxAllocs = _currentAllocs;
+        T*  _mem;
+        T   _pool[INITIAL_SIZE];
+        int _allocated;     // objects allocated
+        int _size;          // number objects in use
+    };
+
+
+    /*
+        Parent virtual class of a pool for fast allocation
+        and deallocation of objects.
+    */
+    class MemPool {
+    public:
+        MemPool() {}
+        virtual ~MemPool() {}
+
+        virtual int ItemSize() const = 0;
+        virtual void* Alloc() = 0;
+        virtual void Free(void*) = 0;
+        virtual void SetTracked() = 0;
+    };
+
+
+    /*
+        Template child class to create pools of the correct type.
+    */
+    template< int ITEM_SIZE >
+    class MemPoolT : public MemPool {
+    public:
+        MemPoolT() : _blockPtrs(), _root(0), _currentAllocs(0), _nAllocs(0), _maxAllocs(0), _nUntracked(0)  {}
+        ~MemPoolT() {
+            MemPoolT< ITEM_SIZE >::Clear();
         }
-        ++_nAllocs;
-        ++_nUntracked;
-        return result;
-    }
-    
-    virtual void Free( void* mem ) {
-        if ( !mem ) {
-            return;
+
+        void Clear() {
+            // Delete the blocks.
+            while (!_blockPtrs.Empty()) {
+                Block* lastBlock = _blockPtrs.Pop();
+                delete lastBlock;
+            }
+            _root = 0;
+            _currentAllocs = 0;
+            _nAllocs = 0;
+            _maxAllocs = 0;
+            _nUntracked = 0;
         }
-        --_currentAllocs;
-        Item* item = static_cast<Item*>( mem );
+
+        virtual int ItemSize() const    {
+            return ITEM_SIZE;
+        }
+        int CurrentAllocs() const       {
+            return _currentAllocs;
+        }
+
+        virtual void* Alloc() {
+            if (!_root) {
+                // Need a new block.
+                Block* block = new Block();
+                _blockPtrs.Push(block);
+
+                Item* blockItems = block->items;
+                for (int i = 0; i < ITEMS_PER_BLOCK - 1; ++i) {
+                    blockItems[i].next = &(blockItems[i + 1]);
+                }
+                blockItems[ITEMS_PER_BLOCK - 1].next = 0;
+                _root = blockItems;
+            }
+            Item* const result = _root;
+            TIXMLASSERT(result != 0);
+            _root = _root->next;
+
+            ++_currentAllocs;
+            if (_currentAllocs > _maxAllocs) {
+                _maxAllocs = _currentAllocs;
+            }
+            ++_nAllocs;
+            ++_nUntracked;
+            return result;
+        }
+
+        virtual void Free(void* mem) {
+            if (!mem) {
+                return;
+            }
+            --_currentAllocs;
+            Item* item = static_cast<Item*>(mem);
 #ifdef TINYXML2_DEBUG
-        memset( item, 0xfe, sizeof( *item ) );
+            memset(item, 0xfe, sizeof(*item));
 #endif
-        item->next = _root;
-        _root = item;
-    }
-    void Trace( const char* name ) {
-        printf( "Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
-                name, _maxAllocs, _maxAllocs * ITEM_SIZE / 1024, _currentAllocs,
-                ITEM_SIZE, _nAllocs, _blockPtrs.Size() );
-    }
+            item->next = _root;
+            _root = item;
+        }
+        void Trace(const char* name) {
+            printf("Mempool %s watermark=%d [%dk] current=%d size=%d nAlloc=%d blocks=%d\n",
+                   name, _maxAllocs, _maxAllocs * ITEM_SIZE / 1024, _currentAllocs,
+                   ITEM_SIZE, _nAllocs, _blockPtrs.Size());
+        }
 
-    void SetTracked() {
-        --_nUntracked;
-    }
+        void SetTracked() {
+            --_nUntracked;
+        }
 
-    int Untracked() const {
-        return _nUntracked;
-    }
+        int Untracked() const {
+            return _nUntracked;
+        }
 
-	// This number is perf sensitive. 4k seems like a good tradeoff on my machine.
-	// The test file is large, 170k.
-	// Release:		VS2010 gcc(no opt)
-	//		1k:		4000
-	//		2k:		4000
-	//		4k:		3900	21000
-	//		16k:	5200
-	//		32k:	4300
-	//		64k:	4000	21000
-    // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
-    // in private part if ITEMS_PER_BLOCK is private
-    enum { ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE };
+        // This number is perf sensitive. 4k seems like a good tradeoff on my machine.
+        // The test file is large, 170k.
+        // Release:     VS2010 gcc(no opt)
+        //      1k:     4000
+        //      2k:     4000
+        //      4k:     3900    21000
+        //      16k:    5200
+        //      32k:    4300
+        //      64k:    4000    21000
+        // Declared public because some compilers do not accept to use ITEMS_PER_BLOCK
+        // in private part if ITEMS_PER_BLOCK is private
+        enum { ITEMS_PER_BLOCK = (4 * 1024) / ITEM_SIZE };
 
-private:
-    MemPoolT( const MemPoolT& ); // not supported
-    void operator=( const MemPoolT& ); // not supported
+    private:
+        MemPoolT(const MemPoolT&);   // not supported
+        void operator=(const MemPoolT&);   // not supported
 
-    union Item {
-        Item*   next;
-        char    itemData[ITEM_SIZE];
+        union Item {
+            Item*   next;
+            char    itemData[ITEM_SIZE];
+        };
+        struct Block {
+            Item items[ITEMS_PER_BLOCK];
+        };
+        DynArray< Block*, 10 > _blockPtrs;
+        Item* _root;
+
+        int _currentAllocs;
+        int _nAllocs;
+        int _maxAllocs;
+        int _nUntracked;
     };
-    struct Block {
-        Item items[ITEMS_PER_BLOCK];
+
+
+
+    /**
+        Implements the interface to the "Visitor pattern" (see the Accept() method.)
+        If you call the Accept() method, it requires being passed a XMLVisitor
+        class to handle callbacks. For nodes that contain other nodes (Document, Element)
+        you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
+        are simply called with Visit().
+
+        If you return 'true' from a Visit method, recursive parsing will continue. If you return
+        false, <b>no children of this node or its siblings</b> will be visited.
+
+        All flavors of Visit methods have a default implementation that returns 'true' (continue
+        visiting). You need to only override methods that are interesting to you.
+
+        Generally Accept() is called on the XMLDocument, although all nodes support visiting.
+
+        You should never change the document from a callback.
+
+        @sa XMLNode::Accept()
+    */
+    class TINYXML2_LIB XMLVisitor {
+    public:
+        virtual ~XMLVisitor() {}
+
+        /// Visit a document.
+        virtual bool VisitEnter(const XMLDocument& /*doc*/)            {
+            return true;
+        }
+        /// Visit a document.
+        virtual bool VisitExit(const XMLDocument& /*doc*/)         {
+            return true;
+        }
+
+        /// Visit an element.
+        virtual bool VisitEnter(const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/) {
+            return true;
+        }
+        /// Visit an element.
+        virtual bool VisitExit(const XMLElement& /*element*/)          {
+            return true;
+        }
+
+        /// Visit a declaration.
+        virtual bool Visit(const XMLDeclaration& /*declaration*/)      {
+            return true;
+        }
+        /// Visit a text node.
+        virtual bool Visit(const XMLText& /*text*/)                    {
+            return true;
+        }
+        /// Visit a comment node.
+        virtual bool Visit(const XMLComment& /*comment*/)              {
+            return true;
+        }
+        /// Visit an unknown node.
+        virtual bool Visit(const XMLUnknown& /*unknown*/)              {
+            return true;
+        }
     };
-    DynArray< Block*, 10 > _blockPtrs;
-    Item* _root;
-
-    int _currentAllocs;
-    int _nAllocs;
-    int _maxAllocs;
-    int _nUntracked;
-};
-
-
-
-/**
-	Implements the interface to the "Visitor pattern" (see the Accept() method.)
-	If you call the Accept() method, it requires being passed a XMLVisitor
-	class to handle callbacks. For nodes that contain other nodes (Document, Element)
-	you will get called with a VisitEnter/VisitExit pair. Nodes that are always leafs
-	are simply called with Visit().
-
-	If you return 'true' from a Visit method, recursive parsing will continue. If you return
-	false, <b>no children of this node or its siblings</b> will be visited.
-
-	All flavors of Visit methods have a default implementation that returns 'true' (continue
-	visiting). You need to only override methods that are interesting to you.
-
-	Generally Accept() is called on the XMLDocument, although all nodes support visiting.
-
-	You should never change the document from a callback.
-
-	@sa XMLNode::Accept()
-*/
-class TINYXML2_LIB XMLVisitor
-{
-public:
-    virtual ~XMLVisitor() {}
-
-    /// Visit a document.
-    virtual bool VisitEnter( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-    /// Visit a document.
-    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-
-    /// Visit an element.
-    virtual bool VisitEnter( const XMLElement& /*element*/, const XMLAttribute* /*firstAttribute*/ )	{
-        return true;
-    }
-    /// Visit an element.
-    virtual bool VisitExit( const XMLElement& /*element*/ )			{
-        return true;
-    }
-
-    /// Visit a declaration.
-    virtual bool Visit( const XMLDeclaration& /*declaration*/ )		{
-        return true;
-    }
-    /// Visit a text node.
-    virtual bool Visit( const XMLText& /*text*/ )					{
-        return true;
-    }
-    /// Visit a comment node.
-    virtual bool Visit( const XMLComment& /*comment*/ )				{
-        return true;
-    }
-    /// Visit an unknown node.
-    virtual bool Visit( const XMLUnknown& /*unknown*/ )				{
-        return true;
-    }
-};
 
 // WARNING: must match XMLDocument::_errorNames[]
-enum XMLError {
-    XML_SUCCESS = 0,
-    XML_NO_ATTRIBUTE,
-    XML_WRONG_ATTRIBUTE_TYPE,
-    XML_ERROR_FILE_NOT_FOUND,
-    XML_ERROR_FILE_COULD_NOT_BE_OPENED,
-    XML_ERROR_FILE_READ_ERROR,
-    UNUSED_XML_ERROR_ELEMENT_MISMATCH,	// remove at next major version
-    XML_ERROR_PARSING_ELEMENT,
-    XML_ERROR_PARSING_ATTRIBUTE,
-    UNUSED_XML_ERROR_IDENTIFYING_TAG,	// remove at next major version
-    XML_ERROR_PARSING_TEXT,
-    XML_ERROR_PARSING_CDATA,
-    XML_ERROR_PARSING_COMMENT,
-    XML_ERROR_PARSING_DECLARATION,
-    XML_ERROR_PARSING_UNKNOWN,
-    XML_ERROR_EMPTY_DOCUMENT,
-    XML_ERROR_MISMATCHED_ELEMENT,
-    XML_ERROR_PARSING,
-    XML_CAN_NOT_CONVERT_TEXT,
-    XML_NO_TEXT_NODE,
-
-	XML_ERROR_COUNT
-};
-
-
-/*
-	Utility functionality.
-*/
-class TINYXML2_LIB XMLUtil
-{
-public:
-    static const char* SkipWhiteSpace( const char* p, int* curLineNumPtr )	{
-        TIXMLASSERT( p );
-
-        while( IsWhiteSpace(*p) ) {
-            if (curLineNumPtr && *p == '\n') {
-                ++(*curLineNumPtr);
-            }
-            ++p;
-        }
-        TIXMLASSERT( p );
-        return p;
-    }
-    static char* SkipWhiteSpace( char* p, int* curLineNumPtr )				{
-        return const_cast<char*>( SkipWhiteSpace( const_cast<const char*>(p), curLineNumPtr ) );
-    }
-
-    // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
-    // correct, but simple, and usually works.
-    static bool IsWhiteSpace( char p )					{
-        return !IsUTF8Continuation(p) && isspace( static_cast<unsigned char>(p) );
-    }
-    
-    inline static bool IsNameStartChar( unsigned char ch ) {
-        if ( ch >= 128 ) {
-            // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
-            return true;
-        }
-        if ( isalpha( ch ) ) {
-            return true;
-        }
-        return ch == ':' || ch == '_';
-    }
-    
-    inline static bool IsNameChar( unsigned char ch ) {
-        return IsNameStartChar( ch )
-               || isdigit( ch )
-               || ch == '.'
-               || ch == '-';
-    }
-
-    inline static bool StringEqual( const char* p, const char* q, int nChar=INT_MAX )  {
-        if ( p == q ) {
-            return true;
-        }
-        TIXMLASSERT( p );
-        TIXMLASSERT( q );
-        TIXMLASSERT( nChar >= 0 );
-        return strncmp( p, q, nChar ) == 0;
-    }
-    
-    inline static bool IsUTF8Continuation( char p ) {
-        return ( p & 0x80 ) != 0;
-    }
-
-    static const char* ReadBOM( const char* p, bool* hasBOM );
-    // p is the starting location,
-    // the UTF-8 value of the entity will be placed in value, and length filled in.
-    static const char* GetCharacterRef( const char* p, char* value, int* length );
-    static void ConvertUTF32ToUTF8( unsigned long input, char* output, int* length );
-
-    // converts primitive types to strings
-    static void ToStr( int v, char* buffer, int bufferSize );
-    static void ToStr( unsigned v, char* buffer, int bufferSize );
-    static void ToStr( bool v, char* buffer, int bufferSize );
-    static void ToStr( float v, char* buffer, int bufferSize );
-    static void ToStr( double v, char* buffer, int bufferSize );
-	static void ToStr(int64_t v, char* buffer, int bufferSize);
-
-    // converts strings to primitive types
-    static bool	ToInt( const char* str, int* value );
-    static bool ToUnsigned( const char* str, unsigned* value );
-    static bool	ToBool( const char* str, bool* value );
-    static bool	ToFloat( const char* str, float* value );
-    static bool ToDouble( const char* str, double* value );
-	static bool ToInt64(const char* str, int64_t* value);
-
-	// Changes what is serialized for a boolean value.
-	// Default to "true" and "false". Shouldn't be changed
-	// unless you have a special testing or compatibility need.
-	// Be careful: static, global, & not thread safe.
-	// Be sure to set static const memory as parameters.
-	static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
-
-private:
-	static const char* writeBoolTrue;
-	static const char* writeBoolFalse;
-};
-
-
-/** XMLNode is a base class for every object that is in the
-	XML Document Object Model (DOM), except XMLAttributes.
-	Nodes have siblings, a parent, and children which can
-	be navigated. A node is always in a XMLDocument.
-	The type of a XMLNode can be queried, and it can
-	be cast to its more defined type.
-
-	A XMLDocument allocates memory for all its Nodes.
-	When the XMLDocument gets deleted, all its Nodes
-	will also be deleted.
-
-	@verbatim
-	A Document can contain:	Element	(container or leaf)
-							Comment (leaf)
-							Unknown (leaf)
-							Declaration( leaf )
-
-	An Element can contain:	Element (container or leaf)
-							Text	(leaf)
-							Attributes (not on tree)
-							Comment (leaf)
-							Unknown (leaf)
-
-	@endverbatim
-*/
-class TINYXML2_LIB XMLNode
-{
-    friend class XMLDocument;
-    friend class XMLElement;
-public:
-
-    /// Get the XMLDocument that owns this XMLNode.
-    const XMLDocument* GetDocument() const	{
-        TIXMLASSERT( _document );
-        return _document;
-    }
-    /// Get the XMLDocument that owns this XMLNode.
-    XMLDocument* GetDocument()				{
-        TIXMLASSERT( _document );
-        return _document;
-    }
-
-    /// Safely cast to an Element, or null.
-    virtual XMLElement*		ToElement()		{
-        return 0;
-    }
-    /// Safely cast to Text, or null.
-    virtual XMLText*		ToText()		{
-        return 0;
-    }
-    /// Safely cast to a Comment, or null.
-    virtual XMLComment*		ToComment()		{
-        return 0;
-    }
-    /// Safely cast to a Document, or null.
-    virtual XMLDocument*	ToDocument()	{
-        return 0;
-    }
-    /// Safely cast to a Declaration, or null.
-    virtual XMLDeclaration*	ToDeclaration()	{
-        return 0;
-    }
-    /// Safely cast to an Unknown, or null.
-    virtual XMLUnknown*		ToUnknown()		{
-        return 0;
-    }
-
-    virtual const XMLElement*		ToElement() const		{
-        return 0;
-    }
-    virtual const XMLText*			ToText() const			{
-        return 0;
-    }
-    virtual const XMLComment*		ToComment() const		{
-        return 0;
-    }
-    virtual const XMLDocument*		ToDocument() const		{
-        return 0;
-    }
-    virtual const XMLDeclaration*	ToDeclaration() const	{
-        return 0;
-    }
-    virtual const XMLUnknown*		ToUnknown() const		{
-        return 0;
-    }
-
-    /** The meaning of 'value' changes for the specific type.
-    	@verbatim
-    	Document:	empty (NULL is returned, not an empty string)
-    	Element:	name of the element
-    	Comment:	the comment text
-    	Unknown:	the tag contents
-    	Text:		the text string
-    	@endverbatim
-    */
-    const char* Value() const;
-
-    /** Set the Value of an XML node.
-    	@sa Value()
-    */
-    void SetValue( const char* val, bool staticMem=false );
-
-    /// Gets the line number the node is in, if the document was parsed from a file.
-    int GetLineNum() const { return _parseLineNum; }
-
-    /// Get the parent of this node on the DOM.
-    const XMLNode*	Parent() const			{
-        return _parent;
-    }
-
-    XMLNode* Parent()						{
-        return _parent;
-    }
-
-    /// Returns true if this node has no children.
-    bool NoChildren() const					{
-        return !_firstChild;
-    }
-
-    /// Get the first child node, or null if none exists.
-    const XMLNode*  FirstChild() const		{
-        return _firstChild;
-    }
-
-    XMLNode*		FirstChild()			{
-        return _firstChild;
-    }
-
-    /** Get the first child element, or optionally the first child
-        element with the specified name.
-    */
-    const XMLElement* FirstChildElement( const char* name = 0 ) const;
-
-    XMLElement* FirstChildElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement( name ));
-    }
-
-    /// Get the last child node, or null if none exists.
-    const XMLNode*	LastChild() const						{
-        return _lastChild;
-    }
-
-    XMLNode*		LastChild()								{
-        return _lastChild;
-    }
-
-    /** Get the last child element or optionally the last child
-        element with the specified name.
-    */
-    const XMLElement* LastChildElement( const char* name = 0 ) const;
-
-    XMLElement* LastChildElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(name) );
-    }
-
-    /// Get the previous (left) sibling node of this node.
-    const XMLNode*	PreviousSibling() const					{
-        return _prev;
-    }
-
-    XMLNode*	PreviousSibling()							{
-        return _prev;
-    }
-
-    /// Get the previous (left) sibling element of this node, with an optionally supplied name.
-    const XMLElement*	PreviousSiblingElement( const char* name = 0 ) const ;
-
-    XMLElement*	PreviousSiblingElement( const char* name = 0 ) {
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement( name ) );
-    }
-
-    /// Get the next (right) sibling node of this node.
-    const XMLNode*	NextSibling() const						{
-        return _next;
-    }
-
-    XMLNode*	NextSibling()								{
-        return _next;
-    }
-
-    /// Get the next (right) sibling element of this node, with an optionally supplied name.
-    const XMLElement*	NextSiblingElement( const char* name = 0 ) const;
-
-    XMLElement*	NextSiblingElement( const char* name = 0 )	{
-        return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement( name ) );
-    }
-
-    /**
-    	Add a child node as the last (right) child.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the node does not
-		belong to the same document.
-    */
-    XMLNode* InsertEndChild( XMLNode* addThis );
-
-    XMLNode* LinkEndChild( XMLNode* addThis )	{
-        return InsertEndChild( addThis );
-    }
-    /**
-    	Add a child node as the first (left) child.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the node does not
-		belong to the same document.
-    */
-    XMLNode* InsertFirstChild( XMLNode* addThis );
-    /**
-    	Add a node after the specified child node.
-		If the child node is already part of the document,
-		it is moved from its old location to the new location.
-		Returns the addThis argument or 0 if the afterThis node
-		is not a child of this node, or if the node does not
-		belong to the same document.
-    */
-    XMLNode* InsertAfterChild( XMLNode* afterThis, XMLNode* addThis );
-
-    /**
-    	Delete all the children of this node.
-    */
-    void DeleteChildren();
-
-    /**
-    	Delete a child of this node.
-    */
-    void DeleteChild( XMLNode* node );
-
-    /**
-    	Make a copy of this node, but not its children.
-    	You may pass in a Document pointer that will be
-    	the owner of the new Node. If the 'document' is
-    	null, then the node returned will be allocated
-    	from the current Document. (this->GetDocument())
-
-    	Note: if called on a XMLDocument, this will return null.
-    */
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const = 0;
-
-	/**
-		Make a copy of this node and all its children.
-
-		If the 'target' is null, then the nodes will
-		be allocated in the current document. If 'target' 
-        is specified, the memory will be allocated is the 
-        specified XMLDocument.
-
-		NOTE: This is probably not the correct tool to 
-		copy a document, since XMLDocuments can have multiple
-		top level XMLNodes. You probably want to use
-        XMLDocument::DeepCopy()
-	*/
-	XMLNode* DeepClone( XMLDocument* target ) const;
-
-    /**
-    	Test if 2 nodes are the same, but don't test children.
-    	The 2 nodes do not need to be in the same Document.
-
-    	Note: if called on a XMLDocument, this will return false.
-    */
-    virtual bool ShallowEqual( const XMLNode* compare ) const = 0;
-
-    /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
-    	XML tree will be conditionally visited and the host will be called back
-    	via the XMLVisitor interface.
-
-    	This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
-    	the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
-    	interface versus any other.)
-
-    	The interface has been based on ideas from:
-
-    	- http://www.saxproject.org/
-    	- http://c2.com/cgi/wiki?HierarchicalVisitorPattern
-
-    	Which are both good references for "visiting".
-
-    	An example of using Accept():
-    	@verbatim
-    	XMLPrinter printer;
-    	tinyxmlDoc.Accept( &printer );
-    	const char* xmlcstr = printer.CStr();
-    	@endverbatim
-    */
-    virtual bool Accept( XMLVisitor* visitor ) const = 0;
-
-	/** 
-		Set user data into the XMLNode. TinyXML-2 in 
-		no way processes or interprets user data.
-		It is initially 0.
-	*/
-	void SetUserData(void* userData)	{ _userData = userData; }
-
-	/**
-		Get user data set into the XMLNode. TinyXML-2 in
-		no way processes or interprets user data.
-		It is initially 0.
-	*/
-	void* GetUserData() const			{ return _userData; }
-
-protected:
-    XMLNode( XMLDocument* );
-    virtual ~XMLNode();
-
-    virtual char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
-
-    XMLDocument*	_document;
-    XMLNode*		_parent;
-    mutable StrPair	_value;
-    int             _parseLineNum;
-
-    XMLNode*		_firstChild;
-    XMLNode*		_lastChild;
-
-    XMLNode*		_prev;
-    XMLNode*		_next;
-
-	void*			_userData;
-
-private:
-    MemPool*		_memPool;
-    void Unlink( XMLNode* child );
-    static void DeleteNode( XMLNode* node );
-    void InsertChildPreamble( XMLNode* insertThis ) const;
-    const XMLElement* ToElementWithName( const char* name ) const;
-
-    XMLNode( const XMLNode& );	// not supported
-    XMLNode& operator=( const XMLNode& );	// not supported
-};
-
-
-/** XML text.
-
-	Note that a text node can have child element nodes, for example:
-	@verbatim
-	<root>This is <b>bold</b></root>
-	@endverbatim
-
-	A text node can have 2 ways to output the next. "normal" output
-	and CDATA. It will default to the mode it was parsed from the XML file and
-	you generally want to leave it alone, but you can change the output mode with
-	SetCData() and query it with CData().
-*/
-class TINYXML2_LIB XMLText : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLText* ToText()			{
-        return this;
-    }
-    virtual const XMLText* ToText() const	{
-        return this;
-    }
-
-    /// Declare whether this should be CDATA or standard text.
-    void SetCData( bool isCData )			{
-        _isCData = isCData;
-    }
-    /// Returns true if this is a CDATA text element.
-    bool CData() const						{
-        return _isCData;
-    }
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    XMLText( XMLDocument* doc )	: XMLNode( doc ), _isCData( false )	{}
-    virtual ~XMLText()												{}
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    bool _isCData;
-
-    XMLText( const XMLText& );	// not supported
-    XMLText& operator=( const XMLText& );	// not supported
-};
-
-
-/** An XML Comment. */
-class TINYXML2_LIB XMLComment : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLComment*	ToComment()					{
-        return this;
-    }
-    virtual const XMLComment* ToComment() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    XMLComment( XMLDocument* doc );
-    virtual ~XMLComment();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr);
-
-private:
-    XMLComment( const XMLComment& );	// not supported
-    XMLComment& operator=( const XMLComment& );	// not supported
-};
-
-
-/** In correct XML the declaration is the first entry in the file.
-	@verbatim
-		<?xml version="1.0" standalone="yes"?>
-	@endverbatim
-
-	TinyXML-2 will happily read or write files without a declaration,
-	however.
-
-	The text of the declaration isn't interpreted. It is parsed
-	and written as a string.
-*/
-class TINYXML2_LIB XMLDeclaration : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLDeclaration*	ToDeclaration()					{
-        return this;
-    }
-    virtual const XMLDeclaration* ToDeclaration() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    XMLDeclaration( XMLDocument* doc );
-    virtual ~XMLDeclaration();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLDeclaration( const XMLDeclaration& );	// not supported
-    XMLDeclaration& operator=( const XMLDeclaration& );	// not supported
-};
-
-
-/** Any tag that TinyXML-2 doesn't recognize is saved as an
-	unknown. It is a tag of text, but should not be modified.
-	It will be written back to the XML, unchanged, when the file
-	is saved.
-
-	DTD tags get thrown into XMLUnknowns.
-*/
-class TINYXML2_LIB XMLUnknown : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    virtual XMLUnknown*	ToUnknown()					{
-        return this;
-    }
-    virtual const XMLUnknown* ToUnknown() const		{
-        return this;
-    }
-
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    XMLUnknown( XMLDocument* doc );
-    virtual ~XMLUnknown();
-
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLUnknown( const XMLUnknown& );	// not supported
-    XMLUnknown& operator=( const XMLUnknown& );	// not supported
-};
-
-
-
-/** An attribute is a name-value pair. Elements have an arbitrary
-	number of attributes, each with a unique name.
-
-	@note The attributes are not XMLNodes. You may only query the
-	Next() attribute in a list.
-*/
-class TINYXML2_LIB XMLAttribute
-{
-    friend class XMLElement;
-public:
-    /// The name of the attribute.
-    const char* Name() const;
-
-    /// The value of the attribute.
-    const char* Value() const;
-
-    /// Gets the line number the attribute is in, if the document was parsed from a file.
-    int GetLineNum() const { return _parseLineNum; }
-
-    /// The next attribute in the list.
-    const XMLAttribute* Next() const {
-        return _next;
-    }
-
-    /** IntValue interprets the attribute as an integer, and returns the value.
-        If the value isn't an integer, 0 will be returned. There is no error checking;
-    	use QueryIntValue() if you need error checking.
-    */
-	int	IntValue() const {
-		int i = 0;
-		QueryIntValue(&i);
-		return i;
-	}
-
-	int64_t Int64Value() const {
-		int64_t i = 0;
-		QueryInt64Value(&i);
-		return i;
-	}
-
-    /// Query as an unsigned integer. See IntValue()
-    unsigned UnsignedValue() const			{
-        unsigned i=0;
-        QueryUnsignedValue( &i );
-        return i;
-    }
-    /// Query as a boolean. See IntValue()
-    bool	 BoolValue() const				{
-        bool b=false;
-        QueryBoolValue( &b );
-        return b;
-    }
-    /// Query as a double. See IntValue()
-    double 	 DoubleValue() const			{
-        double d=0;
-        QueryDoubleValue( &d );
-        return d;
-    }
-    /// Query as a float. See IntValue()
-    float	 FloatValue() const				{
-        float f=0;
-        QueryFloatValue( &f );
-        return f;
-    }
-
-    /** QueryIntValue interprets the attribute as an integer, and returns the value
-    	in the provided parameter. The function will return XML_SUCCESS on success,
-    	and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
-    */
-    XMLError QueryIntValue( int* value ) const;
-    /// See QueryIntValue
-    XMLError QueryUnsignedValue( unsigned int* value ) const;
-	/// See QueryIntValue
-	XMLError QueryInt64Value(int64_t* value) const;
-	/// See QueryIntValue
-    XMLError QueryBoolValue( bool* value ) const;
-    /// See QueryIntValue
-    XMLError QueryDoubleValue( double* value ) const;
-    /// See QueryIntValue
-    XMLError QueryFloatValue( float* value ) const;
-
-    /// Set the attribute to a string value.
-    void SetAttribute( const char* value );
-    /// Set the attribute to value.
-    void SetAttribute( int value );
-    /// Set the attribute to value.
-    void SetAttribute( unsigned value );
-	/// Set the attribute to value.
-	void SetAttribute(int64_t value);
-	/// Set the attribute to value.
-    void SetAttribute( bool value );
-    /// Set the attribute to value.
-    void SetAttribute( double value );
-    /// Set the attribute to value.
-    void SetAttribute( float value );
-
-private:
-    enum { BUF_SIZE = 200 };
-
-    XMLAttribute() : _name(), _value(),_parseLineNum( 0 ), _next( 0 ), _memPool( 0 ) {}
-    virtual ~XMLAttribute()	{}
-
-    XMLAttribute( const XMLAttribute& );	// not supported
-    void operator=( const XMLAttribute& );	// not supported
-    void SetName( const char* name );
-
-    char* ParseDeep( char* p, bool processEntities, int* curLineNumPtr );
-
-    mutable StrPair _name;
-    mutable StrPair _value;
-    int             _parseLineNum;
-    XMLAttribute*   _next;
-    MemPool*        _memPool;
-};
-
-
-/** The element is a container class. It has a value, the element name,
-	and can contain other elements, text, comments, and unknowns.
-	Elements also contain an arbitrary number of attributes.
-*/
-class TINYXML2_LIB XMLElement : public XMLNode
-{
-    friend class XMLDocument;
-public:
-    /// Get the name of an element (which is the Value() of the node.)
-    const char* Name() const		{
-        return Value();
-    }
-    /// Set the name of the element.
-    void SetName( const char* str, bool staticMem=false )	{
-        SetValue( str, staticMem );
-    }
-
-    virtual XMLElement* ToElement()				{
-        return this;
-    }
-    virtual const XMLElement* ToElement() const {
-        return this;
-    }
-    virtual bool Accept( XMLVisitor* visitor ) const;
-
-    /** Given an attribute name, Attribute() returns the value
-    	for the attribute of that name, or null if none
-    	exists. For example:
-
-    	@verbatim
-    	const char* value = ele->Attribute( "foo" );
-    	@endverbatim
-
-    	The 'value' parameter is normally null. However, if specified,
-    	the attribute will only be returned if the 'name' and 'value'
-    	match. This allow you to write code:
-
-    	@verbatim
-    	if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
-    	@endverbatim
-
-    	rather than:
-    	@verbatim
-    	if ( ele->Attribute( "foo" ) ) {
-    		if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
-    	}
-    	@endverbatim
-    */
-    const char* Attribute( const char* name, const char* value=0 ) const;
-
-    /** Given an attribute name, IntAttribute() returns the value
-    	of the attribute interpreted as an integer. The default
-        value will be returned if the attribute isn't present,
-        or if there is an error. (For a method with error
-    	checking, see QueryIntAttribute()).
-    */
-	int IntAttribute(const char* name, int defaultValue = 0) const;
-    /// See IntAttribute()
-	unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
-	/// See IntAttribute()
-	int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
-	/// See IntAttribute()
-	bool BoolAttribute(const char* name, bool defaultValue = false) const;
-    /// See IntAttribute()
-	double DoubleAttribute(const char* name, double defaultValue = 0) const;
-    /// See IntAttribute()
-	float FloatAttribute(const char* name, float defaultValue = 0) const;
-
-    /** Given an attribute name, QueryIntAttribute() returns
-    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
-    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
-    	doesn't exist. If successful, the result of the conversion
-    	will be written to 'value'. If not successful, nothing will
-    	be written to 'value'. This allows you to provide default
-    	value:
-
-    	@verbatim
-    	int value = 10;
-    	QueryIntAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
-    	@endverbatim
-    */
-    XMLError QueryIntAttribute( const char* name, int* value ) const				{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryIntValue( value );
-    }
-
-	/// See QueryIntAttribute()
-    XMLError QueryUnsignedAttribute( const char* name, unsigned int* value ) const	{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryUnsignedValue( value );
-    }
-
-	/// See QueryIntAttribute()
-	XMLError QueryInt64Attribute(const char* name, int64_t* value) const {
-		const XMLAttribute* a = FindAttribute(name);
-		if (!a) {
-			return XML_NO_ATTRIBUTE;
-		}
-		return a->QueryInt64Value(value);
-	}
-
-	/// See QueryIntAttribute()
-    XMLError QueryBoolAttribute( const char* name, bool* value ) const				{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryBoolValue( value );
-    }
-    /// See QueryIntAttribute()
-    XMLError QueryDoubleAttribute( const char* name, double* value ) const			{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryDoubleValue( value );
-    }
-    /// See QueryIntAttribute()
-    XMLError QueryFloatAttribute( const char* name, float* value ) const			{
-        const XMLAttribute* a = FindAttribute( name );
-        if ( !a ) {
-            return XML_NO_ATTRIBUTE;
-        }
-        return a->QueryFloatValue( value );
-    }
-
-	/// See QueryIntAttribute()
-	XMLError QueryStringAttribute(const char* name, const char** value) const {
-		const XMLAttribute* a = FindAttribute(name);
-		if (!a) {
-			return XML_NO_ATTRIBUTE;
-		}
-		*value = a->Value();
-		return XML_SUCCESS;
-	}
-
-
-	
-    /** Given an attribute name, QueryAttribute() returns
-    	XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
-    	can't be performed, or XML_NO_ATTRIBUTE if the attribute
-    	doesn't exist. It is overloaded for the primitive types,
-		and is a generally more convenient replacement of
-		QueryIntAttribute() and related functions.
-		
-		If successful, the result of the conversion
-    	will be written to 'value'. If not successful, nothing will
-    	be written to 'value'. This allows you to provide default
-    	value:
-
-    	@verbatim
-    	int value = 10;
-    	QueryAttribute( "foo", &value );		// if "foo" isn't found, value will still be 10
-    	@endverbatim
-    */
-	int QueryAttribute( const char* name, int* value ) const {
-		return QueryIntAttribute( name, value );
-	}
-
-	int QueryAttribute( const char* name, unsigned int* value ) const {
-		return QueryUnsignedAttribute( name, value );
-	}
-
-	int QueryAttribute(const char* name, int64_t* value) const {
-		return QueryInt64Attribute(name, value);
-	}
-
-	int QueryAttribute( const char* name, bool* value ) const {
-		return QueryBoolAttribute( name, value );
-	}
-
-	int QueryAttribute( const char* name, double* value ) const {
-		return QueryDoubleAttribute( name, value );
-	}
-
-	int QueryAttribute( const char* name, float* value ) const {
-		return QueryFloatAttribute( name, value );
-	}
-
-	/// Sets the named attribute to value.
-    void SetAttribute( const char* name, const char* value )	{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, int value )			{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, unsigned value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-
-	/// Sets the named attribute to value.
-	void SetAttribute(const char* name, int64_t value) {
-		XMLAttribute* a = FindOrCreateAttribute(name);
-		a->SetAttribute(value);
-	}
-
-	/// Sets the named attribute to value.
-    void SetAttribute( const char* name, bool value )			{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, double value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-    /// Sets the named attribute to value.
-    void SetAttribute( const char* name, float value )		{
-        XMLAttribute* a = FindOrCreateAttribute( name );
-        a->SetAttribute( value );
-    }
-
-    /**
-    	Delete an attribute.
-    */
-    void DeleteAttribute( const char* name );
-
-    /// Return the first attribute in the list.
-    const XMLAttribute* FirstAttribute() const {
-        return _rootAttribute;
-    }
-    /// Query a specific attribute in the list.
-    const XMLAttribute* FindAttribute( const char* name ) const;
-
-    /** Convenience function for easy access to the text inside an element. Although easy
-    	and concise, GetText() is limited compared to getting the XMLText child
-    	and accessing it directly.
-
-    	If the first child of 'this' is a XMLText, the GetText()
-    	returns the character string of the Text node, else null is returned.
-
-    	This is a convenient method for getting the text of simple contained text:
-    	@verbatim
-    	<foo>This is text</foo>
-    		const char* str = fooElement->GetText();
-    	@endverbatim
-
-    	'str' will be a pointer to "This is text".
-
-    	Note that this function can be misleading. If the element foo was created from
-    	this XML:
-    	@verbatim
-    		<foo><b>This is text</b></foo>
-    	@endverbatim
-
-    	then the value of str would be null. The first child node isn't a text node, it is
-    	another element. From this XML:
-    	@verbatim
-    		<foo>This is <b>text</b></foo>
-    	@endverbatim
-    	GetText() will return "This is ".
-    */
-    const char* GetText() const;
-
-    /** Convenience function for easy access to the text inside an element. Although easy
-    	and concise, SetText() is limited compared to creating an XMLText child
-    	and mutating it directly.
-
-    	If the first child of 'this' is a XMLText, SetText() sets its value to
-		the given string, otherwise it will create a first child that is an XMLText.
-
-    	This is a convenient method for setting the text of simple contained text:
-    	@verbatim
-    	<foo>This is text</foo>
-    		fooElement->SetText( "Hullaballoo!" );
-     	<foo>Hullaballoo!</foo>
-		@endverbatim
-
-    	Note that this function can be misleading. If the element foo was created from
-    	this XML:
-    	@verbatim
-    		<foo><b>This is text</b></foo>
-    	@endverbatim
-
-    	then it will not change "This is text", but rather prefix it with a text element:
-    	@verbatim
-    		<foo>Hullaballoo!<b>This is text</b></foo>
-    	@endverbatim
-		
-		For this XML:
-    	@verbatim
-    		<foo />
-    	@endverbatim
-    	SetText() will generate
-    	@verbatim
-    		<foo>Hullaballoo!</foo>
-    	@endverbatim
-    */
-	void SetText( const char* inText );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( int value );
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( unsigned value );  
-	/// Convenience method for setting text inside an element. See SetText() for important limitations.
-	void SetText(int64_t value);
-	/// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( bool value );  
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( double value );  
-    /// Convenience method for setting text inside an element. See SetText() for important limitations.
-    void SetText( float value );  
-
-    /**
-    	Convenience method to query the value of a child text node. This is probably best
-    	shown by example. Given you have a document is this form:
-    	@verbatim
-    		<point>
-    			<x>1</x>
-    			<y>1.4</y>
-    		</point>
-    	@endverbatim
-
-    	The QueryIntText() and similar functions provide a safe and easier way to get to the
-    	"value" of x and y.
-
-    	@verbatim
-    		int x = 0;
-    		float y = 0;	// types of x and y are contrived for example
-    		const XMLElement* xElement = pointElement->FirstChildElement( "x" );
-    		const XMLElement* yElement = pointElement->FirstChildElement( "y" );
-    		xElement->QueryIntText( &x );
-    		yElement->QueryFloatText( &y );
-    	@endverbatim
-
-    	@returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
-    			 to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
-
-    */
-    XMLError QueryIntText( int* ival ) const;
-    /// See QueryIntText()
-    XMLError QueryUnsignedText( unsigned* uval ) const;
-	/// See QueryIntText()
-	XMLError QueryInt64Text(int64_t* uval) const;
-	/// See QueryIntText()
-    XMLError QueryBoolText( bool* bval ) const;
-    /// See QueryIntText()
-    XMLError QueryDoubleText( double* dval ) const;
-    /// See QueryIntText()
-    XMLError QueryFloatText( float* fval ) const;
-
-	int IntText(int defaultValue = 0) const;
-
-	/// See QueryIntText()
-	unsigned UnsignedText(unsigned defaultValue = 0) const;
-	/// See QueryIntText()
-	int64_t Int64Text(int64_t defaultValue = 0) const;
-	/// See QueryIntText()
-	bool BoolText(bool defaultValue = false) const;
-	/// See QueryIntText()
-	double DoubleText(double defaultValue = 0) const;
-	/// See QueryIntText()
-	float FloatText(float defaultValue = 0) const;
-
-    // internal:
-    enum ElementClosingType {
-        OPEN,		// <foo>
-        CLOSED,		// <foo/>
-        CLOSING		// </foo>
+    enum XMLError {
+        XML_SUCCESS = 0,
+        XML_NO_ATTRIBUTE,
+        XML_WRONG_ATTRIBUTE_TYPE,
+        XML_ERROR_FILE_NOT_FOUND,
+        XML_ERROR_FILE_COULD_NOT_BE_OPENED,
+        XML_ERROR_FILE_READ_ERROR,
+        XML_ERROR_PARSING_ELEMENT,
+        XML_ERROR_PARSING_ATTRIBUTE,
+        XML_ERROR_PARSING_TEXT,
+        XML_ERROR_PARSING_CDATA,
+        XML_ERROR_PARSING_COMMENT,
+        XML_ERROR_PARSING_DECLARATION,
+        XML_ERROR_PARSING_UNKNOWN,
+        XML_ERROR_EMPTY_DOCUMENT,
+        XML_ERROR_MISMATCHED_ELEMENT,
+        XML_ERROR_PARSING,
+        XML_CAN_NOT_CONVERT_TEXT,
+        XML_NO_TEXT_NODE,
+        XML_ELEMENT_DEPTH_EXCEEDED,
+
+        XML_ERROR_COUNT
     };
-    ElementClosingType ClosingType() const {
-        return _closingType;
-    }
-    virtual XMLNode* ShallowClone( XMLDocument* document ) const;
-    virtual bool ShallowEqual( const XMLNode* compare ) const;
-
-protected:
-    char* ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr );
-
-private:
-    XMLElement( XMLDocument* doc );
-    virtual ~XMLElement();
-    XMLElement( const XMLElement& );	// not supported
-    void operator=( const XMLElement& );	// not supported
-
-    XMLAttribute* FindAttribute( const char* name ) {
-        return const_cast<XMLAttribute*>(const_cast<const XMLElement*>(this)->FindAttribute( name ));
-    }
-    XMLAttribute* FindOrCreateAttribute( const char* name );
-    //void LinkAttribute( XMLAttribute* attrib );
-    char* ParseAttributes( char* p, int* curLineNumPtr );
-    static void DeleteAttribute( XMLAttribute* attribute );
-    XMLAttribute* CreateAttribute();
-
-    enum { BUF_SIZE = 200 };
-    ElementClosingType _closingType;
-    // The attribute list is ordered; there is no 'lastAttribute'
-    // because the list needs to be scanned for dupes before adding
-    // a new attribute.
-    XMLAttribute* _rootAttribute;
-};
 
 
-enum Whitespace {
-    PRESERVE_WHITESPACE,
-    COLLAPSE_WHITESPACE
-};
-
-
-/** A Document binds together all the functionality.
-	It can be saved, loaded, and printed to the screen.
-	All Nodes are connected and allocated to a Document.
-	If the Document is deleted, all its Nodes are also deleted.
-*/
-class TINYXML2_LIB XMLDocument : public XMLNode
-{
-    friend class XMLElement;
-    // Gives access to SetError, but over-access for everything else.
-    // Wishing C++ had "internal" scope.
-    friend class XMLNode;       
-    friend class XMLText;
-    friend class XMLComment;
-    friend class XMLDeclaration;
-    friend class XMLUnknown;
-public:
-    /// constructor
-    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
-    ~XMLDocument();
-
-    virtual XMLDocument* ToDocument()				{
-        TIXMLASSERT( this == _document );
-        return this;
-    }
-    virtual const XMLDocument* ToDocument() const	{
-        TIXMLASSERT( this == _document );
-        return this;
-    }
-
-    /**
-    	Parse an XML file from a character string.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
-
-    	You may optionally pass in the 'nBytes', which is
-    	the number of bytes which will be parsed. If not
-    	specified, TinyXML-2 will assume 'xml' points to a
-    	null terminated string.
+    /*
+        Utility functionality.
     */
-    XMLError Parse( const char* xml, size_t nBytes=(size_t)(-1) );
+    class TINYXML2_LIB XMLUtil {
+    public:
+        static const char* SkipWhiteSpace(const char* p, int* curLineNumPtr)   {
+            TIXMLASSERT(p);
 
-    /**
-    	Load an XML file from disk.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
+            while (IsWhiteSpace(*p)) {
+                if (curLineNumPtr && *p == '\n') {
+                    ++(*curLineNumPtr);
+                }
+                ++p;
+            }
+            TIXMLASSERT(p);
+            return p;
+        }
+        static char* SkipWhiteSpace(char* const p, int* curLineNumPtr) {
+            return const_cast<char*>(SkipWhiteSpace(const_cast<const char*>(p), curLineNumPtr));
+        }
+
+        // Anything in the high order range of UTF-8 is assumed to not be whitespace. This isn't
+        // correct, but simple, and usually works.
+        static bool IsWhiteSpace(char p)                   {
+            return !IsUTF8Continuation(p) && isspace(static_cast<unsigned char>(p));
+        }
+
+        inline static bool IsNameStartChar(unsigned char ch) {
+            if (ch >= 128) {
+                // This is a heuristic guess in attempt to not implement Unicode-aware isalpha()
+                return true;
+            }
+            if (isalpha(ch)) {
+                return true;
+            }
+            return ch == ':' || ch == '_';
+        }
+
+        inline static bool IsNameChar(unsigned char ch) {
+            return IsNameStartChar(ch)
+                   || isdigit(ch)
+                   || ch == '.'
+                   || ch == '-';
+        }
+
+        inline static bool StringEqual(const char* p, const char* q, int nChar=INT_MAX)  {
+            if (p == q) {
+                return true;
+            }
+            TIXMLASSERT(p);
+            TIXMLASSERT(q);
+            TIXMLASSERT(nChar >= 0);
+            return strncmp(p, q, nChar) == 0;
+        }
+
+        inline static bool IsUTF8Continuation(const char p) {
+            return (p & 0x80) != 0;
+        }
+
+        static const char* ReadBOM(const char* p, bool* hasBOM);
+        // p is the starting location,
+        // the UTF-8 value of the entity will be placed in value, and length filled in.
+        static const char* GetCharacterRef(const char* p, char* value, int* length);
+        static void ConvertUTF32ToUTF8(unsigned long input, char* output, int* length);
+
+        // converts primitive types to strings
+        static void ToStr(int v, char* buffer, int bufferSize);
+        static void ToStr(unsigned v, char* buffer, int bufferSize);
+        static void ToStr(bool v, char* buffer, int bufferSize);
+        static void ToStr(float v, char* buffer, int bufferSize);
+        static void ToStr(double v, char* buffer, int bufferSize);
+        static void ToStr(int64_t v, char* buffer, int bufferSize);
+        static void ToStr(uint64_t v, char* buffer, int bufferSize);
+
+        // converts strings to primitive types
+        static bool ToInt(const char* str, int* value);
+        static bool ToUnsigned(const char* str, unsigned* value);
+        static bool ToBool(const char* str, bool* value);
+        static bool ToFloat(const char* str, float* value);
+        static bool ToDouble(const char* str, double* value);
+        static bool ToInt64(const char* str, int64_t* value);
+        static bool ToUnsigned64(const char* str, uint64_t* value);
+        // Changes what is serialized for a boolean value.
+        // Default to "true" and "false". Shouldn't be changed
+        // unless you have a special testing or compatibility need.
+        // Be careful: static, global, & not thread safe.
+        // Be sure to set static const memory as parameters.
+        static void SetBoolSerialization(const char* writeTrue, const char* writeFalse);
+
+    private:
+        static const char* writeBoolTrue;
+        static const char* writeBoolFalse;
+    };
+
+
+    /** XMLNode is a base class for every object that is in the
+        XML Document Object Model (DOM), except XMLAttributes.
+        Nodes have siblings, a parent, and children which can
+        be navigated. A node is always in a XMLDocument.
+        The type of a XMLNode can be queried, and it can
+        be cast to its more defined type.
+
+        A XMLDocument allocates memory for all its Nodes.
+        When the XMLDocument gets deleted, all its Nodes
+        will also be deleted.
+
+        @verbatim
+        A Document can contain: Element (container or leaf)
+                                Comment (leaf)
+                                Unknown (leaf)
+                                Declaration( leaf )
+
+        An Element can contain: Element (container or leaf)
+                                Text    (leaf)
+                                Attributes (not on tree)
+                                Comment (leaf)
+                                Unknown (leaf)
+
+        @endverbatim
     */
-    XMLError LoadFile( const char* filename );
+    class TINYXML2_LIB XMLNode {
+        friend class XMLDocument;
+        friend class XMLElement;
+    public:
 
-    /**
-    	Load an XML file from disk. You are responsible
-    	for providing and closing the FILE*. 
-     
-        NOTE: The file should be opened as binary ("rb")
-        not text in order for TinyXML-2 to correctly
-        do newline normalization.
+        /// Get the XMLDocument that owns this XMLNode.
+        const XMLDocument* GetDocument() const  {
+            TIXMLASSERT(_document);
+            return _document;
+        }
+        /// Get the XMLDocument that owns this XMLNode.
+        XMLDocument* GetDocument()              {
+            TIXMLASSERT(_document);
+            return _document;
+        }
 
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
+        /// Safely cast to an Element, or null.
+        virtual XMLElement*     ToElement()     {
+            return 0;
+        }
+        /// Safely cast to Text, or null.
+        virtual XMLText*        ToText()        {
+            return 0;
+        }
+        /// Safely cast to a Comment, or null.
+        virtual XMLComment*     ToComment()     {
+            return 0;
+        }
+        /// Safely cast to a Document, or null.
+        virtual XMLDocument*    ToDocument()    {
+            return 0;
+        }
+        /// Safely cast to a Declaration, or null.
+        virtual XMLDeclaration* ToDeclaration() {
+            return 0;
+        }
+        /// Safely cast to an Unknown, or null.
+        virtual XMLUnknown*     ToUnknown()     {
+            return 0;
+        }
+
+        virtual const XMLElement*       ToElement() const       {
+            return 0;
+        }
+        virtual const XMLText*          ToText() const          {
+            return 0;
+        }
+        virtual const XMLComment*       ToComment() const       {
+            return 0;
+        }
+        virtual const XMLDocument*      ToDocument() const      {
+            return 0;
+        }
+        virtual const XMLDeclaration*   ToDeclaration() const   {
+            return 0;
+        }
+        virtual const XMLUnknown*       ToUnknown() const       {
+            return 0;
+        }
+
+        /** The meaning of 'value' changes for the specific type.
+            @verbatim
+            Document:   empty (NULL is returned, not an empty string)
+            Element:    name of the element
+            Comment:    the comment text
+            Unknown:    the tag contents
+            Text:       the text string
+            @endverbatim
+        */
+        const char* Value() const;
+
+        /** Set the Value of an XML node.
+            @sa Value()
+        */
+        void SetValue(const char* val, bool staticMem=false);
+
+        /// Gets the line number the node is in, if the document was parsed from a file.
+        int GetLineNum() const {
+            return _parseLineNum;
+        }
+
+        /// Get the parent of this node on the DOM.
+        const XMLNode*  Parent() const          {
+            return _parent;
+        }
+
+        XMLNode* Parent()                       {
+            return _parent;
+        }
+
+        /// Returns true if this node has no children.
+        bool NoChildren() const                 {
+            return !_firstChild;
+        }
+
+        /// Get the first child node, or null if none exists.
+        const XMLNode*  FirstChild() const      {
+            return _firstChild;
+        }
+
+        XMLNode*        FirstChild()            {
+            return _firstChild;
+        }
+
+        /** Get the first child element, or optionally the first child
+            element with the specified name.
+        */
+        const XMLElement* FirstChildElement(const char* name = 0) const;
+
+        XMLElement* FirstChildElement(const char* name = 0)    {
+            return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->FirstChildElement(name));
+        }
+
+        /// Get the last child node, or null if none exists.
+        const XMLNode*  LastChild() const                       {
+            return _lastChild;
+        }
+
+        XMLNode*        LastChild()                             {
+            return _lastChild;
+        }
+
+        /** Get the last child element or optionally the last child
+            element with the specified name.
+        */
+        const XMLElement* LastChildElement(const char* name = 0) const;
+
+        XMLElement* LastChildElement(const char* name = 0) {
+            return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->LastChildElement(name));
+        }
+
+        /// Get the previous (left) sibling node of this node.
+        const XMLNode*  PreviousSibling() const                 {
+            return _prev;
+        }
+
+        XMLNode*    PreviousSibling()                           {
+            return _prev;
+        }
+
+        /// Get the previous (left) sibling element of this node, with an optionally supplied name.
+        const XMLElement*   PreviousSiblingElement(const char* name = 0) const ;
+
+        XMLElement* PreviousSiblingElement(const char* name = 0) {
+            return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->PreviousSiblingElement(name));
+        }
+
+        /// Get the next (right) sibling node of this node.
+        const XMLNode*  NextSibling() const                     {
+            return _next;
+        }
+
+        XMLNode*    NextSibling()                               {
+            return _next;
+        }
+
+        /// Get the next (right) sibling element of this node, with an optionally supplied name.
+        const XMLElement*   NextSiblingElement(const char* name = 0) const;
+
+        XMLElement* NextSiblingElement(const char* name = 0)   {
+            return const_cast<XMLElement*>(const_cast<const XMLNode*>(this)->NextSiblingElement(name));
+        }
+
+        /**
+            Add a child node as the last (right) child.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the node does not
+            belong to the same document.
+        */
+        XMLNode* InsertEndChild(XMLNode* addThis);
+
+        XMLNode* LinkEndChild(XMLNode* addThis)    {
+            return InsertEndChild(addThis);
+        }
+        /**
+            Add a child node as the first (left) child.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the node does not
+            belong to the same document.
+        */
+        XMLNode* InsertFirstChild(XMLNode* addThis);
+        /**
+            Add a node after the specified child node.
+            If the child node is already part of the document,
+            it is moved from its old location to the new location.
+            Returns the addThis argument or 0 if the afterThis node
+            is not a child of this node, or if the node does not
+            belong to the same document.
+        */
+        XMLNode* InsertAfterChild(XMLNode* afterThis, XMLNode* addThis);
+
+        /**
+            Delete all the children of this node.
+        */
+        void DeleteChildren();
+
+        /**
+            Delete a child of this node.
+        */
+        void DeleteChild(XMLNode* node);
+
+        /**
+            Make a copy of this node, but not its children.
+            You may pass in a Document pointer that will be
+            the owner of the new Node. If the 'document' is
+            null, then the node returned will be allocated
+            from the current Document. (this->GetDocument())
+
+            Note: if called on a XMLDocument, this will return null.
+        */
+        virtual XMLNode* ShallowClone(XMLDocument* document) const = 0;
+
+        /**
+            Make a copy of this node and all its children.
+
+            If the 'target' is null, then the nodes will
+            be allocated in the current document. If 'target'
+            is specified, the memory will be allocated is the
+            specified XMLDocument.
+
+            NOTE: This is probably not the correct tool to
+            copy a document, since XMLDocuments can have multiple
+            top level XMLNodes. You probably want to use
+            XMLDocument::DeepCopy()
+        */
+        XMLNode* DeepClone(XMLDocument* target) const;
+
+        /**
+            Test if 2 nodes are the same, but don't test children.
+            The 2 nodes do not need to be in the same Document.
+
+            Note: if called on a XMLDocument, this will return false.
+        */
+        virtual bool ShallowEqual(const XMLNode* compare) const = 0;
+
+        /** Accept a hierarchical visit of the nodes in the TinyXML-2 DOM. Every node in the
+            XML tree will be conditionally visited and the host will be called back
+            via the XMLVisitor interface.
+
+            This is essentially a SAX interface for TinyXML-2. (Note however it doesn't re-parse
+            the XML for the callbacks, so the performance of TinyXML-2 is unchanged by using this
+            interface versus any other.)
+
+            The interface has been based on ideas from:
+
+            - http://www.saxproject.org/
+            - http://c2.com/cgi/wiki?HierarchicalVisitorPattern
+
+            Which are both good references for "visiting".
+
+            An example of using Accept():
+            @verbatim
+            XMLPrinter printer;
+            tinyxmlDoc.Accept( &printer );
+            const char* xmlcstr = printer.CStr();
+            @endverbatim
+        */
+        virtual bool Accept(XMLVisitor* visitor) const = 0;
+
+        /**
+            Set user data into the XMLNode. TinyXML-2 in
+            no way processes or interprets user data.
+            It is initially 0.
+        */
+        void SetUserData(void* userData)    {
+            _userData = userData;
+        }
+
+        /**
+            Get user data set into the XMLNode. TinyXML-2 in
+            no way processes or interprets user data.
+            It is initially 0.
+        */
+        void* GetUserData() const           {
+            return _userData;
+        }
+
+    protected:
+        explicit XMLNode(XMLDocument*);
+        virtual ~XMLNode();
+
+        virtual char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+        XMLDocument*    _document;
+        XMLNode*        _parent;
+        mutable StrPair _value;
+        int             _parseLineNum;
+
+        XMLNode*        _firstChild;
+        XMLNode*        _lastChild;
+
+        XMLNode*        _prev;
+        XMLNode*        _next;
+
+        void*           _userData;
+
+    private:
+        MemPool*        _memPool;
+        void Unlink(XMLNode* child);
+        static void DeleteNode(XMLNode* node);
+        void InsertChildPreamble(XMLNode* insertThis) const;
+        const XMLElement* ToElementWithName(const char* name) const;
+
+        XMLNode(const XMLNode&);     // not supported
+        XMLNode& operator=(const XMLNode&);      // not supported
+    };
+
+
+    /** XML text.
+
+        Note that a text node can have child element nodes, for example:
+        @verbatim
+        <root>This is <b>bold</b></root>
+        @endverbatim
+
+        A text node can have 2 ways to output the next. "normal" output
+        and CDATA. It will default to the mode it was parsed from the XML file and
+        you generally want to leave it alone, but you can change the output mode with
+        SetCData() and query it with CData().
     */
-    XMLError LoadFile( FILE* );
+    class TINYXML2_LIB XMLText : public XMLNode {
+        friend class XMLDocument;
+    public:
+        virtual bool Accept(XMLVisitor* visitor) const;
 
-    /**
-    	Save the XML file to disk.
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
+        virtual XMLText* ToText()           {
+            return this;
+        }
+        virtual const XMLText* ToText() const   {
+            return this;
+        }
+
+        /// Declare whether this should be CDATA or standard text.
+        void SetCData(bool isCData)            {
+            _isCData = isCData;
+        }
+        /// Returns true if this is a CDATA text element.
+        bool CData() const                      {
+            return _isCData;
+        }
+
+        virtual XMLNode* ShallowClone(XMLDocument* document) const;
+        virtual bool ShallowEqual(const XMLNode* compare) const;
+
+    protected:
+        explicit XMLText(XMLDocument* doc) : XMLNode(doc), _isCData(false)   {}
+        virtual ~XMLText()                                              {}
+
+        char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    private:
+        bool _isCData;
+
+        XMLText(const XMLText&);     // not supported
+        XMLText& operator=(const XMLText&);      // not supported
+    };
+
+
+    /** An XML Comment. */
+    class TINYXML2_LIB XMLComment : public XMLNode {
+        friend class XMLDocument;
+    public:
+        virtual XMLComment* ToComment()                 {
+            return this;
+        }
+        virtual const XMLComment* ToComment() const     {
+            return this;
+        }
+
+        virtual bool Accept(XMLVisitor* visitor) const;
+
+        virtual XMLNode* ShallowClone(XMLDocument* document) const;
+        virtual bool ShallowEqual(const XMLNode* compare) const;
+
+    protected:
+        explicit XMLComment(XMLDocument* doc);
+        virtual ~XMLComment();
+
+        char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    private:
+        XMLComment(const XMLComment&);   // not supported
+        XMLComment& operator=(const XMLComment&);    // not supported
+    };
+
+
+    /** In correct XML the declaration is the first entry in the file.
+        @verbatim
+            <?xml version="1.0" standalone="yes"?>
+        @endverbatim
+
+        TinyXML-2 will happily read or write files without a declaration,
+        however.
+
+        The text of the declaration isn't interpreted. It is parsed
+        and written as a string.
     */
-    XMLError SaveFile( const char* filename, bool compact = false );
+    class TINYXML2_LIB XMLDeclaration : public XMLNode {
+        friend class XMLDocument;
+    public:
+        virtual XMLDeclaration* ToDeclaration()                 {
+            return this;
+        }
+        virtual const XMLDeclaration* ToDeclaration() const     {
+            return this;
+        }
 
-    /**
-    	Save the XML file to disk. You are responsible
-    	for providing and closing the FILE*.
+        virtual bool Accept(XMLVisitor* visitor) const;
 
-    	Returns XML_SUCCESS (0) on success, or
-    	an errorID.
+        virtual XMLNode* ShallowClone(XMLDocument* document) const;
+        virtual bool ShallowEqual(const XMLNode* compare) const;
+
+    protected:
+        explicit XMLDeclaration(XMLDocument* doc);
+        virtual ~XMLDeclaration();
+
+        char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    private:
+        XMLDeclaration(const XMLDeclaration&);   // not supported
+        XMLDeclaration& operator=(const XMLDeclaration&);    // not supported
+    };
+
+
+    /** Any tag that TinyXML-2 doesn't recognize is saved as an
+        unknown. It is a tag of text, but should not be modified.
+        It will be written back to the XML, unchanged, when the file
+        is saved.
+
+        DTD tags get thrown into XMLUnknowns.
     */
-    XMLError SaveFile( FILE* fp, bool compact = false );
+    class TINYXML2_LIB XMLUnknown : public XMLNode {
+        friend class XMLDocument;
+    public:
+        virtual XMLUnknown* ToUnknown()                 {
+            return this;
+        }
+        virtual const XMLUnknown* ToUnknown() const     {
+            return this;
+        }
 
-    bool ProcessEntities() const		{
-        return _processEntities;
-    }
-    Whitespace WhitespaceMode() const	{
-        return _whitespaceMode;
-    }
+        virtual bool Accept(XMLVisitor* visitor) const;
 
-    /**
-    	Returns true if this document has a leading Byte Order Mark of UTF8.
+        virtual XMLNode* ShallowClone(XMLDocument* document) const;
+        virtual bool ShallowEqual(const XMLNode* compare) const;
+
+    protected:
+        explicit XMLUnknown(XMLDocument* doc);
+        virtual ~XMLUnknown();
+
+        char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    private:
+        XMLUnknown(const XMLUnknown&);   // not supported
+        XMLUnknown& operator=(const XMLUnknown&);    // not supported
+    };
+
+
+
+    /** An attribute is a name-value pair. Elements have an arbitrary
+        number of attributes, each with a unique name.
+
+        @note The attributes are not XMLNodes. You may only query the
+        Next() attribute in a list.
     */
-    bool HasBOM() const {
-        return _writeBOM;
-    }
-    /** Sets whether to write the BOM when writing the file.
+    class TINYXML2_LIB XMLAttribute {
+        friend class XMLElement;
+    public:
+        /// The name of the attribute.
+        const char* Name() const;
+
+        /// The value of the attribute.
+        const char* Value() const;
+
+        /// Gets the line number the attribute is in, if the document was parsed from a file.
+        int GetLineNum() const {
+            return _parseLineNum;
+        }
+
+        /// The next attribute in the list.
+        const XMLAttribute* Next() const {
+            return _next;
+        }
+
+        /** IntValue interprets the attribute as an integer, and returns the value.
+            If the value isn't an integer, 0 will be returned. There is no error checking;
+            use QueryIntValue() if you need error checking.
+        */
+        int IntValue() const {
+            int i = 0;
+            QueryIntValue(&i);
+            return i;
+        }
+
+        int64_t Int64Value() const {
+            int64_t i = 0;
+            QueryInt64Value(&i);
+            return i;
+        }
+
+        uint64_t Unsigned64Value() const {
+            uint64_t i = 0;
+            QueryUnsigned64Value(&i);
+            return i;
+        }
+
+        /// Query as an unsigned integer. See IntValue()
+        unsigned UnsignedValue() const          {
+            unsigned i=0;
+            QueryUnsignedValue(&i);
+            return i;
+        }
+        /// Query as a boolean. See IntValue()
+        bool     BoolValue() const              {
+            bool b=false;
+            QueryBoolValue(&b);
+            return b;
+        }
+        /// Query as a double. See IntValue()
+        double   DoubleValue() const            {
+            double d=0;
+            QueryDoubleValue(&d);
+            return d;
+        }
+        /// Query as a float. See IntValue()
+        float    FloatValue() const             {
+            float f=0;
+            QueryFloatValue(&f);
+            return f;
+        }
+
+        /** QueryIntValue interprets the attribute as an integer, and returns the value
+            in the provided parameter. The function will return XML_SUCCESS on success,
+            and XML_WRONG_ATTRIBUTE_TYPE if the conversion is not successful.
+        */
+        XMLError QueryIntValue(int* value) const;
+        /// See QueryIntValue
+        XMLError QueryUnsignedValue(unsigned int* value) const;
+        /// See QueryIntValue
+        XMLError QueryInt64Value(int64_t* value) const;
+        /// See QueryIntValue
+        XMLError QueryUnsigned64Value(uint64_t* value) const;
+        /// See QueryIntValue
+        XMLError QueryBoolValue(bool* value) const;
+        /// See QueryIntValue
+        XMLError QueryDoubleValue(double* value) const;
+        /// See QueryIntValue
+        XMLError QueryFloatValue(float* value) const;
+
+        /// Set the attribute to a string value.
+        void SetAttribute(const char* value);
+        /// Set the attribute to value.
+        void SetAttribute(int value);
+        /// Set the attribute to value.
+        void SetAttribute(unsigned value);
+        /// Set the attribute to value.
+        void SetAttribute(int64_t value);
+        /// Set the attribute to value.
+        void SetAttribute(uint64_t value);
+        /// Set the attribute to value.
+        void SetAttribute(bool value);
+        /// Set the attribute to value.
+        void SetAttribute(double value);
+        /// Set the attribute to value.
+        void SetAttribute(float value);
+
+    private:
+        enum { BUF_SIZE = 200 };
+
+        XMLAttribute() : _name(), _value(),_parseLineNum(0), _next(0), _memPool(0) {}
+        virtual ~XMLAttribute() {}
+
+        XMLAttribute(const XMLAttribute&);   // not supported
+        void operator=(const XMLAttribute&);     // not supported
+        void SetName(const char* name);
+
+        char* ParseDeep(char* p, bool processEntities, int* curLineNumPtr);
+
+        mutable StrPair _name;
+        mutable StrPair _value;
+        int             _parseLineNum;
+        XMLAttribute*   _next;
+        MemPool*        _memPool;
+    };
+
+
+    /** The element is a container class. It has a value, the element name,
+        and can contain other elements, text, comments, and unknowns.
+        Elements also contain an arbitrary number of attributes.
     */
-    void SetBOM( bool useBOM ) {
-        _writeBOM = useBOM;
-    }
+    class TINYXML2_LIB XMLElement : public XMLNode {
+        friend class XMLDocument;
+    public:
+        /// Get the name of an element (which is the Value() of the node.)
+        const char* Name() const        {
+            return Value();
+        }
+        /// Set the name of the element.
+        void SetName(const char* str, bool staticMem=false)    {
+            SetValue(str, staticMem);
+        }
 
-    /** Return the root element of DOM. Equivalent to FirstChildElement().
-        To get the first node, use FirstChild().
+        virtual XMLElement* ToElement()             {
+            return this;
+        }
+        virtual const XMLElement* ToElement() const {
+            return this;
+        }
+        virtual bool Accept(XMLVisitor* visitor) const;
+
+        /** Given an attribute name, Attribute() returns the value
+            for the attribute of that name, or null if none
+            exists. For example:
+
+            @verbatim
+            const char* value = ele->Attribute( "foo" );
+            @endverbatim
+
+            The 'value' parameter is normally null. However, if specified,
+            the attribute will only be returned if the 'name' and 'value'
+            match. This allow you to write code:
+
+            @verbatim
+            if ( ele->Attribute( "foo", "bar" ) ) callFooIsBar();
+            @endverbatim
+
+            rather than:
+            @verbatim
+            if ( ele->Attribute( "foo" ) ) {
+                if ( strcmp( ele->Attribute( "foo" ), "bar" ) == 0 ) callFooIsBar();
+            }
+            @endverbatim
+        */
+        const char* Attribute(const char* name, const char* value=0) const;
+
+        /** Given an attribute name, IntAttribute() returns the value
+            of the attribute interpreted as an integer. The default
+            value will be returned if the attribute isn't present,
+            or if there is an error. (For a method with error
+            checking, see QueryIntAttribute()).
+        */
+        int IntAttribute(const char* name, int defaultValue = 0) const;
+        /// See IntAttribute()
+        unsigned UnsignedAttribute(const char* name, unsigned defaultValue = 0) const;
+        /// See IntAttribute()
+        int64_t Int64Attribute(const char* name, int64_t defaultValue = 0) const;
+        /// See IntAttribute()
+        uint64_t Unsigned64Attribute(const char* name, uint64_t defaultValue = 0) const;
+        /// See IntAttribute()
+        bool BoolAttribute(const char* name, bool defaultValue = false) const;
+        /// See IntAttribute()
+        double DoubleAttribute(const char* name, double defaultValue = 0) const;
+        /// See IntAttribute()
+        float FloatAttribute(const char* name, float defaultValue = 0) const;
+
+        /** Given an attribute name, QueryIntAttribute() returns
+            XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+            can't be performed, or XML_NO_ATTRIBUTE if the attribute
+            doesn't exist. If successful, the result of the conversion
+            will be written to 'value'. If not successful, nothing will
+            be written to 'value'. This allows you to provide default
+            value:
+
+            @verbatim
+            int value = 10;
+            QueryIntAttribute( "foo", &value );     // if "foo" isn't found, value will still be 10
+            @endverbatim
+        */
+        XMLError QueryIntAttribute(const char* name, int* value) const             {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryIntValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryUnsignedAttribute(const char* name, unsigned int* value) const   {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryUnsignedValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryInt64Attribute(const char* name, int64_t* value) const {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryInt64Value(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryUnsigned64Attribute(const char* name, uint64_t* value) const {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryUnsigned64Value(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryBoolAttribute(const char* name, bool* value) const               {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryBoolValue(value);
+        }
+        /// See QueryIntAttribute()
+        XMLError QueryDoubleAttribute(const char* name, double* value) const           {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryDoubleValue(value);
+        }
+        /// See QueryIntAttribute()
+        XMLError QueryFloatAttribute(const char* name, float* value) const         {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            return a->QueryFloatValue(value);
+        }
+
+        /// See QueryIntAttribute()
+        XMLError QueryStringAttribute(const char* name, const char** value) const {
+            const XMLAttribute* a = FindAttribute(name);
+            if (!a) {
+                return XML_NO_ATTRIBUTE;
+            }
+            *value = a->Value();
+            return XML_SUCCESS;
+        }
+
+
+
+        /** Given an attribute name, QueryAttribute() returns
+            XML_SUCCESS, XML_WRONG_ATTRIBUTE_TYPE if the conversion
+            can't be performed, or XML_NO_ATTRIBUTE if the attribute
+            doesn't exist. It is overloaded for the primitive types,
+            and is a generally more convenient replacement of
+            QueryIntAttribute() and related functions.
+
+            If successful, the result of the conversion
+            will be written to 'value'. If not successful, nothing will
+            be written to 'value'. This allows you to provide default
+            value:
+
+            @verbatim
+            int value = 10;
+            QueryAttribute( "foo", &value );        // if "foo" isn't found, value will still be 10
+            @endverbatim
+        */
+        XMLError QueryAttribute(const char* name, int* value) const {
+            return QueryIntAttribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, unsigned int* value) const {
+            return QueryUnsignedAttribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, int64_t* value) const {
+            return QueryInt64Attribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, uint64_t* value) const {
+            return QueryUnsigned64Attribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, bool* value) const {
+            return QueryBoolAttribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, double* value) const {
+            return QueryDoubleAttribute(name, value);
+        }
+
+        XMLError QueryAttribute(const char* name, float* value) const {
+            return QueryFloatAttribute(name, value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, const char* value) {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, int value)         {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, unsigned value)        {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, int64_t value) {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, uint64_t value) {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, bool value)            {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, double value)      {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+        /// Sets the named attribute to value.
+        void SetAttribute(const char* name, float value)       {
+            XMLAttribute* a = FindOrCreateAttribute(name);
+            a->SetAttribute(value);
+        }
+
+        /**
+            Delete an attribute.
+        */
+        void DeleteAttribute(const char* name);
+
+        /// Return the first attribute in the list.
+        const XMLAttribute* FirstAttribute() const {
+            return _rootAttribute;
+        }
+        /// Query a specific attribute in the list.
+        const XMLAttribute* FindAttribute(const char* name) const;
+
+        /** Convenience function for easy access to the text inside an element. Although easy
+            and concise, GetText() is limited compared to getting the XMLText child
+            and accessing it directly.
+
+            If the first child of 'this' is a XMLText, the GetText()
+            returns the character string of the Text node, else null is returned.
+
+            This is a convenient method for getting the text of simple contained text:
+            @verbatim
+            <foo>This is text</foo>
+                const char* str = fooElement->GetText();
+            @endverbatim
+
+            'str' will be a pointer to "This is text".
+
+            Note that this function can be misleading. If the element foo was created from
+            this XML:
+            @verbatim
+                <foo><b>This is text</b></foo>
+            @endverbatim
+
+            then the value of str would be null. The first child node isn't a text node, it is
+            another element. From this XML:
+            @verbatim
+                <foo>This is <b>text</b></foo>
+            @endverbatim
+            GetText() will return "This is ".
+        */
+        const char* GetText() const;
+
+        /** Convenience function for easy access to the text inside an element. Although easy
+            and concise, SetText() is limited compared to creating an XMLText child
+            and mutating it directly.
+
+            If the first child of 'this' is a XMLText, SetText() sets its value to
+            the given string, otherwise it will create a first child that is an XMLText.
+
+            This is a convenient method for setting the text of simple contained text:
+            @verbatim
+            <foo>This is text</foo>
+                fooElement->SetText( "Hullaballoo!" );
+            <foo>Hullaballoo!</foo>
+            @endverbatim
+
+            Note that this function can be misleading. If the element foo was created from
+            this XML:
+            @verbatim
+                <foo><b>This is text</b></foo>
+            @endverbatim
+
+            then it will not change "This is text", but rather prefix it with a text element:
+            @verbatim
+                <foo>Hullaballoo!<b>This is text</b></foo>
+            @endverbatim
+
+            For this XML:
+            @verbatim
+                <foo />
+            @endverbatim
+            SetText() will generate
+            @verbatim
+                <foo>Hullaballoo!</foo>
+            @endverbatim
+        */
+        void SetText(const char* inText);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(int value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(unsigned value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(int64_t value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(uint64_t value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(bool value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(double value);
+        /// Convenience method for setting text inside an element. See SetText() for important limitations.
+        void SetText(float value);
+
+        /**
+            Convenience method to query the value of a child text node. This is probably best
+            shown by example. Given you have a document is this form:
+            @verbatim
+                <point>
+                    <x>1</x>
+                    <y>1.4</y>
+                </point>
+            @endverbatim
+
+            The QueryIntText() and similar functions provide a safe and easier way to get to the
+            "value" of x and y.
+
+            @verbatim
+                int x = 0;
+                float y = 0;    // types of x and y are contrived for example
+                const XMLElement* xElement = pointElement->FirstChildElement( "x" );
+                const XMLElement* yElement = pointElement->FirstChildElement( "y" );
+                xElement->QueryIntText( &x );
+                yElement->QueryFloatText( &y );
+            @endverbatim
+
+            @returns XML_SUCCESS (0) on success, XML_CAN_NOT_CONVERT_TEXT if the text cannot be converted
+                     to the requested type, and XML_NO_TEXT_NODE if there is no child text to query.
+
+        */
+        XMLError QueryIntText(int* ival) const;
+        /// See QueryIntText()
+        XMLError QueryUnsignedText(unsigned* uval) const;
+        /// See QueryIntText()
+        XMLError QueryInt64Text(int64_t* uval) const;
+        /// See QueryIntText()
+        XMLError QueryUnsigned64Text(uint64_t* uval) const;
+        /// See QueryIntText()
+        XMLError QueryBoolText(bool* bval) const;
+        /// See QueryIntText()
+        XMLError QueryDoubleText(double* dval) const;
+        /// See QueryIntText()
+        XMLError QueryFloatText(float* fval) const;
+
+        int IntText(int defaultValue = 0) const;
+
+        /// See QueryIntText()
+        unsigned UnsignedText(unsigned defaultValue = 0) const;
+        /// See QueryIntText()
+        int64_t Int64Text(int64_t defaultValue = 0) const;
+        /// See QueryIntText()
+        uint64_t Unsigned64Text(uint64_t defaultValue = 0) const;
+        /// See QueryIntText()
+        bool BoolText(bool defaultValue = false) const;
+        /// See QueryIntText()
+        double DoubleText(double defaultValue = 0) const;
+        /// See QueryIntText()
+        float FloatText(float defaultValue = 0) const;
+
+        /**
+            Convenience method to create a new XMLElement and add it as last (right)
+            child of this node. Returns the created and inserted element.
+        */
+        XMLElement* InsertNewChildElement(const char* name);
+        /// See InsertNewChildElement()
+        XMLComment* InsertNewComment(const char* comment);
+        /// See InsertNewChildElement()
+        XMLText* InsertNewText(const char* text);
+        /// See InsertNewChildElement()
+        XMLDeclaration* InsertNewDeclaration(const char* text);
+        /// See InsertNewChildElement()
+        XMLUnknown* InsertNewUnknown(const char* text);
+
+
+        // internal:
+        enum ElementClosingType {
+            OPEN,       // <foo>
+            CLOSED,     // <foo/>
+            CLOSING     // </foo>
+        };
+        ElementClosingType ClosingType() const {
+            return _closingType;
+        }
+        virtual XMLNode* ShallowClone(XMLDocument* document) const;
+        virtual bool ShallowEqual(const XMLNode* compare) const;
+
+    protected:
+        char* ParseDeep(char* p, StrPair* parentEndTag, int* curLineNumPtr);
+
+    private:
+        XMLElement(XMLDocument* doc);
+        virtual ~XMLElement();
+        XMLElement(const XMLElement&);   // not supported
+        void operator=(const XMLElement&);   // not supported
+
+        XMLAttribute* FindOrCreateAttribute(const char* name);
+        char* ParseAttributes(char* p, int* curLineNumPtr);
+        static void DeleteAttribute(XMLAttribute* attribute);
+        XMLAttribute* CreateAttribute();
+
+        enum { BUF_SIZE = 200 };
+        ElementClosingType _closingType;
+        // The attribute list is ordered; there is no 'lastAttribute'
+        // because the list needs to be scanned for dupes before adding
+        // a new attribute.
+        XMLAttribute* _rootAttribute;
+    };
+
+
+    enum Whitespace {
+        PRESERVE_WHITESPACE,
+        COLLAPSE_WHITESPACE
+    };
+
+
+    /** A Document binds together all the functionality.
+        It can be saved, loaded, and printed to the screen.
+        All Nodes are connected and allocated to a Document.
+        If the Document is deleted, all its Nodes are also deleted.
     */
-    XMLElement* RootElement()				{
-        return FirstChildElement();
-    }
-    const XMLElement* RootElement() const	{
-        return FirstChildElement();
-    }
+    class TINYXML2_LIB XMLDocument : public XMLNode {
+        friend class XMLElement;
+        // Gives access to SetError and Push/PopDepth, but over-access for everything else.
+        // Wishing C++ had "internal" scope.
+        friend class XMLNode;
+        friend class XMLText;
+        friend class XMLComment;
+        friend class XMLDeclaration;
+        friend class XMLUnknown;
+    public:
+        /// constructor
+        XMLDocument(bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE);
+        ~XMLDocument();
 
-    /** Print the Document. If the Printer is not provided, it will
-        print to stdout. If you provide Printer, this can print to a file:
-    	@verbatim
-    	XMLPrinter printer( fp );
-    	doc.Print( &printer );
-    	@endverbatim
+        virtual XMLDocument* ToDocument()               {
+            TIXMLASSERT(this == _document);
+            return this;
+        }
+        virtual const XMLDocument* ToDocument() const   {
+            TIXMLASSERT(this == _document);
+            return this;
+        }
 
-    	Or you can use a printer to print to memory:
-    	@verbatim
-    	XMLPrinter printer;
-    	doc.Print( &printer );
-    	// printer.CStr() has a const char* to the XML
-    	@endverbatim
-    */
-    void Print( XMLPrinter* streamer=0 ) const;
-    virtual bool Accept( XMLVisitor* visitor ) const;
+        /**
+            Parse an XML file from a character string.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
 
-    /**
-    	Create a new Element associated with
-    	this Document. The memory for the Element
-    	is managed by the Document.
-    */
-    XMLElement* NewElement( const char* name );
-    /**
-    	Create a new Comment associated with
-    	this Document. The memory for the Comment
-    	is managed by the Document.
-    */
-    XMLComment* NewComment( const char* comment );
-    /**
-    	Create a new Text associated with
-    	this Document. The memory for the Text
-    	is managed by the Document.
-    */
-    XMLText* NewText( const char* text );
-    /**
-    	Create a new Declaration associated with
-    	this Document. The memory for the object
-    	is managed by the Document.
+            You may optionally pass in the 'nBytes', which is
+            the number of bytes which will be parsed. If not
+            specified, TinyXML-2 will assume 'xml' points to a
+            null terminated string.
+        */
+        XMLError Parse(const char* xml, size_t nBytes=static_cast<size_t>(-1));
 
-    	If the 'text' param is null, the standard
-    	declaration is used.:
-    	@verbatim
-    		<?xml version="1.0" encoding="UTF-8"?>
-    	@endverbatim
-    */
-    XMLDeclaration* NewDeclaration( const char* text=0 );
-    /**
-    	Create a new Unknown associated with
-    	this Document. The memory for the object
-    	is managed by the Document.
-    */
-    XMLUnknown* NewUnknown( const char* text );
+        /**
+            Load an XML file from disk.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError LoadFile(const char* filename);
 
-    /**
-    	Delete a node associated with this document.
-    	It will be unlinked from the DOM.
-    */
-    void DeleteNode( XMLNode* node );
+        /**
+            Load an XML file from disk. You are responsible
+            for providing and closing the FILE*.
 
-    void ClearError() {
-        SetError(XML_SUCCESS, 0, 0);
-    }
+            NOTE: The file should be opened as binary ("rb")
+            not text in order for TinyXML-2 to correctly
+            do newline normalization.
 
-    /// Return true if there was an error parsing the document.
-    bool Error() const {
-        return _errorID != XML_SUCCESS;
-    }
-    /// Return the errorID.
-    XMLError  ErrorID() const {
-        return _errorID;
-    }
-	const char* ErrorName() const;
-    static const char* ErrorIDToName(XMLError errorID);
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError LoadFile(FILE*);
 
-    /** Returns a "long form" error description. A hopefully helpful 
-        diagnostic with location, line number, and/or additional info.
-    */
-	const char* ErrorStr() const;
+        /**
+            Save the XML file to disk.
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError SaveFile(const char* filename, bool compact = false);
 
-    /// A (trivial) utility function that prints the ErrorStr() to stdout.
-    void PrintError() const;
+        /**
+            Save the XML file to disk. You are responsible
+            for providing and closing the FILE*.
 
-    /// Return the line where the error occurred, or zero if unknown.
-    int ErrorLineNum() const
-    {
-        return _errorLineNum;
-    }
-    
-    /// Clear the document, resetting it to the initial state.
-    void Clear();
+            Returns XML_SUCCESS (0) on success, or
+            an errorID.
+        */
+        XMLError SaveFile(FILE* fp, bool compact = false);
 
-	/**
-		Copies this document to a target document.
-		The target will be completely cleared before the copy.
-		If you want to copy a sub-tree, see XMLNode::DeepClone().
+        bool ProcessEntities() const        {
+            return _processEntities;
+        }
+        Whitespace WhitespaceMode() const   {
+            return _whitespaceMode;
+        }
 
-		NOTE: that the 'target' must be non-null.
-	*/
-	void DeepCopy(XMLDocument* target) const;
+        /**
+            Returns true if this document has a leading Byte Order Mark of UTF8.
+        */
+        bool HasBOM() const {
+            return _writeBOM;
+        }
+        /** Sets whether to write the BOM when writing the file.
+        */
+        void SetBOM(bool useBOM) {
+            _writeBOM = useBOM;
+        }
 
-	// internal
-    char* Identify( char* p, XMLNode** node );
+        /** Return the root element of DOM. Equivalent to FirstChildElement().
+            To get the first node, use FirstChild().
+        */
+        XMLElement* RootElement()               {
+            return FirstChildElement();
+        }
+        const XMLElement* RootElement() const   {
+            return FirstChildElement();
+        }
 
-	// internal
-	void MarkInUse(XMLNode*);
+        /** Print the Document. If the Printer is not provided, it will
+            print to stdout. If you provide Printer, this can print to a file:
+            @verbatim
+            XMLPrinter printer( fp );
+            doc.Print( &printer );
+            @endverbatim
 
-    virtual XMLNode* ShallowClone( XMLDocument* /*document*/ ) const	{
-        return 0;
-    }
-    virtual bool ShallowEqual( const XMLNode* /*compare*/ ) const	{
-        return false;
-    }
+            Or you can use a printer to print to memory:
+            @verbatim
+            XMLPrinter printer;
+            doc.Print( &printer );
+            // printer.CStr() has a const char* to the XML
+            @endverbatim
+        */
+        void Print(XMLPrinter* streamer=0) const;
+        virtual bool Accept(XMLVisitor* visitor) const;
 
-private:
-    XMLDocument( const XMLDocument& );	// not supported
-    void operator=( const XMLDocument& );	// not supported
+        /**
+            Create a new Element associated with
+            this Document. The memory for the Element
+            is managed by the Document.
+        */
+        XMLElement* NewElement(const char* name);
+        /**
+            Create a new Comment associated with
+            this Document. The memory for the Comment
+            is managed by the Document.
+        */
+        XMLComment* NewComment(const char* comment);
+        /**
+            Create a new Text associated with
+            this Document. The memory for the Text
+            is managed by the Document.
+        */
+        XMLText* NewText(const char* text);
+        /**
+            Create a new Declaration associated with
+            this Document. The memory for the object
+            is managed by the Document.
 
-    bool			_writeBOM;
-    bool			_processEntities;
-    XMLError		_errorID;
-    Whitespace		_whitespaceMode;
-    mutable StrPair	_errorStr;
-    int             _errorLineNum;
-    char*			_charBuffer;
-    int				_parseCurLineNum;
-	// Memory tracking does add some overhead.
-	// However, the code assumes that you don't
-	// have a bunch of unlinked nodes around.
-	// Therefore it takes less memory to track
-	// in the document vs. a linked list in the XMLNode,
-	// and the performance is the same.
-	DynArray<XMLNode*, 10> _unlinked;
+            If the 'text' param is null, the standard
+            declaration is used.:
+            @verbatim
+                <?xml version="1.0" encoding="UTF-8"?>
+            @endverbatim
+        */
+        XMLDeclaration* NewDeclaration(const char* text=0);
+        /**
+            Create a new Unknown associated with
+            this Document. The memory for the object
+            is managed by the Document.
+        */
+        XMLUnknown* NewUnknown(const char* text);
 
-    MemPoolT< sizeof(XMLElement) >	 _elementPool;
-    MemPoolT< sizeof(XMLAttribute) > _attributePool;
-    MemPoolT< sizeof(XMLText) >		 _textPool;
-    MemPoolT< sizeof(XMLComment) >	 _commentPool;
+        /**
+            Delete a node associated with this document.
+            It will be unlinked from the DOM.
+        */
+        void DeleteNode(XMLNode* node);
 
-	static const char* _errorNames[XML_ERROR_COUNT];
+        void ClearError() {
+            SetError(XML_SUCCESS, 0, 0);
+        }
 
-    void Parse();
+        /// Return true if there was an error parsing the document.
+        bool Error() const {
+            return _errorID != XML_SUCCESS;
+        }
+        /// Return the errorID.
+        XMLError  ErrorID() const {
+            return _errorID;
+        }
+        const char* ErrorName() const;
+        static const char* ErrorIDToName(XMLError errorID);
 
-    void SetError( XMLError error, int lineNum, const char* format, ... );
+        /** Returns a "long form" error description. A hopefully helpful
+            diagnostic with location, line number, and/or additional info.
+        */
+        const char* ErrorStr() const;
+
+        /// A (trivial) utility function that prints the ErrorStr() to stdout.
+        void PrintError() const;
+
+        /// Return the line where the error occurred, or zero if unknown.
+        int ErrorLineNum() const {
+            return _errorLineNum;
+        }
+
+        /// Clear the document, resetting it to the initial state.
+        void Clear();
+
+        /**
+            Copies this document to a target document.
+            The target will be completely cleared before the copy.
+            If you want to copy a sub-tree, see XMLNode::DeepClone().
+
+            NOTE: that the 'target' must be non-null.
+        */
+        void DeepCopy(XMLDocument* target) const;
+
+        // internal
+        char* Identify(char* p, XMLNode** node);
+
+        // internal
+        void MarkInUse(const XMLNode* const);
+
+        virtual XMLNode* ShallowClone(XMLDocument* /*document*/) const {
+            return 0;
+        }
+        virtual bool ShallowEqual(const XMLNode* /*compare*/) const    {
+            return false;
+        }
+
+    private:
+        XMLDocument(const XMLDocument&);     // not supported
+        void operator=(const XMLDocument&);      // not supported
+
+        bool            _writeBOM;
+        bool            _processEntities;
+        XMLError        _errorID;
+        Whitespace      _whitespaceMode;
+        mutable StrPair _errorStr;
+        int             _errorLineNum;
+        char*           _charBuffer;
+        int             _parseCurLineNum;
+        int             _parsingDepth;
+        // Memory tracking does add some overhead.
+        // However, the code assumes that you don't
+        // have a bunch of unlinked nodes around.
+        // Therefore it takes less memory to track
+        // in the document vs. a linked list in the XMLNode,
+        // and the performance is the same.
+        DynArray<XMLNode*, 10> _unlinked;
+
+        MemPoolT< sizeof(XMLElement) >   _elementPool;
+        MemPoolT< sizeof(XMLAttribute) > _attributePool;
+        MemPoolT< sizeof(XMLText) >      _textPool;
+        MemPoolT< sizeof(XMLComment) >   _commentPool;
+
+        static const char* _errorNames[XML_ERROR_COUNT];
+
+        void Parse();
+
+        void SetError(XMLError error, int lineNum, const char* format, ...);
+
+        // Something of an obvious security hole, once it was discovered.
+        // Either an ill-formed XML or an excessively deep one can overflow
+        // the stack. Track stack depth, and error out if needed.
+        class DepthTracker {
+        public:
+            explicit DepthTracker(XMLDocument * document) {
+                this->_document = document;
+                document->PushDepth();
+            }
+            ~DepthTracker() {
+                _document->PopDepth();
+            }
+        private:
+            XMLDocument * _document;
+        };
+        void PushDepth();
+        void PopDepth();
+
+        template<class NodeType, int PoolElementSize>
+        NodeType* CreateUnlinkedNode(MemPoolT<PoolElementSize>& pool);
+    };
 
     template<class NodeType, int PoolElementSize>
-    NodeType* CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool );
-};
+    inline NodeType* XMLDocument::CreateUnlinkedNode(MemPoolT<PoolElementSize>& pool)
+    {
+        TIXMLASSERT(sizeof(NodeType) == PoolElementSize);
+        TIXMLASSERT(sizeof(NodeType) == pool.ItemSize());
+        NodeType* returnNode = new (pool.Alloc()) NodeType(this);
+        TIXMLASSERT(returnNode);
+        returnNode->_memPool = &pool;
 
-template<class NodeType, int PoolElementSize>
-inline NodeType* XMLDocument::CreateUnlinkedNode( MemPoolT<PoolElementSize>& pool )
-{
-    TIXMLASSERT( sizeof( NodeType ) == PoolElementSize );
-    TIXMLASSERT( sizeof( NodeType ) == pool.ItemSize() );
-    NodeType* returnNode = new (pool.Alloc()) NodeType( this );
-    TIXMLASSERT( returnNode );
-    returnNode->_memPool = &pool;
-
-	_unlinked.Push(returnNode);
-    return returnNode;
-}
-
-/**
-	A XMLHandle is a class that wraps a node pointer with null checks; this is
-	an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
-	DOM structure. It is a separate utility class.
-
-	Take an example:
-	@verbatim
-	<Document>
-		<Element attributeA = "valueA">
-			<Child attributeB = "value1" />
-			<Child attributeB = "value2" />
-		</Element>
-	</Document>
-	@endverbatim
-
-	Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
-	easy to write a *lot* of code that looks like:
-
-	@verbatim
-	XMLElement* root = document.FirstChildElement( "Document" );
-	if ( root )
-	{
-		XMLElement* element = root->FirstChildElement( "Element" );
-		if ( element )
-		{
-			XMLElement* child = element->FirstChildElement( "Child" );
-			if ( child )
-			{
-				XMLElement* child2 = child->NextSiblingElement( "Child" );
-				if ( child2 )
-				{
-					// Finally do something useful.
-	@endverbatim
-
-	And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
-	of such code. A XMLHandle checks for null pointers so it is perfectly safe
-	and correct to use:
-
-	@verbatim
-	XMLHandle docHandle( &document );
-	XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
-	if ( child2 )
-	{
-		// do something useful
-	@endverbatim
-
-	Which is MUCH more concise and useful.
-
-	It is also safe to copy handles - internally they are nothing more than node pointers.
-	@verbatim
-	XMLHandle handleCopy = handle;
-	@endverbatim
-
-	See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
-*/
-class TINYXML2_LIB XMLHandle
-{
-public:
-    /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
-    XMLHandle( XMLNode* node ) : _node( node ) {
+        _unlinked.Push(returnNode);
+        return returnNode;
     }
-    /// Create a handle from a node.
-    XMLHandle( XMLNode& node ) : _node( &node ) {
-    }
-    /// Copy constructor
-    XMLHandle( const XMLHandle& ref ) : _node( ref._node ) {
-    }
-    /// Assignment
-    XMLHandle& operator=( const XMLHandle& ref )							{
-        _node = ref._node;
-        return *this;
-    }
-
-    /// Get the first child of this handle.
-    XMLHandle FirstChild() 													{
-        return XMLHandle( _node ? _node->FirstChild() : 0 );
-    }
-    /// Get the first child element of this handle.
-    XMLHandle FirstChildElement( const char* name = 0 )						{
-        return XMLHandle( _node ? _node->FirstChildElement( name ) : 0 );
-    }
-    /// Get the last child of this handle.
-    XMLHandle LastChild()													{
-        return XMLHandle( _node ? _node->LastChild() : 0 );
-    }
-    /// Get the last child element of this handle.
-    XMLHandle LastChildElement( const char* name = 0 )						{
-        return XMLHandle( _node ? _node->LastChildElement( name ) : 0 );
-    }
-    /// Get the previous sibling of this handle.
-    XMLHandle PreviousSibling()												{
-        return XMLHandle( _node ? _node->PreviousSibling() : 0 );
-    }
-    /// Get the previous sibling element of this handle.
-    XMLHandle PreviousSiblingElement( const char* name = 0 )				{
-        return XMLHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
-    }
-    /// Get the next sibling of this handle.
-    XMLHandle NextSibling()													{
-        return XMLHandle( _node ? _node->NextSibling() : 0 );
-    }
-    /// Get the next sibling element of this handle.
-    XMLHandle NextSiblingElement( const char* name = 0 )					{
-        return XMLHandle( _node ? _node->NextSiblingElement( name ) : 0 );
-    }
-
-    /// Safe cast to XMLNode. This can return null.
-    XMLNode* ToNode()							{
-        return _node;
-    }
-    /// Safe cast to XMLElement. This can return null.
-    XMLElement* ToElement() 					{
-        return ( _node ? _node->ToElement() : 0 );
-    }
-    /// Safe cast to XMLText. This can return null.
-    XMLText* ToText() 							{
-        return ( _node ? _node->ToText() : 0 );
-    }
-    /// Safe cast to XMLUnknown. This can return null.
-    XMLUnknown* ToUnknown() 					{
-        return ( _node ? _node->ToUnknown() : 0 );
-    }
-    /// Safe cast to XMLDeclaration. This can return null.
-    XMLDeclaration* ToDeclaration() 			{
-        return ( _node ? _node->ToDeclaration() : 0 );
-    }
-
-private:
-    XMLNode* _node;
-};
-
-
-/**
-	A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
-	same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
-*/
-class TINYXML2_LIB XMLConstHandle
-{
-public:
-    XMLConstHandle( const XMLNode* node ) : _node( node ) {
-    }
-    XMLConstHandle( const XMLNode& node ) : _node( &node ) {
-    }
-    XMLConstHandle( const XMLConstHandle& ref ) : _node( ref._node ) {
-    }
-
-    XMLConstHandle& operator=( const XMLConstHandle& ref )							{
-        _node = ref._node;
-        return *this;
-    }
-
-    const XMLConstHandle FirstChild() const											{
-        return XMLConstHandle( _node ? _node->FirstChild() : 0 );
-    }
-    const XMLConstHandle FirstChildElement( const char* name = 0 ) const				{
-        return XMLConstHandle( _node ? _node->FirstChildElement( name ) : 0 );
-    }
-    const XMLConstHandle LastChild()	const										{
-        return XMLConstHandle( _node ? _node->LastChild() : 0 );
-    }
-    const XMLConstHandle LastChildElement( const char* name = 0 ) const				{
-        return XMLConstHandle( _node ? _node->LastChildElement( name ) : 0 );
-    }
-    const XMLConstHandle PreviousSibling() const									{
-        return XMLConstHandle( _node ? _node->PreviousSibling() : 0 );
-    }
-    const XMLConstHandle PreviousSiblingElement( const char* name = 0 ) const		{
-        return XMLConstHandle( _node ? _node->PreviousSiblingElement( name ) : 0 );
-    }
-    const XMLConstHandle NextSibling() const										{
-        return XMLConstHandle( _node ? _node->NextSibling() : 0 );
-    }
-    const XMLConstHandle NextSiblingElement( const char* name = 0 ) const			{
-        return XMLConstHandle( _node ? _node->NextSiblingElement( name ) : 0 );
-    }
-
-
-    const XMLNode* ToNode() const				{
-        return _node;
-    }
-    const XMLElement* ToElement() const			{
-        return ( _node ? _node->ToElement() : 0 );
-    }
-    const XMLText* ToText() const				{
-        return ( _node ? _node->ToText() : 0 );
-    }
-    const XMLUnknown* ToUnknown() const			{
-        return ( _node ? _node->ToUnknown() : 0 );
-    }
-    const XMLDeclaration* ToDeclaration() const	{
-        return ( _node ? _node->ToDeclaration() : 0 );
-    }
-
-private:
-    const XMLNode* _node;
-};
-
-
-/**
-	Printing functionality. The XMLPrinter gives you more
-	options than the XMLDocument::Print() method.
-
-	It can:
-	-# Print to memory.
-	-# Print to a file you provide.
-	-# Print XML without a XMLDocument.
-
-	Print to Memory
-
-	@verbatim
-	XMLPrinter printer;
-	doc.Print( &printer );
-	SomeFunction( printer.CStr() );
-	@endverbatim
-
-	Print to a File
-
-	You provide the file pointer.
-	@verbatim
-	XMLPrinter printer( fp );
-	doc.Print( &printer );
-	@endverbatim
-
-	Print without a XMLDocument
-
-	When loading, an XML parser is very useful. However, sometimes
-	when saving, it just gets in the way. The code is often set up
-	for streaming, and constructing the DOM is just overhead.
-
-	The Printer supports the streaming case. The following code
-	prints out a trivially simple XML file without ever creating
-	an XML document.
-
-	@verbatim
-	XMLPrinter printer( fp );
-	printer.OpenElement( "foo" );
-	printer.PushAttribute( "foo", "bar" );
-	printer.CloseElement();
-	@endverbatim
-*/
-class TINYXML2_LIB XMLPrinter : public XMLVisitor
-{
-public:
-    /** Construct the printer. If the FILE* is specified,
-    	this will print to the FILE. Else it will print
-    	to memory, and the result is available in CStr().
-    	If 'compact' is set to true, then output is created
-    	with only required whitespace and newlines.
-    */
-    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
-    virtual ~XMLPrinter()	{}
-
-    /** If streaming, write the BOM and declaration. */
-    void PushHeader( bool writeBOM, bool writeDeclaration );
-    /** If streaming, start writing an element.
-        The element must be closed with CloseElement()
-    */
-    void OpenElement( const char* name, bool compactMode=false );
-    /// If streaming, add an attribute to an open element.
-    void PushAttribute( const char* name, const char* value );
-    void PushAttribute( const char* name, int value );
-    void PushAttribute( const char* name, unsigned value );
-	void PushAttribute(const char* name, int64_t value);
-	void PushAttribute( const char* name, bool value );
-    void PushAttribute( const char* name, double value );
-    /// If streaming, close the Element.
-    virtual void CloseElement( bool compactMode=false );
-
-    /// Add a text node.
-    void PushText( const char* text, bool cdata=false );
-    /// Add a text node from an integer.
-    void PushText( int value );
-    /// Add a text node from an unsigned.
-    void PushText( unsigned value );
-	/// Add a text node from an unsigned.
-	void PushText(int64_t value);
-	/// Add a text node from a bool.
-    void PushText( bool value );
-    /// Add a text node from a float.
-    void PushText( float value );
-    /// Add a text node from a double.
-    void PushText( double value );
-
-    /// Add a comment
-    void PushComment( const char* comment );
-
-    void PushDeclaration( const char* value );
-    void PushUnknown( const char* value );
-
-    virtual bool VisitEnter( const XMLDocument& /*doc*/ );
-    virtual bool VisitExit( const XMLDocument& /*doc*/ )			{
-        return true;
-    }
-
-    virtual bool VisitEnter( const XMLElement& element, const XMLAttribute* attribute );
-    virtual bool VisitExit( const XMLElement& element );
-
-    virtual bool Visit( const XMLText& text );
-    virtual bool Visit( const XMLComment& comment );
-    virtual bool Visit( const XMLDeclaration& declaration );
-    virtual bool Visit( const XMLUnknown& unknown );
 
     /**
-    	If in print to memory mode, return a pointer to
-    	the XML file in memory.
+        A XMLHandle is a class that wraps a node pointer with null checks; this is
+        an incredibly useful thing. Note that XMLHandle is not part of the TinyXML-2
+        DOM structure. It is a separate utility class.
+
+        Take an example:
+        @verbatim
+        <Document>
+            <Element attributeA = "valueA">
+                <Child attributeB = "value1" />
+                <Child attributeB = "value2" />
+            </Element>
+        </Document>
+        @endverbatim
+
+        Assuming you want the value of "attributeB" in the 2nd "Child" element, it's very
+        easy to write a *lot* of code that looks like:
+
+        @verbatim
+        XMLElement* root = document.FirstChildElement( "Document" );
+        if ( root )
+        {
+            XMLElement* element = root->FirstChildElement( "Element" );
+            if ( element )
+            {
+                XMLElement* child = element->FirstChildElement( "Child" );
+                if ( child )
+                {
+                    XMLElement* child2 = child->NextSiblingElement( "Child" );
+                    if ( child2 )
+                    {
+                        // Finally do something useful.
+        @endverbatim
+
+        And that doesn't even cover "else" cases. XMLHandle addresses the verbosity
+        of such code. A XMLHandle checks for null pointers so it is perfectly safe
+        and correct to use:
+
+        @verbatim
+        XMLHandle docHandle( &document );
+        XMLElement* child2 = docHandle.FirstChildElement( "Document" ).FirstChildElement( "Element" ).FirstChildElement().NextSiblingElement();
+        if ( child2 )
+        {
+            // do something useful
+        @endverbatim
+
+        Which is MUCH more concise and useful.
+
+        It is also safe to copy handles - internally they are nothing more than node pointers.
+        @verbatim
+        XMLHandle handleCopy = handle;
+        @endverbatim
+
+        See also XMLConstHandle, which is the same as XMLHandle, but operates on const objects.
     */
-    const char* CStr() const {
-        return _buffer.Mem();
-    }
-    /**
-    	If in print to memory mode, return the size
-    	of the XML file in memory. (Note the size returned
-    	includes the terminating null.)
-    */
-    int CStrSize() const {
-        return _buffer.Size();
-    }
-    /**
-    	If in print to memory mode, reset the buffer to the
-    	beginning.
-    */
-    void ClearBuffer() {
-        _buffer.Clear();
-        _buffer.Push(0);
-		_firstElement = true;
-    }
+    class TINYXML2_LIB XMLHandle {
+    public:
+        /// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
+        explicit XMLHandle(XMLNode* node) : _node(node) {
+        }
+        /// Create a handle from a node.
+        explicit XMLHandle(XMLNode& node) : _node(&node) {
+        }
+        /// Copy constructor
+        XMLHandle(const XMLHandle& ref) : _node(ref._node) {
+        }
+        /// Assignment
+        XMLHandle& operator=(const XMLHandle& ref)                         {
+            _node = ref._node;
+            return *this;
+        }
 
-protected:
-	virtual bool CompactMode( const XMLElement& )	{ return _compactMode; }
+        /// Get the first child of this handle.
+        XMLHandle FirstChild()                                                  {
+            return XMLHandle(_node ? _node->FirstChild() : 0);
+        }
+        /// Get the first child element of this handle.
+        XMLHandle FirstChildElement(const char* name = 0)                      {
+            return XMLHandle(_node ? _node->FirstChildElement(name) : 0);
+        }
+        /// Get the last child of this handle.
+        XMLHandle LastChild()                                                   {
+            return XMLHandle(_node ? _node->LastChild() : 0);
+        }
+        /// Get the last child element of this handle.
+        XMLHandle LastChildElement(const char* name = 0)                       {
+            return XMLHandle(_node ? _node->LastChildElement(name) : 0);
+        }
+        /// Get the previous sibling of this handle.
+        XMLHandle PreviousSibling()                                             {
+            return XMLHandle(_node ? _node->PreviousSibling() : 0);
+        }
+        /// Get the previous sibling element of this handle.
+        XMLHandle PreviousSiblingElement(const char* name = 0)             {
+            return XMLHandle(_node ? _node->PreviousSiblingElement(name) : 0);
+        }
+        /// Get the next sibling of this handle.
+        XMLHandle NextSibling()                                                 {
+            return XMLHandle(_node ? _node->NextSibling() : 0);
+        }
+        /// Get the next sibling element of this handle.
+        XMLHandle NextSiblingElement(const char* name = 0)                 {
+            return XMLHandle(_node ? _node->NextSiblingElement(name) : 0);
+        }
 
-	/** Prints out the space before an element. You may override to change
-	    the space and tabs used. A PrintSpace() override should call Print().
-	*/
-    virtual void PrintSpace( int depth );
-    void Print( const char* format, ... );
-    void Write( const char* data, size_t size );
-    inline void Write( const char* data )           { Write( data, strlen( data ) ); }
-    void Putc( char ch );
+        /// Safe cast to XMLNode. This can return null.
+        XMLNode* ToNode()                           {
+            return _node;
+        }
+        /// Safe cast to XMLElement. This can return null.
+        XMLElement* ToElement()                     {
+            return (_node ? _node->ToElement() : 0);
+        }
+        /// Safe cast to XMLText. This can return null.
+        XMLText* ToText()                           {
+            return (_node ? _node->ToText() : 0);
+        }
+        /// Safe cast to XMLUnknown. This can return null.
+        XMLUnknown* ToUnknown()                     {
+            return (_node ? _node->ToUnknown() : 0);
+        }
+        /// Safe cast to XMLDeclaration. This can return null.
+        XMLDeclaration* ToDeclaration()             {
+            return (_node ? _node->ToDeclaration() : 0);
+        }
 
-    void SealElementIfJustOpened();
-    bool _elementJustOpened;
-    DynArray< const char*, 10 > _stack;
-
-private:
-    void PrintString( const char*, bool restrictedEntitySet );	// prints out, after detecting entities.
-
-    bool _firstElement;
-    FILE* _fp;
-    int _depth;
-    int _textDepth;
-    bool _processEntities;
-	bool _compactMode;
-
-    enum {
-        ENTITY_RANGE = 64,
-        BUF_SIZE = 200
+    private:
+        XMLNode* _node;
     };
-    bool _entityFlag[ENTITY_RANGE];
-    bool _restrictedEntityFlag[ENTITY_RANGE];
-
-    DynArray< char, 20 > _buffer;
-
-    // Prohibit cloning, intentionally not implemented
-    XMLPrinter( const XMLPrinter& );
-    XMLPrinter& operator=( const XMLPrinter& );
-};
 
 
-}	// tinyxml2
+    /**
+        A variant of the XMLHandle class for working with const XMLNodes and Documents. It is the
+        same in all regards, except for the 'const' qualifiers. See XMLHandle for API.
+    */
+    class TINYXML2_LIB XMLConstHandle {
+    public:
+        explicit XMLConstHandle(const XMLNode* node) : _node(node) {
+        }
+        explicit XMLConstHandle(const XMLNode& node) : _node(&node) {
+        }
+        XMLConstHandle(const XMLConstHandle& ref) : _node(ref._node) {
+        }
+
+        XMLConstHandle& operator=(const XMLConstHandle& ref)                           {
+            _node = ref._node;
+            return *this;
+        }
+
+        const XMLConstHandle FirstChild() const                                         {
+            return XMLConstHandle(_node ? _node->FirstChild() : 0);
+        }
+        const XMLConstHandle FirstChildElement(const char* name = 0) const             {
+            return XMLConstHandle(_node ? _node->FirstChildElement(name) : 0);
+        }
+        const XMLConstHandle LastChild()    const                                       {
+            return XMLConstHandle(_node ? _node->LastChild() : 0);
+        }
+        const XMLConstHandle LastChildElement(const char* name = 0) const              {
+            return XMLConstHandle(_node ? _node->LastChildElement(name) : 0);
+        }
+        const XMLConstHandle PreviousSibling() const                                    {
+            return XMLConstHandle(_node ? _node->PreviousSibling() : 0);
+        }
+        const XMLConstHandle PreviousSiblingElement(const char* name = 0) const        {
+            return XMLConstHandle(_node ? _node->PreviousSiblingElement(name) : 0);
+        }
+        const XMLConstHandle NextSibling() const                                        {
+            return XMLConstHandle(_node ? _node->NextSibling() : 0);
+        }
+        const XMLConstHandle NextSiblingElement(const char* name = 0) const            {
+            return XMLConstHandle(_node ? _node->NextSiblingElement(name) : 0);
+        }
+
+
+        const XMLNode* ToNode() const               {
+            return _node;
+        }
+        const XMLElement* ToElement() const         {
+            return (_node ? _node->ToElement() : 0);
+        }
+        const XMLText* ToText() const               {
+            return (_node ? _node->ToText() : 0);
+        }
+        const XMLUnknown* ToUnknown() const         {
+            return (_node ? _node->ToUnknown() : 0);
+        }
+        const XMLDeclaration* ToDeclaration() const {
+            return (_node ? _node->ToDeclaration() : 0);
+        }
+
+    private:
+        const XMLNode* _node;
+    };
+
+
+    /**
+        Printing functionality. The XMLPrinter gives you more
+        options than the XMLDocument::Print() method.
+
+        It can:
+        -# Print to memory.
+        -# Print to a file you provide.
+        -# Print XML without a XMLDocument.
+
+        Print to Memory
+
+        @verbatim
+        XMLPrinter printer;
+        doc.Print( &printer );
+        SomeFunction( printer.CStr() );
+        @endverbatim
+
+        Print to a File
+
+        You provide the file pointer.
+        @verbatim
+        XMLPrinter printer( fp );
+        doc.Print( &printer );
+        @endverbatim
+
+        Print without a XMLDocument
+
+        When loading, an XML parser is very useful. However, sometimes
+        when saving, it just gets in the way. The code is often set up
+        for streaming, and constructing the DOM is just overhead.
+
+        The Printer supports the streaming case. The following code
+        prints out a trivially simple XML file without ever creating
+        an XML document.
+
+        @verbatim
+        XMLPrinter printer( fp );
+        printer.OpenElement( "foo" );
+        printer.PushAttribute( "foo", "bar" );
+        printer.CloseElement();
+        @endverbatim
+    */
+    class TINYXML2_LIB XMLPrinter : public XMLVisitor {
+    public:
+        /** Construct the printer. If the FILE* is specified,
+            this will print to the FILE. Else it will print
+            to memory, and the result is available in CStr().
+            If 'compact' is set to true, then output is created
+            with only required whitespace and newlines.
+        */
+        XMLPrinter(FILE* file=0, bool compact = false, int depth = 0);
+        virtual ~XMLPrinter()   {}
+
+        /** If streaming, write the BOM and declaration. */
+        void PushHeader(bool writeBOM, bool writeDeclaration);
+        /** If streaming, start writing an element.
+            The element must be closed with CloseElement()
+        */
+        void OpenElement(const char* name, bool compactMode=false);
+        /// If streaming, add an attribute to an open element.
+        void PushAttribute(const char* name, const char* value);
+        void PushAttribute(const char* name, int value);
+        void PushAttribute(const char* name, unsigned value);
+        void PushAttribute(const char* name, int64_t value);
+        void PushAttribute(const char* name, uint64_t value);
+        void PushAttribute(const char* name, bool value);
+        void PushAttribute(const char* name, double value);
+        /// If streaming, close the Element.
+        virtual void CloseElement(bool compactMode=false);
+
+        /// Add a text node.
+        void PushText(const char* text, bool cdata=false);
+        /// Add a text node from an integer.
+        void PushText(int value);
+        /// Add a text node from an unsigned.
+        void PushText(unsigned value);
+        /// Add a text node from a signed 64bit integer.
+        void PushText(int64_t value);
+        /// Add a text node from an unsigned 64bit integer.
+        void PushText(uint64_t value);
+        /// Add a text node from a bool.
+        void PushText(bool value);
+        /// Add a text node from a float.
+        void PushText(float value);
+        /// Add a text node from a double.
+        void PushText(double value);
+
+        /// Add a comment
+        void PushComment(const char* comment);
+
+        void PushDeclaration(const char* value);
+        void PushUnknown(const char* value);
+
+        virtual bool VisitEnter(const XMLDocument& /*doc*/);
+        virtual bool VisitExit(const XMLDocument& /*doc*/)         {
+            return true;
+        }
+
+        virtual bool VisitEnter(const XMLElement& element, const XMLAttribute* attribute);
+        virtual bool VisitExit(const XMLElement& element);
+
+        virtual bool Visit(const XMLText& text);
+        virtual bool Visit(const XMLComment& comment);
+        virtual bool Visit(const XMLDeclaration& declaration);
+        virtual bool Visit(const XMLUnknown& unknown);
+
+        /**
+            If in print to memory mode, return a pointer to
+            the XML file in memory.
+        */
+        const char* CStr() const {
+            return _buffer.Mem();
+        }
+        /**
+            If in print to memory mode, return the size
+            of the XML file in memory. (Note the size returned
+            includes the terminating null.)
+        */
+        int CStrSize() const {
+            return _buffer.Size();
+        }
+        /**
+            If in print to memory mode, reset the buffer to the
+            beginning.
+        */
+        void ClearBuffer(bool resetToFirstElement = true) {
+            _buffer.Clear();
+            _buffer.Push(0);
+            _firstElement = resetToFirstElement;
+        }
+
+    protected:
+        virtual bool CompactMode(const XMLElement&)    {
+            return _compactMode;
+        }
+
+        /** Prints out the space before an element. You may override to change
+            the space and tabs used. A PrintSpace() override should call Print().
+        */
+        virtual void PrintSpace(int depth);
+        void Print(const char* format, ...);
+        void Write(const char* data, size_t size);
+        inline void Write(const char* data)           {
+            Write(data, strlen(data));
+        }
+        void Putc(char ch);
+
+        void SealElementIfJustOpened();
+        bool _elementJustOpened;
+        DynArray< const char*, 10 > _stack;
+
+    private:
+        void PrintString(const char*, bool restrictedEntitySet);     // prints out, after detecting entities.
+
+        bool _firstElement;
+        FILE* _fp;
+        int _depth;
+        int _textDepth;
+        bool _processEntities;
+        bool _compactMode;
+
+        enum {
+            ENTITY_RANGE = 64,
+            BUF_SIZE = 200
+        };
+        bool _entityFlag[ENTITY_RANGE];
+        bool _restrictedEntityFlag[ENTITY_RANGE];
+
+        DynArray< char, 20 > _buffer;
+
+        // Prohibit cloning, intentionally not implemented
+        XMLPrinter(const XMLPrinter&);
+        XMLPrinter& operator=(const XMLPrinter&);
+    };
+
+
+}   // tinyxml2
 
 #if defined(_MSC_VER)
 #   pragma warning(pop)


### PR DESCRIPTION
Update tinyxml2 dependency to latest upstream version 8.0.0.

Contents of PR#811 correcting deficiency of initial indent of new nodes applied to sources.

astyle formatting applied to `project/externals/tinyxml/tinyxml2.[h,cpp]` to ensure sources are consistently formatted/styled(corrects numerous inconsistent leading spaces/tabs for lines).

Project compiled successfully with updated dependency.
TestRunner completed all +3600 tests without errors or warnings.