### PR TITLE
Misra severity

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1057,10 +1057,12 @@ class MisraChecker:
 
         self.stdversion = stdversion
 
+        self.severity = None
+
     def __repr__(self):
         attrs = ["settings", "verify_expected", "verify_actual", "violations",
                  "ruleTexts", "suppressedRules", "dumpfileSuppressions",
-                 "filePrefix", "suppressionStats", "stdversion"]
+                 "filePrefix", "suppressionStats", "stdversion", "severity"]
         return "{}({})".format(
             "MisraChecker",
             ", ".join(("{}={}".format(a, repr(getattr(self, a))) for a in attrs))
@@ -2675,6 +2677,12 @@ class MisraChecker:
         """
         self.filePrefix = prefix
 
+    def setSeverity(self, severity):
+        """
+        Set the severity for all errors.
+        """
+        self.severity = severity
+
     def setSuppressionList(self, suppressionlist):
         num1 = 0
         num2 = 0
@@ -2714,6 +2722,10 @@ class MisraChecker:
                 errmsg = 'misra violation (use --rule-texts=<file> to get proper output)'
             else:
                 return
+
+            if self.severity:
+                cppcheck_severity = self.severity
+
             cppcheckdata.reportError(location, cppcheck_severity, errmsg, 'misra', errorId, misra_severity)
 
             if misra_severity not in self.violations:
@@ -3017,6 +3029,7 @@ def get_args():
     parser.add_argument("-P", "--file-prefix", type=str, help="Prefix to strip when matching suppression file rules")
     parser.add_argument("-generate-table", help=argparse.SUPPRESS, action="store_true")
     parser.add_argument("-verify", help=argparse.SUPPRESS, action="store_true")
+    parser.add_argument("--severity", type=str, help="Set a custom severity string, for example 'error' or 'warning'. ")
     return parser.parse_args()
 
 
@@ -3054,6 +3067,9 @@ def main():
         if not args.quiet:
             print("No input files.")
         sys.exit(0)
+
+    if args.severity:
+        checker.setSeverity(args.severity)
 
     exitCode = 0
     for item in args.dumpfile:

--- a/addons/test/test-misra.py
+++ b/addons/test/test-misra.py
@@ -96,6 +96,15 @@ def test_rules_cppcheck_severity(checker, capsys):
     assert("(warning)" not in captured)
     assert("(style)" in captured)
 
+def test_rules_cppcheck_severity_custom(checker, capsys):
+    checker.loadRuleTexts("./addons/test/misra/misra_rules_dummy.txt")
+    checker.setSeverity("custom-severity")
+    checker.parseDump("./addons/test/misra/misra-test.c.dump")
+    captured = capsys.readouterr().err
+    assert("(error)" not in captured)
+    assert("(warning)" not in captured)
+    assert("(style)" not in captured)
+    assert("(custom-severity)" in captured)
 
 def test_rules_suppression(checker, capsys):
     test_sources = ["addons/test/misra/misra-suppressions1-test.c",
@@ -122,7 +131,8 @@ def test_arguments_regression():
                "--cli",
                "--no-summary",
                "--show-suppressed-rules",
-               "-P=src/", "--file-prefix=src/"]
+               "-P=src/", "--file-prefix=src/",
+               "--severity=misra-warning"]
     # Arguments with expected SystemExit
     args_exit = ["--non-exists", "--non-exists-param=42", "-h", "--help"]
 

--- a/addons/test/util.py
+++ b/addons/test/util.py
@@ -7,6 +7,7 @@ import os
 def find_cppcheck_binary():
     possible_locations = [
         "./cppcheck",
+        "./build/bin/cppcheck",
         r".\bin\cppcheck.exe",
     ]
     for location in possible_locations:


### PR DESCRIPTION
Implemented the option `--severity` for `misra.py` to set a custom severity string for all misra warnings.

The severity string is not limited to `info`, `warning`, `error` etc but it will accept any string, so you could use for example  `misra-warning`.