### PR TITLE
lib: Add condition for include externals/tinyxml2

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,8 @@
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/)
 include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/picojson/)
-include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/tinyxml2/)
+if(USE_BUNDLED_TINYXML2)
+    include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/externals/tinyxml2/)
+endif()
 include_directories(${PROJECT_SOURCE_DIR}/externals/simplecpp/)
 
 file(GLOB_RECURSE hdrs "*.h")


### PR DESCRIPTION
Include **`externals/tinyxml2`** in **`lib/CMakeLists.txt`** only if
`USE_BUNDLED_TINYXML2` is `ON`, which is the default.
This is a follow-up commit to 8ac55a8
