### PR TITLE
MISRA rule 10.2 Expressions of essentially character type in additions and subtraction

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1535,7 +1535,7 @@ class MisraChecker:
             return op.isChar
 
         for token in data.tokenlist:
-            if not token.isArithmeticalOp or not token.str in ['+', '-']:
+            if not token.isArithmeticalOp or token.str not in ['+', '-']:
                 continue
 
             operand1 = token.astOperand1

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1523,6 +1523,40 @@ class MisraChecker:
                     if e1_et == 'char' and e2_et == 'char':
                         self.reportError(token, 10, 1)
 
+    def misra_10_2(self, data):
+        def isEssentiallySignedOrUnsigned(op):
+            if op and op.valueType and op.valueType.sign:
+                return True
+            return False 
+
+        def isEssentiallyChar(op):
+            if op.isName:
+                return getEssentialType(op) == 'char'
+            return op.isChar
+
+        for token in data.tokenlist:
+            if not token.isArithmeticalOp or not token.str in ['+', '-']:
+                continue
+
+            operand1 = token.astOperand1
+            operand2 = token.astOperand2
+            if not operand1 or not operand2:
+                continue
+            if not operand1.isChar and not operand2.isChar:
+                continue
+
+            if token.str == '+':
+                if isEssentiallyChar(operand1) and not isEssentiallySignedOrUnsigned(operand2):
+                    self.reportError(token, 10, 2)
+                if isEssentiallyChar(operand2) and not isEssentiallySignedOrUnsigned(operand1):
+                    self.reportError(token, 10, 2)
+
+            if token.str == '-':
+                if not isEssentiallyChar(operand1):
+                    self.reportError(token, 10, 2)
+                if not isEssentiallyChar(operand2) and not isEssentiallySignedOrUnsigned(operand2): 
+                    self.reportError(token, 10, 2)
+
     def misra_10_4(self, data):
         op = {'+', '-', '*', '/', '%', '&', '|', '^', '+=', '-=', ':'}
         for token in data.tokenlist:
@@ -3077,6 +3111,7 @@ class MisraChecker:
                 self.executeCheck(814, self.misra_8_14, data.rawTokens)
                 self.executeCheck(905, self.misra_9_5, data.rawTokens)
             self.executeCheck(1001, self.misra_10_1, cfg)
+            self.executeCheck(1002, self.misra_10_2, cfg)
             self.executeCheck(1004, self.misra_10_4, cfg)
             self.executeCheck(1006, self.misra_10_6, cfg)
             self.executeCheck(1008, self.misra_10_8, cfg)

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1525,8 +1525,9 @@ class MisraChecker:
 
     def misra_10_2(self, data):
         def isEssentiallySignedOrUnsigned(op):
-            if op and op.valueType and op.valueType.sign:
-                return True
+            if op and op.valueType:
+                if op.valueType.sign in ['unsigned', 'signed']:
+                    return True
             return False 
 
         def isEssentiallyChar(op):

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -354,6 +354,24 @@ void misra_10_1_ternary()
 
 }
 
+void misra_10_2() {
+    unsigned int u8a = 0;
+    char cha = 0;
+    signed int s8a = 0;
+    signed short s16a = 0;
+    float f32a = 0.0;
+    char res;
+
+    res = '0' + u8a; // 10.4
+    res = s8a + '0';
+    res = cha - '0';
+    res = '0' - s8a;
+
+    res = s16a - 'a'; // 10.2
+    res = '0' + f32a; // 10.2 10.4
+    res = cha + ':';  // 10.2
+}
+
 void misra_10_4(u32 x, s32 y) {
   z = x + 3; // 10.4
   enum misra_10_4_enuma { misra_10_4_A1, misra_10_4_A2, misra_10_4_A3 } a;

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -351,7 +351,6 @@ void misra_10_1_ternary()
     a = (get_bool(42) ? (get_bool(34) ? ui16 : ui8) : ui8) << (get_bool(19) ? ui16 : ui8); // 10.4
     a = (get_bool(42) ? (get_bool(34) ? i16 : ui8) : ui8) << (get_bool(19) ? ui16 : ui8); // 10.1 10.4
     a = (get_bool(42) ? (get_bool(34) ? ui16 : ui8) : ui8) << (get_bool(19) ? i16 : ui8); // 10.1 10.4
-
 }
 
 void misra_10_2() {

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -355,7 +355,7 @@ void misra_10_1_ternary()
 
 void misra_10_2() {
     unsigned int u8a = 0;
-    char cha = 0;
+    signed char cha = 0;
     signed int s8a = 0;
     signed short s16a = 0;
     float f32a = 0.0;
@@ -365,10 +365,10 @@ void misra_10_2() {
     res = s8a + '0';
     res = cha - '0';
     res = '0' - s8a;
+    res = cha + ':';
 
     res = s16a - 'a'; // 10.2
     res = '0' + f32a; // 10.2 10.4
-    res = cha + ':';  // 10.2
 }
 
 void misra_10_4(u32 x, s32 y) {


### PR DESCRIPTION
Rule 10.2: Expressions of essentially character type shall not be used inappropriately in addition and subtraction operations