### PR TITLE
Add fix to support "dealloc" element in memory or resource section of…

### DIFF
--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -198,13 +198,29 @@ static CppcheckLibraryData::MemoryResource loadMemoryResource(QXmlStreamReader &
         if (type != QXmlStreamReader::StartElement)
             continue;
         const QString elementName = xmlReader.name().toString();
-        if (elementName == "alloc") {
+        if (elementName == "alloc" || elementName == "realloc") {
             CppcheckLibraryData::MemoryResource::Alloc alloc;
+            alloc.isRealloc = (elementName == "realloc");
             alloc.init = (xmlReader.attributes().value("init").toString() == "true");
+            if (xmlReader.attributes().hasAttribute("arg")) {
+                alloc.arg = xmlReader.attributes().value("arg").toInt();
+            }
+            if (alloc.isRealloc && xmlReader.attributes().hasAttribute("realloc-arg")) {
+                alloc.reallocArg = xmlReader.attributes().value("realloc-arg").toInt();
+            }
+            if (memoryresource.type == "memory") {
+                alloc.bufferSize = xmlReader.attributes().value("buffer-size").toString();
+            }
             alloc.name = xmlReader.readElementText();
             memoryresource.alloc.append(alloc);
-        } else if (elementName == "dealloc")
-            memoryresource.dealloc.append(xmlReader.readElementText());
+        } else if (elementName == "dealloc") {
+            CppcheckLibraryData::MemoryResource::Dealloc dealloc;
+            if (xmlReader.attributes().hasAttribute("arg")) {
+                dealloc.arg = xmlReader.attributes().value("arg").toInt();
+            }
+            dealloc.name = xmlReader.readElementText();
+            memoryresource.dealloc.append(dealloc);
+        }
         else if (elementName == "use")
             memoryresource.use.append(xmlReader.readElementText());
         else
@@ -437,14 +453,34 @@ static void writeMemoryResource(QXmlStreamWriter &xmlWriter, const CppcheckLibra
 {
     xmlWriter.writeStartElement(mr.type);
     foreach (const CppcheckLibraryData::MemoryResource::Alloc &alloc, mr.alloc) {
+        if (alloc.isRealloc) {
+            xmlWriter.writeStartElement("realloc");
+        } else {
         xmlWriter.writeStartElement("alloc");
+        }
         xmlWriter.writeAttribute("init", alloc.init ? "true" : "false");
+        if (alloc.arg != -1) {
+            xmlWriter.writeAttribute("arg", QString("%1").arg(alloc.arg));
+        }
+        if (alloc.isRealloc && alloc.reallocArg != -1) {
+            xmlWriter.writeAttribute("realloc-arg", QString("%1").arg(alloc.reallocArg));
+        }
+        if (mr.type == "memory" && !alloc.bufferSize.isEmpty()) {
+            xmlWriter.writeAttribute("buffer-size", alloc.bufferSize);
+        }
         xmlWriter.writeCharacters(alloc.name);
         xmlWriter.writeEndElement();
     }
-    foreach (const QString &dealloc, mr.dealloc) {
-        xmlWriter.writeTextElement("dealloc", dealloc);
+
+    foreach (const CppcheckLibraryData::MemoryResource::Dealloc &dealloc, mr.dealloc) {
+        xmlWriter.writeStartElement("dealloc");
+        if (dealloc.arg != -1) {
+            xmlWriter.writeAttribute("arg", QString("%1").arg(dealloc.arg));
+    	}
+        xmlWriter.writeCharacters(dealloc.name);
+        xmlWriter.writeEndElement();
     }
+
     foreach (const QString &use, mr.use) {
         xmlWriter.writeTextElement("use", use);
     }

--- a/gui/cppchecklibrarydata.h
+++ b/gui/cppchecklibrarydata.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2018 Cppcheck team.
+ * Copyright (C) 2007-2020 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -136,12 +136,31 @@ public:
     struct MemoryResource {
         QString type; // "memory" or "resource"
         struct Alloc {
-            Alloc() : init(false) {}
+            Alloc() :
+                isRealloc(false),
+                init(false),
+                arg(-1),        // -1: Has no optional "arg" attribute
+                reallocArg(-1)  // -1: Has no optional "realloc-arg" attribute
+            {}
+
+            bool isRealloc;
             bool init;
+            int arg;
+            int reallocArg;
+            QString bufferSize;
             QString name;
         };
+        struct Dealloc {
+            Dealloc() :
+                arg(-1)        // -1: Has no optional "arg" attribute
+            {}
+
+            int arg;
+            QString name;
+        };
+
         QList<struct Alloc> alloc;
-        QStringList dealloc;
+        QList<struct Dealloc> dealloc;
         QStringList use;
     };
 
@@ -181,4 +200,4 @@ public:
     QStringList undefines;
 };
 
-#endif // LIBRARYDATA_H
+#endif // CPPCHECKLIBRARYDATA_H


### PR DESCRIPTION
… library configuration. Add missing attributes to avoid loss during library configuration save.

Fix to be able to load a library configuration via Library Editor which contains "realloc" element in memory or resource section.
This fix also adds missing attributes for alloc, realloc and dealloc to avoid loss during library configuration save.

For realloc support the existing Alloc structure has been extended as alloc and realloc just differs by its naming and one aditional attribute (realloc-arg) for realloc.
A separate Realloc structure derived from Alloc might be an option too but i didn't want to break existing structure too much.
There is a new Dealloc structure to support "arg" attribute.

I don't know if there are any tests for this part of Cppcheck which should be extended or updated. I didn't find any so far.
I did some testing with a build on a machine running Windows 10 as well as a machine running Ubuntu Linux 20.10 .