### PR TITLE
fix getUnmatchedLocalSuppressions() called with file name not simplified

### DIFF
--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -381,7 +381,7 @@ std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions
             continue;
         if (!unusedFunctionChecking && s.errorId == "unusedFunction")
             continue;
-        if (file.empty() || !s.isLocal() || s.fileName != file)
+        if (file.empty() || !s.isLocal() || (s.fileName != Path::simplifyPath(file)))
             continue;
         result.push_back(s);
     }


### PR DESCRIPTION
Some paths to calling getUnmatchedLocalSuppressions() has not simplified the file name. So I added a call to simplifyPath() at the compare. I do not really like to do this at the compare for many reasons. But at the same time I did not want to change more in the function to use a temporary variable for the file name.

Maybe a 'bigger' refactor when and where to use simplifyPath() should be done instead?