### PR TITLE
release-windows.yml: Remove redundant online-help

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -59,11 +59,6 @@ jobs:
           lupdate gui.pro
           lrelease gui.pro -removeidentical
 
-      - name: Create online-help
-        run: |
-          cd gui\help
-          qhelpgenerator online-help.qhcp -o online-help.qhc
-
       - name: Matchcompiler
         run: python tools\matchcompiler.py --write-dir lib
 


### PR DESCRIPTION
The step "Create online-help" is not needed anymore since fa84b30.
The online-help files are generated now automatically during
`qmake HAVE_QCHART=yes`