### PR TITLE
Github CI: AddUbuntu 20.04 and MacOS 11.0

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11.0]
       fail-fast: false # Prefer quick result
 
     runs-on: ${{ matrix.os }}
@@ -33,7 +33,7 @@ jobs:
           sudo apt-get install z3 libz3-dev
 
       - name: Install missing software on macos
-        if: matrix.os == 'macos-latest'
+        if: contains(matrix.os, 'macos')
         run: |
           brew install coreutils z3
           cp externals/z3_version_old.h externals/z3_version.h

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
       fail-fast: false # not worthwhile...
 
     runs-on: ${{ matrix.os }}
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install missing software on ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'  || matrix.os == 'ubuntu-20.04' 
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-utils

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install missing software on ubuntu
+      - name: Install missing software on ubuntu 18.04
         if: matrix.os == 'ubuntu-18.04'  || matrix.os == 'ubuntu-20.04' 
         run: |
           sudo apt-get update
@@ -25,13 +25,20 @@ jobs:
           sudo apt-get install z3 libz3-dev
           cp externals/z3_version_old.h externals/z3_version.h
 
+      - name: Install missing software on ubuntu 20.04
+        if: matrix.os == 'ubuntu-18.04'  || matrix.os == 'ubuntu-20.04' 
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-utils
+          sudo apt-get install z3 libz3-dev
+
       - name: Install missing software on macos
         if: matrix.os == 'macos-latest'
         run: |
           brew install coreutils z3
           
       - name: Install Qt
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os, 'ubuntu')
         uses: jurplel/install-qt-action@v2
         with:
           modules: 'qtcharts'
@@ -74,14 +81,14 @@ jobs:
           ./cppcheck --addon=threadsafety --std=c++03 addons/test/threadsafety
 
       - name: Build GUI on ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd gui
           qmake HAVE_QCHART=yes
           make -j$(nproc)
 
       - name: Run GUI tests on ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd gui/test/projectfile
           qmake
@@ -89,14 +96,14 @@ jobs:
           ./test-projectfile
 
       - name: Generate Qt help file on ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd gui/help
           qhelpgenerator online-help.qhcp -o online-help.qhc
 
       # Run self check after "Build GUI" to include generated headers in analysis
       - name: Self check
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: |
           # compile with verification and ast matchers
           make clean
@@ -111,13 +118,14 @@ jobs:
           ./cppcheck -q -j$(nproc) --template=gcc -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli -Igui --inconclusive --enable=style,performance,portability,warning,internal --exception-handling test/*.cpp tools
 
       - name: Build triage on ubuntu
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-18.04'
         run: |
           pushd tools/triage
           qmake
           make -j$(nproc)
 
       - name: Build Fuzzer
+        if: matrix.os == 'ubuntu-18.04'
         run: |
           g++ -fsyntax-only -std=c++11 -Ilib oss-fuzz/*.cpp
 

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
-      fail-fast: false # not worthwhile...
+      fail-fast: false # Prefer quick result
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install missing software on ubuntu 18.04
-        if: matrix.os == 'ubuntu-18.04'  || matrix.os == 'ubuntu-20.04' 
+        if: matrix.os == 'ubuntu-18.04'
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-utils
@@ -26,7 +26,7 @@ jobs:
           cp externals/z3_version_old.h externals/z3_version.h
 
       - name: Install missing software on ubuntu 20.04
-        if: matrix.os == 'ubuntu-18.04'  || matrix.os == 'ubuntu-20.04' 
+        if: matrix.os == 'ubuntu-20.04' 
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-utils
@@ -36,6 +36,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install coreutils z3
+          cp externals/z3_version_old.h externals/z3_version.h
           
       - name: Install Qt
         if: contains(matrix.os, 'ubuntu')
@@ -60,7 +61,6 @@ jobs:
       - name: Build cppcheck
         run: |
           make clean
-          cp externals/z3_version_old.h externals/z3_version.h
           make -j$(nproc) USE_Z3=yes HAVE_RULES=yes
 
       - name: Build test


### PR DESCRIPTION
That is part of the preparations for the upcoming change in "ubuntu.latest" platform (see https://github.com/actions/virtual-environments/issues/1816)
Probably we shouldn't use `.latest` at all.