### PR TITLE
ExprEngine: Handle pointer to struct passed as an argument to the function

### DIFF
--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -2611,8 +2611,19 @@ static std::string execute(const Token *start, const Token *end, Data &data)
                         if (!structVal1)
                             structVal1 = createVariableValue(*structToken->variable(), data);
                         auto structVal = std::dynamic_pointer_cast<ExprEngine::StructValue>(structVal1);
-                        if (!structVal)
-                            throw ExprEngineException(tok2, "Unhandled assignment in loop");
+                        if (!structVal) {
+                            // Handle pointer to a struct
+                            if (auto structPtr = std::dynamic_pointer_cast<ExprEngine::ArrayValue>(structVal1)) {
+                                if (structPtr && structPtr->pointer && !structPtr->data.empty()) {
+                                    auto indexValue = std::make_shared<ExprEngine::IntRange>("0", 0, 0);
+                                    for (auto val: structPtr->read(indexValue)) {
+                                        structVal = std::dynamic_pointer_cast<ExprEngine::StructValue>(val.second);
+                                    }
+                                }
+                            }
+                            if (!structVal)
+                                throw ExprEngineException(tok2, "Unhandled assignment in loop");
+                        }
 
                         data.assignStructMember(tok2, &*structVal, memberName, memberValue);
                         continue;

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -113,6 +113,8 @@ private:
         TEST_CASE(structMember2);
         TEST_CASE(structMember3);
 
+        TEST_CASE(pointerToStructInLoop);
+
         TEST_CASE(ternaryOperator1);
 #endif
     }
@@ -803,6 +805,20 @@ private:
 
         const char expected[] = "(and (>= $3 (- 2147483648)) (<= $3 2147483647))\n"
                                 "(= $3 1)\n"
+                                "z3::sat\n";
+
+        ASSERT_EQUALS(expected, expr(code, "=="));
+    }
+
+    void pointerToStructInLoop() {
+        const char code[] = "struct S { int x; };\n"
+                            "void foo(struct S *s) {\n"
+                            "  while (1)\n"
+                            "    s->x = 42; \n"
+                            "}";
+
+        const char expected[] = "(and (>= $3 (- 2147483648)) (<= $3 2147483647))\n"
+                                "(= $3 42)\n"
                                 "z3::sat\n";
 
         ASSERT_EQUALS(expected, expr(code, "=="));


### PR DESCRIPTION
This is related to false negative in CVE-2020-12654 discussed [on the forum](https://sourceforge.net/p/cppcheck/discussion/development/thread/834110f0e7/?page=1&limit=25#195f).

I managed to reduce the CVE source code to this snippet (see commentary):

```c
#include <string.h>

struct some_struct {
  int disabled;
  int field[32];
};

int mwifiex_ret_wmm_get_status(struct some_struct *sin)
{
  char buf[32] = {0};
  memcpy(sin->field, &buf, 32);
  while (1) {
    switch (1) {
    case 1:
      sin->disabled = 1; // Comment this to "fix" false negative
      memcpy(sin->field, &buf, 32); // False negative
      break;
    }
  }
  return 0;
}
```

[expr-printer.py](https://github.com/jubnzv/cppcheck-nvd-checker) can now print exceptions from Cppcheck, so this helps in investigation.