### PR TITLE
misra.py: Fix 12.3 FP for variables defined in headers

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1690,8 +1690,9 @@ class MisraChecker:
                 continue
             nt = v.nameToken
             if nt and nt.scope and nt.scope.type not in ('Enum', 'Class', 'Struct'):
-                name_tokens_map.setdefault(nt.linenr, set())
-                name_tokens_map[nt.linenr].add(nt.column)
+                if nt.file == filename:
+                    name_tokens_map.setdefault(nt.linenr, set())
+                    name_tokens_map[nt.linenr].add(nt.column)
         if not name_tokens_map:
             return
 


### PR DESCRIPTION
When we include the header file with variables definitions, Cppcheck will write `variables` entries with line numbers from the header to the dump file.

If the line number in the header file and the source file are equal, misra.py performs an additional check [here](https://github.com/danmar/cppcheck/blob/e52c4f9aa776cf9b9d60c9e6fa062bd520a2b995/addons/misra.py#L1710-L1726), what leads to false positives.

Minimal example that demonstrates the problem:

`misra_fp.c`:
```c
#include "misra_fp.h"
void test_12_3_fp(void)
{
    //Initialize the events queue
    QEQueue_init(&me->deferred_event_queue, me->deferred_events_queue_buf, Q_DIM(me->deferred_events_queue_buf));
}
```

`misra_fp.h`:
```c
 
 
 
 
static const uint32_t timer_max_blocking_call_us;
```

This commit closes [ticket 9874](https://trac.cppcheck.net/ticket/9874).