### PR TITLE
misra.py: Treat enum constants as constant known at compile time

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -625,10 +625,17 @@ def isBoolExpression(expr):
     return expr.str in ['!', '==', '!=', '<', '<=', '>', '>=', '&&', '||', '0', '1', 'true', 'false']
 
 
+def isEnumConstant(expr):
+    if not expr or not expr.values:
+        return False
+    values = expr.values
+    return len(values) == 1 and values[0].valueKind == 'known'
+
+
 def isConstantExpression(expr):
     if expr.isNumber:
         return True
-    if expr.isName:
+    if expr.isName and not isEnumConstant(expr):
         return False
     if simpleMatch(expr.previous, 'sizeof ('):
         return True

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1009,11 +1009,17 @@ struct {
   uint8_t data_2[   ]; // 18.7
 } r18_7_struct;
 
+typedef enum {
+    R18_8_ENUM_CONSTANT_0,
+    R18_8_ENUM_CONSTANT_1,
+} r18_8_enum;
+
 void misra_18_8(int x) {
   int buf1[10];
   int buf2[sizeof(int)];
   int vla[x]; // 18.8
   static const unsigned char arr18_8_1[] = UNDEFINED_ID;
+  static uint32_t enum_test_0[R18_8_ENUM_CONSTANT_0] = {0};
 }
 
 union misra_19_2 { }; // 19.2


### PR DESCRIPTION
C89 standard defines enum members as enumeration contants at ch. 6.4.4.3, and they are always known at compile time.

This commit fix false positives for rule 18.8 (and possible other rules that check "constentness") with enumeration members.

Fix [Trac#9913](https://trac.cppcheck.net/ticket/9913).
Reported on the forum: https://sourceforge.net/p/cppcheck/discussion/general/thread/fbf8cb7d38/.