### PR TITLE
Prevent copying in range-based for loops

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -1173,7 +1173,7 @@ bool CppCheckExecutor::executeCommand(std::string exe, std::vector<std::string> 
     output->clear();
 
     std::string joinedArgs;
-    for (const std::string arg: args) {
+    for (const std::string &arg : args) {
         if (!joinedArgs.empty())
             joinedArgs += " ";
         joinedArgs += arg;

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -588,7 +588,7 @@ namespace {
         std::string str() const {
             std::ostringstream ret;
             std::map<std::string, ExprEngine::ValuePtr> vars;
-            for (const auto mem: memory) {
+            for (const auto &mem: memory) {
                 if (!mem.second)
                     continue;
                 const Variable *var = tokenizer->getSymbolDatabase()->getVariableFromVarId(mem.first);
@@ -597,11 +597,11 @@ namespace {
                 ret << " @" << mem.first << ":" << mem.second->name;
                 getSymbols(vars, mem.second);
             }
-            for (const auto var: vars) {
+            for (const auto &var: vars) {
                 if (var.second->name[0] == '$')
                     ret << " " << ::str(var.second);
             }
-            for (const auto c: constraints)
+            for (const auto &c: constraints)
                 ret << " (" << c->getSymbolicExpression() << ")";
             ret << std::endl;
             return ret.str();
@@ -1851,7 +1851,7 @@ static ExprEngine::ValuePtr executeFunctionCall(const Token *tok, Data &data)
 #endif
         } else if (!argValues.empty()) {
             bool bailout = false;
-            for (const auto v: argValues)
+            for (const auto &v: argValues)
                 bailout |= (v && v->type == ExprEngine::ValueType::BailoutValue);
             if (!bailout)
                 data.addMissingContract(functionName);


### PR DESCRIPTION
Found when building Cppcheck with clang++-12 with `-Wrange-loop-construct`.