### PR TITLE
Test for syntax error in nested templates

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -243,6 +243,10 @@ void TemplateSimplifier::fixAngleBrackets()
             if (endTok && endTok->str() == ">>") {
                 endTok->str(">");
                 endTok->insertToken(">");
+            } else if (endTok && endTok->str() == ">>=") {
+                endTok->str(">");
+                endTok->insertToken("=");
+                endTok->insertToken(">");
             }
         } else if (Token::Match(tok, "class|struct|union|=|:|public|protected|private %name% <")) {
             Token *endTok = tok->tokAt(2)->findClosingBracket();
@@ -432,7 +436,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
                 if (closing->str() == ">>")
                     return numberOfParameters;
                 tok = closing->next();
-                if (tok->str() == ">" || tok->str() == ">>")
+                if (Token::Match(tok, ">|>>|>>="))
                     return numberOfParameters;
                 else if (tok->str() == ",") {
                     ++numberOfParameters;
@@ -467,7 +471,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
                 if (level == 0)
                     return numberOfParameters;
                 --level;
-            } else if (tok->str() == ">>") {
+            } else if (tok->str() == ">>" || tok->str() == ">>=") {
                 if (level == 1)
                     return numberOfParameters;
                 level -= 2;
@@ -493,7 +497,7 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
                 return 0;
             if (tok->str() == ">" && level == 0)
                 return numberOfParameters;
-            else if (tok->str() == ">>" && level == 1)
+            else if ((tok->str() == ">>" || tok->str() == ">>=") && level == 1)
                 return numberOfParameters;
             else if (tok->str() == ",") {
                 if (level == 0)
@@ -550,11 +554,11 @@ unsigned int TemplateSimplifier::templateParameters(const Token *tok)
             return 0;
 
         // ,/>
-        while (Token::Match(tok, ">|>>")) {
+        while (Token::Match(tok, ">|>>|>>=")) {
             if (level == 0)
                 return tok->str() == ">" && !Token::Match(tok->next(), "%num%") ? numberOfParameters : 0;
             --level;
-            if (tok->str() == ">>") {
+            if (tok->str() == ">>" || tok->str() == ">>=") {
                 if (level == 0)
                     return !Token::Match(tok->next(), "%num%") ? numberOfParameters : 0;
                 --level;

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -885,7 +885,7 @@ const Token * Token::findClosingBracket() const
         else if (closing->str() == ">") {
             if (--depth == 0)
                 return closing;
-        } else if (closing->str() == ">>") {
+        } else if (closing->str() == ">>" || closing->str() == ">>=") {
             if (depth <= 2)
                 return closing;
             depth -= 2;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -245,8 +245,6 @@ private:
         TEST_CASE(moduloOfOne);
 
         TEST_CASE(sameExpressionPointers);
-
-        TEST_CASE(incorrectTokenization1);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool runSimpleChecks=true, bool verbose=false, Settings* settings = nullptr) {
@@ -8742,20 +8740,6 @@ private:
               "    if (b && c != *a) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
-    }
-
-    void  incorrectTokenization1() {
-        //Fine
-        check("template <typename T>\n"
-              "constexpr bool is_ratio_v = false;\n"
-              "template <std::intmax_t Num, std::intmax_t Den>\n"
-              "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n");
-
-        //Syntax Error
-        check("template <typename T>\n"
-              "constexpr bool is_ratio_v = false;\n"
-              "template <std::intmax_t Num, std::intmax_t Den>\n"
-              "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n");
     }
 };
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -245,6 +245,8 @@ private:
         TEST_CASE(moduloOfOne);
 
         TEST_CASE(sameExpressionPointers);
+
+        TEST_CASE(incorrectTokenization1);
     }
 
     void check(const char code[], const char *filename = nullptr, bool experimental = false, bool inconclusive = true, bool runSimpleChecks=true, bool verbose=false, Settings* settings = nullptr) {
@@ -8740,6 +8742,20 @@ private:
               "    if (b && c != *a) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void  incorrectTokenization1() {
+        //Fine
+        check("template <typename T>\n"
+              "constexpr bool is_ratio_v = false;\n"
+              "template <std::intmax_t Num, std::intmax_t Den>\n"
+              "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n");
+
+        //Syntax Error
+        check("template <typename T>\n"
+              "constexpr bool is_ratio_v = false;\n"
+              "template <std::intmax_t Num, std::intmax_t Den>\n"
+              "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n");
     }
 };
 

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -4119,6 +4119,18 @@ private:
             "    A a;\n"
             "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        //both of these should work but in cppcheck 2.1 only the first option will work (ticket #9843)
+        tok("template <typename T>\n"
+            "constexpr bool is_ratio_v = false;\n"
+            "template <std::intmax_t Num, std::intmax_t Den>\n"
+            "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n");
+        ASSERT_EQUALS("", errout.str());
+        tok("template <typename T>\n"
+            "constexpr bool is_ratio_v = false;\n"
+            "template <std::intmax_t Num, std::intmax_t Den>\n"
+            "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void template_member_ptr() { // Ticket #5786

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -4122,18 +4122,14 @@ private:
 
         //both of these should work but in cppcheck 2.1 only the first option will work (ticket #9843)
         {
-            const std::string expected = "template < typename T > const bool is_ratio_v = false ; template < long Num , long Den > const bool is_ratio_v < std :: ratio < Num , Den > > = true ;";
+            const std::string expected = "template < long Num > const bool foo < bar < Num > > = true ;";
             ASSERT_EQUALS(expected,
-                tok("template <typename T>\n"
-                    "constexpr bool is_ratio_v = false;\n"
-                    "template <long Num, long Den>\n"
-                    "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n"));
+                tok("template <long Num>\n"
+                    "constexpr bool foo<bar<Num> > = true;\n"));
             ASSERT_EQUALS("", errout.str());
             ASSERT_EQUALS(expected,
-                tok("template <typename T>\n"
-                    "constexpr bool is_ratio_v = false;\n"
-                    "template <long Num, long Den>\n"
-                    "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n"));
+                tok("template <long Num>\n"
+                    "constexpr bool foo<bar<Num>> = true;\n"));
             ASSERT_EQUALS("", errout.str());
         }
     }

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -4121,16 +4121,21 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         //both of these should work but in cppcheck 2.1 only the first option will work (ticket #9843)
-        tok("template <typename T>\n"
-            "constexpr bool is_ratio_v = false;\n"
-            "template <std::intmax_t Num, std::intmax_t Den>\n"
-            "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n");
-        ASSERT_EQUALS("", errout.str());
-        tok("template <typename T>\n"
-            "constexpr bool is_ratio_v = false;\n"
-            "template <std::intmax_t Num, std::intmax_t Den>\n"
-            "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n");
-        ASSERT_EQUALS("", errout.str());
+        {
+            const std::string expected = "template < typename T > const bool is_ratio_v = false ; template < long Num , long Den > const bool is_ratio_v < std :: ratio < Num , Den > > = true ;";
+            ASSERT_EQUALS(expected,
+                tok("template <typename T>\n"
+                    "constexpr bool is_ratio_v = false;\n"
+                    "template <std::intmax_t Num, std::intmax_t Den>\n"
+                    "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n"));
+            ASSERT_EQUALS("", errout.str());
+            ASSERT_EQUALS(expected,
+                tok("template <typename T>\n"
+                    "constexpr bool is_ratio_v = false;\n"
+                    "template <std::intmax_t Num, std::intmax_t Den>\n"
+                    "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n"));
+            ASSERT_EQUALS("", errout.str());
+        }
     }
 
     void template_member_ptr() { // Ticket #5786

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -4126,13 +4126,13 @@ private:
             ASSERT_EQUALS(expected,
                 tok("template <typename T>\n"
                     "constexpr bool is_ratio_v = false;\n"
-                    "template <std::intmax_t Num, std::intmax_t Den>\n"
+                    "template <long Num, long Den>\n"
                     "constexpr bool is_ratio_v<std::ratio<Num, Den> > = true;\n"));
             ASSERT_EQUALS("", errout.str());
             ASSERT_EQUALS(expected,
                 tok("template <typename T>\n"
                     "constexpr bool is_ratio_v = false;\n"
-                    "template <std::intmax_t Num, std::intmax_t Den>\n"
+                    "template <long Num, long Den>\n"
                     "constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;\n"));
             ASSERT_EQUALS("", errout.str());
         }


### PR DESCRIPTION
This code compiles fine but is detected as a syntax error by cppcheck:
```
template <typename T>
constexpr bool is_ratio_v = false;
template <std::intmax_t Num, std::intmax_t Den>
constexpr bool is_ratio_v<std::ratio<Num, Den>> = true;
```

The issue is the >>.

Currently this pull request simply adds a test demonstrating the problem. I would appreciate:
-  if someone with a Trac account would raise a corresponding issue.
- advice on where this test should be located
- currently this test results in an unhanded exception terminating the test runner. How should this be better handled or should I not worry about it since if the test passes it doesn't happen?
- any advice on where to look in the code to fix this.

