### PR TITLE
Change the definition of wxUnusedVar to eliminate false positive constParameters

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -581,7 +581,6 @@
   <define name="wxCHECK2(condition, operation)" value=""/>
   <define name="wxCHECK(condition, retValue)" value=""/>
   <define name="wxFAIL_MSG(message)" value=""/>
-  <define name="wxUnusedVar(var)" value="(void)var"/>
   <define name="wxCOMPILE_TIME_ASSERT(condition, retValue)" value="assert(condition)"/>
   <define name="wxCHECK_MSG(condition, retValue, msg)" value=""/>
   <define name="wxCHECK_RET(condition, retValue)" value=""/>
@@ -14345,5 +14344,12 @@ wxItemKind kind = wxITEM_NORMAL) -->
       <not-uninit/>
       <valid>0:</valid>
     </arg>
+  </function>
+  <!-- void wxUnusedVar<T> (T var) -->
+  <function name="wxUnusedVar">
+    <leak-ignore/>
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1" direction="in"/>
   </function>
 </def>


### PR DESCRIPTION
Perhaps this isn't the best way to do it, but the previous definition of `(void)var` I thought took care of (unused/unreadVariable) issues. Honestly I can't seem to reproduce that now. This new definition takes care of `constParameter` warnings, but I don't know that this is necessarily the right way or not so I'll let you be the judge of that. So feel free to reject this if you don't approve. Though I will say this better resembles the actual method anyway:
```
        template <class T>
            inline void wxUnusedVar(const T& WXUNUSED(t)) { }
```

Here's an example of a false positive:
```
void MyFrame::OnTimer(wxTimerEvent& event)
{
    wxUnusedVar(event);
    // Do something, but not with event
}
```

These methods are event handlers that are bound and this specific definition is expected so the event parameter can't be const. It's common to either call `event.Skip()` or sometimes not use the parameter at all. If you remove the name of the argument then it doesn't complain that it can be const, but presumably some code was written this way possibly for debug purposes or something. However, even with this change if you were to only call const members on event then it would still potentially generate false positives for `constParameter`.  Luckily none of the const functions for `wxEvent` or any subclasses have been defined in wxwidgets.cfg yet so using the variable in almost anyway cppcheck must assume it can't be const.

Also on a slightly unrelated note and should probably go in the forum, but it seems you can override defines by simply ordering your --library where the first library takes priority over subsequent ones. However, this same functionality doesn't work for providing functions in your library cfg.