### PR TITLE
Fix wrong escapeing in test string

### DIFF
--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -194,14 +194,14 @@ private:
     void importCompileCommands7() const {
         const char json[] = R"([{
                                    "directory": "/tmp",
-                                   "command": "gcc -DFILESDIR=\"\\\"/home/danielm/cppcheck 2\\\"\" -I\"/home/danielm/cppcheck 2/build/externals/tinyxml\" -DTEST1 -DTEST2=2 -o /tmp/src.o -c /tmp/src.c",
+                                   "command": "gcc -DFILESDIR=\"/home/danielm/cppcheck 2\" -I\"/home/danielm/cppcheck 2/build/externals/tinyxml\" -DTEST1 -DTEST2=2 -o /tmp/src.o -c /tmp/src.c",
                                    "file": "/tmp/src.c"
                                }])";
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        //FIXME ASSERT_EQUALS("FILESDIR=\"/home/danielm/cppcheck 2\";TEST1=1;TEST2=2", importer.fileSettings.begin()->defines);
+        ASSERT_EQUALS("FILESDIR=\"/home/danielm/cppcheck 2\";TEST1=1;TEST2=2", importer.fileSettings.begin()->defines);
         ASSERT_EQUALS(1, importer.fileSettings.begin()->includePaths.size());
         ASSERT_EQUALS("/home/danielm/cppcheck 2/build/externals/tinyxml/", importer.fileSettings.begin()->includePaths.front());
     }


### PR DESCRIPTION
This PR is here to address an open issue from PR https://github.com/danmar/cppcheck/pull/2749.

### Context:

So @danmar reported the following:
For information.. with this command: cmake -DFILESDIR="c:\some path" ..
For me, the compile commands file says:
```json
{
  "directory": "/home/danielm/cppcheck/b/externals/tinyxml",
  "command": "/usr/bin/c++  -DFILESDIR=\"\\\"c:\\\\some path\\\"\" -D_GLIBCXX_DEBUG -I/home/danielm/cppcheck/b/externals/tinyxml -I/home/danielm/cppcheck/externals/tinyxml  -g   -Wcast-qual -Wno-deprecated-declarations -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Woverloaded-virtual -Wpacked -Wredundant-decls -Wundef -Wno-shadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar -Wno-maybe-uninitialized -Wno-suggest-attribute=format -std=gnu++11 -o CMakeFiles/tinyxml_objs.dir/tinyxml2.cpp.o -c /home/danielm/cppcheck/externals/tinyxml/tinyxml2.cpp",
  "file": "/home/danielm/cppcheck/externals/tinyxml/tinyxml2.cpp"
},
```
I assume that everything inside the string is double escaped..


### My investigations:
I tried to reproduce this on my Windows10 system. but without luck.

CMake either says the variables is not used. or if I add it to the include paths then it is correctly escaped.
both tested with Ninja and make(make for mingw/git-bash)

### My Conclusions
So unless producible by an actual typical use case, I think just fixing the test is enough.

 

