### PR TITLE
9768: Fix ast with throw in the middle of return

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -762,8 +762,10 @@ static void compileTerm(Token *&tok, AST_state& state)
         if (Token::Match(tok, "return|case") || (state.cpp && tok->str() == "throw")) {
             if (tok->str() == "case")
                 state.inCase = true;
+            const bool tokIsReturn = tok->str() == "return";
             compileUnaryOp(tok, state, compileExpression);
-            state.op.pop();
+            if (tokIsReturn)
+                state.op.pop();
             if (state.inCase && Token::simpleMatch(tok, ": ;")) {
                 state.inCase = false;
                 tok = tok->next();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7486,6 +7486,8 @@ private:
         ASSERT_EQUALS("check(result_type00,{invalid:?return", testAst("return check() ? result_type {0, 0} : invalid;"));
         ASSERT_EQUALS("x01:?return", testAst("return x ? 0 : 1;"));
         ASSERT_EQUALS("x00throw:?return", testAst("return x ? 0 : throw 0;")); // #9768
+        ASSERT_EQUALS("val0<1throwval:?return", testAst("return val < 0 ? throw 1 : val;")); // #8526
+        ASSERT_EQUALS("ix0<00throw:?=", testAst("int i = x < 0 ? 0 : throw 0;"));
 
         ASSERT_EQUALS("a\"\"=", testAst("a=\"\""));
         ASSERT_EQUALS("a\'\'=", testAst("a=\'\'"));

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7484,6 +7484,8 @@ private:
         ASSERT_EQUALS("fabc,de,:?=", testAst("f = (a ? b, c : (d, e));"));
         ASSERT_EQUALS("ab35,4:?foo(:?return", testAst("return (a ? b ? (3,5) : 4 : foo());"));
         ASSERT_EQUALS("check(result_type00,{invalid:?return", testAst("return check() ? result_type {0, 0} : invalid;"));
+        ASSERT_EQUALS("x01:?return", testAst("return x ? 0 : 1;"));
+        ASSERT_EQUALS("x00throw:?return", testAst("return x ? 0 : throw 0;")); // #9768
 
         ASSERT_EQUALS("a\"\"=", testAst("a=\"\""));
         ASSERT_EQUALS("a\'\'=", testAst("a=\'\'"));
@@ -7927,6 +7929,7 @@ private:
         ASSERT_EQUALS("0case", testAst("case 0:"));
         ASSERT_EQUALS("12+case", testAst("case 1+2:"));
         ASSERT_EQUALS("xyz:?case", testAst("case (x?y:z):"));
+        ASSERT_EQUALS("switchx( 1case y++ 2case", testAst("switch(x){case 1:{++y;break;case 2:break;}}"));
     }
 
     void astrefqualifier() {


### PR DESCRIPTION
```
int f(bool x)
{
    return x ? 0 : throw 0;
}
```

The `throw` part was not included in the ast, leading to an invalid
ternary operator.