### PR TITLE
knownConditionTrueFalse bug for float types

### DIFF
--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3561,6 +3561,24 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (style) Condition '-128>x' is always false\n", errout.str());
+
+        //We expect this to trigger for an int but not a float
+        check("void f() {\n"
+            "    int xint = getx();\n"
+            "    if (xint <= 0)\n"
+            "        A();\n"
+            "    else if (xint < 1)\n"
+            "        B();\n"
+            "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:5]: (style) Condition 'xint<1' is always false\n", errout.str());
+        check("void f() {\n"
+              "    float xfloat = getx();\n"
+              "    if (xfloat <= 0)\n"
+              "        A();\n"
+              "    else if (xfloat < 1)\n"
+              "        B();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void alwaysTrueContainer() {


### PR DESCRIPTION
```
void f() {
    float xfloat = getx();
    if (xfloat <= 0)
        A();
    else if (xfloat < 1)
        B();
}
```
erroneously generates a knownConditionTrueFalse warning. If xfloat were an integer this would make sense but for a float there are plenty of values between 0 and 1.

If someone could raise a bug report that would be great.
Any advice on how to fix would be appreciated.

So far I've determined that in CheckCondition::alwaysTrueFalse, tok->hasKnownIntValue() is returning true which is surprising to me though I note that ValueType::INT is the default which seems slightly odd to me.