### PR TITLE
Fix false positive memoryleak

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -213,7 +213,12 @@ const Token * astIsVariableComparison(const Token *tok, const std::string &comp,
             ret = tok->astOperand1();
         }
     } else if (comp == "!=" && rhs == std::string("0")) {
-        ret = tok;
+        if (tok->str() == "!") {
+            ret = tok->astOperand1();
+            // handle (!(x==0)) as (x!=0)
+            astIsVariableComparison(ret, "==", "0", &ret);
+        } else
+            ret = tok;
     } else if (comp == "==" && rhs == std::string("0")) {
         if (tok->str() == "!") {
             ret = tok->astOperand1();

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -138,6 +138,7 @@ private:
         TEST_CASE(ifelse14); // #9130 - if (x == (char*)NULL)
         TEST_CASE(ifelse15); // #9206 - if (global_ptr = malloc(1))
         TEST_CASE(ifelse16); // #9635 - if (p = malloc(4), p == NULL)
+        TEST_CASE(ifelse17); //  if (!!(!p))
 
         // switch
         TEST_CASE(switch1);
@@ -1513,6 +1514,24 @@ private:
               "        return;\n"
               "    free(p);\n"
               "    return;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void ifelse17() {
+        check("int *f() {\n"
+              "    int *p = realloc(nullptr, 10);\n"
+              "    if (!p)\n"
+              "        return NULL;\n"
+              "    return p;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int *f() {\n"
+              "    int *p = realloc(nullptr, 10);\n"
+              "    if (!!(!p))\n"
+              "        return NULL;\n"
+              "    return p;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
```
int *f() {
  int *p = static_cast<int *>(realloc(nullptr, 10));
  if (!!(!p)) {
    return nullptr;
  }
  return p;
}

```
would give
```
memleak2.cpp:4:5: error: Memory leak: p [memleak]
    return nullptr;
    ^
```
Because of the additional `!!̀ .