### PR TITLE
Fix addons for installed cppcheck

### DIFF
--- a/gui/projectfile.cpp
+++ b/gui/projectfile.cpp
@@ -1151,7 +1151,11 @@ QString ProjectFile::getAddonFilePath(QString filesDir, const QString &addon)
         filesDir += "/";
 
     QStringList searchPaths;
-    searchPaths << filesDir << (filesDir + "addons/") << (filesDir + "../addons/");
+    searchPaths << filesDir << (filesDir + "addons/") << (filesDir + "../addons/")
+#ifdef FILESDIR
+                << (QLatin1String(FILESDIR) + "/addons/")
+#endif
+                ;
 
     foreach (QString path, searchPaths) {
         QString f = path + addon + ".py";


### PR DESCRIPTION
- getAddonFilePath is used with getDataDir, this works fine
  for a local build cppcheck, but not for a system installed one.
  As getDataDir reports the location relative to the executable (/usr/bin/)
  and the addons are localed in FILESDIR (/usr/share/cppcheck).
  Extend the search path by FILESDIR/addons to also make it work for
  the installed cppcheck version.