### PR TITLE
Create separate scripts for building HTML and PDF documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,10 @@ snap/.snapcraft
 # Manual folder
 man/manual.log
 man/manual.tex
+man/*.pdf
+man/*.html
 
 # CLion
 .idea
 /.metadata/
 cmake-*
-man/manual.pdf
-man/manual.html

--- a/man/build-html.sh
+++ b/man/build-html.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo Building $1.html
+pandoc $1.md -o $1.html -s --number-sections --toc --css manual.css

--- a/man/build-pdf.sh
+++ b/man/build-pdf.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# This uses installed fonts, which vary between systems
+# Segoe UI and Consolas are standard in Windows 10, DejaVu is more common on Linux
+echo Building $1.pdf
+
+MainFont="Segoe UI"
+MonoFont="Consolas"
+
+is_font_installed() {
+    fontname=$1
+    fc-list | grep -i "$fontname" >/dev/null
+}
+
+if ! is_font_installed "$MainFont"; then
+    MainFont="DejaVu Sans"
+fi
+if ! is_font_installed "$MonoFont"; then
+    MonoFont="DejaVu Sans Mono"
+fi
+
+# echo Using $MainFont / $MonoFont
+
+pandoc $1.md -o $1.pdf -s --number-sections --toc \
+    --pdf-engine=xelatex \
+    --listings \
+    -f markdown \
+    -V mainfont="$MainFont" \
+    -V monofont="$Consolas" \
+    -V geometry:a4paper \
+    -V geometry:margin=2.4cm \
+    -V subparagraph \
+    -H manual-style.tex

--- a/man/buildman.sh
+++ b/man/buildman.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 # To install required tools in debian:
 # sudo apt-get install pandoc texlive-latex-base texlive-fonts-recommended texlive-latex-extra
+# For Windows you can use the MiKTeX installer https://miktex.org/download
 
-pandoc manual.md -o manual.pdf -s --number-sections --toc -f markdown --pdf-engine=xelatex --listings -V mainfont="Segoe UI" -V monofont="Consolas" -V geometry:a4paper -V geometry:margin=2.4cm -H manual-style.tex
+./build-pdf.sh manual
+./build-html.sh manual
 
-pandoc manual.md -o manual.html -s --number-sections --toc --css manual.css
-
-pandoc reference-cfg-format.md -o reference-cfg-format.pdf -s --number-sections --toc
-pandoc reference-cfg-format.md -o reference-cfg-format.html -s --number-sections --toc
+./build-pdf.sh reference-cfg-format
+./build-html.sh reference-cfg-format


### PR DESCRIPTION
The PDF build command line is getting very long, and it needs another option. Create separate build scripts for HTML and PDF and just pass in the name of the markdown file.

Adds -V subparagraph to fix a LaTeX error.

Adds fallback font selection to the PDF script.