### PR TITLE
cppcheckdata.py: Reorder addon error message parts

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -1101,4 +1101,8 @@ def reportError(location, severity, message, addon, errorId, extra=''):
         loc = '[%s:%i]' % (location.file, location.linenr)
         if len(extra) > 0:
             message += ' (' + extra + ')'
-        sys.stderr.write('%s (%s) %s [%s-%s]\n' % (loc, severity, message, addon, errorId))
+
+        errorkey = '[{}-{}]'.format(addon, errorId)
+        severity  = '({})'.format(severity)
+        output = '{} {} {} {}\n'.format(loc, errorkey, severity, message)
+        sys.stderr.write(output)


### PR DESCRIPTION
When viewing the error output stream from addons being able to easily
find the error key (addon+errorID) is helpful.

Currently the error key is show after any description of the error
message. Since the error description is much more variable in length
than the error location it is difficult to visually parse the output,
especially if the description is long enough for the message to cause
the terminal to wrap the line.

Move the error key location to immediately after the error location.
This makes it much easier to see when looking at the console output.