### PR TITLE
Fixed crash on garbage code: comparisson with empty second operand

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9624,11 +9624,18 @@ void Tokenizer::findGarbageCode() const
             if (match1 && match2)
                 syntaxError(tok);
         }
-        if (Token::Match(tok, "%or%|%oror%|~|^|!|%comp%|+|-|/|% )|]|}")) {
-            if (isC())
-                syntaxError(tok, tok->str() + tok->next()->str());
-            if (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator"))
-                syntaxError(tok, tok->str() + " " + tok->next()->str());
+        if (Token::Match(tok, "%or%|%oror%|~|^|!|%comp%|+|-|/|%")) {
+            std::string code = "";
+            if (Token::Match(tok->next(), ")|]|}"))
+                code = tok->str() + tok->next()->str();
+            if (Token::simpleMatch(tok->next(), "( )"))
+                code = tok->str() + "()";
+            if (!code.empty()) {
+                if (isC())
+                    syntaxError(tok, code);
+                if (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator"))
+                    syntaxError(tok, code);
+            }
         }
         if (Token::Match(tok, "%num%|%bool%|%char%|%str% %num%|%bool%|%char%|%str%") && !Token::Match(tok, "%str% %str%"))
             syntaxError(tok);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9631,9 +9631,7 @@ void Tokenizer::findGarbageCode() const
             if (Token::simpleMatch(tok->next(), "( )"))
                 code = tok->str() + "()";
             if (!code.empty()) {
-                if (isC())
-                    syntaxError(tok, code);
-                if (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator"))
+                if (isC() || (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator")))
                     syntaxError(tok, code);
             }
         }

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -1402,7 +1402,7 @@ private:
 
     void garbageCode164() {
         //7234
-        checkCode("class d{k p;}(){d::d():B<()}");
+        ASSERT_THROW(checkCode("class d{k p;}(){d::d():B<()}"), InternalError);
     }
 
     void garbageCode165() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -8087,7 +8087,7 @@ private:
         ASSERT_THROW(tokenizeAndStringify("void foo() { for_chain( if (!done) done = 1); }"), InternalError);
         ASSERT_THROW(tokenizeAndStringify("void foo() { for_chain( a, b, if (!done) done = 1); }"), InternalError);
 
-        ASSERT_THROW_EQUALS(tokenizeAndStringify("void f() { if (retval==){} }"), InternalError, "syntax error: == )");
+        ASSERT_THROW_EQUALS(tokenizeAndStringify("void f() { if (retval==){} }"), InternalError, "syntax error: ==)");
 
         // after (expr)
         ASSERT_NO_THROW(tokenizeAndStringify("void f() { switch (a) int b; }"));
@@ -8108,6 +8108,9 @@ private:
 
         // Ticket #9664
         ASSERT_NO_THROW(tokenizeAndStringify("S s = { .x { 2 }, .y[0] { 3 } };"));
+
+        ASSERT_THROW_EQUALS(tokenizeAndStringify("void f() { assert(a==()); }"), InternalError, "syntax error: ==()");
+        ASSERT_THROW_EQUALS(tokenizeAndStringify("void f() { assert(a+()); }"), InternalError, "syntax error: +()");
     }
 
 


### PR DESCRIPTION
This will fix [#9774](https://trac.cppcheck.net/ticket/9774).