### PR TITLE
fix passedByValueError on enums

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2807,7 +2807,9 @@ bool Type::isClassType() const
 
 bool Type::isEnumType() const
 {
-    return classScope && classScope->type == Scope::ScopeType::eEnum;
+    //We explicitly check for "enum" because a forward declared enum doesn't get its own scope
+    return (classDef && classDef->str() == "enum") ||
+           (classScope && classScope->type == Scope::ScopeType::eEnum);
 }
 
 bool Type::isStructType() const

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1614,6 +1614,24 @@ private:
               "    virtual void func(const std::string str) {}\n"
               "};");
         ASSERT_EQUALS("[test.cpp:2]: (performance) Function parameter 'str' should be passed by const reference.\n", errout.str());
+
+        check("enum X;\n"
+              "void foo(X x1){}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("enum X { a, b, c };\n"
+              "void foo(X x2){}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("enum X { a, b, c };\n"
+              "enum X;"
+              "void foo(X x3){}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("enum X;\n"
+              "enum X { a, b, c };"
+              "void foo(X x4){}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void passedByValue_nonConst() {


### PR DESCRIPTION
I ran into this bug with the 2.2 release. I'm not sure exactly when it was introduced but it wasn't happening in my local dev build which was running 9f690fb47.

The cppcheck was warning me that my function which accepted an enum should do so as a const&. As far as I can see this is incorrect and appears to be a bug in the determination of whether a type is an enum. The specific setup that I had was that I defined the enum, declared and defined the method, _then_ forward declared the enum (in a subsequent include). It appears that the most recent declaration of the enum is used. I think this is probably a mistake as it should use the most complete information rather than the most recent.

However the simpler fix for my problem was to correct the isEnumType logic to be more comprehensive. It might be good to fix the type logic to correctly use the enum definition if it can find it but that wouldn't fix this specific symptom in the case where cppcheck _can't_ find the enum definition which could occur if it's in a header it doesn't have access to.