### PR TITLE
Adjust Codeql2 build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,18 +38,6 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
         setup-python-dependencies: false 
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
     - run: |
          make -j$(nproc) USE_Z3=yes HAVE_RULES=yes cppcheck
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,13 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      
+    - name: Install missing software on ubuntu
+      run: |
+         sudo apt-get update
+         sudo apt-get install libxml2-utils
+         sudo apt-get install z3 libz3-dev
+         cp externals/z3_version_old.h externals/z3_version.h
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -43,9 +50,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+         make -j$(nproc) USE_Z3=yes HAVE_RULES=yes cppcheck
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Adjust build to avoid matchcompiler but also use Z3 and PCRE

The former was suggested  here: https://github.com/danmar/cppcheck/commit/308b150351a278b4f22c52e036ed5c8b934a4390#commitcomment-43916193