### PR TITLE
threadsafety shall not warn about const vars (in C++11)

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -44,7 +44,7 @@ jobs:
           make -j$(nproc) check
           cd ..
 
-      - name: Unsigned char
+      - name: Build and test with Unsigned char
         run: |
           make clean
           make -j$(nproc) CXXFLAGS=-funsigned-char testrunner
@@ -70,8 +70,8 @@ jobs:
           
       - name: Test addons
         run: |
-          ./cppcheck --addons=threadsafety addons/test/threadsafety
-          ./cppcheck --addons=threadsafety -std=c++03 addons/test/threadsafety
+          ./cppcheck --addon=threadsafety addons/test/threadsafety
+          ./cppcheck --addon=threadsafety -std=c++03 addons/test/threadsafety
 
       - name: Build GUI on ubuntu
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Validate
         run: |
           make -j$(nproc) validateCFG validatePlatforms
+          
+      - name: Test addons
+        run: |
+          ./cppcheck --addons=threadsafety addons/test/threadsafety
+          ./cppcheck --addons=threadsafety -std=c++03 addons/test/threadsafety
 
       - name: Build GUI on ubuntu
         if: matrix.os == 'ubuntu-latest'
@@ -106,7 +111,7 @@ jobs:
           qmake
           make -j$(nproc)
 
-      - name: Fuzzer
+      - name: Build Fuzzer
         run: |
           g++ -fsyntax-only -std=c++11 -Ilib oss-fuzz/*.cpp
 

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install missing software on macos
         if: matrix.os == 'macos-latest'
         run: |
-          brew install z3
+          brew install coreutils z3
           
       - name: Install Qt
         if: matrix.os == 'ubuntu-latest'
@@ -71,7 +71,7 @@ jobs:
       - name: Test addons
         run: |
           ./cppcheck --addon=threadsafety addons/test/threadsafety
-          ./cppcheck --addon=threadsafety -std=c++03 addons/test/threadsafety
+          ./cppcheck --addon=threadsafety --std=c++03 addons/test/threadsafety
 
       - name: Build GUI on ubuntu
         if: matrix.os == 'ubuntu-latest'

--- a/addons/test/threadsafety/local_static.cpp
+++ b/addons/test/threadsafety/local_static.cpp
@@ -1,0 +1,6 @@
+struct Dummy {
+ int x;
+};
+void func() {
+  static Dummy dummy;
+}

--- a/addons/test/threadsafety/local_static_const.cpp
+++ b/addons/test/threadsafety/local_static_const.cpp
@@ -1,0 +1,6 @@
+struct Dummy {
+ int x;
+};
+void func() {
+  static const Dummy dummy;
+}

--- a/addons/threadsafety.py
+++ b/addons/threadsafety.py
@@ -19,10 +19,7 @@ def checkstatic(data):
                 type = 'object'
             else:
                 type = 'variable'
-            if var.isConst:
-                reportError(var.typeStartToken, 'warning', 'Local constant static ' + type + ' \'' + var.nameToken.str + '\', dangerous if it is initialized in parallel threads', 'threadsafety')
-            else:
-                reportError(var.typeStartToken, 'warning', 'Local static ' + type + ': ' + var.nameToken.str, 'threadsafety')
+            reportError(var.typeStartToken, 'warning', 'Local static ' + type + ': ' + var.nameToken.str, 'threadsafety')
 
 for arg in sys.argv[1:]:
     if arg.startswith('-'):

--- a/addons/threadsafety.py
+++ b/addons/threadsafety.py
@@ -19,7 +19,11 @@ def checkstatic(data):
                 type = 'object'
             else:
                 type = 'variable'
-            reportError(var.typeStartToken, 'warning', 'Local static ' + type + ': ' + var.nameToken.str, 'threadsafety')
+            if var.isConst:
+                if data.standards.cpp == 'c++03':
+                    reportError(var.typeStartToken, 'warning', 'Local constant static ' + type + ' \'' + var.nameToken.str + '\', dangerous if it is initialized in parallel threads', 'threadsafety-const')
+            else:
+                reportError(var.typeStartToken, 'warning', 'Local static ' + type + ': ' + var.nameToken.str, 'threadsafety')
 
 for arg in sys.argv[1:]:
     if arg.startswith('-'):


### PR DESCRIPTION
C++11 guarantees static initialization to be thread-safe: 6.7  Declaration statement

Do addons have information about the  language standard being configured?