### PR TITLE
cppcheck.wxs: Use underscore instead of dash

### DIFF
--- a/win_installer/cppcheck.wxs
+++ b/win_installer/cppcheck.wxs
@@ -132,9 +132,9 @@
               <File Id='arm64wchar_t2.xml' Name='arm64-wchar_t2.xml' Source='$(var.PtfsDir)\arm64-wchar_t2.xml' />
               <File Id='arm64wchar_t4.xml' Name='arm64-wchar_t4.xml' Source='$(var.PtfsDir)\arm64-wchar_t4.xml' />
               <File Id='avr8.xml' Name='avr8.xml' Source='$(var.PtfsDir)\avr8.xml' />
-              <File Id='elbrus-e1cp.xml' Name='elbrus-e1cp.xml' Source='$(var.PtfsDir)\elbrus-e1cp.xml' />
+              <File Id='elbrus_e1cp.xml' Name='elbrus-e1cp.xml' Source='$(var.PtfsDir)\elbrus-e1cp.xml' />
               <File Id='pic8.xml' Name='pic8.xml' Source='$(var.PtfsDir)\pic8.xml' />
-              <File Id='pic8-enhanced.xml' Name='pic8-enhanced.xml' Source='$(var.PtfsDir)\pic8-enhanced.xml' />
+              <File Id='pic8_enhanced.xml' Name='pic8-enhanced.xml' Source='$(var.PtfsDir)\pic8-enhanced.xml' />
               <File Id='pic16.xml' Name='pic16.xml' Source='$(var.PtfsDir)\pic16.xml' />
               <File Id='mips32.xml' Name='mips32.xml' Source='$(var.PtfsDir)\mips32.xml' />
               <File Id='cray_sv1.xml' Name='cray_sv1.xml' Source='$(var.PtfsDir)\cray_sv1.xml' />


### PR DESCRIPTION
Fixes the following errors during the `Build Installer` step of
**`release-windows`** GitHub Action:

```console
cppcheck.wxs(135): error CNDL0014: The File/@Id attribute's value,
'elbrus-e1cp.xml', is not a legal identifier. Identifiers may contain
ASCII characters A-Z, a-z, digits, underscores (_), or periods (.).

cppcheck.wxs(137): error CNDL0014: The File/@Id attribute's value,
'pic8-enhanced.xml', is not a legal identifier.
```

Successful GitHub Action test run of **`release-windows`**:
https://github.com/c72578/cppcheck/actions/runs/375485795
