### PR TITLE
MISRA Rule 7.4 Check if variables assigned as string literals are const

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -761,11 +761,6 @@ def getArguments(ftok):
     getArgumentsRecursive(ftok.astOperand2, arguments)
     return arguments
 
-def getFunction(functions, functionName, numberOfArguments):
-    for f in functions:
-        if (f.name == functionName and 
-            len(f.argument) == numberOfArguments):
-            return f
 
 def isalnum(c):
     return c in string.digits or c in string.ascii_letters
@@ -1421,10 +1416,9 @@ class MisraChecker:
                         self.reportError(token, 7, 4)
 
             # Check use as function parameter
-            if isFunctionCall(token):
+            if isFunctionCall(token) and token.astOperand1 and token.astOperand1.function:
+                functionDeclaration = token.astOperand1.function
                 parametersUsed = getArguments(token)
-                functionDeclaration = getFunction(data.functions,
-                    token.astOperand1.str, len(parametersUsed))
 
                 if functionDeclaration and functionDeclaration.tokenDef:
                     if functionDeclaration.tokenDef.Id == token.astOperand1.Id:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -234,7 +234,7 @@ void misra_7_3() {
   }
 
 typedef const char* MISRA_7_4_CHAR_CONST;
-MISRA_7_4_CHAR_CONST misra_7_4_return_const_type_def (void) { return "return_typedef_const"; } // 18.4
+MISRA_7_4_CHAR_CONST misra_7_4_return_const_type_def (void) { return "return_typedef_const"; }
 char *misra_7_4_return_non_const (void) { return 1 + "return_non_const"; } // 7.4 18.4
 const char *misra_7_4_return_const (void) { return 1 + "return_const"; } // 18.4
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -233,13 +233,22 @@ void misra_7_3() {
   long double misra_7_3_e = 7.3l; //7.3
   }
 
-void misra_7_4_const_call(int a, const char* b) { } // 2.7
-void misra_7_4_call(int a, char* b) { } // 2.7
+typedef const char* MISRA_7_4_CHAR_CONST;
+MISRA_7_4_CHAR_CONST misra_7_4_return_const (void) { return "return_typedef_const"; } // 18.4
+char *misra_7_4_return_non_const (void) { return 1 + "return_non_const"; } // 7.4 18.4
+const char *misra_7_4_return_const (void) { return 1 + "return_const"; } // 18.4
+
+void misra_7_4_const_call(int a, const char* b) { }
+void misra_7_4_call(int a, char* b) { }
 
 void misra_7_4()
 {
-   const char *a = "string_a"; 
-   char *b = "string_b";  // 7.4
+   const char *a = "text a";
+   char* const b = "text_b"; // 7.4
+   char *c = "text c";  // 7.4
+   char *d = 1 + "text d"; // 7.4 18.4
+   char *e = "text e" + 1 + 2; // 7.4 18.4
+   char *f = 1 + "text f" + 2; // 7.4 18.4
    
    misra_7_4_const_call(1, ("text")); 
    misra_7_4_call(1, "text"); // 7.4

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -253,7 +253,7 @@ void misra_7_4()
    wchar_t *h = "text_h"; // 7.4
    
    misra_7_4_const_call(1, ("text_const_call")); 
-   misra_7_4_call(1, "text_call"); // 7.4
+   misra_7_4_call(1, "text_call"); // 7.4 11.8
 }
 
 extern int a811[]; // 8.11

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -233,6 +233,17 @@ void misra_7_3() {
   long double misra_7_3_e = 7.3l; //7.3
   }
 
+void misra_7_4_const_call(int a, const char* b) { }
+void misra_7_4_call(int a, char* b) { }
+
+void misra_7_4()
+{
+   const char *a = "string_a"; 
+   char *b = "string_b";  // 7.4
+   
+   misra_7_4_const_call(1, ("text")); 
+   misra_7_4_call(1, "text"); // 7.4
+}
 
 extern int a811[]; // 8.11
 

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -234,12 +234,12 @@ void misra_7_3() {
   }
 
 typedef const char* MISRA_7_4_CHAR_CONST;
-MISRA_7_4_CHAR_CONST misra_7_4_return_const (void) { return "return_typedef_const"; } // 18.4
+MISRA_7_4_CHAR_CONST misra_7_4_return_const_type_def (void) { return "return_typedef_const"; } // 18.4
 char *misra_7_4_return_non_const (void) { return 1 + "return_non_const"; } // 7.4 18.4
 const char *misra_7_4_return_const (void) { return 1 + "return_const"; } // 18.4
 
-void misra_7_4_const_call(int a, const char* b) { }
-void misra_7_4_call(int a, char* b) { }
+void misra_7_4_const_call(int a, const char* b) { } // 2.7
+void misra_7_4_call(int a, char* b) { } // 2.7
 
 void misra_7_4()
 {

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -250,8 +250,8 @@ void misra_7_4()
    char *e = "text e" + 1 + 2; // 7.4 18.4
    char *f = 1 + "text f" + 2; // 7.4 18.4
    
-   misra_7_4_const_call(1, ("text")); 
-   misra_7_4_call(1, "text"); // 7.4
+   misra_7_4_const_call(1, ("text_const_call")); 
+   misra_7_4_call(1, "text_call"); // 7.4
 }
 
 extern int a811[]; // 8.11

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -249,6 +249,8 @@ void misra_7_4()
    char *d = 1 + "text d"; // 7.4 18.4
    char *e = "text e" + 1 + 2; // 7.4 18.4
    char *f = 1 + "text f" + 2; // 7.4 18.4
+   const wchar_t *g = "text_g";
+   wchar_t *h = "text_h"; // 7.4
    
    misra_7_4_const_call(1, ("text_const_call")); 
    misra_7_4_call(1, "text_call"); // 7.4

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -233,8 +233,8 @@ void misra_7_3() {
   long double misra_7_3_e = 7.3l; //7.3
   }
 
-void misra_7_4_const_call(int a, const char* b) { }
-void misra_7_4_call(int a, char* b) { }
+void misra_7_4_const_call(int a, const char* b) { } // 2.7
+void misra_7_4_call(int a, char* b) { } // 2.7
 
 void misra_7_4()
 {


### PR DESCRIPTION
For all string tokens: check that the variable being assigned is of type const.
For all function calls, check that if a parameter is a string then the argument definition needs to be const.