### PR TITLE
Add GitHub styling to the PDF manual too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ man/manual.tex
 .idea
 /.metadata/
 cmake-*
+man/manual.pdf
+man/manual.html

--- a/man/buildman.sh
+++ b/man/buildman.sh
@@ -2,7 +2,8 @@
 # To install required tools in debian:
 # sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra
 
-pandoc manual.md -o manual.pdf -s --number-sections --toc --css manual.css
+pandoc manual.md -o manual.pdf -s --number-sections --toc -f markdown --pdf-engine=xelatex --listings -V mainfont="Segoe UI" -V monofont="Consolas" -V geometry:a4paper -V geometry:margin=2.4cm -H manual-style.tex
+
 pandoc manual.md -o manual.html -s --number-sections --toc --css manual.css
 
 pandoc reference-cfg-format.md -o reference-cfg-format.pdf -s --number-sections --toc

--- a/man/manual-style.tex
+++ b/man/manual-style.tex
@@ -1,0 +1,32 @@
+\usepackage{titlesec}
+\usepackage{fancyvrb,newverbs,xcolor}
+\usepackage{xcolor}
+
+\titleformat{\chapter}[display]   
+{\normalfont\huge\bfseries}{\chaptertitlename\ \thechapter}{20pt}{\Huge}   
+\titlespacing*{\chapter}{0pt}{-20pt}{20pt}
+
+
+\definecolor{Light}{HTML}{EEEEEE}
+\let\oldtexttt\texttt
+\renewcommand{\texttt}[1]{
+  \colorbox{Light}{\oldtexttt{#1}}
+}
+
+\lstset{
+    basicstyle=\ttfamily,
+    backgroundcolor=\color{Light},
+    xleftmargin=10pt,
+    frame=lrtb,
+    framesep=10pt,
+    framerule=0pt,
+    showspaces=false,
+    showstringspaces=false,
+    showtabs=false,
+    tabsize=2,
+    captionpos=b,
+    breaklines=true,
+    breakatwhitespace=true,
+    breakautoindent=true,
+    linewidth=\textwidth
+}


### PR DESCRIPTION
The CSS styling only works for HTML files. PDF generation uses LaTeX as an intermediate format, so styling has to be done using latex settings. This now uses the xelatex engine which allows for using any font on your system. I've used Segoe UI and Consolas, fonts but you may need to change those if they aren't supported on your system. I think Consolas is a Windows font, so it may need a more Linux-centric choice.

These are the alternatives which GitHub uses in its own CSS.

BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji

SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace