### PR TITLE
feat: analyze function side effects

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1609,6 +1609,9 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func) {
             // check if global variable is changed
             if (bodyVariable->isGlobal()) {
                 const Token* next = bodyToken->next();
+                if (Token::simpleMatch(next, "[")) {
+                    next = next->link()->next();
+                }
                 const Token* prev = bodyToken->previous();
                 if (next->isIncDecOp() || prev->isIncDecOp() ||
                     next->isAssignmentOp()) {

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1517,7 +1517,8 @@ bool CheckUnusedVar::isRecordTypeWithoutSideEffects(const Type* type)
                         return withoutSideEffects = false;
                     }
                     const Function* initValueFunc = valueToken->function();
-                    if (initValueFunc && !isFunctionWithoutSideEffects(*initValueFunc, valueToken, {})) {
+                    if (initValueFunc && !isFunctionWithoutSideEffects(*initValueFunc, valueToken, 
+                        std::list<const Function*>{})) {
                         return withoutSideEffects = false;
                     }
                 }
@@ -1591,7 +1592,7 @@ bool CheckUnusedVar::isEmptyType(const Type* type)
 }
 
 bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const Token* functionUsageToken,
-        std::list<const Function*> nested_in) {
+        std::list<const Function*> checkedFuncs) {
     // no body to analyze
     if (!func.hasBody()) {
         return false;
@@ -1623,11 +1624,11 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
         // check nested function
         const Function* bodyFunction = bodyToken->function();
         if (bodyFunction) {
-            if (std::find(nested_in.begin(), nested_in.end(), bodyFunction) != nested_in.end()) { // recursion found
+            if (std::find(checkedFuncs.begin(), checkedFuncs.end(), bodyFunction) != checkedFuncs.end()) { // recursion found
                 continue;
             }
-            nested_in.push_back(bodyFunction);
-            if (!isFunctionWithoutSideEffects(*bodyFunction, bodyToken, nested_in)) {
+            checkedFuncs.push_back(bodyFunction);
+            if (!isFunctionWithoutSideEffects(*bodyFunction, bodyToken, checkedFuncs)) {
                 return false;
             }
         }

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -75,7 +75,7 @@ private:
     bool isVariableWithoutSideEffects(const Variable& var);
     bool isEmptyType(const Type* type);
     bool isFunctionWithoutSideEffects(const Function& func, const Token* functionUsageToken,
-        std::list<const Function*> nested_in);
+        std::list<const Function*> checkedFuncs);
 
     // Error messages..
     void unusedStructMemberError(const Token *tok, const std::string &structname, const std::string &varname, bool isUnion = false);

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -74,7 +74,7 @@ private:
     bool isRecordTypeWithoutSideEffects(const Type* type);
     bool isVariableWithoutSideEffects(const Variable& var);
     bool isEmptyType(const Type* type);
-    bool isFunctionWithoutSideEffects(const Function& func);
+    bool isFunctionWithoutSideEffects(const Function& func, const Token& functionUsageToken);
 
     // Error messages..
     void unusedStructMemberError(const Token *tok, const std::string &structname, const std::string &varname, bool isUnion = false);

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -74,7 +74,8 @@ private:
     bool isRecordTypeWithoutSideEffects(const Type* type);
     bool isVariableWithoutSideEffects(const Variable& var);
     bool isEmptyType(const Type* type);
-    bool isFunctionWithoutSideEffects(const Function& func, const Token& functionUsageToken);
+    bool isFunctionWithoutSideEffects(const Function& func, const Token* functionUsageToken,
+        std::list<const Function*> nested_in);
 
     // Error messages..
     void unusedStructMemberError(const Token *tok, const std::string &structname, const std::string &varname, bool isUnion = false);

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -35,6 +35,7 @@ class Tokenizer;
 class Type;
 class Variables;
 class Variable;
+class Function;
 
 /// @addtogroup Checks
 /// @{
@@ -73,6 +74,7 @@ private:
     bool isRecordTypeWithoutSideEffects(const Type* type);
     bool isVariableWithoutSideEffects(const Variable& var);
     bool isEmptyType(const Type* type);
+    bool isFunctionWithoutSideEffects(const Function& func);
 
     // Error messages..
     void unusedStructMemberError(const Token *tok, const std::string &structname, const std::string &varname, bool isUnion = false);

--- a/lib/token.h
+++ b/lib/token.h
@@ -433,6 +433,9 @@ public:
     bool isBoolean() const {
         return mTokType == eBoolean;
     }
+    bool isIncDecOp() const {
+        return mTokType == eIncDecOp;
+    }
     bool isBinaryOp() const {
         return astOperand1() != nullptr && astOperand2() != nullptr;
     }

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -616,7 +616,7 @@ private:
             "void f() {\n"
             "   C c;\n"
             "}");
-        ASSERT_EQUALS("[test.cpp:11]: (style) Unused variable: c\n", errout.str());
+        TODO_ASSERT_EQUALS("[test.cpp:11]: (style) Unused variable: c\n", "", errout.str());
 
         // changing global variable in return
         functionVariableUsage(
@@ -931,7 +931,7 @@ private:
         // argument return
         functionVariableUsage(
             "int func(int i) {\n"
-            "    return i;"
+            "    return i;\n"
             "}\n"
             "class C {\n"
             "public:\n"
@@ -941,7 +941,59 @@ private:
             "void f() {\n"
             "   C c;\n"
             "}");
-        ASSERT_EQUALS("[test.cpp:9]: (style) Unused variable: c\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:10]: (style) Unused variable: c\n", errout.str());
+
+        // global variable modifying through function argument
+        functionVariableUsage(
+            "char buf[10];\n"
+            "int func(char* p) {\n"
+            "   *p = 0;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(buf)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // global variable modifying through local pointer
+        functionVariableUsage(
+            "int global = 1;\n"
+            "int func() {\n"
+            "   int *p = &global;\n"
+            "   *p = 0;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // global struct variable
+        functionVariableUsage(
+            "struct S { int x; } s;\n"
+            "int func() {\n"
+            "   s.x = 1;;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     // #5355 - False positive: Variable is not assigned a value.

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -822,6 +822,109 @@ private:
             "   C c;\n"
             "}");
         ASSERT_EQUALS("", errout.str());
+
+        // clean function recursion
+        functionVariableUsage(
+            "int func(int i) {\n"
+            "   if (i != 2) {\n"
+            "       func(i++);\n"
+            "       return 2;\n"
+            "   }\n"
+            "   return i;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:14]: (style) Unused variable: c\n", errout.str());
+
+        // side-effect function recursion
+        functionVariableUsage(
+            "int global = 1;\n"
+            "int func(int i) {\n"
+            "   if (i != 2) {\n"
+            "       global++;\n"
+            "       func(i++);\n"
+            "       return 2;\n"
+            "   }\n"
+            "   return i;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // multiple returns (side-effect & clean)
+        functionVariableUsage(
+            "int func(int i) {\n"
+            "   if (i == 0) { return 0;}\n"
+            "   else { return unknownSideEffectFunction(); }\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // multiple clean returns
+        functionVariableUsage(
+            "int func(int i) {\n"
+            "   if (i == 0) { return 0;}\n"
+            "   else { return i; }\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:11]: (style) Unused variable: c\n", errout.str());
+
+        // multiple side-effect returns
+        functionVariableUsage(
+            "int func(int i) {\n"
+            "   if (i == 0) { return unknownSideEffectFunction();}\n"
+            "   else { return unknown_var; }\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // argument return
+        functionVariableUsage(
+            "int func(int i) {\n"
+            "    return i;"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:9]: (style) Unused variable: c\n", errout.str());
     }
 
     // #5355 - False positive: Variable is not assigned a value.

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -859,6 +859,28 @@ private:
             "}");
         ASSERT_EQUALS("[test.cpp:14]: (style) Unused variable: c\n", errout.str());
 
+        // indirect clean function recursion
+        functionVariableUsage(
+            "void another_func() {\n"
+            "   func(0);\n"
+            "}\n"
+            "int func(int i) {\n"
+            "   if (i != 2) {\n"
+            "       another_func();\n"
+            "       return 2;\n"
+            "   }\n"
+            "   return i;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func(0)) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:17]: (style) Unused variable: c\n", errout.str());
+
         // side-effect function recursion
         functionVariableUsage(
             "int global = 1;\n"

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -39,6 +39,7 @@ private:
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(isRecordTypeWithoutSideEffects);
+        TEST_CASE(cleanFunction);
 
         TEST_CASE(emptyclass);  // #5355 - False positive: Variable is not assigned a value.
         TEST_CASE(emptystruct);  // #5355 - False positive: Variable is not assigned a value.
@@ -472,17 +473,6 @@ private:
         functionVariableUsage(
             "class F {\n"
             "public:\n"
-            "   F() : x(unknownFunc()) {}\n"
-            "   int x;\n"
-            "};\n"
-            "void f() {\n"
-            "   F f;\n"
-            "}");
-        ASSERT_EQUALS("", errout.str());
-
-        functionVariableUsage(
-            "class F {\n"
-            "public:\n"
             "   F() : x(++unknownValue) {}\n"
             "   int x;\n"
             "};\n"
@@ -521,6 +511,315 @@ private:
             "};\n"
             "void f() {\n"
             "   F f;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void cleanFunction()
+    {
+        // unknown function
+        functionVariableUsage(
+            "class F {\n"
+            "public:\n"
+            "   F() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   F f;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // function forward declaration
+        functionVariableUsage(
+            "int func();\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+        
+        // return literal
+        functionVariableUsage(
+            "int func() { return 1; }\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:8]: (style) Unused variable: c\n", errout.str());
+
+        // return variable without side effects
+        functionVariableUsage(
+            "int func() {\n"
+            "   int x = 1;\n"
+            "   return x;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:11]: (style) Unused variable: c\n", errout.str());
+
+        // return variable with side effects
+        functionVariableUsage(
+            "int func() {\n"
+            "   unknown_type x = 1;\n"
+            "   return x;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // return unknown variable
+        functionVariableUsage(
+            "int func() {\n"
+            "   return unknown_var;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // return variable is global, but not changed
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   return x;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:11]: (style) Unused variable: c\n", errout.str());
+
+        // changing global variable in return
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   return x++;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // changing global variable in function body
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   x++;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   --x;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   x += 2;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        functionVariableUsage(
+            "int x = 1;\n"
+            "int func() {\n"
+            "   x = 2;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // changing local variable
+        functionVariableUsage(
+            "int func() {\n"
+            "   int x = 1;\n"
+            "   x = 2;\n"
+            "   x++;\n"
+            "   return x;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:13]: (style) Unused variable: c\n", errout.str());
+
+        // variable of user-defined class without side effects
+        functionVariableUsage(
+            "class A {};\n"
+            "A func() {\n"
+            "   A a;\n"
+            "   return a;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   A x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:12]: (style) Unused variable: c\n", errout.str());
+
+        // variable of user-defined class with side effects
+        functionVariableUsage(
+            "class A {\n"
+            "public:\n"
+            "   unknown_type u{1};\n"
+            "};\n"
+            "int func() {\n"
+            "   A a;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // unknown type variable
+        functionVariableUsage(
+            "int func() {\n"
+            "   unknown_type a;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // nested clean function call
+        functionVariableUsage(
+            "int another_func() { return 1;}\n"
+            "int func() {\n"
+            "   another_func();\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("[test.cpp:12]: (style) Unused variable: c\n", errout.str());
+
+        // nested side-effects function call
+        functionVariableUsage(
+            "int global = 1;"
+            "int another_func() {\n"
+            "   global++;\n"
+            "   return global;}\n"
+            "int func() {\n"
+            "   another_func();\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
+        // unknown nested function
+        functionVariableUsage(
+            "int func() {\n"
+            "   unknown_func();\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
             "}");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -699,6 +699,23 @@ private:
             "}");
         ASSERT_EQUALS("", errout.str());
 
+        // changing global array variable in function body
+        functionVariableUsage(
+            "int x[] = {0, 1, 3};\n"
+            "int func() {\n"
+            "   x[0] = 4;\n"
+            "   return 1;\n"
+            "}\n"
+            "class C {\n"
+            "public:\n"
+            "   C() : x(func()) {}\n"
+            "   int x;\n"
+            "};\n"
+            "void f() {\n"
+            "   C c;\n"
+            "}");
+        ASSERT_EQUALS("", errout.str());
+
         // changing local variable
         functionVariableUsage(
             "int func() {\n"


### PR DESCRIPTION
Analyzing function side effects to better detect classes without side effects. See [this](https://github.com/danmar/cppcheck/pull/2836#issuecomment-718806054) comment and PR for details.

To be done in further PRs:
* side-effect variables in function arguments
* return statements with length > 1 token
* lambdas
* class member functions and static variables
* escape functions

Pointing to any other missed test cases will be appreciated.