### PR TITLE
Add support for comments at end of suppression in suppression files

### DIFF
--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -173,10 +173,9 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
     Suppressions::Suppression suppression;
     if (std::getline(lineStream, suppression.errorId, ':')) {
         if (std::getline(lineStream, suppression.fileName)) {
-            size_t hashpos, cppcommentpos, endpos;
-            hashpos = suppression.fileName.find("#");
-            cppcommentpos = suppression.fileName.find("//");
-            endpos = std::min(hashpos, cppcommentpos);
+            const std::string::size_type hashpos = suppression.fileName.find("#");
+            const std::string::size_type cppcommentpos = suppression.fileName.find("//");
+            std::string::size_type endpos = std::min(hashpos, cppcommentpos);
             if (endpos != std::string::npos) {
                 while (endpos > 0 && std::isspace(suppression.fileName[endpos-1])) {
                     endpos--;

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -173,6 +173,16 @@ std::string Suppressions::addSuppressionLine(const std::string &line)
     Suppressions::Suppression suppression;
     if (std::getline(lineStream, suppression.errorId, ':')) {
         if (std::getline(lineStream, suppression.fileName)) {
+            size_t hashpos, cppcommentpos, endpos;
+            hashpos = suppression.fileName.find("#");
+            cppcommentpos = suppression.fileName.find("//");
+            endpos = std::min(hashpos, cppcommentpos);
+            if (endpos != std::string::npos) {
+                while (endpos > 0 && std::isspace(suppression.fileName[endpos-1])) {
+                    endpos--;
+                }
+                suppression.fileName = suppression.fileName.substr(0, endpos);
+            }
             // If there is not a dot after the last colon in "file" then
             // the colon is a separator and the contents after the colon
             // is a line number..

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -169,19 +169,22 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(c
 
 std::string Suppressions::addSuppressionLine(const std::string &line)
 {
-    std::istringstream lineStream(line);
+    std::istringstream lineStream;
     Suppressions::Suppression suppression;
+
+    // Strip any end of line comments
+    std::string::size_type endpos = std::min(line.find("#"), line.find("//"));
+    if (endpos != std::string::npos) {
+        while (endpos > 0 && std::isspace(line[endpos-1])) {
+            endpos--;
+        }
+        lineStream.str(line.substr(0, endpos));
+    } else {
+        lineStream.str(line);
+    }
+
     if (std::getline(lineStream, suppression.errorId, ':')) {
         if (std::getline(lineStream, suppression.fileName)) {
-            const std::string::size_type hashpos = suppression.fileName.find("#");
-            const std::string::size_type cppcommentpos = suppression.fileName.find("//");
-            std::string::size_type endpos = std::min(hashpos, cppcommentpos);
-            if (endpos != std::string::npos) {
-                while (endpos > 0 && std::isspace(suppression.fileName[endpos-1])) {
-                    endpos--;
-                }
-                suppression.fileName = suppression.fileName.substr(0, endpos);
-            }
             // If there is not a dot after the last colon in "file" then
             // the colon is a separator and the contents after the colon
             // is a line number..

--- a/man/manual.md
+++ b/man/manual.md
@@ -391,10 +391,10 @@ You can create a suppressions file. Example:
     memleak:src/file1.cpp
     exceptNew:src/file1.cpp
 
-    // suppress all uninitvar errors in all files
-    uninitvar
+    uninitvar // suppress all uninitvar errors in all files
 
 Note that you may add empty lines and comments in the suppressions file.
+Comments must start with `#` or `//` and be at the start of the line, or after the suppression line.
 
 You can use the suppressions file like this:
 

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -493,6 +493,26 @@ private:
         Suppressions suppressions2;
         suppressions2.parseFile(file2);
         ASSERT_EQUALS(true, suppressions2.isSuppressed(errorMessage("abc", "test.cpp", 123)));
+
+        std::istringstream file3("abc // comment");
+        Suppressions suppressions3;
+        suppressions3.parseFile(file3);
+        ASSERT_EQUALS(true, suppressions3.isSuppressed(errorMessage("abc", "test.cpp", 123)));
+
+        std::istringstream file4("abc\t\t # comment");
+        Suppressions suppressions4;
+        suppressions4.parseFile(file4);
+        ASSERT_EQUALS(true, suppressions4.isSuppressed(errorMessage("abc", "test.cpp", 123)));
+
+        std::istringstream file5("abc:test.cpp\t\t # comment");
+        Suppressions suppressions5;
+        suppressions5.parseFile(file5);
+        ASSERT_EQUALS(true, suppressions5.isSuppressed(errorMessage("abc", "test.cpp", 123)));
+
+        std::istringstream file6("abc:test.cpp:123\t\t # comment with . inside");
+        Suppressions suppressions6;
+        suppressions6.parseFile(file6);
+        ASSERT_EQUALS(true, suppressions6.isSuppressed(errorMessage("abc", "test.cpp", 123)));
     }
 
     void inlinesuppress() {


### PR DESCRIPTION
We've been adding comments behind our suppressions (in a suppression file) for justifying the suppressions.  This turned out to work okayish until the justification contains a dot.

It turns out that comments after at suppression was not supported at all.

I've added checking for comments as "#" and "//" at the end of suppression lines (and strip whitespace in front), so that this part is ignored when parsing a suppression.  The suppression parsing is kept as before, allthough, the special handling of dots is confusing.

I also added some lines to the manual, and changed one of the examples to use an end-of-line comment.