### PR TITLE
Fix ticket 9839: AST broken; range for loop that uses decltype

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -485,6 +485,9 @@ static Token * skipDecl(Token *tok)
         } else if (Token::Match(vartok, "%var% [:=(]")) {
             return vartok;
         }
+        else if (Token::simpleMatch(vartok, "decltype (")) {
+            return vartok->linkAt(1)->next();
+        }
         vartok = vartok->next();
     }
     return tok;

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6291,6 +6291,10 @@ private:
                    "        for (const auto & e : array)\n"
                    "            foo(e);\n"
                    "    }\n"
+                   "    void f3() {\n"
+                   "        for (decltype(auto) e : array)\n"
+                   "            foo(e);\n"
+                   "    }\n"
                    "};");
         ASSERT_EQUALS("[test.cpp:8]: (style, inconclusive) Technically the member function 'Fred::f2' can be const.\n", errout.str());
     }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7538,6 +7538,7 @@ private:
         ASSERT_EQUALS("forx0=y(8<z;;(", testAst("for (x=0;(int)y<8;z);"));
         ASSERT_EQUALS("forab,c:(", testAst("for (auto [a,b]: c);"));
         ASSERT_EQUALS("fora*++;;(", testAst("for (++(*a);;);"));
+        ASSERT_EQUALS("foryz:(", testAst("for (decltype(x) *y : z);"));
 
         // problems with multiple expressions
         ASSERT_EQUALS("ax( whilex(", testAst("a(x) while (x)"));


### PR DESCRIPTION
### Context:
 https://trac.cppcheck.net/ticket/9839

### Disclaimer:
So this seams to fix the issue, but I'm very confident that this is not done in a good way 😄 
But is shall be more of a starting point, as this is the very first time for me looking into and changing the code in this project.

### Discussion:
So I think the problem basically boils down to the issue that the function `` static Token * skipDecl(Token *tok) `` does not skip `` decltype(auto) `` 

so adding my hack 
```cpp
  else if (Token::Match(vartok, "decltype ( auto ) ")) {
    return vartok->next()->next()->next()->next();
  }
```

let still all the test pass.

But...
1)  I'm not really sure this is the real cause of this issue
2)  I don't know if this should be handled in a more generic way?
3) I don't know/understand the bigger picture of cppcheck to dig deeper.


So any guidance to have this fixed would be very appreciated.

All the best and keep up the good work

dan-42