### PR TITLE
Fix #9941: Return value type of library functions returning unsigned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -730,7 +730,7 @@ test/testsuite.o: test/testsuite.cpp lib/config.h lib/errorlogger.h lib/errortyp
 test/testsuppressions.o: test/testsuppressions.cpp cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/testsuite.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testsuppressions.o test/testsuppressions.cpp
 
-test/testsymboldatabase.o: test/testsymboldatabase.cpp lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h test/testutils.h
+test/testsymboldatabase.o: test/testsymboldatabase.cpp externals/tinyxml/tinyxml2.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h test/testutils.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testsymboldatabase.o test/testsymboldatabase.cpp
 
 test/testthreadexecutor.o: test/testthreadexecutor.cpp cli/threadexecutor.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/testsuite.h

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -6148,6 +6148,7 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
                     TokenList tokenList(mSettings);
                     std::istringstream istr(typestr+";");
                     tokenList.createTokens(istr);
+                    tokenList.simplifyStdType();
                     if (parsedecl(tokenList.front(), &valuetype, mDefaultSignedness, mSettings)) {
                         valuetype.originalTypeName = typestr;
                         setValueType(tok, valuetype);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <tinyxml2.h>
 #include <vector>
 
 struct InternalError;
@@ -6930,6 +6931,35 @@ private:
         ASSERT_EQUALS("unsigned long", typeOf("enum E : unsigned long { }; void foo() { E e[3]; bar(e[0]); }", "[ 0"));
         ASSERT_EQUALS("signed long long", typeOf("enum E : long long { }; void foo() { E e[3]; bar(e[0]); }", "[ 0"));
         ASSERT_EQUALS("unsigned long long", typeOf("enum E : unsigned long long { }; void foo() { E e[3]; bar(e[0]); }", "[ 0"));
+
+#define CHECK_LIBRARY_FUNCTION_RETURN_TYPE(type) do { \
+        Settings sF; \
+        const char xmldata[] = "<?xml version=\"1.0\"?>\n" \
+                               "<def>\n" \
+                               "<function name=\"g\">\n" \
+                               "<returnValue type=\"" #type "\"/>\n" \
+                               "</function>\n" \
+                               "</def>"; \
+        tinyxml2::XMLDocument doc; \
+        doc.Parse(xmldata, sizeof(xmldata)); \
+        sF.library.load(doc); \
+        ASSERT_EQUALS(#type, typeOf("void f() { auto x = g(); }", "x", "test.cpp", &sF)); \
+    } while (false)
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(bool);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(signed char);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(unsigned char);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(signed short);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(unsigned short);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(signed int);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(unsigned int);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(signed long);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(unsigned long);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(signed long long);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(unsigned long long);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(void *);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(void * *);
+        CHECK_LIBRARY_FUNCTION_RETURN_TYPE(const void *);
+#undef CHECK_LIBRARY_FUNCTION_RETURN_TYPE
 
         // Library types
         {


### PR DESCRIPTION
Fix return value types of library functions returning unsigned.
Previously, the valueType of `auto x = f()` would be signed even if `f()`
was specified to return an unsigned type.

This fixes [#9941](https://trac.cppcheck.net/ticket/9941), which is a regression in cppcheck 2.2 compared to 2.1.
The regression was introduced in 32df807b2287.