### PR TITLE
Fix crash when typeScope is missing

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1320,6 +1320,8 @@ static const Variable* getArgumentVar(const Token* tok, int argnr)
         if (!type)
             return nullptr;
         const Scope* typeScope = type->classScope;
+        if (!typeScope)
+            return nullptr;
         const int argCount = numberOfArguments(tok);
         for (const Function &function : typeScope->functionList) {
             if (function.isConstructor())


### PR DESCRIPTION
I was unable to get a reduced test case for this.