### PR TITLE
9955: Fix ast when throwing a cast

### DIFF
--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7884,6 +7884,7 @@ private:
         ASSERT_EQUALS("x(throw", testAst(";throw x();"));
         ASSERT_EQUALS("a*bc:?return", testAst("return *a ? b : c;"));
         ASSERT_EQUALS("xy*--=", testAst("x = -- * y;"));
+        ASSERT_EQUALS("x(throw", testAst(";throw (foo) x;")); // #9955
 
         // Unary :: operator
         ASSERT_EQUALS("abcd::12,(e/:?=", testAst("a = b ? c : ::d(1,2) / e;"));


### PR DESCRIPTION
```
throw (std::string)"Error: " + strerror(errnum);
```
would result in a broken ast:
```
throw
`-::
  |-std
  `-string
```
instead of
```
throw
`-+ 'signed char *'
  |-( 'container(std :: string|wstring|u16string|u32string)'
  | `-"Error: " 'const char *'
  `-( 'signed char *'
    |-strerror
    `-errnum 'signed int'
```