### PR TITLE
Fix #9652 (fp memleak with function call with cast)

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -856,7 +856,8 @@ void CheckLeakAutoVar::functionCall(const Token *tokName, const Token *tokOpenin
     }
 
     int argNr = 1;
-    for (const Token *arg = tokFirstArg; arg; arg = arg->nextArgument()) {
+    for (const Token *funcArg = tokFirstArg; funcArg; funcArg = funcArg->nextArgument()) {
+        const Token* arg = funcArg;
         if (mTokenizer->isCPP() && arg->str() == "new") {
             arg = arg->next();
             if (Token::simpleMatch(arg, "( std :: nothrow )"))


### PR DESCRIPTION
When the first argument was `(void *)(1)`, at the start of the second
iteration, arg was pointing to the `1`, which caused problems for
`nextArgument()`, which saw the `)` as the next token and returned
`nullptr`, signalling that there are no more arguments.

Instead, save the first token in the argument, which makes
`nextArgument()` do the right thing.