### PR TITLE
9757: skip template parameters when computing scope

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1712,7 +1712,7 @@ namespace {
             return;
         while (tok->str() == "}" && !scopeInfo->empty() && tok == scopeInfo->back().bodyEnd)
             scopeInfo->pop_back();
-        if (!Token::Match(tok, "namespace|class|struct|union %name% {|:|::")) {
+        if (!Token::Match(tok, "namespace|class|struct|union %name% {|:|::|<")) {
             // check for using namespace
             if (Token::Match(tok, "using namespace %name% ;|::")) {
                 const Token * tok1 = tok->tokAt(2);
@@ -1776,6 +1776,12 @@ namespace {
         tok = tok->next();
         if (tok && tok->str() == ":") {
             while (tok && !Token::Match(tok, ";|{"))
+                tok = tok->next();
+        }
+        // skip template parameters
+        if (tok && tok->str() == "<") {
+            tok = tok->findClosingBracket();
+            if (tok)
                 tok = tok->next();
         }
         if (tok && tok->str() == "{") {

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -69,6 +69,7 @@ private:
         TEST_CASE(simplifyUsing9385);
         TEST_CASE(simplifyUsing9388);
         TEST_CASE(simplifyUsing9518);
+        TEST_CASE(simplifyUsing9757);
     }
 
     std::string tok(const char code[], bool simplify = true, Settings::PlatformType type = Settings::Native, bool debugwarnings = true) {
@@ -627,6 +628,21 @@ private:
         ASSERT_EQUALS(exp, tok(code, false));
     }
 
+    void simplifyUsing9757() {
+        const char code[] = "enum class Type_t { Nil = 0 };\n"
+                            "template<Type_t type> class MappedType { };\n"
+                            "template<> class MappedType<Type_t::Nil> { using type = void; };\n"
+                            "std::string to_string (Example::Type_t type) {\n"
+                            "   switch (type) {}\n"
+                            "}";
+        const char exp[] = "enum class Type_t { Nil = 0 } ; "
+                           "class MappedType<Type_t::Nil> ; "
+                           "template < Type_t type > class MappedType { } ; "
+                           "class MappedType<Type_t::Nil> { } ; "
+                           "std :: string to_string ( Example :: Type_t type ) { "
+                           "switch ( type ) { } }";
+        ASSERT_EQUALS(exp, tok(code, false));
+    }
 };
 
 REGISTER_TEST(TestSimplifyUsing)


### PR DESCRIPTION
The template parameter is confusing simplifyUsing: it does not compute
properly the scope, and we end up replace "type" in "to_string" with
"void", then later "void" is removed and we have an internal error.