### PR TITLE
MISRA Rule 6.1/6.2 Bit field check

### DIFF
--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -203,6 +203,20 @@ void misra_5_5_func1()
   }
 }
 
+typedef unsigned int UINT_TYPEDEF;
+struct struct_with_bitfields
+{
+  unsigned int a:2; // Compliant 
+  signed int   b:2; // Compliant
+  UINT_TYPEDEF c:2; // Compliant
+  int          d:2; // 6.1 - plain int not compliant  
+
+  bool         e:2; // Compliant
+  signed long  f:2; // 6.1 - signed long not compliant
+                             
+  unsigned int g:1; // Compliant
+  signed int   h:1; // 6.2 - signed int with size 1 is not compliant
+};
 
 void misra_7_1() {
   int x = 066; // 7.1


### PR DESCRIPTION
Using the bits info for tokens to find bitfields. Then checking if the token's length and type.