### PR TITLE
misra.py: Fix 7.4 false positive

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1398,7 +1398,7 @@ class MisraChecker:
         # is constant.
         def reportErrorIfVariableIsNotConst(variable, stringLiteral):
             if variable.valueType:
-                if variable.valueType.constness != 1:
+                if (variable.valueType.constness % 2) != 1:
                     self.reportError(stringLiteral, 7, 4)
 
         for token in data.tokenlist:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -239,6 +239,7 @@ char *misra_7_4_return_non_const (void) { return 1 + "return_non_const"; } // 7.
 const char *misra_7_4_return_const (void) { return 1 + "return_const"; } // 18.4
 
 void misra_7_4_const_call(int a, const char* b) { } // 2.7
+void misra_7_4_const_ptr_call(int a, const char const* b) { } // 2.7
 void misra_7_4_call(int a, char* b) { } // 2.7
 
 void misra_7_4()
@@ -253,6 +254,7 @@ void misra_7_4()
    wchar_t *h = "text_h"; // 7.4
    
    misra_7_4_const_call(1, ("text_const_call")); 
+   misra_7_4_const_ptr_call(1, ("text_const_call"));
    misra_7_4_call(1, "text_call"); // 7.4 11.8
 }
 


### PR DESCRIPTION
Fix false positives for the function calls with "const pointer to const value" arguments: https://trac.cppcheck.net/ticket/9967.
The variable.valueType.constness have the same encoding as `ValueType::constness` in Cppcheck.

See also: the same fix for cert.py: 8f21ba91e3abd5c59e19c6022d33288c41be0d4a.