### PR TITLE
Add missing operators <<= and >>=

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2106,6 +2106,10 @@ static bool evalAssignment(ValueFlow::Value &lhsValue, const std::string &assign
             lhsValue.intvalue |= rhsValue.intvalue;
         else if (assign == "^=")
             lhsValue.intvalue ^= rhsValue.intvalue;
+        else if (assign == "<<=")
+            lhsValue.intvalue <<= rhsValue.intvalue;
+        else if (assign == ">>=")
+            lhsValue.intvalue >>= rhsValue.intvalue;
         else
             return false;
     } else if (lhsValue.isFloatValue()) {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -2530,6 +2530,20 @@ private:
                "    return x;\n"
                "}";
         ASSERT_EQUALS(true, testValueOfX(code, 4U, 123.45F + 67, 0.01F));
+
+        code = "void f() {\n"
+               "    int x = 123;\n"
+               "    x >>= 1;\n"
+               "    return x;\n"
+               "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 61));
+
+        code = "void f() {\n"
+               "    int x = 123;\n"
+               "    x <<= 1;\n"
+               "    return x;\n"
+               "}";
+        ASSERT_EQUALS(true, testValueOfX(code, 4U, 246));
     }
 
     void valueFlowForwardCorrelatedVariables() {


### PR DESCRIPTION
This fixes issues (at least false positives) in code using them.
For instance:

```
unsigned compute(unsigned long long a) {
    unsigned num = 0;
    while (a > 0xFFFFFFFF) {
      a >>= 32;
      num += 32;
    }
    if (a > 0xFFFF) {
      a >>= 16;
      num += 16;
    }
    if (a > 0xFF) {
      num += 8;
    }
    return num;
}
```

would give false positive:
```
cppcheck --enable=style  sl3.cpp
Checking sl3.cpp ...
sl3.cpp:11:11: style: Condition 'a>0xFF' is always false [knownConditionTrueFalse]
    if (a > 0xFF) {
          ^
sl3.cpp:3:14: note: Assuming that condition 'a>0xFFFFFFFF' is not redundant
    while (a > 0xFFFFFFFF) {
             ^
sl3.cpp:11:11: note: Condition 'a>0xFF' is always false
    if (a > 0xFF) {
          ^
```