### PR TITLE
Remove not-null from wxCommandEvent::SetClientData

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -13466,7 +13466,6 @@ wxItemKind kind = wxITEM_NORMAL) -->
     <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
-      <not-null/>
       <not-bool/>
     </arg>
   </function>


### PR DESCRIPTION
This creates false positives when calling SetClientData with a nullptr which is completely valid.