### PR TITLE
fixed excessive spawning of child processes / fixed potential zombie processes

### DIFF
--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -182,7 +182,7 @@ unsigned int ThreadExecutor::check()
     std::list<ImportProject::FileSettings>::const_iterator iFileSettings = mSettings.project.fileSettings.begin();
     for (;;) {
         // Start a new child
-        size_t nchildren = rpipes.size();
+        size_t nchildren = childFile.size();
         if ((iFile != mFiles.end() || iFileSettings != mSettings.project.fileSettings.end()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
             int pipes[2];
             if (pipe(pipes) == -1) {

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -295,21 +295,17 @@ unsigned int ThreadExecutor::check()
                     childFile.erase(c);
                 }
 
-                if (WIFSIGNALED(stat)) {
+                if (WIFEXITED(stat)) {
+                    const int exitstaus = WEXITSTATUS(stat);
+                    if (exitstaus != 0) {
+                        std::ostringstream oss;
+                        oss << "Child process exited with " << exitstaus;
+                        reportInternalChildErr(childname, oss.str());
+                    }
+                } else if (WIFSIGNALED(stat)) {
                     std::ostringstream oss;
-                    oss << "Internal error: Child process crashed with signal " << WTERMSIG(stat);
-
-                    std::list<ErrorMessage::FileLocation> locations;
-                    locations.emplace_back(childname, 0, 0);
-                    const ErrorMessage errmsg(locations,
-                                              emptyString,
-                                              Severity::error,
-                                              oss.str(),
-                                              "cppcheckError",
-                                              false);
-
-                    if (!mSettings.nomsg.isSuppressed(errmsg.toSuppressionsErrorMessage()))
-                        mErrorLogger.reportErr(errmsg);
+                    oss << "Child process crashed with signal " << WTERMSIG(stat);
+                    reportInternalChildErr(childname, oss.str());
                 }
             }
         } else {
@@ -357,6 +353,21 @@ void ThreadExecutor::reportInfo(const ErrorMessage &msg)
 void ThreadExecutor::bughuntingReport(const std::string &str)
 {
     writeToPipe(REPORT_VERIFICATION, str.c_str());
+}
+
+void ThreadExecutor::reportInternalChildErr(const std::string &childname, const std::string &msg)
+{
+    std::list<ErrorMessage::FileLocation> locations;
+    locations.emplace_back(childname, 0, 0);
+    const ErrorMessage errmsg(locations,
+                              emptyString,
+                              Severity::error,
+                              "Internal error: " + msg,
+                              "cppcheckError",
+                              false);
+
+    if (!mSettings.nomsg.isSuppressed(errmsg.toSuppressionsErrorMessage()))
+        mErrorLogger.reportErr(errmsg);
 }
 
 #elif defined(THREADING_MODEL_WIN)

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -284,7 +284,7 @@ unsigned int ThreadExecutor::check()
                         ++rp;
                 }
             }
-
+        } else if (!childFile.empty()) {
             int stat = 0;
             pid_t child = waitpid(0, &stat, WNOHANG);
             if (child > 0) {

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -102,6 +102,12 @@ private:
      */
     bool checkLoadAverage(size_t nchildren);
 
+    /**
+     * @brief Reports internal errors related to child processes
+     * @param msg The error message
+     */
+    void reportInternalChildErr(const std::string &childname, const std::string &msg);
+
 public:
     /**
      * @return true if support for threads exist.


### PR DESCRIPTION
This fixes the excessive spawning of processes since the pipes are done earlier than the actual process. I think this might explain some out-of-memory issues with bigger projects.

We also now wait for all child processes to be finished (handling was also bound to the pipes) which should get rid of zombie processes - at least in the `testrunner` as during normal scanning those would have been gone with the parent process after scanning. You will still see zombie processes during run-time as the processes are not being explicitly waited for so up to n processes might already done but not yet handled.

There still seem to be issues since LSAN still reports
```
TestSuppressions::suppressionsSettings
==6089==Running thread 6067 was not suspended. False leaks are possible.
```