### PR TITLE
fix daca insighttoolkit crash in template simplifier

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -2937,6 +2937,9 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
     bool instantiated = false;
 
     for (const TokenAndName &instantiation : mTemplateInstantiations) {
+        // skip deleted instantiations
+        if (!instantiation.token())
+            continue;
         if (numberOfTemplateInstantiations != mTemplateInstantiations.size()) {
             numberOfTemplateInstantiations = mTemplateInstantiations.size();
             ++recursiveCount;


### PR DESCRIPTION
Don't count deleted instantiations in the recursive count.
I can't reduce the daca code because creduce requires a preprocessed
file to reduce and the problem doesn't show up when the file is
preprocessed with cppcheck.
There is no test because I couldn't reduce the problem files.