### PR TITLE
feat(unused_var): analyze global variables inside function body

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1609,7 +1609,7 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
     }
 
     bool sideEffectReturnFound = false;
-    std::list<const Variable*> pointersToGlobals;
+    std::set<const Variable*> pointersToGlobals;
     for (Token* bodyToken = func.functionScope->bodyStart->next(); bodyToken != func.functionScope->bodyEnd;
             bodyToken = bodyToken->next())
     {
@@ -1623,7 +1623,8 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
             if (bodyVariable->isGlobal() ||
                 (std::find(pointersToGlobals.begin(), pointersToGlobals.end(), bodyVariable) != pointersToGlobals.end()))
             {
-                if (isVariableChanged(bodyToken, 20, nullptr, true)) {
+                const int depth = 20;
+                if (isVariableChanged(bodyToken, depth, mSettings, mTokenizer->isCPP())) {
                     return false;
                 }
                 // check if pointer to global variable assigned to another variable (another_var = &global_var)
@@ -1631,7 +1632,7 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
                     const Token* assigned_var_token = bodyToken->tokAt(-3);
                     if (assigned_var_token && assigned_var_token->variable())
                     {
-                        pointersToGlobals.push_back(assigned_var_token->variable());
+                        pointersToGlobals.insert(assigned_var_token->variable());
                     }
                 }
             }

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1627,8 +1627,8 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
                     return false;
                 }
                 // check if pointer to global variable assigned to another variable (another_var = &global_var)
-                if (Token::simpleMatch(bodyToken->previous(), "&") && Token::simpleMatch(bodyToken->previous()->previous(), "=")) {
-                    const Token* assigned_var_token = bodyToken->previous()->previous()->previous();
+                if (Token::simpleMatch(bodyToken->tokAt(-1), "&") && Token::simpleMatch(bodyToken->tokAt(-2), "=")) {
+                    const Token* assigned_var_token = bodyToken->tokAt(-3);
                     if (assigned_var_token && assigned_var_token->variable())
                     {
                         pointersToGlobals.push_back(assigned_var_token->variable());

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1623,6 +1623,9 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
             if (bodyVariable->isGlobal() ||
                 (std::find(pointersToGlobals.begin(), pointersToGlobals.end(), bodyVariable) != pointersToGlobals.end()))
             {
+                if (bodyVariable->isPointer() || bodyVariable->isArray()) {
+                    return false; // TODO: Update astutils.cpp:1544 isVariableChanged() and remove this. Unhandled case: `*(global_arr + 1) = new_val`
+                }
                 const int depth = 20;
                 if (isVariableChanged(bodyToken, depth, mSettings, mTokenizer->isCPP())) {
                     return false;

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1620,9 +1620,7 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
                 return false;
             }
             // check if global variable is changed
-            if (bodyVariable->isGlobal() ||
-                (std::find(pointersToGlobals.begin(), pointersToGlobals.end(), bodyVariable) != pointersToGlobals.end()))
-            {
+            if (bodyVariable->isGlobal() || (pointersToGlobals.find(bodyVariable) != pointersToGlobals.end()) ) {
                 if (bodyVariable->isPointer() || bodyVariable->isArray()) {
                     return false; // TODO: Update astutils.cpp:1544 isVariableChanged() and remove this. Unhandled case: `*(global_arr + 1) = new_val`
                 }

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -762,8 +762,7 @@ private:
             "void f() {\n"
             "   C c;\n"
             "}");
-        // TODO: update astutils.cpp:1544 isVariableChanged() - array change through pointer arithmetic is not handled
-        TODO_ASSERT_EQUALS("", "[test.cpp:12]: (style) Unused variable: c\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
 
         // changing local variable
         functionVariableUsage(
@@ -1065,7 +1064,8 @@ private:
             "void f() {\n"
             "   C c;\n"
             "}");
-        ASSERT_EQUALS("[test.cpp:13]: (style) Unused variable: c\n", errout.str());
+        // TODO: see TODO for global vars under CheckUnusedVar::isFunctionWithoutSideEffects()
+        TODO_ASSERT_EQUALS("[test.cpp:13]: (style) Unused variable: c\n", "", errout.str());
 
         // global struct variable modification
         functionVariableUsage(
@@ -1135,7 +1135,8 @@ private:
             "void f() {\n"
             "   C c;\n"
             "}");
-        ASSERT_EQUALS("[test.cpp:13]: (style) Unused variable: c\n", errout.str());
+        // TODO: see TODO for global vars under CheckUnusedVar::isFunctionWithoutSideEffects()
+        TODO_ASSERT_EQUALS("[test.cpp:13]: (style) Unused variable: c\n", "", errout.str());
     }
 
     // #5355 - False positive: Variable is not assigned a value.


### PR DESCRIPTION
Before this PR, any global variable found in function body marked this function as side-effect one. Analyzing global variables more precisely from now.
Any help with missed test cases will be highly appreciated. 