### PR TITLE
Enable building of Qt online-help in gui.pro

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,6 +79,7 @@ build_script:
   - ECHO MYQTDIR=%MYQTDIR%
   - 'IF defined MYQTDIR cd gui'
   - 'IF defined MYQTDIR set QTDIR=%MYQTDIR%'
+  - 'IF defined MYQTDIR set PATH=%PATH%;%QTDIR%\bin'
   - 'IF defined MYQTDIR %QTDIR%\bin\qmake'
   - 'IF defined MYQTDIR nmake'
   - 'IF defined MYQTDIR cd ..'

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -13,10 +13,15 @@ QT += printsupport
 QT += help
 
 # Build online help
-#onlinehelp.target = online-help.qhc
-#onlinehelp.commands = qhelpgenerator $$PWD/help/online-help.qhp -o online-help.qch ; qhelpgenerator $$PWD/help/online-help.qhcp -o online-help.qhc
-#QMAKE_EXTRA_TARGETS += onlinehelp
-#PRE_TARGETDEPS += online-help.qhc
+onlinehelp.target = online-help.qhc
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 12) {
+    # qcollectiongenerator is used in case of QT version < 5.12
+    onlinehelp.commands = qcollectiongenerator $$PWD/help/online-help.qhcp -o $$PWD/help/online-help.qhc
+} else {
+    onlinehelp.commands = qhelpgenerator $$PWD/help/online-help.qhcp -o $$PWD/help/online-help.qhc
+}
+QMAKE_EXTRA_TARGETS += onlinehelp
+PRE_TARGETDEPS += online-help.qhc
 
 contains(LINKCORE, [yY][eE][sS]) {
     LIBS += -l../bin/cppcheck-core


### PR DESCRIPTION
- gui.pro: Update the path of the output file, so that it is also built
  inside the `help` sub-directory (add `$$PWD/help/` to the path):
  `-o $$PWD/help/online-help.qhc`
- Use **`qcollectiongenerator`** in case of Qt version < 5.12, otherwise
  **`qhelpgenerator`**
- appveyor.yml: Add `%QTDIR%\bin` to `PATH`. This allows **`qhelpgenerator`**
  or **`qcollectiongenerator`** to be found
