### PR TITLE
fixed FILESDIR in CMake with Windows file separators

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -26,4 +26,5 @@ if (ENABLE_CHECK_INTERNAL)
     add_definitions(-DCHECK_INTERNAL)
 endif()
 
-add_definitions(-DFILESDIR="${FILESDIR}")
+file(TO_CMAKE_PATH ${FILESDIR} _filesdir)
+add_definitions(-DFILESDIR="${_filesdir}")


### PR DESCRIPTION
Passing `-DFILESDIR=S:\GitHub\cppcheck-fw` resulted in these compiler warnings (and none of the library files being found) since the backslashes were not escaped:
```
S:\GitHub\cppcheck-fw\cli\cppcheckexecutor.cpp(874): warning C4129: 'G': unrecognized character escape sequence
S:\GitHub\cppcheck-fw\cli\cppcheckexecutor.cpp(874): warning C4129: 'c': unrecognized character escape sequence
S:\GitHub\cppcheck-fw\cli\cppcheckexecutor.cpp(875): warning C4129: 'G': unrecognized character escape sequence
S:\GitHub\cppcheck-fw\cli\cppcheckexecutor.cpp(875): warning C4129: 'c': unrecognized character escape sequence
```

We should probably add some validation for the path on start-up as well.