### PR TITLE
Refactor: Simplify checkSignConversion

### DIFF
--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -239,12 +239,8 @@ void CheckType::checkSignConversion()
             continue;
 
         // Check if an operand can be negative..
-        std::stack<const Token *> tokens;
-        tokens.push(tok->astOperand1());
-        tokens.push(tok->astOperand2());
-        while (!tokens.empty()) {
-            const Token *tok1 = tokens.top();
-            tokens.pop();
+        const Token * astOperands[] = { tok->astOperand1(), tok->astOperand2() };
+        for (const Token * tok1 : astOperands) {
             if (!tok1)
                 continue;
             const ValueFlow::Value *negativeValue = tok1->getValueLE(-1,mSettings);

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -252,6 +252,9 @@ private:
         check("x = -4 * (unsigned)y;");
         ASSERT_EQUALS("[test.cpp:1]: (warning) Expression '-4' has a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
 
+        check("x = (unsigned)y * -4;");
+        ASSERT_EQUALS("[test.cpp:1]: (warning) Expression '-4' has a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
+
         check("unsigned int dostuff(int x) {\n" // x is signed
               "  if (x==0) {}\n"
               "  return (x-1)*sizeof(int);\n"


### PR DESCRIPTION
The loop only checks astoperand1 and astoperand2. Simplify the condition
to loop over these instead of using a stack. Also, add a testcase for
when astoperand2 is negative.