### PR TITLE
travis: Test htmlreport with python2 and python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,11 @@ matrix:
 # Validate rule files
         - make validateRules
 # check htmlreport stuff
-        - ./htmlreport/test_htmlreport.py
+        - python2 htmlreport/test_htmlreport.py
+        - python3 htmlreport/test_htmlreport.py
         - cd htmlreport
-        - ./check.sh
+        - PYTHON=python2 ./check.sh
+        - PYTHON=python3 ./check.sh
         - cd ../
 # check if DESTDIR works  TODO: actually execute this
         - mkdir install_test

--- a/htmlreport/check.sh
+++ b/htmlreport/check.sh
@@ -21,6 +21,10 @@ function validate_html {
     fi
 }
 
+if [ -z "$PYTHON" ]; then
+    PYTHON=python
+fi
+
 REPORT_DIR=$(mktemp -d -t htmlreport-XXXXXXXXXX)
 INDEX_HTML="$REPORT_DIR/index.html"
 STATS_HTML="$REPORT_DIR/stats.html"
@@ -28,7 +32,7 @@ GUI_TEST_XML="$REPORT_DIR/gui_test.xml"
 ERRORLIST_XML="$REPORT_DIR/errorlist.xml"
 UNMATCHEDSUPPR_XML="$REPORT_DIR/unmatchedSuppr.xml"
 
-./cppcheck-htmlreport --file ../gui/test/data/xmlfiles/xmlreport_v2.xml --title "xml2 test" --report-dir "$REPORT_DIR" --source-dir ../test/
+$PYTHON cppcheck-htmlreport --file ../gui/test/data/xmlfiles/xmlreport_v2.xml --title "xml2 test" --report-dir "$REPORT_DIR" --source-dir ../test/
 echo -e "\n"
 # Check HTML syntax
 validate_html "$INDEX_HTML"
@@ -37,7 +41,7 @@ validate_html "$STATS_HTML"
 
 ../cppcheck ../gui/test --enable=all  --inconclusive --xml-version=2 2> "$GUI_TEST_XML"
 xmllint --noout "$GUI_TEST_XML"
-./cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive test" --report-dir "$REPORT_DIR"
+$PYTHON cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive test" --report-dir "$REPORT_DIR"
 echo ""
 # Check HTML syntax
 validate_html "$INDEX_HTML"
@@ -46,7 +50,7 @@ validate_html "$STATS_HTML"
 
 ../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml-version=2 2> "$GUI_TEST_XML"
 xmllint --noout "$GUI_TEST_XML"
-./cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive + verbose test" --report-dir "$REPORT_DIR"
+$PYTHON cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive + verbose test" --report-dir "$REPORT_DIR"
 echo -e "\n"
 # Check HTML syntax
 validate_html "$INDEX_HTML"
@@ -55,7 +59,7 @@ validate_html "$STATS_HTML"
 
 ../cppcheck --errorlist --inconclusive --xml-version=2 > "$ERRORLIST_XML"
 xmllint --noout "$ERRORLIST_XML"
-./cppcheck-htmlreport --file "$ERRORLIST_XML" --title "errorlist" --report-dir "$REPORT_DIR"
+$PYTHON cppcheck-htmlreport --file "$ERRORLIST_XML" --title "errorlist" --report-dir "$REPORT_DIR"
 # Check HTML syntax
 validate_html "$INDEX_HTML"
 validate_html "$STATS_HTML"
@@ -63,7 +67,7 @@ validate_html "$STATS_HTML"
 
 ../cppcheck ../samples/memleak/good.c ../samples/resourceLeak/good.c  --xml-version=2 --enable=information --suppressions-list=test_suppressions.txt --xml 2> "$UNMATCHEDSUPPR_XML"
 xmllint --noout "$UNMATCHEDSUPPR_XML"
-./cppcheck-htmlreport --file "$UNMATCHEDSUPPR_XML" --title "unmatched Suppressions" --report-dir="$REPORT_DIR"
+$PYTHON cppcheck-htmlreport --file "$UNMATCHEDSUPPR_XML" --title "unmatched Suppressions" --report-dir="$REPORT_DIR"
 grep "unmatchedSuppression<.*>information<.*>Unmatched suppression: variableScope*<" "$INDEX_HTML"
 grep ">unmatchedSuppression</.*>information<.*>Unmatched suppression: uninitstring<" "$INDEX_HTML"
 grep "notexisting" "$INDEX_HTML"

--- a/htmlreport/check.sh
+++ b/htmlreport/check.sh
@@ -21,46 +21,55 @@ function validate_html {
     fi
 }
 
-./cppcheck-htmlreport --file ../gui/test/data/xmlfiles/xmlreport_v2.xml --title "xml2 test" --report-dir . --source-dir ../test/
+REPORT_DIR=$(mktemp -d -t htmlreport-XXXXXXXXXX)
+INDEX_HTML="$REPORT_DIR/index.html"
+STATS_HTML="$REPORT_DIR/stats.html"
+GUI_TEST_XML="$REPORT_DIR/gui_test.xml"
+ERRORLIST_XML="$REPORT_DIR/errorlist.xml"
+UNMATCHEDSUPPR_XML="$REPORT_DIR/unmatchedSuppr.xml"
+
+./cppcheck-htmlreport --file ../gui/test/data/xmlfiles/xmlreport_v2.xml --title "xml2 test" --report-dir "$REPORT_DIR" --source-dir ../test/
 echo -e "\n"
 # Check HTML syntax
