### PR TITLE
qmake improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ cmake-*
 # clang tooling temporary files
 .clangd/
 compile_commands.json
+
+# qmake
+/gui/.qmake.stash

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -198,11 +198,11 @@ win32 {
 }
 
 contains(QMAKE_CC, gcc) {
-    QMAKE_CXXFLAGS += -std=c++11 -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-deprecated-declarations
+    QMAKE_CXXFLAGS += -std=c++0x -pedantic -Wall -Wextra -Wcast-qual -Wno-deprecated-declarations -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-shadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar
 }
 
 contains(QMAKE_CXX, clang++) {
-    QMAKE_CXXFLAGS += -std=c++11
+    QMAKE_CXXFLAGS += -std=c++0x -pedantic -Wall -Wextra -Wcast-qual -Wno-deprecated-declarations -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-shadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar
 }
 
 contains(HAVE_QCHART, [yY][eE][sS]) {

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -103,8 +103,18 @@ contains(LINKCORE, [yY][eE][sS]) {
     include($$PWD/../lib/lib.pri)
 }
 
-CONFIG += precompile_header
-PRECOMPILED_HEADER = precompiled_qmake.h
+win32-msvc* {
+    MSVC_VER = $$(VisualStudioVersion)
+    message($$MSVC_VER)
+    MSVC_VER_SPLIT = $$split(MSVC_VER, .)
+    MSVC_VER_MAJOR = $$first(MSVC_VER_SPLIT)
+    # doesn't compile with older VS versions - assume VS2019 (16.x) is the first working for now
+    !lessThan(MSVC_VER_MAJOR, 16) {
+        message("using precompiled header")
+        CONFIG += precompile_header
+        PRECOMPILED_HEADER = precompiled_qmake.h
+    }
+}
 
 HEADERS += aboutdialog.h \
            application.h \

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -103,6 +103,9 @@ contains(LINKCORE, [yY][eE][sS]) {
     include($$PWD/../lib/lib.pri)
 }
 
+CONFIG += precompile_header
+PRECOMPILED_HEADER = precompiled_qmake.h
+
 HEADERS += aboutdialog.h \
            application.h \
            applicationdialog.h \

--- a/gui/precompiled_qmake.h
+++ b/gui/precompiled_qmake.h
@@ -1,0 +1,23 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2020 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "precompiled.h"
+#include <QDialog>
+#include <QObject>
+#include <QWidget>


### PR DESCRIPTION
Before
```
Compilation (245 times):
  Parsing (frontend):          521.3 s
  Codegen & opts (backend):     62.3 s
```

After
```
Compilation (247 times):
  Parsing (frontend):          353.5 s
  Codegen & opts (backend):     63.0 s
```

Tested with a default build on WSL 2 Kali with Clang 10.

There should be probably a `precompiled_gui.h` include which will be used by `precompiled_qmake.h`, but I will address that when I actually tackled a build needing it.