### PR TITLE
fix a large number of valgrind warnings in testrunner

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3547,11 +3547,12 @@ static void valueFlowLifetimeConstructor(Token* tok, TokenList* tokenlist, Error
 
 struct Lambda {
     enum class Capture {
+        Undefined,
         ByValue,
         ByReference
     };
     explicit Lambda(const Token * tok)
-        : capture(nullptr), arguments(nullptr), returnTok(nullptr), bodyTok(nullptr), explicitCaptures() {
+        : capture(nullptr), arguments(nullptr), returnTok(nullptr), bodyTok(nullptr), explicitCaptures(), implicitCapture(Capture::Undefined) {
         if (!Token::simpleMatch(tok, "[") || !tok->link())
             return;
         capture = tok;


### PR DESCRIPTION
==28830== Conditional jump or move depends on uninitialised value(s)
==28830==    at 0x10252E4: valueFlowLifetime(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*)::{lambda(Token const*, Lambda::Capture, std::function<bool (Token const*)>)#2}::operator()(Token const*, Lambda::Capture, std::function<bool (Token const*)>) const (valueflow.cpp:3656)
==28830==    by 0x1025A03: valueFlowLifetime(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) (valueflow.cpp:3685)
==28830==    by 0x1038E94: ValueFlow::setValues(TokenList*, SymbolDatabase*, ErrorLogger*, Settings const*) (valueflow.cpp:6569)
==28830==    by 0xF8D155: Tokenizer::simplifyTokens1(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (tokenize.cpp:2384)
==28830==    by 0xF8D390: Tokenizer::tokenize(std::istream&, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (tokenize.cpp:2401)
==28830==    by 0x80918B: TestAssert::check(char const*, char const*) (testassert.cpp:40)
==28830==    by 0x809F6D: TestAssert::assignmentInAssert() (testassert.cpp:231)
==28830==    by 0x809386: TestAssert::run() (testassert.cpp:50)
==28830==    by 0xA99ED7: TestFixture::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (testsuite.cpp:309)
==28830==    by 0xA9A1FA: TestFixture::runTests(options const&) (testsuite.cpp:332)
==28830==    by 0x9EDEC9: main (testrunner.cpp:44)