-validate_html index.html
-validate_html stats.html
+validate_html "$INDEX_HTML"
+validate_html "$STATS_HTML"
 
 
-../cppcheck ../gui/test --enable=all  --inconclusive --xml-version=2 2> gui_test.xml
-xmllint --noout gui_test.xml
-./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive test" --report-dir .
+../cppcheck ../gui/test --enable=all  --inconclusive --xml-version=2 2> "$GUI_TEST_XML"
+xmllint --noout "$GUI_TEST_XML"
+./cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive test" --report-dir "$REPORT_DIR"
 echo ""
 # Check HTML syntax
-validate_html index.html
-validate_html stats.html
+validate_html "$INDEX_HTML"
+validate_html "$STATS_HTML"
 
 
-../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml-version=2 2> gui_test.xml
-xmllint --noout gui_test.xml
-./cppcheck-htmlreport --file ./gui_test.xml --title "xml2 + inconclusive + verbose test" --report-dir .
+../cppcheck ../gui/test --enable=all --inconclusive --verbose --xml-version=2 2> "$GUI_TEST_XML"
+xmllint --noout "$GUI_TEST_XML"
+./cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive + verbose test" --report-dir "$REPORT_DIR"
 echo -e "\n"
 # Check HTML syntax
-validate_html index.html
-validate_html stats.html
+validate_html "$INDEX_HTML"
+validate_html "$STATS_HTML"
 
 
-../cppcheck --errorlist --inconclusive --xml-version=2 > errorlist.xml
-xmllint --noout errorlist.xml
-./cppcheck-htmlreport --file ./errorlist.xml --title "errorlist" --report-dir .
+../cppcheck --errorlist --inconclusive --xml-version=2 > "$ERRORLIST_XML"
+xmllint --noout "$ERRORLIST_XML"
+./cppcheck-htmlreport --file "$ERRORLIST_XML" --title "errorlist" --report-dir "$REPORT_DIR"
 # Check HTML syntax
-validate_html index.html
-validate_html stats.html
+validate_html "$INDEX_HTML"
+validate_html "$STATS_HTML"
 
 
-../cppcheck ../samples/memleak/good.c ../samples/resourceLeak/good.c  --xml-version=2 --enable=information --suppressions-list=test_suppressions.txt --xml 2> unmatchedSuppr.xml
-xmllint --noout unmatchedSuppr.xml
-./cppcheck-htmlreport --file ./unmatchedSuppr.xml --title "unmatched Suppressions" --report-dir=.
-grep "unmatchedSuppression<.*>information<.*>Unmatched suppression: variableScope*<" index.html
-grep ">unmatchedSuppression</.*>information<.*>Unmatched suppression: uninitstring<" index.html
-grep "notexisting" index.html
-grep ">unmatchedSuppression<.*>information<.*>Unmatched suppression: \*<" index.html
+../cppcheck ../samples/memleak/good.c ../samples/resourceLeak/good.c  --xml-version=2 --enable=information --suppressions-list=test_suppressions.txt --xml 2> "$UNMATCHEDSUPPR_XML"
+xmllint --noout "$UNMATCHEDSUPPR_XML"
+./cppcheck-htmlreport --file "$UNMATCHEDSUPPR_XML" --title "unmatched Suppressions" --report-dir="$REPORT_DIR"
+grep "unmatchedSuppression<.*>information<.*>Unmatched suppression: variableScope*<" "$INDEX_HTML"
+grep ">unmatchedSuppression</.*>information<.*>Unmatched suppression: uninitstring<" "$INDEX_HTML"
+grep "notexisting" "$INDEX_HTML"
+grep ">unmatchedSuppression<.*>information<.*>Unmatched suppression: \*<" "$INDEX_HTML"
 # Check HTML syntax
-validate_html index.html
-validate_html stats.html
+validate_html "$INDEX_HTML"
+validate_html "$STATS_HTML"
+
+rm -rf "$REPORT_DIR"

--- a/htmlreport/check.sh
+++ b/htmlreport/check.sh
@@ -7,8 +7,12 @@
 tidy_cmd='tidy -o /dev/null -eq'
 
 function validate_html {
+    if [ ! -f "$1" ]; then
+        echo "File $1 does not exist!"
+	exit 1
+    fi
     set +e
-    ${tidy_cmd} $1
+    ${tidy_cmd} "$1"
     tidy_status=$?
     set -e
     if [ $tidy_status -eq 2 ]; then

--- a/htmlreport/test_htmlreport.py
+++ b/htmlreport/test_htmlreport.py
@@ -98,7 +98,7 @@ def runCheck(source_filename=None, xml_version='1', xml_filename=None):
     assert os.path.exists(xml_filename)
 
     subprocess.check_call(
-        [HTML_REPORT_BIN,
+        [sys.executable, HTML_REPORT_BIN,
          '--file=' + os.path.realpath(xml_filename),
          '--report-dir=' + os.path.realpath(output_directory)],
         cwd=os.path.join(ROOT_DIR, 'htmlreport'))


### PR DESCRIPTION
Somewhat inspired by #2858, make sure htmlreport works in both python2 and python3 by running the tests travis with both python versions. This obviously doubles the time it takes to tests htmlreport, but since it only takes 5 seconds to run, that's ok.