### PR TITLE
Handle static_assert if standard is at least C++11

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2135,7 +2135,7 @@ void CheckOther::checkDuplicateExpression()
                         if (assignment && warningEnabled)
                             selfAssignmentError(tok, tok->astOperand1()->expressionString());
                         else if (styleEnabled) {
-                            if (mTokenizer->isCPP() && mSettings->standards.cpp==Standards::CPP11 && tok->str() == "==") {
+                            if (mTokenizer->isCPP() && mSettings->standards.cpp >= Standards::CPP11 && tok->str() == "==") {
                                 const Token* parent = tok->astParent();
                                 while (parent && parent->astParent()) {
                                     parent = parent->astParent();


### PR DESCRIPTION
Previously it was being handled only if the standard was *exactly* C++11.