### PR TITLE
Update microsoft/setup-msbuild

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup msbuild.exe
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
                   
       - name: Install PCRE
         run: |


### PR DESCRIPTION
microsoft/setup-msbuild@v1.0.2 should cure the issue mentioned on https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/