### PR TITLE
Add test cases for assign operators with default implementation

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2712,6 +2712,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
                             const Token *closeParen = (*tok)->next()->link();
                             if (closeParen) {
                                 if (Token::Match(closeParen, ") noexcept| = default ;") ||
+                                    Token::Match(closeParen, ") . const| %type% &| = default ;") ||
                                     (Token::simpleMatch(closeParen, ") noexcept (") &&
                                      Token::simpleMatch(closeParen->linkAt(2), ") = default ;"))) {
                                     func->isDefault(true);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -322,6 +322,7 @@ private:
         TEST_CASE(symboldatabase83); // #9431
         TEST_CASE(symboldatabase84);
         TEST_CASE(symboldatabase85);
+        TEST_CASE(symboldatabase86);
 
         TEST_CASE(createSymbolDatabaseFindAllScopes1);
 
@@ -4608,6 +4609,15 @@ private:
 
         const Token *vartok2 = Token::findsimplematch(tokenizer.tokens(), "( _mode ) ;")->next();
         ASSERT_EQUALS(std::intptr_t(vartok1->variable()), std::intptr_t(vartok2->variable()));
+    }
+
+    void symboldatabase86() {
+        GET_SYMBOL_DB("class C { auto operator=(const C&) -> C&; };\n"
+            "auto C::operator=(const C&) -> C& = default;");
+        ASSERT(db->scopeList.size() == 2);
+        ASSERT(db->scopeList.back().functionList.size() == 1);
+        ASSERT(db->scopeList.back().functionList.front().isDefault() == true);
+        ASSERT(db->scopeList.back().functionList.front().hasBody() == false);
     }
 
     void createSymbolDatabaseFindAllScopes1() {


### PR DESCRIPTION
👋 @danmar 

Sorry to bother you again 🙃 

So I have found another issue, and after cutting down my code this fails
```cpp
struct foobar
{
  auto operator=(const foobar&) -> foobar&;
};
auto foobar::operator=(const foobar&) -> foobar& = default;
```
with:
```sh
$ cppcheck --enable=all "foobar.cpp"
Checking foobar.cpp ...
foobar.cpp:0:0: error: Internal Error: Invalid syntax [cppcheckError]
^
foobar.cpp:0:0: note: Internal Error: Invalid syntax
^
foobar.cpp:0:0: note: Internal Error: Invalid syntax
^
```

 * adding `` { } `` instead of `` default `` works
 * adding `` default  `` inside the struct definition works 
 * changing it to the classical form ``` foobar& foobar::operator=(const foobar&)  = default; ``` works 


So I added two test cases to reproduce the issue.
cppcheck failes here:
```cpp
void CheckClass::initializeVarList(const Function &func, std::list<const Function *> &callstack, const Scope *scope, std::vector<Usage> &usage)
{
    if (!func.functionScope)
        throw InternalError(nullptr, "Internal Error: Invalid syntax"); // #5702
    bool initList = func.isConstructor();
```
call comes from this function ` CheckClass::constructors() ` 
and on line ` 147 ` it is checked:
```cpp
   for (const Function &func : scope->functionList) {
            if (!func.hasBody() || !(func.isConstructor() || func.type == Function::eOperatorEqual))
                continue;
```

So I wonder why the check for ```cpp  func.type == Function::eOperatorEqual ``` 

So the issue boils down that ``` func.functionScope ``` is  ``` nullptr ``` 

Could you point me in a direction, is this more of a tokenizing issue?





