### PR TITLE
Fix gcc11 build errors

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -5,6 +5,7 @@
 #include "symboldatabase.h"
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <memory>
 
 void ProgramMemory::setValue(nonneg int varid, const ValueFlow::Value &value)

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <list>
 #include <map>
 #include <set>


### PR DESCRIPTION
- Include required header file `<limits>`
- Fixes the following errors when compiling with GCC 11:
```console
  lib/programmemory.cpp:477:44: error: 'numeric_limits' is not a member of 'std'

  test/testsymboldatabase.cpp:5978:18: error: 'numeric_limits' is not a member of 'std'
```
See also:
https://en.cppreference.com/w/cpp/types/numeric_limits
