### PR TITLE
MISRA rule 7.2 Require 'u' prefix when using large unsigned integer constants

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -889,23 +889,6 @@ def tokenFollowsSequence(token, sequence):
         token = prev
     return True
 
-# Parse a C string as an unsigned number. Example '0xaU' (text) returns 10 (numeric)
-def parseUnsignedNumber(stringValue, defaultValue):
-    # Remove possible trailing U and L
-    while (stringValue.upper().endswith('U') or stringValue.upper().endswith('L')):
-        stringValue = stringValue[:-1]
-
-    try:
-        if stringValue.upper().startswith('0B'):
-            return int(stringValue, 2)
-        if stringValue.upper().startswith('0X'):
-            return int(stringValue, 16)
-        if stringValue.upper().startswith('0'):
-            return int(stringValue, 8)
-        return int(stringValue, 10)
-    except (TypeError, ValueError):
-        return defaultValue
-
 class Define:
     def __init__(self, directive):
         self.args = []
@@ -1410,11 +1393,11 @@ class MisraChecker:
             if value and value.isNumber:
                 if variable and variable.valueType and variable.valueType.sign == 'unsigned':
                     if variable.valueType.type in ['char', 'short', 'int', 'long', 'long long']:
-                        constantValue = parseUnsignedNumber(value.str, 0)
                         limit = 1 << (bitsOfEssentialType(variable.valueType.type) -1)
-                        if constantValue >= limit:
-                            if not 'U' in value.str.upper():
-                                self.reportError(value, 7, 2)
+                        for v in value.values:
+                            if v.valueKind == 'known' and v.intvalue >= limit:
+                                if not 'U' in value.str.upper():    
+                                    self.reportError(value, 7, 2)
         
         for token in data.tokenlist:
             # Check normal variable assignment

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -239,12 +239,10 @@ void misra_7_2() {
     unsigned short h = 0x8000U;
     unsigned int i = 0x80000000; // 7.2
     unsigned int j = 0x80000000U;
-    unsigned long k = 0x80000000; // 7.2
-    unsigned long l = 0x80000000UL;
-    unsigned long long m = 0x8000000000000000; // 7.2
-    unsigned long long n = 0x8000000000000000ULL;
+    unsigned long long k = 0x8000000000000000; // 7.2
+    unsigned long long l = 0x8000000000000000ULL;
 
-    unsigned int o = 1 + 0x80000000; // 7.2 10.4
+    unsigned int m = 1 + 0x80000000; // 7.2 10.4
 
     misra_7_2_call_test(1, 2, 2147483648U);
     misra_7_2_call_test(1, 2, 2147483648); // 7.2

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -225,6 +225,32 @@ void misra_7_1() {
   int x = 066; // 7.1
 }
 
+void misra_7_2_call_test(int a, unsigned int b, unsigned int c) { } // 2.7
+
+void misra_7_2() {
+    unsigned int a = 2147483647;
+    const unsigned int b = 2147483648U;
+    const unsigned int c = 2147483648; // 7.2
+    unsigned int d = 2147483649; // 7.2
+
+    unsigned char e = 0x80; // 7.2
+    unsigned char f = 0x80U;
+    unsigned short g = 0x8000; // 7.2
+    unsigned short h = 0x8000U;
+    unsigned int i = 0x80000000; // 7.2
+    unsigned int j = 0x80000000U;
+    unsigned long k = 0x80000000; // 7.2
+    unsigned long l = 0x80000000UL;
+    unsigned long long m = 0x8000000000000000; // 7.2
+    unsigned long long n = 0x8000000000000000ULL;
+
+    unsigned int o = 1 + 0x80000000; // 7.2 10.4
+
+    misra_7_2_call_test(1, 2, 2147483648U);
+    misra_7_2_call_test(1, 2, 2147483648); // 7.2
+    misra_7_2_call_test(1, 0x80000000, 3); // 7.2
+}
+
 void misra_7_3() {
   long misra_7_3_a = 0l; //7.3
   long misra_7_3_b = 0lU; //7.3


### PR DESCRIPTION
MISRA rule 7.2 Require 'u' prefix when using large unsigned integer constants