### PR TITLE
fix compile-time rounding error

### DIFF
--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -27,6 +27,7 @@
 #include "token.h"
 #include "tokenize.h"
 
+#include <cmath>
 #include <cstddef>
 #include <list>
 #include <ostream>
@@ -425,9 +426,9 @@ void CheckType::checkFloatToIntegerOverflow(const Token *tok, const ValueType *v
             continue;
         if (!mSettings->isEnabled(&f, false))
             continue;
-        if (f.floatValue > ~0ULL)
+        if (f.floatValue >= std::exp2(mSettings->long_long_bit))
             floatToIntegerOverflowError(tok, f);
-        else if ((-f.floatValue) > (1ULL<<62))
+        else if ((-f.floatValue) > std::exp2(mSettings->long_long_bit - 1))
             floatToIntegerOverflowError(tok, f);
         else if (mSettings->platformType != Settings::Unspecified) {
             int bits = 0;


### PR DESCRIPTION
fixes implicit conversion from 'unsigned long long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]

This warning is emitted by clang-10 when compiling cppcheck via
```
CXX=clang++-10 cmake -DCMAKE_BUILD_TYPE=Release -DUSE_MATCHCOMPILER=ON
```
