### PR TITLE
add failing test for mem leak in loop

### DIFF
--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -145,6 +145,7 @@ private:
 
         // loops
         TEST_CASE(loop1);
+        TEST_CASE(loop2);
 
         // mismatching allocation/deallocation
         TEST_CASE(mismatchAllocDealloc);
@@ -1557,6 +1558,16 @@ private:
               "    else { a = p; }\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void loop2() {
+        // test malloc-ing and never calling free
+        check("void f() {\n"
+              "    while (1) {\n"
+              "        char *p = malloc(10);\n"
+              "    }\n"
+              "}");
+        ASSERT_EQUALS("[test.c:4]: (error) Memory leak: p\n", errout.str());
     }
 
     void mismatchAllocDealloc() {


### PR DESCRIPTION
Cool got the tests working, had to brew reinstall pcre...

This appears to have been the offending commit, but I see it's tied to a bigger complex project.
https://github.com/danmar/cppcheck/commit/822718878669152e62453fdc95c2221ddc969f70

I added a failing test for the mem-leak-in-loop case and opened a PR:

the case
```
void main() {
  while (1) {
    char *p = malloc(100);
  }
}
```

I hope this helps! I don't think I'm knowledgeable enough with this code base to implement this feature.

