### PR TITLE
Updated cmake script so cppcheck.exe works in place during development

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -11,8 +11,7 @@ if (UNIX)
     # TODO: check if this can be enabled again for Clang - also done in Makefile
     if (CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
         add_definitions(-D_GLIBCXX_DEBUG)
-    endif()
-    add_definitions(-DFILESDIR="${FILESDIR}")
+    endif()    
 endif()
 
 if (HAVE_RULES)
@@ -26,3 +25,5 @@ endif()
 if (ENABLE_CHECK_INTERNAL)
     add_definitions(-DCHECK_INTERNAL)
 endif()
+
+add_definitions(-DFILESDIR="${FILESDIR}")


### PR DESCRIPTION
Moved -DFILESDIR out of Linux only block so FILESDIR is defined for Windows too