### PR TITLE
cfg/windows.cfg - fixed definition of GetSystemInfo

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -5374,8 +5374,7 @@ HFONT CreateFont(
     <noreturn>false</noreturn>
     <returnValue type="void"/>
     <leak-ignore/>
-    <arg nr="1" direction="inout">
-      <not-uninit/>
+    <arg nr="1" direction="out">
       <not-null/>
     </arg>
   </function>


### PR DESCRIPTION
```
SYSTEM_INFO SystemInfo;
GetSystemInfo(&SystemInfo);
```

causes false positive:
```
error: Uninitialized variable: SystemInfo [uninitvar]
 GetSystemInfo(&SystemInfo);
                ^
```

I'm not sure how exactly cfg files work, but the change included in this PR fixes false positive.


