### PR TITLE
False positive dynamic_cast auto variable which has been checked against null

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -488,7 +488,7 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value, const Setti
 
     // cast..
     if (const Token *castType = getCastTypeStartToken(parent)) {
-        if (astIsPointer(tok) && value.valueType == ValueFlow::Value::INT &&
+        if ((tok->valueType() == nullptr || (astIsPointer(tok) && value.valueType == ValueFlow::Value::INT)) &&
             Token::simpleMatch(parent->astOperand1(), "dynamic_cast"))
             return;
         const ValueType &valueType = ValueType::parseDecl(castType, settings);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -488,7 +488,7 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value, const Setti
 
     // cast..
     if (const Token *castType = getCastTypeStartToken(parent)) {
-        if ((tok->valueType() == nullptr || (astIsPointer(tok) && value.valueType == ValueFlow::Value::INT)) &&
+        if (((tok->valueType() == nullptr && value.isImpossible()) || astIsPointer(tok)) && value.valueType == ValueFlow::Value::INT &&
             Token::simpleMatch(parent->astOperand1(), "dynamic_cast"))
             return;
         const ValueType &valueType = ValueType::parseDecl(castType, settings);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3317,6 +3317,17 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
+        check("int foo() {\n"
+            "    auto x = getX();\n"
+            "    if (x == nullptr)\n"
+            "        return 1;\n"
+            "    auto y = dynamic_cast<Y*>(x)\n"
+            "    if (y == nullptr)\n"
+            "        return 2;\n"
+            "    return 3;\n"
+            "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         // handleKnownValuesInLoop
         check("bool g();\n"
               "void f(bool x) {\n"


### PR DESCRIPTION
The code added in test fails because it incorrectly determines that y must be null. It looks like the modified code is there to detect and prevent that case (Related to https://trac.cppcheck.net/ticket/9318 and #2186) however I believe it is failing in this case because the variable in question is defined as auto so astIsPointer returns false (because we don't know if it's a pointer at that stage).

I think in the event that we do know whether the variable is a pointer we should continue to check that because dynamic_casting a reference probably doesn't change what we know about the value (though I suppose it could in the case of non-virtual properties). In the interest of keeping the behavior as similar as possible I've added a check for whether valueType() is null and if it is I skip checking whether the type is a pointer (because we don't know).

@pfultz2 I'd like your input on this if possible since you probably have better insight as to the intent of the original code.