### PR TITLE
testclangimport.cpp: fixed potential nullptr dereference in parse()

### DIFF
--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -127,6 +127,9 @@ private:
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(&tokenizer, istr);
+        if (!tokenizer.tokens()) {
+        	return std::string();
+        }
         return tokenizer.tokens()->stringifyList(true, false, false, false, false);
     }
 


### PR DESCRIPTION
Reported by Clang UBSAN

```
TestClangImport::classTemplateDecl1
test/testclangimport.cpp:130:36: runtime error: member call on null pointer of type 'Token'
    #0 0x92f5cf in TestClangImport::parse[abi:cxx11](char const*) /home/runner/work/cppcheck/cppcheck/test/testclangimport.cpp:130:36
    #1 0x923c25 in TestClangImport::classTemplateDecl1() /home/runner/work/cppcheck/cppcheck/test/testclangimport.cpp:220:9
    #2 0x91c833 in TestClangImport::run() /home/runner/work/cppcheck/cppcheck/test/testclangimport.cpp:38:9
    #3 0xde6c2c in TestFixture::runTests(options const&) /home/runner/work/cppcheck/cppcheck/test/testsuite.cpp:332:23
    #4 0xcbdde4 in main /home/runner/work/cppcheck/cppcheck/test/testrunner.cpp:44:46
    #5 0x7efea62fdbf6 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21bf6)
    #6 0x8570b9 in _start (/home/runner/work/cppcheck/cppcheck/testrunner+0x8570b9)
```