### PR TITLE
add temporary clangd and clang project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ man/*.html
 .idea
 /.metadata/
 cmake-*
+
+# clang tooling temporary files
+.clangd/
+compile_commands.json


### PR DESCRIPTION
Keep files generated by clangd and clang tooling project files from git.