### PR TITLE
Prevent crash when we don't have the valueType

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -469,7 +469,7 @@ void CheckCondition::duplicateCondition()
                 }
             }
             if (tok3->varId() > 0 &&
-                isVariableChanged(scope.classDef->next(), cond2, tok3->valueType()->pointer, tok3->varId(), false, mSettings, mTokenizer->isCPP())) {
+                isVariableChanged(scope.classDef->next(), cond2, tok3->valueType() ? tok3->valueType()->pointer : 0, tok3->varId(), false, mSettings, mTokenizer->isCPP())) {
                 modified = true;
                 return ChildrenToVisit::done;
             }


### PR DESCRIPTION
I couldn't find a small test case (I only have reproducers with big files
and include files...).

Sorry about that, I missed that in #2854 .