### PR TITLE
Fixed MISRA 12.3 and 13.4 false positives due to C++ syntax

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1663,6 +1663,8 @@ class MisraChecker:
                         # This comma is used in initlist, do not warn
                         continue
                 prev = token.previous
+                if prev.previous.str == "<": # QMap<prev,
+                    continue
                 while prev:
                     if prev.str == ';':
                         self.reportError(token, 12, 3)
@@ -1738,7 +1740,12 @@ class MisraChecker:
                 continue
             if not token.astParent:
                 continue
-            if token.astOperand1.str == '[' and token.astOperand1.previous.str in ('{', ','):
+            if token.astOperand1 is not None and token.astOperand1.str == '[':
+                if token.astOperand1 is None or token.astOperand1.previous is None:
+                    continue
+                if token.astOperand1.previous.str in ('{', ','):
+                    continue
+            if token.next.str == ']': # [=] CPP lamda
                 continue
             if not (token.astParent.str in [',', ';', '{']):
                 self.reportError(token, 13, 4)

--- a/addons/test/misra/misra-test.cpp
+++ b/addons/test/misra/misra-test.cpp
@@ -23,3 +23,23 @@ static bool test_misra_21_1_crash()
     auto misra_21_1_C a, b; // 12.3
     a = b;
 }
+
+static void test_misra_12_3()
+{
+    // this is not a 12.3
+    new QMap<int, void*>();
+}
+
+static void test_misra_13_4()
+{
+    // this is not a 13.4
+    std::function<void(std::vector<uint8_t>)> CommTestReceived= [=] (std::vector<uint8_t> payload)
+    {
+        this->commTestReceived(payload);
+    };
+
+    // this is a 13.4 violation
+    a [ x ] = a[ x = y ];
+}
+
+


### PR DESCRIPTION
Sometimes MISRA C addon gets confused by C++ syntax.
For instance the map `QMap<int, Request*>` fails under Rule 12.3 or C++ lambdas fails under Rule 13.4.

Please note that this merge request is not ready to be merged. While it "works" on real code, it is hardcoded (eg. it will fail to recogize templates with more that 2 parameters). Instead, I would like to discuss how this kind of issues should be addressed.

Thank you,
Francesco