### PR TITLE
Update setup-msbuild also in release-windows

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup msbuild.exe
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Install PCRE
         run: |


### PR DESCRIPTION
- Fixes:
The `add-path` command is deprecated and will be disabled on
November 16th. Please upgrade to using Environment Files.
For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- This is a follow-up commit to: a6a5cbe6