### PR TITLE
library: Add new warning: ignoredReturnErrorCode

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -216,9 +216,7 @@ void CheckFunctions::checkIgnoredReturnValue()
             }
 
             if ((!tok->function() || !Token::Match(tok->function()->retDef, "void %name%")) &&
-                ((mSettings->library.getUseRetValType(tok) != Library::UseRetValType::NONE) ||
-                (tok->function() && tok->function()->isAttributeNodiscard())) &&
-                !WRONG_DATA(!tok->next()->astOperand1(), tok)) {
+                 !WRONG_DATA(!tok->next()->astOperand1(), tok)) {
                 const Library::UseRetValType retvalTy = mSettings->library.getUseRetValType(tok);
                 if (mSettings->isEnabled(Settings::WARNING) &&
                     ((retvalTy == Library::UseRetValType::DEFAULT) ||

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -220,9 +220,9 @@ void CheckFunctions::checkIgnoredReturnValue()
                 (tok->function() && tok->function()->isAttributeNodiscard())) &&
                 !WRONG_DATA(!tok->next()->astOperand1(), tok)) {
                 const Library::UseRetValType retvalTy = mSettings->library.getUseRetValType(tok);
-                if ((mSettings->isEnabled(Settings::WARNING) &&
-                     retvalTy == Library::UseRetValType::DEFAULT) ||
-                    (tok->function() && tok->function()->isAttributeNodiscard()))
+                if (mSettings->isEnabled(Settings::WARNING) &&
+                    ((retvalTy == Library::UseRetValType::DEFAULT) ||
+                    (tok->function() && tok->function()->isAttributeNodiscard())))
                   ignoredReturnValueError(tok, tok->next()->astOperand1()->expressionString());
                 else if (mSettings->isEnabled(Settings::STYLE) &&
                          retvalTy == Library::UseRetValType::ERROR_CODE)

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -216,13 +216,16 @@ void CheckFunctions::checkIgnoredReturnValue()
             }
 
             if ((!tok->function() || !Token::Match(tok->function()->retDef, "void %name%")) &&
-                (mSettings->library.getUseRetValType(tok) != Library::UseRetValType::NONE ||
+                ((mSettings->library.getUseRetValType(tok) != Library::UseRetValType::NONE) ||
                 (tok->function() && tok->function()->isAttributeNodiscard())) &&
                 !WRONG_DATA(!tok->next()->astOperand1(), tok)) {
                 const Library::UseRetValType retvalTy = mSettings->library.getUseRetValType(tok);
-                if (mSettings->isEnabled(Settings::WARNING) && retvalTy == Library::UseRetValType::DEFAULT)
+                if ((mSettings->isEnabled(Settings::WARNING) &&
+                     retvalTy == Library::UseRetValType::DEFAULT) ||
+                    (tok->function() && tok->function()->isAttributeNodiscard()))
                   ignoredReturnValueError(tok, tok->next()->astOperand1()->expressionString());
-                else if (!mSettings->isEnabled(Settings::STYLE) && retvalTy == Library::UseRetValType::ERROR_CODE)
+                else if (mSettings->isEnabled(Settings::STYLE) &&
+                         retvalTy == Library::UseRetValType::ERROR_CODE)
                   ignoredReturnErrorCode(tok, tok->next()->astOperand1()->expressionString());
             }
         }

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -216,12 +216,13 @@ void CheckFunctions::checkIgnoredReturnValue()
             }
 
             if ((!tok->function() || !Token::Match(tok->function()->retDef, "void %name%")) &&
-                (mSettings->library.isUseRetVal(tok) || (tok->function() && tok->function()->isAttributeNodiscard())) &&
+                (mSettings->library.getUseRetValType(tok) != Library::UseRetValType::NONE ||
+                (tok->function() && tok->function()->isAttributeNodiscard())) &&
                 !WRONG_DATA(!tok->next()->astOperand1(), tok)) {
-                const auto retvalTy = mSettings->library.getUseRetvalErrorType(tok);
-                if (retvalTy == Library::RetvalErrorType::DEFAULT)
+                const Library::UseRetValType retvalTy = mSettings->library.getUseRetValType(tok);
+                if (mSettings->isEnabled(Settings::WARNING) && retvalTy == Library::UseRetValType::DEFAULT)
                   ignoredReturnValueError(tok, tok->next()->astOperand1()->expressionString());
-                else if (retvalTy == Library::RetvalErrorType::ERROR_CODE)
+                else if (!mSettings->isEnabled(Settings::STYLE) && retvalTy == Library::UseRetValType::ERROR_CODE)
                   ignoredReturnErrorCode(tok, tok->next()->astOperand1()->expressionString());
             }
         }

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -109,6 +109,7 @@ private:
     void invalidFunctionArgBoolError(const Token *tok, const std::string &functionName, int argnr);
     void invalidFunctionArgStrError(const Token *tok, const std::string &functionName, nonneg int argnr);
     void ignoredReturnValueError(const Token* tok, const std::string& function);
