### PR TITLE
Fix #9635 (FP: Memory leak with comma operator in if-statement)

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -465,7 +465,11 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
 
                 // Recursively scan variable comparisons in condition
                 std::stack<const Token *> tokens;
-                tokens.push(tok->next()->astOperand2());
+                // Skip expressions before commas
+                const Token * astOperand2AfterCommas = tok->next()->astOperand2();
+                while (Token::simpleMatch(astOperand2AfterCommas, ","))
+                    astOperand2AfterCommas = astOperand2AfterCommas->astOperand2();
+                tokens.push(astOperand2AfterCommas);
                 while (!tokens.empty()) {
                     const Token *tok3 = tokens.top();
                     tokens.pop();

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -134,6 +134,7 @@ private:
         TEST_CASE(ifelse13); // #8392
         TEST_CASE(ifelse14); // #9130 - if (x == (char*)NULL)
         TEST_CASE(ifelse15); // #9206 - if (global_ptr = malloc(1))
+        TEST_CASE(ifelse16); // #9635 - if (p = malloc(4), p == NULL)
 
         // switch
         TEST_CASE(switch1);
@@ -1480,6 +1481,26 @@ private:
               "int openFile( void ) {\n"
               "   if ((hFile = fopen(\"1.txt\", \"wb\" )) == NULL) return 0;\n"
               "   return 1;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void ifelse16() { // #9635
+        check("void f(void) {\n"
+              "    char *p;\n"
+              "    if(p = malloc(4), p == NULL)\n"
+              "        return;\n"
+              "    free(p);\n"
+              "    return;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(void) {\n"
+              "    char *p, q;\n"
+              "    if(p = malloc(4), q = 1, p == NULL)\n"
+              "        return;\n"
+              "    free(p);\n"
+              "    return;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
When checking for comparisons in if-statements, if there are comma
operators in the if-statement, skip until after the last comma.