### PR TITLE
Improve memleakOnRealloc with assignment to NULL

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -550,6 +550,11 @@ void CheckMemoryLeakInFunction::checkReallocUsage()
                     Token::findmatch(scope->bodyStart, "[{};] %varid% = *| %name% .| %name%| [;=]", tok, tok->varId()))
                     continue;
 
+                // Check if the argument is known to be null, which means it is not a memory leak
+                if (arg->hasKnownIntValue() && arg->getKnownIntValue() == 0) {
+                    continue;
+                }
+
                 const Token* tokEndRealloc = reallocTok->linkAt(1);
                 // Check that the allocation isn't followed immediately by an 'if (!var) { error(); }' that might handle failure
                 if (Token::simpleMatch(tokEndRealloc->next(), "; if (") &&

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -547,7 +547,7 @@ void CheckMemoryLeakInFunction::checkReallocUsage()
 
                 // Check that another copy of the pointer wasn't saved earlier in the function
                 if (Token::findmatch(scope->bodyStart, "%name% = %varid% ;", tok, tok->varId()) ||
-                    Token::findmatch(scope->bodyStart, "[{};] %varid% = *| %name% .| %name%| [;=]", tok, tok->varId()))
+                    Token::findmatch(scope->bodyStart, "[{};] %varid% = *| %var% .| %var%| [;=]", tok, tok->varId()))
                     continue;
 
                 // Check if the argument is known to be null, which means it is not a memory leak

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -201,7 +201,7 @@ private:
               "    free(a);\n"
               "}");
 
-        TODO_ASSERT_EQUALS("", "[test.cpp:4]: (error) Common realloc mistake: 'a' nulled but not freed upon failure\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
     }
 
     void realloc4() {
@@ -296,7 +296,7 @@ private:
               "        return;\n"
               "    free(a);\n"
               "}");
-        TODO_ASSERT_EQUALS("", "[test.cpp:4]: (error) Common realloc mistake: 'a' nulled but not freed upon failure\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
     }
 
     void realloc13() {

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -169,6 +169,7 @@ private:
         TEST_CASE(realloc21);
         TEST_CASE(realloc22);
         TEST_CASE(realloc23);
+        TEST_CASE(realloc24); // #9228
         TEST_CASE(reallocarray1);
     }
 
@@ -406,6 +407,35 @@ private:
               "    if (!(cigar = realloc(cigar, 100 * sizeof(*cigar))))\n"
               "        return;\n"
               "    s->cigar = cigar;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void realloc24() { // #9228
+        check("void f() {\n"
+              "void *a = NULL;\n"
+              "a = realloc(a, 20);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "void *a = NULL;\n"
+              "a = malloc(10);\n"
+              "a = realloc(a, 20);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Common realloc mistake: \'a\' nulled but not freed upon failure\n", errout.str());
+
+        check("void f() {\n"
+              "void *a = std::nullptr;\n"
+              "a = malloc(10);\n"
+              "a = realloc(a, 20);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Common realloc mistake: \'a\' nulled but not freed upon failure\n", errout.str());
+
+        check("void f(char *b) {\n"
+              "void *a = NULL;\n"
+              "a = b;\n"
+              "a = realloc(a, 20);\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
Two improvements are made. First, check if the pointer is NULL and do not issue a warning if that is the case. This fixes a few TODO test cases where we know the pointer that is being reallocated is NULL.

Second, fix FN in [#9228](https://trac.cppcheck.net/ticket/9228), that is
```c
void f() {
    void *a = NULL;
    a = malloc(10);
    a = realloc(a, 20); // No warning here due to a = NULL above
}
```
This is done by checking if we assign to a, we avoid assignments with NULL. This change felt a little kludgy but I didn't find a better way to do it.