### PR TITLE
Fixed #9993 (false positive: misra-c2012-9.2)

### DIFF
--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -306,6 +306,12 @@ void misra_9_2() {
     const char string_wrong_level_b[2][20]   = "Hello world";                          // 9.2
     const char string_correct_level_a[]      = "Hello world";
     const char string_correct_level_b[2][12] = { "Hello world" };
+    const char *char_p_correct_level[2]      = { "Hello", [1] = "world" };
+    const char *char_p_incorrect_level[1]    = "Hello world";                          // 9.2
+
+    char **str_p = &char_p_correct_level[0];
+    char **str_p_array_correct_level[1]      = { str_p };
+    char **str_p_array_incorrect_level[1]    = { { str_p } };                          // 9.2
 
     int array_init_incorrect_levels_a[3][2]  = { 1, 2, 3, 4, 5, 6 };                   // 9.2
     int array_init_correct_levels_a[3][2]    = { { 1, 2 }, { 3, 4 }, { 5, 6 } };


### PR DESCRIPTION
I now use the value of `valueType.pointer` and compare it to the size of the dimensions for the array `len(dimensions)` to determine if a string is an array initializer or a value initializer for a char pointer.

My assumption (after some investigation) is that this value will be at least one higher than the dimensions of the array (Eg. two dimensional array to char pointers will have valueType.pointer = 3).

Points of interest are lines 1591 and 1609

I deliberately don't check the type of the pointer, since I don't believe that to be within the scope of 9.2