### PR TITLE
disabled precompiled headers in CMake as they currently do not emit a…

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -41,11 +41,12 @@ option(WITH_QCHART          "When building GUI(need BUILD_GUI=ON), use Qt5 Chart
 option(HAVE_RULES           "Usage of rules (needs PCRE library and headers)"               OFF)
 option(USE_Z3               "Usage of z3 library"                                           OFF)
 
-if (CMAKE_VERSION VERSION_EQUAL "3.16" OR CMAKE_VERSION VERSION_GREATER "3.16")
-    set(CMAKE_DISABLE_PRECOMPILE_HEADERS Off CACHE BOOL "Disable precompiled headers")
-else()
+# precompiled headers do not emit compiler warnings so we cannot use them right now
+#if (CMAKE_VERSION VERSION_EQUAL "3.16" OR CMAKE_VERSION VERSION_GREATER "3.16")
+#    set(CMAKE_DISABLE_PRECOMPILE_HEADERS Off CACHE BOOL "Disable precompiled headers")
+#else()
     set(CMAKE_DISABLE_PRECOMPILE_HEADERS On CACHE BOOL "Disable precompiled headers")
-endif()
+#endif()
 
 set(CMAKE_INCLUDE_DIRS_CONFIGCMAKE ${CMAKE_INSTALL_PREFIX}/include      CACHE PATH "Output directory for headers")
 set(CMAKE_LIB_DIRS_CONFIGCMAKE     ${CMAKE_INSTALL_PREFIX}/lib          CACHE PATH "Output directory for libraries")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@ if (BUILD_TESTS)
         target_link_libraries(testrunner ${Z3_LIBRARIES})
     endif()
 
-    if (CMAKE_VERSION VERSION_EQUAL "3.16" OR CMAKE_VERSION VERSION_GREATER "3.16")
+    if (NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
         target_precompile_headers(testrunner PRIVATE precompiled.h)
     endif()
 


### PR DESCRIPTION
…ny compiler warnings / adjusted check for precompiled header

I stumbled across this by accident when I compared it with an old branch which had some `-Wdocumentation` compiler warnings fixed which somehow were no longer emitted for the latest code.

I open a ticket with CMake about this - see https://gitlab.kitware.com/cmake/cmake/-/issues/21219.