### PR TITLE
Update Qt version for release-windows to 5.15.2

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
         with:
-          version: '5.15.1'
+          version: '5.15.2'
           modules: 'qtcharts qthelp'
 
       - name: Create .qm


### PR DESCRIPTION
Qt 5.15.2 has been released on 2020-11-20 [1]. This is the currently newest
patch release of the 5.15 LTS series.
- The update of Qt to version 5.15.2 fixes an issue with the index of
  Qt help files as reported upstream:
  https://bugreports.qt.io/browse/QTBUG-88342

[1] https://www.qt.io/blog/qt-5.15.2-released

GitHub Actions test-build against Qt 5.15.2:
https://github.com/c72578/cppcheck/actions/runs/375809396
