### PR TITLE
Fix #8327 (Memleak with mmap return value check)

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -510,6 +510,8 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                         varInfo2.erase(vartok->varId());
                     } else if (astIsVariableComparison(tok3, "==", "-1", &vartok)) {
                         varInfo1.erase(vartok->varId());
+                    } else if (astIsVariableComparison(tok3, "!=", "-1", &vartok)) {
+                        varInfo2.erase(vartok->varId());
                     }
                     return ChildrenToVisit::none;
                 });

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -200,6 +200,14 @@ void memleak_mmap(int fd)
     // cppcheck-suppress memleak
 }
 
+void * memleak_mmap2() // #8327
+{
+    void * data = mmap(NULL, 10, PROT_READ, MAP_PRIVATE, 1, 0);
+    if (data != MAP_FAILED)
+        return data;
+    return NULL;
+}
+
 void resourceLeak_fdopen(int fd)
 {
     // cppcheck-suppress unreadVariable

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -41,6 +41,9 @@ private:
         settings.library.setalloc("malloc", id, -1);
         settings.library.setrealloc("realloc", id, -1);
         settings.library.setdealloc("free", id, 1);
+        while (!Library::ismemory(++id));
+        settings.library.setalloc("socket", id, -1);
+        settings.library.setdealloc("close", id, 1);
         while (!Library::isresource(++id));
         settings.library.setalloc("fopen", id, -1);
         settings.library.setrealloc("freopen", id, -1, 3);
@@ -1392,10 +1395,19 @@ private:
     }
 
     void ifelse8() { // #5747
-        check("void f() {\n"
+        check("int f() {\n"
               "    int fd = socket(AF_INET, SOCK_PACKET, 0 );\n"
               "    if (fd == -1)\n"
-              "        return;\n"
+              "        return -1;\n"
+	      "    return fd;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f() {\n"
+              "    int fd = socket(AF_INET, SOCK_PACKET, 0 );\n"
+              "    if (fd != -1)\n"
+              "        return fd;\n"
+	      "    return -1;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
Also fix a broken test case related to checking the return value -1
where socket was not defined in the library used in the tests.

This was tested running `test-my-pr` with 500 packages. The difference was
six fewer FPs. Log is attached.

[my_check_diff.log](https://github.com/danmar/cppcheck/files/5455213/my_check_diff.log)
