### PR TITLE
not report locally declared functions as missing configuration of --check-library

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -436,11 +436,14 @@ void CheckFunctions::checkLibraryMatchFunctions()
         if (tok->linkAt(1)->strAt(1) == "(")
             continue;
 
+        if (tok->function())
+            continue;
+
         if (!mSettings->library.isNotLibraryFunction(tok))
             continue;
 
         const std::string &functionName = mSettings->library.getFunctionName(tok);
-        if (functionName.empty() || mSettings->library.functions.find(functionName) == mSettings->library.functions.end())
+        if (functionName.empty() || mSettings->library.functions.find(functionName) != mSettings->library.functions.end())
             continue;
 
         reportError(tok,

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -440,7 +440,7 @@ void CheckFunctions::checkLibraryMatchFunctions()
             continue;
 
         const std::string &functionName = mSettings->library.getFunctionName(tok);
-        if (functionName.empty() || mSettings->library.functions.find(functionName) != mSettings->library.functions.end())
+        if (functionName.empty() || mSettings->library.functions.find(functionName) == mSettings->library.functions.end())
             continue;
 
         reportError(tok,

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -364,15 +364,11 @@ public:
 
 void MacroTest2_test()
 {
-    // TODO: remove suppression when #9002 is fixed
-    // cppcheck-suppress checkLibraryFunction
     QString str = MacroTest2::tr("hello");
     QByteArray ba = str.toLatin1();
     printf(ba.data());
 
 #ifndef QT_NO_DEPRECATED
-    // TODO: remove suppression when #9002 is fixed
-    // cppcheck-suppress checkLibraryFunction
     str = MacroTest2::trUtf8("test2");
     ba = str.toLatin1();
     printf(ba.data());

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -3882,7 +3882,6 @@ void valid_vsprintf_helper(const char * format, ...)
 void valid_vsprintf()
 {
     // buffer will contain "2\0" => no bufferAccessOutOfBounds
-    // cppcheck-suppress checkLibraryFunction
     // cppcheck-suppress checkLibraryNoReturn
     valid_vsprintf_helper("%1.0f", 2.0f);
 }


### PR DESCRIPTION
This change only report functions that match name in --library but does not match the use defined in --library. Before this change all other function calls not matching a function in --library will be reported as an error.

This fixes trac ticket #9002.