### PR TITLE
fix an error in Tokenizer::simplifyTypedef()

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -410,9 +410,10 @@ Token * Tokenizer::deleteInvalidTypedef(Token *typeDef)
 
 namespace {
     struct Space {
-        Space() : bodyEnd(nullptr), isNamespace(false) { }
+        Space() : bodyEnd(nullptr), bodyEnd2(nullptr), isNamespace(false) { }
         std::string className;
-        const Token * bodyEnd;
+        const Token * bodyEnd;  // for body contains typedef define
+        const Token * bodyEnd2; // for body contains typedef using
         bool isNamespace;
     };
 }
@@ -609,6 +610,7 @@ void Tokenizer::simplifyTypedef()
                 info.isNamespace = isNamespace;
                 info.className = className;
                 info.bodyEnd = tok->link();
+                info.bodyEnd2 = tok->link();
                 spaceInfo.push_back(info);
 
                 hasClass = false;
@@ -1050,7 +1052,7 @@ void Tokenizer::simplifyTypedef()
                                 inMemberFunc = false;
                         }
 
-                        if (classLevel > 0 && tok2 == spaceInfo[classLevel - 1].bodyEnd) {
+                        if (classLevel > 0 && tok2 == spaceInfo[classLevel - 1].bodyEnd2) {
                             --classLevel;
                             pattern.clear();
 
@@ -1103,7 +1105,7 @@ void Tokenizer::simplifyTypedef()
                             if (classLevel < spaceInfo.size() &&
                                 spaceInfo[classLevel].isNamespace &&
                                 spaceInfo[classLevel].className == tok2->previous()->str()) {
-                                spaceInfo[classLevel].bodyEnd = tok2->link();
+                                spaceInfo[classLevel].bodyEnd2 = tok2->link();
                                 ++classLevel;
                                 pattern.clear();
                                 for (int i = classLevel; i < spaceInfo.size(); ++i)

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -169,6 +169,7 @@ private:
         TEST_CASE(simplifyTypedef131); // ticket #9446
         TEST_CASE(simplifyTypedef132); // ticket #9739 - using
         TEST_CASE(simplifyTypedef133); // ticket #9812 - using
+        TEST_CASE(simplifyTypedef134);
 
         TEST_CASE(simplifyTypedefFunction1);
         TEST_CASE(simplifyTypedefFunction2); // ticket #1685
@@ -2658,6 +2659,14 @@ private:
                             "using array_p = const array_t *;\n"
                             "array_p x;\n";
         ASSERT_EQUALS("using array_p = const unsigned char ( * ) [ 16 ] ; array_p x ;", tok(code, false));
+    }
+
+    void simplifyTypedef134() {
+        const char code[] = "namespace foo { typedef long long int64; }\n"
+                            "typedef int int32;\n"
+                            "namespace foo { int64 i; }\n"
+                            "int32 j;";
+        ASSERT_EQUALS("namespace foo { long long i ; } int j ;", tok(code, false));
     }
 
     void simplifyTypedefFunction1() {


### PR DESCRIPTION
code:
```c++
namespace foo {
    typedef long long int64;
}
 
typedef int int32;
 
namespace foo {
    int64 i;
}
 
int32 j;
```

result:
```
1:
|
6:
7: namespace foo {
8: long long i@1 ;
9: }
10:
11: int32 j@2 ;  # should be: int j;
```