+    void ignoredReturnErrorCode(const Token* tok, const std::string& function);
     void mathfunctionCallWarning(const Token *tok, const nonneg int numParam = 1);
     void mathfunctionCallWarning(const Token *tok, const std::string& oldexp, const std::string& newexp);
     void memsetZeroBytesError(const Token *tok);

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -656,10 +656,10 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
         } else if (functionnodename == "leak-ignore")
             func.leakignore = true;
         else if (functionnodename == "use-retval") {
-            func.useretval = true;
+            func.useretval = Library::UseRetValType::DEFAULT;
             if (const char *type = functionnode->Attribute("type"))
                 if (std::strcmp(type , "error-code") == 0)
-                    mUseRetvalTypes[name] = Library::RetvalErrorType::ERROR_CODE;
+                    func.useretval = Library::UseRetValType::ERROR_CODE;
         } else if (functionnodename == "returnValue") {
             if (const char *expr = functionnode->GetText())
                 mReturnValue[name] = expr;
@@ -1281,24 +1281,14 @@ bool Library::formatstr_secure(const Token* ftok) const
     return functions.at(getFunctionName(ftok)).formatstr_secure;
 }
 
-bool Library::isUseRetVal(const Token* ftok) const
+Library::UseRetValType Library::getUseRetValType(const Token *ftok) const
 {
     if (isNotLibraryFunction(ftok))
-        return false;
+        return Library::UseRetValType::NONE;
     const std::map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
     if (it != functions.cend())
         return it->second.useretval;
-    return false;
-}
-
-Library::RetvalErrorType Library::getUseRetvalErrorType(const Token *ftok) const
-{
-    const std::map<std::string, Library::RetvalErrorType>::const_iterator it =
-        mUseRetvalTypes.find(getFunctionName(ftok));
-    if (it == mUseRetvalTypes.end())
-        return Library::RetvalErrorType::DEFAULT;
-    else
-        return it->second;
+    return Library::UseRetValType::NONE;
 }
 
 const std::string& Library::returnValue(const Token *ftok) const

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -658,7 +658,7 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
         else if (functionnodename == "use-retval") {
             func.useretval = Library::UseRetValType::DEFAULT;
             if (const char *type = functionnode->Attribute("type"))
-                if (std::strcmp(type , "error-code") == 0)
+                if (std::strcmp(type, "error-code") == 0)
                     func.useretval = Library::UseRetValType::ERROR_CODE;
         } else if (functionnodename == "returnValue") {
             if (const char *expr = functionnode->GetText())

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -655,9 +655,12 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
             func.isconst = true; // a constant function is pure
         } else if (functionnodename == "leak-ignore")
             func.leakignore = true;
