### PR TITLE
gui: Add validation for Python path

### DIFF
--- a/gui/settings.ui
+++ b/gui/settings.ui
@@ -292,17 +292,28 @@
          <property name="title">
           <string>Python binary (leave this empty to use python in the PATH)</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLineEdit" name="mEditPythonPath"/>
-          </item>
-          <item>
-           <widget class="QPushButton" name="mBtnBrowsePythonPath">
-            <property name="text">
-             <string>...</string>
-            </property>
-           </widget>
-          </item>
+         <layout class="QVBoxLayout" name="verticalLayout_13">
+           <item>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QLineEdit" name="mEditPythonPath"/>
+              </item>
+              <item>
+               <widget class="QPushButton" name="mBtnBrowsePythonPath">
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+           </item>
+           <item>
+             <widget class="QLabel" name="mPythonPathWarning">
+              <property name="text">
+               <string></string>
+              </property>
+             </widget>
+           </item>
          </layout>
         </widget>
        </item>

--- a/gui/settingsdialog.h
+++ b/gui/settingsdialog.h
@@ -103,6 +103,9 @@ protected slots:
     */
     void ok();
 
+    /** @brief Slot for validating input value in @c editPythonPath */
+    void validateEditPythonPath();
+
     /**
     * @brief Slot for adding a new application to the list
     *


### PR DESCRIPTION
This commit adds to cppcheck-gui validation for the path to the Python interpreter entered by the user.

This will reduce the number of user errors like those described at this thread: https://sourceforge.net/p/cppcheck/discussion/general/thread/ccbe9e89/?limit=25&page=4.