### PR TITLE
Add Q_FLAG macro to qt.cfg

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -181,6 +181,7 @@ Massimo Paladin
 Mateusz Pusz
 Mathias De Maré
 Matthias Krüger
+Matthias Kuhn
 Matthias Schmieder
 Mathias Schmid
 Matt Johnson

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5047,6 +5047,7 @@
   <define name="Q_DISABLE_COPY(C)" value="C(C&amp;);C&amp; operator=(const C&amp;);"/>
   <define name="Q_ENUM(X)" value=""/>
   <define name="Q_ENUMS(X)" value=""/>
+  <define name="Q_FLAG(X)" value=""/>
   <define name="Q_FLAGS(X)" value=""/>
   <define name="Q_FOREVER" value="for (;;)"/>
   <define name="Q_INTERFACES(X)" value=""/>


### PR DESCRIPTION
https://doc.qt.io/qt-5/qobject.html#Q_FLAG

```
error,unknownMacro,There is an unknown macro here somewhere. Configuration is required. If Q_FLAG is a macro then please configure it.
```