### PR TITLE
cfg: cppunit: Fix FP with compareBoolExpressionWithInt within CPPUNIT_ASSERT_EQUAL

### DIFF
--- a/cfg/cppunit.cfg
+++ b/cfg/cppunit.cfg
@@ -8,8 +8,8 @@
   <define name="CPPUNIT_ASSERT(condition)" value="if (!(condition)) throw false;"/>
   <define name="CPPUNIT_ASSERT_MESSAGE(message, condition)" value="if (!(condition)) throw message;"/>
   <define name="CPPUNIT_FAIL(message)" value="throw message;"/>
-  <define name="CPPUNIT_ASSERT_EQUAL(expected, actual)" value="if (expected != actual) throw false;"/>
-  <define name="CPPUNIT_ASSERT_EQUAL_MESSAGE(message, expected, actual)" value="if (expected != actual) throw message;"/>
+  <define name="CPPUNIT_ASSERT_EQUAL(expected, actual)" value="if ((expected) != (actual)) throw false;"/>
+  <define name="CPPUNIT_ASSERT_EQUAL_MESSAGE(message, expected, actual)" value="if ((expected) != (actual)) throw message;"/>
   <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual, delta)" value="if (std::abs((expected) - (actual)) &gt; delta) throw false;"/>
   <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE(message, expected, actual, delta)" value="if (std::abs((expected) - (actual)) &gt; delta) throw message;"/>
   <define name="CPPUNIT_ASSERT_THROW(expression, ExceptionType)" value=""/>

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -1,0 +1,53 @@
+// Test library configuration for cppunit.cfg
+//
+// Usage:
+// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cppunit.cpp
+// =>
+// No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
+//
+
+#include <cppunit/TestAssert.h>
+
+void cppunit_assert_equal(int x, double y)
+{
+    CPPUNIT_ASSERT(true);
+    CPPUNIT_ASSERT(false);
+    CPPUNIT_ASSERT(1 < 2);
+
+    CPPUNIT_ASSERT_MESSAGE("Test failed", true);
+    CPPUNIT_ASSERT_MESSAGE("Test failed", false);
+    CPPUNIT_ASSERT_MESSAGE("Test failed", 1 < 2);
+
+    CPPUNIT_ASSERT_EQUAL(1, 2);
+    //CPPUNIT_ASSERT_EQUAL(true, 3 == x);
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Test failed", 1, 4);
+    //CPPUNIT_ASSERT_EQUAL_MESSAGE("Test failed", true, 4 == x);
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, 2.0, 1e-7);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, y, 1e-7);
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("Test failed", 1.0, 2.0, 1e-7);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("Test failed", 1.0, y, 1e-7);
+}
+
+void cppunit_throw()
+{
+    CPPUNIT_ASSERT_NO_THROW(1 + 1);
+    CPPUNIT_ASSERT_NO_THROW_MESSAGE("Unexpected throw", 1 + 1);
+    CPPUNIT_ASSERT_THROW(1 + 1, CPPUNIT_NS::Exception);
+    CPPUNIT_ASSERT_THROW_MESSAGE("Did not throw", 1 + 1, CPPUNIT_NS::Exception);
+}
+
+void cppunit_assertion_assert()
+{
+    CPPUNIT_ASSERT_ASSERTION_FAIL(true);
+    CPPUNIT_ASSERT_ASSERTION_FAIL_MESSAGE("hello", false);
+    CPPUNIT_ASSERT_ASSERTION_PASS(false);
+    CPPUNIT_ASSERT_ASSERTION_PASS_MESSAGE("goodbye", true);
+}
+
+void cppunit_assert_fail()
+{
+    CPPUNIT_FAIL("This fails");
+}

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -19,10 +19,10 @@ void cppunit_assert_equal(int x, double y)
     CPPUNIT_ASSERT_MESSAGE("Test failed", 1 < 2);
 
     CPPUNIT_ASSERT_EQUAL(1, 2);
-    //CPPUNIT_ASSERT_EQUAL(true, 3 == x);
+    CPPUNIT_ASSERT_EQUAL(true, 3 == x);
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE("Test failed", 1, 4);
-    //CPPUNIT_ASSERT_EQUAL_MESSAGE("Test failed", true, 4 == x);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Test failed", true, 4 == x);
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, 2.0, 1e-7);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, y, 1e-7);

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -392,6 +392,28 @@ else
 fi
 ${CPPCHECK} ${CPPCHECK_OPT} --library=opencv2 ${DIR}opencv2.cpp
 
+# cppunit.cpp
+set +e
+pkg-config --version
+PKGCONFIG_RETURNCODE=$?
+set -e
+
+if [ $PKGCONFIG_RETURNCODE -ne 0 ]; then
+    echo "pkg-config needed to retrieve cppunit configuration is not available, skipping syntax check."
+else
+    set +e
+    CPPUNIT=$(pkg-config cppunit)
+    CPPUNIT_RETURNCODE=$?
+    set -e
+    if [ $CPPUNIT_RETURNCODE -ne 0 ]; then
+        echo "cppunit not found, skipping syntax check for cppunit"
+    else
+        echo "cppunit found, checking syntax with ${CXX} now."
+        ${CXX} ${CXX_OPT} -Wno-deprecated-declarations ${DIR}cppunit.cpp
+    fi
+fi
+${CPPCHECK} ${CPPCHECK_OPT} --inconclusive --library=cppunit -f ${DIR}cppunit.cpp
+
 # Check the syntax of the defines in the configuration files
 set +e
 xmlstarlet --version


### PR DESCRIPTION
Very much inspired by #2876, there were missing parenthesis around macro arguments which could cause FPs.