### PR TITLE
Set _q_readonly property for online-help

### DIFF
--- a/gui/helpdialog.cpp
+++ b/gui/helpdialog.cpp
@@ -66,6 +66,8 @@ HelpDialog::HelpDialog(QWidget *parent) :
     }
 
     mHelpEngine = new QHelpEngine(helpFile);
+    // Disable the timestamp check of online-help.qhc by setting _q_readonly
+    mHelpEngine->setProperty("_q_readonly", QVariant::fromValue<bool>(true));
     mHelpEngine->setupData();
 
     mUi->contents->addWidget(mHelpEngine->contentWidget());


### PR DESCRIPTION
- Setting `_q_readonly` disables the timestamp check of the registered
  **`online-help.qch`** file
- This enables displaying of Contents and Index of the online help,
  even if the timestamp of **`online-help.qch`** is slightly different.
  Differences in the timestamp can result from packing **`online-help.qch`**
  in a cab file, when building the installer (1 or 2 seconds) or from
  installing the file under a different timezone under Linux etc.
- Remark: Qt 5.14 or newer is required to display Contents or Index,
  when the help files are readonly [[1]](https://codereview.qt-project.org/c/qt/qttools/+/282190)

[1] https://codereview.qt-project.org/c/qt/qttools/+/282190

Further info concerning this topic can be found here:
https://github.com/danmar/cppcheck/commit/9693940dadfd54bb0bac2549e1b2d6804be9a1a8#commitcomment-43975388
