### PR TITLE
Fixed #9988 (false positive: misra-c2012-9.2)

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1721,7 +1721,8 @@ class MisraChecker:
             while not eq.isAssignmentOp and eq.astParent:
                 eq = eq.astParent
 
-            if not eq.isAssignmentOp:
+            # We are only looking for initializers
+            if not eq.isAssignmentOp or eq.astOperand2.isName:
                 continue
 
             if variable.isArray :

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1247,7 +1247,7 @@ void misra_18_8(int x) {
   int buf1[10];
   int buf2[sizeof(int)];
   int vla[x]; // 18.8
-  static const unsigned char arr18_8_1[] = UNDEFINED_ID; // 9.2
+  static const unsigned char arr18_8_1[] = UNDEFINED_ID;
   static uint32_t enum_test_0[R18_8_ENUM_CONSTANT_0] = {0};
 }
 


### PR DESCRIPTION
I believe we can skip further checking if we encounter an astOperand2 where isName is True.

This will remove the 9.2 issue on line 1250, which probably also should be considered a false positive.