### PR TITLE
fix use simplifyPath() to make sure file name is same as in the checks

### DIFF
--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -373,6 +373,7 @@ void Suppressions::dump(std::ostream & out) const
 
 std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions(const std::string &file, const bool unusedFunctionChecking) const
 {
+    std::string tmp_file = Path::simplifyPath(file);
     std::list<Suppression> result;
     for (const Suppression &s : mSuppressions) {
         if (s.matched)
@@ -381,7 +382,7 @@ std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions
             continue;
         if (!unusedFunctionChecking && s.errorId == "unusedFunction")
             continue;
-        if (file.empty() || !s.isLocal() || s.fileName != file)
+        if (tmp_file.empty() || !s.isLocal() || s.fileName != tmp_file)
             continue;
         result.push_back(s);
     }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -373,7 +373,7 @@ void Suppressions::dump(std::ostream & out) const
 
 std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions(const std::string &file, const bool unusedFunctionChecking) const
 {
-    std::string tmp_file = Path::simplifyPath(file);
+    std::string tmpFile = Path::simplifyPath(file);
     std::list<Suppression> result;
     for (const Suppression &s : mSuppressions) {
         if (s.matched)
@@ -382,7 +382,7 @@ std::list<Suppressions::Suppression> Suppressions::getUnmatchedLocalSuppressions
             continue;
         if (!unusedFunctionChecking && s.errorId == "unusedFunction")
             continue;
-        if (tmp_file.empty() || !s.isLocal() || s.fileName != tmp_file)
+        if (tmpFile.empty() || !s.isLocal() || s.fileName != tmpFile)
             continue;
         result.push_back(s);
     }

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -20,7 +20,7 @@ def test_unmatched_suppression():
     assert ret == 1
     assert 'Unmatched suppression: some_warning_id' in stderr
 
-def test_unmatched_suppression_2():
+def test_unmatched_suppression_path_with_extra_stuf():
     ret, stdout, stderr = cppcheck(['--inline-suppr', '--enable=information', '--error-exitcode=1', './proj-inline-suppress/2.c'])
     assert ret == 1
     assert 'Unmatched suppression: some_warning_id' in stderr

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -19,3 +19,8 @@ def test_unmatched_suppression():
     ret, stdout, stderr = cppcheck(['--inline-suppr', '--enable=information', '--error-exitcode=1', 'proj-inline-suppress/2.c'])
     assert ret == 1
     assert 'Unmatched suppression: some_warning_id' in stderr
+
+def test_unmatched_suppression_2():
+    ret, stdout, stderr = cppcheck(['--inline-suppr', '--enable=information', '--error-exitcode=1', './proj-inline-suppress/2.c'])
+    assert ret == 1
+    assert 'Unmatched suppression: some_warning_id' in stderr


### PR DESCRIPTION
Suppressions::getUnmatchedLocalSuppressions() is called from places where the file name has not been processed by Path::simplifyPath(). This makes the result a miss match with what checks has used as file name. Now we get the same file names.

I do think that 'sprinkling' Path::simplifyPath() around the code is not the best solution. I would like to move this to the user input/config interface. Not the 'backend'. So a future refactor would be to move some of the use of Path::simplifyPath().