### PR TITLE
ExprEngine: Handle pointer assignments in loops without bailout

### DIFF
--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -357,11 +357,11 @@ private:
     }
 
     void exprAssign2() {
-        ASSERT_EQUALS("2", getRange("void f(unsigned char x) { x = 258; int a = x }", "a=x"));
+        ASSERT_EQUALS("2", getRange("void f(unsigned char x) { x = 258; int a = x; }", "a=x"));
     }
 
     void exprAssign3() {
-        ASSERT_EQUALS("1", getRange("void f(unsigned char *a) { *a = 1 }", "*a=1"));
+        ASSERT_EQUALS("1", getRange("void f(unsigned char *a) { *a = 1; }", "*a=1"));
     }
 
     void exprNot() {

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -80,6 +80,7 @@ private:
         TEST_CASE(while4);
         TEST_CASE(while5);
         TEST_CASE(while6);
+        TEST_CASE(while7);
 
         TEST_CASE(array1);
         TEST_CASE(array2);
@@ -621,6 +622,17 @@ private:
                             "}";
         ASSERT_EQUALS("(= 4 4)\n"
                       "z3::sat\n", expr(code, "=="));
+    }
+
+    void while7() {
+        const char code[] = "void foo() {\n"
+                            "  int a = 2;\n"
+                            "  int *p = &a;\n"
+                            "  while (1) *p = 0;\n"
+                            "  return a == 2;\n"
+                            "}";
+        ASSERT_EQUALS("(= 0 2)\n"
+                      "z3::unsat\n", expr(code, "=="));
     }
 
 

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -50,6 +50,7 @@ private:
         TEST_CASE(expr9);
         TEST_CASE(exprAssign1);
         TEST_CASE(exprAssign2); // Truncation
+        TEST_CASE(exprAssign3);
         TEST_CASE(exprNot);
 
         TEST_CASE(getValueConst1);
@@ -78,6 +79,7 @@ private:
         TEST_CASE(while3);
         TEST_CASE(while4);
         TEST_CASE(while5);
+        TEST_CASE(while6);
 
         TEST_CASE(array1);
         TEST_CASE(array2);
@@ -358,6 +360,10 @@ private:
         ASSERT_EQUALS("2", getRange("void f(unsigned char x) { x = 258; int a = x }", "a=x"));
     }
 
+    void exprAssign3() {
+        ASSERT_EQUALS("1", getRange("void f(unsigned char *a) { *a = 1 }", "*a=1"));
+    }
+
     void exprNot() {
         ASSERT_EQUALS("($1)==(0)", getRange("void f(unsigned char a) { return !a; }", "!a"));
     }
@@ -605,6 +611,16 @@ private:
                             "    x += 4;\n"
                             "}";
         ASSERT(getRange(code, "x", 4).find("?") != std::string::npos);
+    }
+
+    void while6() {
+        const char code[] = "void f(int *arr) {\n"
+                            "  while (cond)\n"
+                            "    *arr = 4;\n"
+                            "  arr[0] == 4;"
+                            "}";
+        ASSERT_EQUALS("(= 4 4)\n"
+                      "z3::sat\n", expr(code, "=="));
     }
 
 


### PR DESCRIPTION
The following source code:

```cpp
void foo(int *a)
{
  while (1)
    *a = 42;
  *a == 42;
}
```

Before this commit generates a redundant "bailout" value on the assigment:
`15:12: 0:memory:{a=($2,[$1],[:]=?,[0]=bailout,[0]=42)}`

After this commit:
`15:12: 0:memory:{a=($2,[$1],[:]=?,[0]=42)}`

The added tests are redundant and can't detect this error, but they increase the number of similar cases to handle possible regressions in the future.