### PR TITLE
Added Elbrus E1C+ platform file

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1128,6 +1128,8 @@ void CmdLineParser::printHelp()
               "                                 64 bit Windows\n"
               "                          * avr8\n"
               "                                 8 bit AVR microcontrollers\n"
+              "                          * elbrus-e1cp\n"
+              "                                 Elbrus e1c+ architecture\n"
               "                          * pic8\n"
               "                                 8 bit PIC microcontrollers\n"
               "                                 Baseline and mid-range architectures\n"

--- a/platforms/elbrus-e1cp.xml
+++ b/platforms/elbrus-e1cp.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<platform>
+  <char_bit>8</char_bit>
+  <default-sign>unsigned</default-sign>
+  <sizeof>
+    <bool>1</bool>
+    <short>2</short>
+    <int>4</int>
+    <long>8</long>
+    <long-long>8</long-long>
+    <float>4</float>
+    <double>8</double>
+    <long-double>16</long-double>
+    <pointer>8</pointer>
+    <size_t>8</size_t>
+    <wchar_t>4</wchar_t>
+  </sizeof>
+</platform>
+

--- a/win_installer/cppcheck.wxs
+++ b/win_installer/cppcheck.wxs
@@ -132,6 +132,7 @@
               <File Id='arm64wchar_t2.xml' Name='arm64-wchar_t2.xml' Source='$(var.PtfsDir)\arm64-wchar_t2.xml' />
               <File Id='arm64wchar_t4.xml' Name='arm64-wchar_t4.xml' Source='$(var.PtfsDir)\arm64-wchar_t4.xml' />
               <File Id='avr8.xml' Name='avr8.xml' Source='$(var.PtfsDir)\avr8.xml' />
+              <File Id='elbrus-e1cp.xml' Name='elbrus-e1cp.xml' Source='$(var.PtfsDir)\elbrus-e1cp.xml' />
               <File Id='pic8.xml' Name='pic8.xml' Source='$(var.PtfsDir)\pic8.xml' />
               <File Id='pic8-enhanced.xml' Name='pic8-enhanced.xml' Source='$(var.PtfsDir)\pic8-enhanced.xml' />
               <File Id='pic16.xml' Name='pic16.xml' Source='$(var.PtfsDir)\pic16.xml' />


### PR DESCRIPTION
Added a configuration file for our [Elbrus](https://en.wikipedia.org/wiki/Elbrus_(computer)) e1c+ machines.
A more detailed description of these processors is available [here](http://www.mcst.ru/elbrus-1c-plus) (in Russian).