### PR TITLE
TestCondition: Don't warn when sizeof is involved

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1472,7 +1472,6 @@ void CheckCondition::alwaysTrueFalse()
 
             // don't warn when condition checks sizeof result
             bool hasSizeof = false;
-            bool hasNonNumber = false;
             visitAstNodes(tok, [&](const Token * tok2) {
                 if (!tok2)
                     return ChildrenToVisit::none;
@@ -1484,11 +1483,10 @@ void CheckCondition::alwaysTrueFalse()
                 }
                 if (tok2->isComparisonOp() || tok2->isArithmeticalOp()) {
                     return ChildrenToVisit::op1_and_op2;
-                } else
-                    hasNonNumber = true;
+                }
                 return ChildrenToVisit::none;
             });
-            if (!hasNonNumber && hasSizeof)
+            if (hasSizeof)
                 continue;
 
             alwaysTrueFalseError(tok, &tok->values().front());

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -700,6 +700,18 @@ private:
               "    else if ( value & (int)Value2 ) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(size_t x) {\n"
+              "    if (x == sizeof(int)) {}\n"
+              "    else { if (x == sizeof(long))} {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(size_t x) {\n"
+              "    if (x == sizeof(long)) {}\n"
+              "    else { if (x == sizeof(long long))} {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void oppositeElseIfCondition() {
@@ -3002,8 +3014,8 @@ private:
               "  if (sizeof(char) != x) {}\n"
               "  if (x != sizeof(char)) {}\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (style) Condition 'sizeof(char)!=x' is always true\n"
-                      "[test.cpp:4]: (style) Condition 'x!=sizeof(char)' is always true\n", errout.str());
+        TODO_ASSERT_EQUALS("[test.cpp:3]: (style) Condition 'sizeof(char)!=x' is always true\n"
+                           "[test.cpp:4]: (style) Condition 'x!=sizeof(char)' is always true\n", "", errout.str());
 
         // Don't warn in assertions. Condition is often 'always true' by intention.
         // If platform,defines,etc cause an 'always false' assertion then that is not very dangerous neither


### PR DESCRIPTION
Sometimes, using `sizeof` is involved in if-statements, cppcheck warns that the condition is always true or false. In some cases, while it is technically correct, the code is perfectly fine as is. For example:

```c
void f(int x) {
    if (x == sizeof(int)) {}
    else if (x == sizeof(long)) {}
}
```
If the size of int and long is the same, cppcheck will warn that the second condition is always false. In my opinion, this code is perfectly fine and cppcheck should not warn about it. Since it's difficult to diagnose when we should warn for `sizeof` or not, disable the condition always true/false checks for now.

In 500 packages tested with `test-my-pr`, there were four fewer warnings, and I believe they are all cases where cppcheck shouldn't warn, or where it at least is debatable.

[my_check_diff.log](https://github.com/danmar/cppcheck/files/5520451/my_check_diff.log)
