### PR TITLE
release-windows: Use current ProductVersion

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -7,9 +7,10 @@ name: release-windows
 on:
   push:
     tags:
-    - '2.*'
+      - '2.*'
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
 
 defaults:
   run:
@@ -88,7 +89,12 @@ jobs:
           mkdir bin
           xcopy /S Build\gui bin
           cd win_installer
-          msbuild -m cppcheck.wixproj /p:Platform=x64,ProductVersion=2.0.${{ github.run_number }}
+          REM Read ProductVersion
+          for /f "tokens=4 delims= " %%a in ('find "ProductVersion" productInfo.wxi') do set PRODUCTVER=%%a
+          REM Remove double quotes
+          set PRODUCTVER=%PRODUCTVER:"=%
+          echo ProductVersion=%PRODUCTVER%
+          msbuild -m cppcheck.wixproj /p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }}
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The filename of the daily built installer still contains 2.0 e.g.:
cppcheck-2.0.182-x64-Setup.msi
- Read the `ProductVersion` from productInfo.wxi and use it in the
file name of the cppcheck setup file.
- Add possibility to manually trigger this GitHub action using
  `workflow_dispatch:`
- Fix indentation, yamllint error:
  `10:5 error wrong indentation: expected 6 but found 4 (indentation)`