### PR TITLE
fixed some modernize-loop-convert clang-tidy warnings

### DIFF
--- a/gui/erroritem.cpp
+++ b/gui/erroritem.cpp
@@ -80,8 +80,8 @@ QString ErrorItem::toString() const
     str += GuiSeverity::toString(severity) +"\n";
     str += summary + "\n";
     str += message + "\n";
-    for (int i = 0; i < errorPath.size(); i++) {
-        str += "  " + errorPath[i].file + ": " + QString::number(errorPath[i].line) + "\n";
+    for (const QErrorPathItem& i : errorPath) {
+        str += "  " + i.file + ": " + QString::number(i.line) + "\n";
     }
     return str;
 }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1042,9 +1042,9 @@ void MainWindow::analysisDone()
 
     enableResultsButtons();
 
-    for (int i = 0; i < MaxRecentProjects + 1; i++) {
-        if (mRecentProjectActs[i] != nullptr)
-            mRecentProjectActs[i]->setEnabled(true);
+    for (QAction* recentProjectAct : mRecentProjectActs) {
+        if (recentProjectAct != nullptr)
+			recentProjectAct->setEnabled(true);
     }
 
     // Notify user - if the window is not active - that check is ready
@@ -1068,9 +1068,9 @@ void MainWindow::checkLockDownUI()
     if (mScratchPad)
         mScratchPad->setEnabled(false);
 
-    for (int i = 0; i < MaxRecentProjects + 1; i++) {
-        if (mRecentProjectActs[i] != nullptr)
-            mRecentProjectActs[i]->setEnabled(false);
+    for (QAction* recentProjectAct : mRecentProjectActs) {
+        if (recentProjectAct != nullptr)
+			recentProjectAct->setEnabled(false);
     }
 }
 
@@ -1772,9 +1772,9 @@ void MainWindow::openRecentProject()
 
 void MainWindow::updateMRUMenuItems()
 {
-    for (int i = 0; i < MaxRecentProjects + 1; i++) {
-        if (mRecentProjectActs[i] != nullptr)
-            mUI.mMenuFile->removeAction(mRecentProjectActs[i]);
+    for (QAction* recentProjectAct : mRecentProjectActs) {
+        if (recentProjectAct != nullptr)
+            mUI.mMenuFile->removeAction(recentProjectAct);
     }
 
     QStringList projects = mSettings->value(SETTINGS_MRU_PROJECTS).toStringList();

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -160,8 +160,8 @@ ProjectFileDialog::ProjectFileDialog(ProjectFile *projectFile, QWidget *parent)
 
     // Platforms..
     Platforms platforms;
-    for (int i = 0; i < numberOfBuiltinPlatforms; i++)
-        mUI.mComboBoxPlatform->addItem(platforms.get(builtinPlatforms[i]).mTitle);
+    for (cppcheck::Platform::PlatformType builtinPlatform : builtinPlatforms)
+        mUI.mComboBoxPlatform->addItem(platforms.get(builtinPlatform).mTitle);
     QStringList platformFiles;
     foreach (QString sp, searchPaths) {
         if (sp.endsWith("/cfg"))

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -726,9 +726,8 @@ void ResultsTree::contextMenuEvent(QContextMenuEvent * e)
             mContextItem = mModel.itemFromIndex(index);
             if (mContextItem && mApplications->getApplicationCount() > 0 && mContextItem->parent()) {
                 //Disconnect all signals
-                for (int i = 0; i < actions.size(); i++) {
-
-                    disconnect(actions[i], SIGNAL(triggered()), signalMapper, SLOT(map()));
+                for (QAction* action : actions) {
+                    disconnect(action, SIGNAL(triggered()), signalMapper, SLOT(map()));
                 }
 
                 disconnect(signalMapper, SIGNAL(mapped(int)),

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -136,13 +136,13 @@ void ThreadHandler::setThreadCount(const int count)
 
 void ThreadHandler::removeThreads()
 {
-    for (int i = 0; i < mThreads.size(); i++) {
-        mThreads[i]->terminate();
-        disconnect(mThreads[i], &CheckThread::done,
+    for (CheckThread* thread : mThreads) {
+		thread->terminate();
+        disconnect(thread, &CheckThread::done,
                    this, &ThreadHandler::threadDone);
-        disconnect(mThreads[i], &CheckThread::fileChecked,
+        disconnect(thread, &CheckThread::fileChecked,
                    &mResults, &ThreadResult::fileChecked);
-        delete mThreads[i];
+        delete thread;
     }
 
     mThreads.clear();
@@ -175,8 +175,8 @@ void ThreadHandler::stop()
 {
     mCheckStartTime = QDateTime();
     mAnalyseWholeProgram = false;
-    for (int i = 0; i < mThreads.size(); i++) {
-        mThreads[i]->stop();
+    for (CheckThread* thread : mThreads) {
+		thread->stop();
     }
 }
 

--- a/lib/checkinternal.cpp
+++ b/lib/checkinternal.cpp
@@ -37,8 +37,7 @@ namespace {
 void CheckInternal::checkTokenMatchPatterns()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope *scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "Token :: Match (") && !Token::simpleMatch(tok, "Token :: findmatch ("))
                 continue;
@@ -130,8 +129,7 @@ void CheckInternal::checkRedundantTokCheckError(const Token* tok)
 void CheckInternal::checkTokenSimpleMatchPatterns()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope* scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "Token :: simpleMatch (") && !Token::simpleMatch(tok, "Token :: findsimplematch ("))
                 continue;
@@ -151,9 +149,7 @@ void CheckInternal::checkTokenSimpleMatchPatterns()
 
             // Check for [xyz] usage - but exclude standalone square brackets
             unsigned int char_count = 0;
-            for (std::string::size_type pos = 0; pos < pattern.size(); ++pos) {
-                char c = pattern[pos];
-
+            for (char c : pattern) {
                 if (c == ' ') {
                     char_count = 0;
                 } else if (c == ']') {
@@ -168,9 +164,7 @@ void CheckInternal::checkTokenSimpleMatchPatterns()
 
             // Check | usage: Count characters before the symbol
             char_count = 0;
-            for (std::string::size_type pos = 0; pos < pattern.size(); ++pos) {
-                const char c = pattern[pos];
-
+            for (char c : pattern) {
                 if (c == ' ') {
                     char_count = 0;
                 } else if (c == '|') {
@@ -219,8 +213,7 @@ namespace {
 void CheckInternal::checkMissingPercentCharacter()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope* scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "Token :: Match (") && !Token::simpleMatch(tok, "Token :: findmatch ("))
                 continue;
@@ -262,8 +255,7 @@ void CheckInternal::checkMissingPercentCharacter()
 void CheckInternal::checkUnknownPattern()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope* scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "Token :: Match (") && !Token::simpleMatch(tok, "Token :: findmatch ("))
                 continue;
@@ -297,8 +289,7 @@ void CheckInternal::checkUnknownPattern()
 void CheckInternal::checkRedundantNextPrevious()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope* scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (tok->str() != ".")
                 continue;
@@ -329,8 +320,7 @@ void CheckInternal::checkRedundantNextPrevious()
 void CheckInternal::checkExtraWhitespace()
 {
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::size_t i = 0; i < symbolDatabase->functionScopes.size(); ++i) {
-        const Scope * scope = symbolDatabase->functionScopes[i];
+    for (const Scope* scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::Match(tok, "Token :: simpleMatch|findsimplematch|Match|findmatch ("))
                 continue;

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -146,22 +146,22 @@ void CheckIO::checkFileUsage()
                 indent++;
             else if (tok->str() == "}") {
                 indent--;
-                for (std::map<int, Filepointer>::iterator i = filepointers.begin(); i != filepointers.end(); ++i) {
-                    if (indent < i->second.mode_indent) {
-                        i->second.mode_indent = 0;
-                        i->second.mode = UNKNOWN_OM;
+                for (std::pair<const int, Filepointer>& filepointer : filepointers) {
+                    if (indent < filepointer.second.mode_indent) {
+                        filepointer.second.mode_indent = 0;
+                        filepointer.second.mode = UNKNOWN_OM;
                     }
-                    if (indent < i->second.op_indent) {
-                        i->second.op_indent = 0;
-                        i->second.lastOperation = Filepointer::UNKNOWN_OP;
+                    if (indent < filepointer.second.op_indent) {
+                        filepointer.second.op_indent = 0;
+                        filepointer.second.lastOperation = Filepointer::UNKNOWN_OP;
                     }
                 }
             } else if (tok->str() == "return" || tok->str() == "continue" || tok->str() == "break" || mSettings->library.isnoreturn(tok)) { // Reset upon return, continue or break
-                for (std::map<int, Filepointer>::iterator i = filepointers.begin(); i != filepointers.end(); ++i) {
-                    i->second.mode_indent = 0;
-                    i->second.mode = UNKNOWN_OM;
-                    i->second.op_indent = 0;
-                    i->second.lastOperation = Filepointer::UNKNOWN_OP;
+                for (std::pair<const int, Filepointer>& filepointer : filepointers) {
+                    filepointer.second.mode_indent = 0;
+                    filepointer.second.mode = UNKNOWN_OM;
+                    filepointer.second.op_indent = 0;
+                    filepointer.second.lastOperation = Filepointer::UNKNOWN_OP;
                 }
             } else if (Token::Match(tok, "%var% =") &&
                        (tok->strAt(2) != "fopen" && tok->strAt(2) != "freopen" && tok->strAt(2) != "tmpfile" &&
@@ -236,13 +236,13 @@ void CheckIO::checkFileUsage()
                     const Token* const end2 = tok->linkAt(1);
                     if (scope->functionOf && scope->functionOf->isClassOrStruct() && !scope->function->isStatic() && ((tok->strAt(-1) != "::" && tok->strAt(-1) != ".") || tok->strAt(-2) == "this")) {
                         if (!tok->function() || (tok->function()->nestedIn && tok->function()->nestedIn->isClassOrStruct())) {
-                            for (std::map<int, Filepointer>::iterator i = filepointers.begin(); i != filepointers.end(); ++i) {
-                                const Variable* var = symbolDatabase->getVariableFromVarId(i->first);
+                            for (std::pair<const int, Filepointer>& filepointer : filepointers) {
+                                const Variable* var = symbolDatabase->getVariableFromVarId(filepointer.first);
                                 if (!var || !(var->isLocal() || var->isGlobal() || var->isStatic())) {
-                                    i->second.mode = UNKNOWN_OM;
-                                    i->second.mode_indent = 0;
-                                    i->second.op_indent = indent;
-                                    i->second.lastOperation = Filepointer::UNKNOWN_OP;
+                                    filepointer.second.mode = UNKNOWN_OM;
+                                    filepointer.second.mode_indent = 0;
+                                    filepointer.second.op_indent = indent;
+                                    filepointer.second.lastOperation = Filepointer::UNKNOWN_OP;
                                 }
                             }
                             continue;
@@ -326,10 +326,10 @@ void CheckIO::checkFileUsage()
                 }
             }
         }
-        for (std::map<int, Filepointer>::iterator i = filepointers.begin(); i != filepointers.end(); ++i) {
-            i->second.op_indent = 0;
-            i->second.mode = UNKNOWN_OM;
-            i->second.lastOperation = Filepointer::UNKNOWN_OP;
+        for (std::pair<const int, Filepointer>& filepointer : filepointers) {
+            filepointer.second.op_indent = 0;
+            filepointer.second.mode = UNKNOWN_OM;
+            filepointer.second.lastOperation = Filepointer::UNKNOWN_OP;
         }
     }
 }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1979,12 +1979,11 @@ namespace {
             for (const Function &func : scope.functionList) {
                 functionsByName[func.tokenDef->str()].push_back(&func);
             }
-            for (StringFunctionMap::iterator it = functionsByName.begin();
-                 it != functionsByName.end(); ++it) {
-                const std::list<const Function*>::const_iterator nc = std::find_if(it->second.begin(), it->second.end(), notconst);
-                if (nc == it->second.end()) {
+            for (std::pair<const std::string, std::list<const Function*>>& it : functionsByName) {
+                const std::list<const Function*>::const_iterator nc = std::find_if(it.second.begin(), it.second.end(), notconst);
+                if (nc == it.second.end()) {
                     // ok to add all of them
-                    constFunctions.splice(constFunctions.end(), it->second);
+                    constFunctions.splice(constFunctions.end(), it.second);
                 }
             }
         }

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -245,8 +245,8 @@ void Variables::readAliases(unsigned int varid, const Token* tok)
     VariableUsage *usage = find(varid);
 
     if (usage) {
-        for (std::set<unsigned int>::iterator aliases = usage->_aliases.begin(); aliases != usage->_aliases.end(); ++aliases) {
-            VariableUsage *aliased = find(*aliases);
+        for (unsigned int aliases : usage->_aliases) {
+            VariableUsage *aliased = find(aliases);
 
             if (aliased) {
                 aliased->_read = true;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -202,14 +202,14 @@ static std::string executeAddon(const AddonInfo &addonInfo,
         pythonExe = cmdFileName(defaultPythonExe);
     else {
 #ifdef _WIN32
-        const char *p[] = { "python3.exe", "python.exe" };
+        const char *py_exes[] = { "python3.exe", "python.exe" };
 #else
-        const char *p[] = { "python3", "python" };
+        const char *py_exes[] = { "python3", "python" };
 #endif
-        for (int i = 0; i < 2; ++i) {
+        for (const char* py_exe : py_exes) {
             std::string out;
-            if (executeCommand(p[i], split("--version"), redirect, &out) && out.compare(0, 7, "Python ") == 0 && std::isdigit(out[7])) {
-                pythonExe = p[i];
+            if (executeCommand(py_exe, split("--version"), redirect, &out) && out.compare(0, 7, "Python ") == 0 && std::isdigit(out[7])) {
+                pythonExe = py_exe;
                 break;
             }
         }

--- a/lib/pathmatch.cpp
+++ b/lib/pathmatch.cpp
@@ -29,8 +29,8 @@ PathMatch::PathMatch(const std::vector<std::string> &excludedPaths, bool caseSen
     : mExcludedPaths(excludedPaths), mCaseSensitive(caseSensitive)
 {
     if (!mCaseSensitive)
-        for (std::vector<std::string>::iterator i = mExcludedPaths.begin(); i != mExcludedPaths.end(); ++i)
-            std::transform(i->begin(), i->end(), i->begin(), ::tolower);
+        for (std::string& excludedPath : mExcludedPaths)
+            std::transform(excludedPath.begin(), excludedPath.end(), excludedPath.begin(), ::tolower);
     mWorkingDirectory.push_back(Path::getCurrentPath());
 }
 

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -69,8 +69,8 @@ Preprocessor::Preprocessor(Settings& settings, ErrorLogger *errorLogger) : mSett
 
 Preprocessor::~Preprocessor()
 {
-    for (std::map<std::string, simplecpp::TokenList *>::iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it)
-        delete it->second;
+    for (std::pair<const std::string, simplecpp::TokenList *>& tokenList : mTokenLists)
+        delete tokenList.second;
 }
 
 namespace {
@@ -657,9 +657,9 @@ bool Preprocessor::loadFiles(const simplecpp::TokenList &rawtokens, std::vector<
 
 void Preprocessor::removeComments()
 {
-    for (std::map<std::string, simplecpp::TokenList*>::iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
-        if (it->second)
-            it->second->removeComments();
+    for (std::pair<const std::string, simplecpp::TokenList*>& tokenList : mTokenLists) {
+        if (tokenList.second)
+			tokenList.second->removeComments();
     }
 }
 
@@ -982,8 +982,8 @@ unsigned int Preprocessor::calculateChecksum(const simplecpp::TokenList &tokens1
 void Preprocessor::simplifyPragmaAsm(simplecpp::TokenList *tokenList)
 {
     Preprocessor::simplifyPragmaAsmPrivate(tokenList);
-    for (std::map<std::string, simplecpp::TokenList *>::iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
-        Preprocessor::simplifyPragmaAsmPrivate(it->second);
+    for (std::pair<const std::string, simplecpp::TokenList *>& list : mTokenLists) {
+        Preprocessor::simplifyPragmaAsmPrivate(list.second);
     }
 }
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6392,13 +6392,13 @@ void Tokenizer::simplifyFunctionParameters()
             if (argumentNames.size() != argumentNames2.size()) {
                 //move back 'tok1' to the last ';'
                 tok1 = tok1->previous();
-                for (std::map<std::string, Token *>::iterator it = argumentNames.begin(); it != argumentNames.end(); ++it) {
-                    if (argumentNames2.find(it->first) == argumentNames2.end()) {
+                for (std::pair<const std::string, Token *>& argumentName : argumentNames) {
+                    if (argumentNames2.find(argumentName.first) == argumentNames2.end()) {
                         //add the missing parameter argument declaration
                         tok1->insertToken(";");
-                        tok1->insertToken(it->first);
+                        tok1->insertToken(argumentName.first);
                         //register the change inside argumentNames2
-                        argumentNames2[it->first] = tok1->next();
+                        argumentNames2[argumentName.first] = tok1->next();
                         tok1->insertToken("int");
                     }
                 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4100,9 +4100,9 @@ static void valueFlowForwardAssign(Token * const               tok,
     if (!var->isPointer() && !var->isSmartPointer())
         values.remove_if(std::mem_fn(&ValueFlow::Value::isTokValue));
     if (tok->astParent()) {
-        for (std::list<ValueFlow::Value>::iterator it = values.begin(); it != values.end(); ++it) {
-            const std::string info = "Assignment '" + tok->astParent()->expressionString() + "', assigned value is " + it->infoString();
-            it->errorPath.emplace_back(tok, info);
+        for (ValueFlow::Value& value : values) {
+            const std::string info = "Assignment '" + tok->astParent()->expressionString() + "', assigned value is " + value.infoString();
+            value.errorPath.emplace_back(tok, info);
         }
     }
 

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -138,10 +138,10 @@ private:
             replace(line, "(fp.gt ", "(> ");
             replace(line, "(fp.lt ", "(< ");
             int par = 0;
-            for (int pos = 0; pos < line.size(); ++pos) {
-                if (line[pos] == '(')
+            for (char pos : line) {
+                if (pos == '(')
                     par++;
-                else if (line[pos] == ')')
+                else if (pos == ')')
                     --par;
             }
             if (par < 0)


### PR DESCRIPTION
I did not convert the loops with `const_iterator` since the range loops do not ensure the constness. That's also the reason I didn't enable the warning yet.