### PR TITLE
Update Qt version for release-windows to 5.15.1

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
+          version: '5.15.1'
           modules: 'qtcharts qthelp'
 
       - name: Create .qm


### PR DESCRIPTION
So far, Qt version 5.12.9 has been used, which is the current default
of jurplel/install-qt-action@v2

- The update of Qt to version 5.15.1 enables displaying of
  Contents and Index of the online help, if it is installed in a
  readonly location, typically: C:\Program Files\Cppcheck\
- Qt 5.14 or newer is required to display Contents or Index,
  when the help files are readonly and the timestamp of online-help.qch
  is not correct to the second.
- This is a follow-up to commit 4a057c1

Remark: Qt 5.15.1 has been released on 2020-09-10 and is the first patch release of Qt 5.15 LTS:
https://www.qt.io/blog/qt-5.15.1-released
