### PR TITLE
Add missing \n in help

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1107,7 +1107,7 @@ void CmdLineParser::printHelp()
               "                         If used together with a Visual Studio Solution (*.sln)\n"
               "                         or Visual Studio Project (*.vcxproj) you can limit\n"
               "                         the configuration cppcheck should check.\n"
-              "                         For example: ""--project-configuration=Release|Win32"""
+              "                         For example: '--project-configuration=Release|Win32'\n"
               "    --max-configs=<limit>\n"
               "                         Maximum number of configurations to check in a file\n"
               "                         before skipping it. Default is '12'. If used together\n"


### PR DESCRIPTION
`cppcheck --help` printed:

    --project-configuration=<config>
                         If used together with a Visual Studio Solution (*.sln)
                         or Visual Studio Project (*.vcxproj) you can limit
                         the configuration cppcheck should check.
                         For example: --project-configuration=Release|Win32    --max-configs=<limit>
                         Maximum number of configurations to check in a file
                         before skipping it. Default is '12'. If used together
                         with '--force', the last option is the one that is
                         effective.

A `\n` was missing before option `--max-configs`, and the double-quotes did nothing.