### PR TITLE
qt.cfg: allow bool as second argument of setProperty()

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -3615,7 +3615,6 @@
     </arg>
     <arg nr="2" direction="in">
       <not-uninit/>
-      <not-bool/>
     </arg>
   </function>
   <!-- void QAction::setShortcut(const QKeySequence &shortcut) -->


### PR DESCRIPTION
A QVariant can be constructed with a bool, so there is no reason to
forbid this.