### PR TITLE
Improve ast generation for templated function parameters

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1229,6 +1229,9 @@ void CheckUnusedVar::checkFunctionVariableUsage()
 
             const Token *expr = varDecl ? varDecl : tok->astOperand1();
 
+            if (isInitialization)
+                expr = tok->previous();
+
             // Is variable in lhs a union member?
             if (tok->previous() && tok->previous()->variable() && tok->previous()->variable()->nameToken()->scope()->type == Scope::eUnion)
                 continue;

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -801,7 +801,7 @@ static void compileTerm(Token *&tok, AST_state& state)
                         tok = tok->next();
                         return true;
                     }
-                    if (tok->next() && Token::Match(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
+                    if (Token::simpleMatch(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
                         tok = tok->next()->link()->next();
                         return true;
                     }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -800,11 +800,11 @@ static void compileTerm(Token *&tok, AST_state& state)
             while (repeat)
             {
                 repeat = false;
-                if (tok->next() && tok->next()->isName()) {
+                if (Token::Match(tok->next(), "%name%")) {
                     tok = tok->next();
                     repeat = true;
                 }
-                if (Token::simpleMatch(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
+                if (Token::simpleMatch(tok->next(), "<") && Token::Match(tok->linkAt(1), "> %name%")) {
                     tok = tok->next()->link()->next();
                     repeat = true;
                 }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -796,8 +796,17 @@ static void compileTerm(Token *&tok, AST_state& state)
             }
         } else if (!state.cpp || !Token::Match(tok, "new|delete %name%|*|&|::|(|[")) {
             tok = skipDecl(tok);
-            while (tok->next() && tok->next()->isName())
-                tok = tok->next();
+            while ([&] {
+                    if (tok->next() && tok->next()->isName()) {
+                        tok = tok->next();
+                        return true;
+                    }
+                    if (tok->next() && Token::Match(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
+                        tok = tok->next()->link()->next();
+                        return true;
+                    }
+                    return false;
+                }());
             state.op.push(tok);
             if (Token::Match(tok, "%name% <") && tok->linkAt(1))
                 tok = tok->linkAt(1);

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -796,17 +796,19 @@ static void compileTerm(Token *&tok, AST_state& state)
             }
         } else if (!state.cpp || !Token::Match(tok, "new|delete %name%|*|&|::|(|[")) {
             tok = skipDecl(tok);
-            while ([&] {
-                    if (tok->next() && tok->next()->isName()) {
-                        tok = tok->next();
-                        return true;
-                    }
-                    if (Token::simpleMatch(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
-                        tok = tok->next()->link()->next();
-                        return true;
-                    }
-                    return false;
-                }());
+            bool repeat = true;
+            while (repeat)
+            {
+                repeat = false;
+                if (tok->next() && tok->next()->isName()) {
+                    tok = tok->next();
+                    repeat = true;
+                }
+                if (Token::simpleMatch(tok->next(), "<") && tok->next()->link() && tok->next()->link()->next() && tok->next()->link()->next()->isName()) {
+                    tok = tok->next()->link()->next();
+                    repeat = true;
+                }
+            }
             state.op.push(tok);
             if (Token::Match(tok, "%name% <") && tok->linkAt(1))
                 tok = tok->linkAt(1);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -490,6 +490,8 @@ private:
         TEST_CASE(noCrash1);
         TEST_CASE(noCrash2);
 
+        TEST_CASE(noCrash3);
+
         // --check-config
         TEST_CASE(checkConfiguration);
 
@@ -8452,6 +8454,10 @@ private:
                             "template <> d<int>::d(const int &, a::b, double, double);\n"
                             "template <> d<int>::d(const d &) {}\n"
                             "template <> d<c>::d(const d &) {}\n"));
+    }
+
+    void noCrash3() {
+        ASSERT_NO_THROW(tokenizeAndStringify("void a(X<int> x, typename Y1::Y2<int, A::B::C, 2> y, Z z = []{});"));
     }
 
     void checkConfig(const char code[]) {


### PR DESCRIPTION
upgrading from cppcheck 1.90 to 2.1 I observe a new parsing error in code of the form
``` void f(std::function<void()> x = [](){});``` complaining that it cannot parse the lambda.
```cppcheckError: Analysis failed (lambda not recognized). If the code is valid then please report this failure.```

See build results for the first commit for an example of the test failing.

The problem is actually the ```<```. When generating the ast for this expression we end up with ```:: std function``` and miss the rest of the type and the variable name from the term. As such I believe this occurs for any function with a lambda default parameter either of a template type or preceded by a template type.

I asked around and @danmar informs me that we don't really care what the ast for function parameters looks like, as there are other mechanisms that should be used when analyzing them, with the exception that default parameter assignment should be parsed correctly. It looks like the intention of the relevant code is to consume the entire parameter declaration but it's a little difficult to tell. I've modified it to do this.

This change resulted in one new test failure in TestUnusedVar::localVarStd wherein it failed to detect an unused parameter in the expression ```std::vector<int> x(100)```. This is because the ast now looks like ```( :: std vector 100``` and it doesn't recognize :: as a variable properly in FwdAnalysis. I've fixed this by recognizing that when initializing a variable, the variable token must be immediately to the left of the (.