### PR TITLE
std.cfg: Fix memcpy return type

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -3861,6 +3861,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- void * memcpy(void *ct, const void *cs, size_t n);-->
   <!-- wchar_t * wmemcpy(wchar_t *ct, const wchar_t *cs, size_t n);-->
   <function name="memcpy,std::memcpy,wmemcpy,std::wmemcpy">
+    <returnValue type="void *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="out">


### PR DESCRIPTION
Reported in the forum: https://sourceforge.net/p/cppcheck/discussion/general/thread/5331c5df2c/