-        else if (functionnodename == "use-retval")
+        else if (functionnodename == "use-retval") {
             func.useretval = true;
-        else if (functionnodename == "returnValue") {
+            if (const char *type = functionnode->Attribute("type"))
+                if (std::strcmp(type , "error-code") == 0)
+                    mUseRetvalTypes[name] = Library::RetvalErrorType::ERROR_CODE;
+        } else if (functionnodename == "returnValue") {
             if (const char *expr = functionnode->GetText())
                 mReturnValue[name] = expr;
             if (const char *type = functionnode->Attribute("type"))
@@ -1286,6 +1289,16 @@ bool Library::isUseRetVal(const Token* ftok) const
     if (it != functions.cend())
         return it->second.useretval;
     return false;
+}
+
+Library::RetvalErrorType Library::getUseRetvalErrorType(const Token *ftok) const
+{
+    const std::map<std::string, Library::RetvalErrorType>::const_iterator it =
+        mUseRetvalTypes.find(getFunctionName(ftok));
+    if (it == mUseRetvalTypes.end())
+        return Library::RetvalErrorType::DEFAULT;
+    else
+        return it->second;
 }
 
 const std::string& Library::returnValue(const Token *ftok) const

--- a/lib/library.h
+++ b/lib/library.h
@@ -179,7 +179,9 @@ public:
     bool isNotLibraryFunction(const Token *ftok) const;
     bool matchArguments(const Token *ftok, const std::string &functionName) const;
 
+    enum RetvalErrorType { DEFAULT, ERROR_CODE };
     bool isUseRetVal(const Token* ftok) const;
+    RetvalErrorType getUseRetvalErrorType(const Token* ftok) const;
 
     const std::string& returnValue(const Token *ftok) const;
     const std::string& returnValueType(const Token *ftok) const;
@@ -559,6 +561,7 @@ private:
     std::map<std::string, AllocFunc> mDealloc; // deallocation functions
     std::map<std::string, AllocFunc> mRealloc; // reallocation functions
     std::map<std::string, bool> mNoReturn; // is function noreturn?
+    std::map<std::string, RetvalErrorType> mUseRetvalTypes; // type of the error for use-retval violations
     std::map<std::string, std::string> mReturnValue;
     std::map<std::string, std::string> mReturnValueType;
     std::map<std::string, int> mReturnValueContainer;

--- a/lib/library.h
+++ b/lib/library.h
@@ -179,9 +179,8 @@ public:
     bool isNotLibraryFunction(const Token *ftok) const;
     bool matchArguments(const Token *ftok, const std::string &functionName) const;
 
-    enum RetvalErrorType { DEFAULT, ERROR_CODE };
-    bool isUseRetVal(const Token* ftok) const;
-    RetvalErrorType getUseRetvalErrorType(const Token* ftok) const;
+    enum class UseRetValType { NONE, DEFAULT, ERROR_CODE };
+    UseRetValType getUseRetValType(const Token* ftok) const;
 
     const std::string& returnValue(const Token *ftok) const;
     const std::string& returnValueType(const Token *ftok) const;
@@ -308,12 +307,12 @@ public:
         bool leakignore;
         bool isconst;
         bool ispure;
-        bool useretval;
+        UseRetValType useretval;
         bool ignore;  // ignore functions/macros from a library (gtk, qt etc)
         bool formatstr;
         bool formatstr_scan;
         bool formatstr_secure;
-        Function() : use(false), leakignore(false), isconst(false), ispure(false), useretval(false), ignore(false), formatstr(false), formatstr_scan(false), formatstr_secure(false) {}
+        Function() : use(false), leakignore(false), isconst(false), ispure(false), useretval(UseRetValType::NONE), ignore(false), formatstr(false), formatstr_scan(false), formatstr_secure(false) {}
     };
 
     const Function *getFunction(const Token *ftok) const;
@@ -561,7 +560,6 @@ private:
     std::map<std::string, AllocFunc> mDealloc; // deallocation functions
     std::map<std::string, AllocFunc> mRealloc; // reallocation functions
     std::map<std::string, bool> mNoReturn; // is function noreturn?
-    std::map<std::string, RetvalErrorType> mUseRetvalTypes; // type of the error for use-retval violations
     std::map<std::string, std::string> mReturnValue;
     std::map<std::string, std::string> mReturnValueType;
     std::map<std::string, int> mReturnValueContainer;

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1235,7 +1235,7 @@ private:
 
     void checkIgnoredErrorCode() {
         Settings settings2;
-        settings2.addEnabled("warning");
+        settings2.addEnabled("style");
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def version=\"2\">\n"
                                "  <function name=\"mystrcmp\">\n"

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -76,6 +76,7 @@ private:
 
         // Ignored return value
         TEST_CASE(checkIgnoredReturnValue);
+        TEST_CASE(checkIgnoredErrorCode);
 
         // memset..
         TEST_CASE(memsetZeroBytes);
@@ -1230,6 +1231,27 @@ private:
               "}\n"
               "A g() { return f(1); }\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkIgnoredErrorCode() {
+        Settings settings2;
+        settings2.addEnabled("warning");
+        const char xmldata[] = "<?xml version=\"1.0\"?>\n"
+                               "<def version=\"2\">\n"
+                               "  <function name=\"mystrcmp\">\n"
+                               "    <use-retval type=\"error-code\"/>\n"
+                               "    <arg nr=\"1\"/>\n"
+                               "    <arg nr=\"2\"/>\n"
+                               "  </function>\n"
+                               "</def>";
+        tinyxml2::XMLDocument doc;
+        doc.Parse(xmldata, sizeof(xmldata));
+        settings2.library.load(doc);
+
+        check("void foo() {\n"
+              "  mystrcmp(a, b);\n"
+              "}", "test.cpp", &settings2);
+        ASSERT_EQUALS("[test.cpp:2]: (style) Error code from the return value of function mystrcmp() is not used.\n", errout.str());
     }
 
     void memsetZeroBytes() {


### PR DESCRIPTION
Added an optional "type" attribute to "use-retval" nodes in the library configuration. When the return type of a function configured with `<use-retval type="error-code"\>` node does not used, the new style error "ignoredReturnErrorCode" will be generated.

See: https://github.com/danmar/cppcheck/pull/2875#issuecomment-720975477