### PR TITLE
Symboldatabase: Don't set unknown enum values

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1278,6 +1278,7 @@ void SymbolDatabase::createSymbolDatabaseEnums()
             continue;
 
         MathLib::bigint value = 0;
+        bool prev_enum_is_known = true;
 
         for (Enumerator & enumerator : it->enumeratorList) {
             // look for initialization tokens that can be converted to enumerators and convert them
@@ -1304,11 +1305,13 @@ void SymbolDatabase::createSymbolDatabaseEnums()
                     enumerator.value = rhs->values().front().intvalue;
                     enumerator.value_known = true;
                     value = enumerator.value + 1;
-                }
+                    prev_enum_is_known = true;
+                } else
+                    prev_enum_is_known = false;
             }
 
             // not initialized so use default value
-            else {
+            else if (prev_enum_is_known) {
                 enumerator.value = value++;
                 enumerator.value_known = true;
             }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -336,6 +336,7 @@ private:
         TEST_CASE(enum5);
         TEST_CASE(enum6);
         TEST_CASE(enum7);
+        TEST_CASE(enum8);
 
         TEST_CASE(sizeOfType);
 
@@ -5006,6 +5007,31 @@ private:
         TEST(settings1.sizeof_long);
         TEST(settings1.sizeof_long_long);
         TEST(settings1.sizeof_long_long);
+    }
+
+    void enum8() {
+        GET_SYMBOL_DB("enum E { X0 = x, X1, X2 = 2, X3, X4 = y, X5 };\n");
+        ASSERT(db != nullptr);
+        const Enumerator *X0 = db->scopeList.back().findEnumerator("X0");
+        ASSERT(X0);
+        ASSERT(!X0->value_known);
+        const Enumerator *X1 = db->scopeList.back().findEnumerator("X1");
+        ASSERT(X1);
+        ASSERT(!X1->value_known);
+        const Enumerator *X2 = db->scopeList.back().findEnumerator("X2");
+        ASSERT(X2);
+        ASSERT(X2->value_known);
+        ASSERT_EQUALS(X2->value, 2);
+        const Enumerator *X3 = db->scopeList.back().findEnumerator("X3");
+        ASSERT(X3);
+        ASSERT(X3->value_known);
+        ASSERT_EQUALS(X3->value, 3);
+        const Enumerator *X4 = db->scopeList.back().findEnumerator("X4");
+        ASSERT(X4);
+        ASSERT(!X4->value_known);
+        const Enumerator *X5 = db->scopeList.back().findEnumerator("X5");
+        ASSERT(X5);
+        ASSERT(!X5->value_known);
     }
 
     void sizeOfType() {


### PR DESCRIPTION
Previously, if an enum value was set to a value unknown to cppcheck, the
next enum value would erroneously be set to the last set value plus one
(or zero, if no enum value had been set before). This partially fixes
Trac ticket [#9647](https://trac.cppcheck.net/ticket/9647), in the sense that it no longer sets wrong values for
these enum values. Further improvements to this would be to set the
correct values instead. It also fixes the false positive mentioned in the
comments in the ticket.

I believe to set the correct enum values, we would need to add an extra pass to
valueflow, right?