### PR TITLE
qt.cfg: Improve QtSql functions

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -4590,6 +4590,17 @@
     <use-retval/>
     <const/>
   </function>
+  <!-- QSqlDatabase https://doc.qt.io/qt-5/qsqldatabase.html -->
+  <!-- bool QSqlDatabase::commit() -->
+  <!-- bool QSqlDatabase::rollback() -->
+  <!-- bool QSqlDatabase::open() -->
+  <!-- bool QSqlDatabase::transaction() -->
+  <function name="QSqlDatabase::commit,QSqlDatabase::rollback,QSqlDatabase::open,QSqlDatabase::transaction">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <use-retval/>
+    <leak-ignore/>
+  </function>
   <!-- QSqlQuery https://doc.qt.io/qt-5/qsqlquery.html -->
   <!-- void QSqlQuery::addBindValue(const QVariant &val, QSql::ParamType paramType = QSql::In) -->
   <function name="QSqlQuery::addBindValue">
@@ -4664,6 +4675,7 @@
   <function name="QSqlQuery::exec">
     <noreturn>false</noreturn>
     <returnValue type="bool"/>
+    <use-retval/>
     <leak-ignore/>
     <arg nr="1" direction="in" default="">
       <not-uninit/>
@@ -4776,6 +4788,7 @@
     <noreturn>false</noreturn>
     <returnValue type="bool"/>
     <leak-ignore/>
+    <use-retval/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>


### PR DESCRIPTION
`QSqlQuery::{prepare,exec}` return false on errors, so the return value must be handled by the user.

Added `QSqlDatabase` functions that can return false on fail.