### PR TITLE
9769: Improve value flow for ternary operator

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -524,6 +524,16 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value, const Setti
         }
     }
 
+    else if (parent->str() == "?" && value.isIntValue() && tok == parent->astOperand1() && value.isKnown() &&
+             parent->astOperand2() && parent->astOperand2()->astOperand1() && parent->astOperand2()->astOperand2()) {
+        const std::list<ValueFlow::Value> &values = (value.intvalue == 0
+                ? parent->astOperand2()->astOperand2()->values()
+                : parent->astOperand2()->astOperand1()->values());
+
+        for (const ValueFlow::Value &v : values)
+            setTokenValue(parent, v, settings);
+    }
+
     // Calculations..
     else if ((parent->isArithmeticalOp() || parent->isComparisonOp() || (parent->tokType() == Token::eBitOp) || (parent->tokType() == Token::eLogicalOp)) &&
              parent->astOperand1() &&

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -674,6 +674,13 @@ private:
         ASSERT_EQUALS(1U, values.size());
         ASSERT_EQUALS(123, values.empty() ? 0 : values.front().intvalue);
 
+        code  = "int f() {\n"
+                "    const int i = 1;\n"
+                "    int x = i < 0 ? 0 : 1;\n"
+                "    return x;\n"
+                "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 1));
+
         // ~
         code  = "x = ~0U;";
         settings.platform(cppcheck::Platform::Native); // ensure platform is native


### PR DESCRIPTION
In some cases, the condition of the ternary operator is assigned a known
value after the two possible results, and in such cases, we would not
take the opportunity to assign a value to the ternary operator (and to
the other parents in the ast).
This patch adds this capability.