### PR TITLE
got rid of some implicit conversions to avoid UBSAN warnings

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -925,7 +925,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
         mSettings->checkAllConfigurations = true;
 
     if (mSettings->force)
-        mSettings->maxConfigs = ~0U;
+        mSettings->maxConfigs = static_cast<int>(~0U);
 
     else if ((def || mSettings->preprocessOnly) && !maxconfigs)
         mSettings->maxConfigs = 1U;

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -549,7 +549,7 @@ MathLib::bigint MathLib::toLongNumber(const std::string & str)
     biguint ret = 0;
     std::istringstream istr(str);
     istr >> ret;
-    return ret;
+    return static_cast<bigint>(ret);
 }
 
 // in-place conversion of (sub)string to double. Requires no heap.

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -274,7 +274,7 @@ static ValueFlow::Value castValue(ValueFlow::Value value, const ValueType::Sign 
         const MathLib::biguint one = 1;
         value.intvalue &= (one << bit) - 1;
         if (sign == ValueType::Sign::SIGNED && value.intvalue & (one << (bit - 1))) {
-            value.intvalue |= ~((one << bit) - 1ULL);
+            value.intvalue |= static_cast<long long>(~((one << bit) - 1ULL));
         }
     }
     return value;
@@ -792,7 +792,7 @@ static void setTokenValue(Token* tok, const ValueFlow::Value &value, const Setti
                     if (value1.tokvalue->tokType() == Token::eString) {
                         const std::string s = value1.tokvalue->strValue();
                         const MathLib::bigint index = value2.intvalue;
-                        if (index == s.size()) {
+                        if (static_cast<std::string::size_type>(index) == s.size()) {
                             result.intvalue = 0;
                             setTokenValue(parent, result, settings);
                         } else if (index >= 0 && index < s.size()) {
@@ -3997,9 +3997,9 @@ static std::list<ValueFlow::Value> truncateValues(std::list<ValueFlow::Value> va
         if (value.isIntValue() && sz > 0 && sz < 8) {
             const MathLib::biguint unsignedMaxValue = (1ULL << (sz * 8)) - 1ULL;
             const MathLib::biguint signBit = 1ULL << (sz * 8 - 1);
-            value.intvalue &= unsignedMaxValue;
+            value.intvalue &= static_cast<long long>(unsignedMaxValue);
             if (valueType->sign == ValueType::Sign::SIGNED && (value.intvalue & signBit))
-                value.intvalue |= ~unsignedMaxValue;
+                value.intvalue |= static_cast<long long>(~unsignedMaxValue);
         }
     }
     return values;

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -1015,7 +1015,7 @@ private:
         GET_SYMBOL_DB(clang);
 
         // Enum scope and type
-        ASSERT_EQUALS(3, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->scopeList.size());
         const Scope &enumScope = db->scopeList.back();
         ASSERT_EQUALS(Scope::ScopeType::eEnum, enumScope.type);
         ASSERT_EQUALS("abc", enumScope.className);
@@ -1039,7 +1039,7 @@ private:
         GET_SYMBOL_DB(clang);
 
         // There is a function foo that has 2 arguments
-        ASSERT_EQUALS(1, db->functionScopes.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
         const Scope *scope = db->functionScopes[0];
         const Function *func = scope->function;
         ASSERT_EQUALS(2, func->argCount());
@@ -1058,12 +1058,12 @@ private:
         GET_SYMBOL_DB(clang);
 
         // There is a function foo that has 2 arguments
-        ASSERT_EQUALS(1, db->functionScopes.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
         const Scope *scope = db->functionScopes[0];
         const Function *func = scope->function;
         ASSERT_EQUALS(2, func->argCount());
-        ASSERT_EQUALS(0, (long long)func->getArgumentVar(0)->nameToken());
-        ASSERT_EQUALS(0, (long long)func->getArgumentVar(1)->nameToken());
+        ASSERT(func->getArgumentVar(0)->nameToken() == nullptr);
+        ASSERT(func->getArgumentVar(1)->nameToken() == nullptr);
     }
 
     void symbolDatabaseFunction3() { // #9640
@@ -1075,7 +1075,7 @@ private:
         GET_SYMBOL_DB(clang);
 
         // There is a function foo that has 2 arguments
-        ASSERT_EQUALS(1, db->functionScopes.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
         const Scope *scope = db->functionScopes[0];
         const Function *func = scope->function;
         ASSERT_EQUALS(2, func->argCount());
@@ -1090,8 +1090,8 @@ private:
         GET_SYMBOL_DB(clang);
 
         // There is a function f that is const
-        ASSERT_EQUALS(2, db->scopeList.size());
-        ASSERT_EQUALS(1, db->scopeList.back().functionList.size());
+        ASSERT_EQUALS(2UL, db->scopeList.size());
+        ASSERT_EQUALS(1UL, db->scopeList.back().functionList.size());
         const Function &func = db->scopeList.back().functionList.back();
         ASSERT(func.isConst());
     }
@@ -1175,7 +1175,7 @@ private:
         ASSERT(!!tok);
         tok = tok->next();
         ASSERT(tok->hasKnownIntValue());
-        ASSERT_EQUALS(44, tok->getKnownIntValue());
+        ASSERT_EQUALS(44LL, tok->getKnownIntValue());
     }
 
     void valueFlow2() {
@@ -1191,7 +1191,7 @@ private:
         ASSERT(!!tok);
         tok = tok->next();
         ASSERT(tok->hasKnownIntValue());
-        ASSERT_EQUALS(10, tok->getKnownIntValue());
+        ASSERT_EQUALS(10LL, tok->getKnownIntValue());
     }
 
     void valueType1() {

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -278,7 +278,7 @@ private:
         const char * const argvsp[] = {"cppcheck", "-rp=C:/foo;C:\\bar", "file.cpp"};
         ASSERT(defParser.parseFromArgs(3, argvsp));
         ASSERT_EQUALS(true, settings.relativePaths);
-        ASSERT_EQUALS(2, settings.basePaths.size());
+        ASSERT_EQUALS(2UL, settings.basePaths.size());
         ASSERT_EQUALS("C:/foo", settings.basePaths[0]);
         ASSERT_EQUALS("C:/bar", settings.basePaths[1]);
 
@@ -288,7 +288,7 @@ private:
         const char * const argvlp[] = {"cppcheck", "--relative-paths=C:/foo;C:\\bar", "file.cpp"};
         ASSERT(defParser.parseFromArgs(3, argvlp));
         ASSERT_EQUALS(true, settings.relativePaths);
-        ASSERT_EQUALS(2, settings.basePaths.size());
+        ASSERT_EQUALS(2UL, settings.basePaths.size());
         ASSERT_EQUALS("C:/foo", settings.basePaths[0]);
         ASSERT_EQUALS("C:/bar", settings.basePaths[1]);
     }
@@ -637,7 +637,7 @@ private:
         const char * const argv[] = {"cppcheck", "-j", "3", "file.cpp"};
         settings.jobs = 0;
         ASSERT(defParser.parseFromArgs(4, argv));
-        ASSERT_EQUALS(3, settings.jobs);
+        ASSERT_EQUALS(3U, settings.jobs);
     }
 
     void jobsMissingCount() {
@@ -945,7 +945,7 @@ private:
         CmdLineParser parser(&settings);
         // Fails since no ignored path given
         ASSERT_EQUALS(false, parser.parseFromArgs(2, argv));
-        ASSERT_EQUALS(0, parser.getIgnoredPaths().size());
+        ASSERT_EQUALS(0UL, parser.getIgnoredPaths().size());
     }
 
     /*
@@ -982,7 +982,7 @@ private:
         const char * const argv[] = {"cppcheck", "-i", "src", "-i", "module", "file.cpp"};
         CmdLineParser parser(&settings);
         ASSERT(parser.parseFromArgs(6, argv));
-        ASSERT_EQUALS(2, parser.getIgnoredPaths().size());
+        ASSERT_EQUALS(2UL, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src/", parser.getIgnoredPaths()[0]);
         ASSERT_EQUALS("module/", parser.getIgnoredPaths()[1]);
     }
@@ -992,7 +992,7 @@ private:
             const char * const argv[] = {"cppcheck", "-ifoo.cpp", "file.cpp"};
             CmdLineParser parser(&settings);
             ASSERT(parser.parseFromArgs(3, argv));
-            ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
+            ASSERT_EQUALS(1UL, parser.getIgnoredPaths().size());
             ASSERT_EQUALS("foo.cpp", parser.getIgnoredPaths()[0]);
         }
     */
@@ -1001,7 +1001,7 @@ private:
         const char * const argv[] = {"cppcheck", "-isrc/foo.cpp", "file.cpp"};
         CmdLineParser parser(&settings);
         ASSERT(parser.parseFromArgs(3, argv));
-        ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
+        ASSERT_EQUALS(1UL, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src/foo.cpp", parser.getIgnoredPaths()[0]);
     }
 
@@ -1024,7 +1024,7 @@ private:
         const char * const argv[] = {"cppcheck", "-U_WIN32", "file.cpp"};
         settings = Settings();
         ASSERT(defParser.parseFromArgs(3, argv));
-        ASSERT_EQUALS(1, settings.userUndefs.size());
+        ASSERT_EQUALS(1UL, settings.userUndefs.size());
         ASSERT(settings.userUndefs.find("_WIN32") != settings.userUndefs.end());
     }
 
@@ -1033,7 +1033,7 @@ private:
         const char * const argv[] = {"cppcheck", "-U_WIN32", "-UNODEBUG", "file.cpp"};
         settings = Settings();
         ASSERT(defParser.parseFromArgs(4, argv));
-        ASSERT_EQUALS(2, settings.userUndefs.size());
+        ASSERT_EQUALS(2UL, settings.userUndefs.size());
         ASSERT(settings.userUndefs.find("_WIN32") != settings.userUndefs.end());
         ASSERT(settings.userUndefs.find("NODEBUG") != settings.userUndefs.end());
     }

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -113,7 +113,7 @@ private:
     void ErrorMessageConstruct() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.", "errorId", false);
-        ASSERT_EQUALS(1, msg.callStack.size());
+        ASSERT_EQUALS(1UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Programming error.", msg.verboseMessage());
         ASSERT_EQUALS("[foo.cpp:5]: (error) Programming error.", msg.toString(false));
@@ -123,7 +123,7 @@ private:
     void ErrorMessageConstructLocations() const {
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.", "errorId", false);
-        ASSERT_EQUALS(2, msg.callStack.size());
+        ASSERT_EQUALS(2UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Programming error.", msg.verboseMessage());
         ASSERT_EQUALS("[foo.cpp:5] -> [bar.cpp:8]: (error) Programming error.", msg.toString(false));
@@ -133,7 +133,7 @@ private:
     void ErrorMessageVerbose() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", false);
-        ASSERT_EQUALS(1, msg.callStack.size());
+        ASSERT_EQUALS(1UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
         ASSERT_EQUALS("[foo.cpp:5]: (error) Programming error.", msg.toString(false));
@@ -143,7 +143,7 @@ private:
     void ErrorMessageVerboseLocations() const {
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", false);
-        ASSERT_EQUALS(2, msg.callStack.size());
+        ASSERT_EQUALS(2UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
         ASSERT_EQUALS("[foo.cpp:5] -> [bar.cpp:8]: (error) Programming error.", msg.toString(false));
@@ -153,7 +153,7 @@ private:
     void CustomFormat() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", false);
-        ASSERT_EQUALS(1, msg.callStack.size());
+        ASSERT_EQUALS(1UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
         ASSERT_EQUALS("foo.cpp:5,error,errorId,Programming error.", msg.toString(false, "{file}:{line},{severity},{id},{message}"));
@@ -163,7 +163,7 @@ private:
     void CustomFormat2() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", false);
-        ASSERT_EQUALS(1, msg.callStack.size());
+        ASSERT_EQUALS(1UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
         ASSERT_EQUALS("Programming error. - foo.cpp(5):(error,errorId)", msg.toString(false, "{message} - {file}({line}):({severity},{id})"));
@@ -174,7 +174,7 @@ private:
         // Check that first location from location stack is used in template
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
         ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", false);
-        ASSERT_EQUALS(2, msg.callStack.size());
+        ASSERT_EQUALS(2UL, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
         ASSERT_EQUALS("Programming error. - bar.cpp(8):(error,errorId)", msg.toString(false, "{message} - {file}({line}):({severity},{id})"));
@@ -306,7 +306,7 @@ private:
         ASSERT_EQUALS("[]:;,()", msg2.callStack.front().getfile(false));
         ASSERT_EQUALS(":/,;", msg2.callStack.front().getOrigFile(false));
         ASSERT_EQUALS(654, msg2.callStack.front().line);
-        ASSERT_EQUALS(33, msg2.callStack.front().column);
+        ASSERT_EQUALS(33U, msg2.callStack.front().column);
         ASSERT_EQUALS("abcd:/,", msg2.callStack.front().getinfo());
     }
 

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -78,7 +78,7 @@ private:
         std::list<std::string> in(1, "../include");
         std::map<std::string, std::string, cppcheck::stricmp> variables;
         fs.setIncludePaths("abc/def/", in, variables);
-        ASSERT_EQUALS(1U, fs.includePaths.size());
+        ASSERT_EQUALS(1UL, fs.includePaths.size());
         ASSERT_EQUALS("abc/include/", fs.includePaths.front());
     }
 
@@ -88,7 +88,7 @@ private:
         std::map<std::string, std::string, cppcheck::stricmp> variables;
         variables["SolutionDir"] = "c:/abc/";
         fs.setIncludePaths("/home/fred", in, variables);
-        ASSERT_EQUALS(1U, fs.includePaths.size());
+        ASSERT_EQUALS(1UL, fs.includePaths.size());
         ASSERT_EQUALS("c:/abc/other/", fs.includePaths.front());
     }
 
@@ -98,7 +98,7 @@ private:
         std::map<std::string, std::string, cppcheck::stricmp> variables;
         variables["SolutionDir"] = "c:/abc/";
         fs.setIncludePaths("/home/fred", in, variables);
-        ASSERT_EQUALS(1U, fs.includePaths.size());
+        ASSERT_EQUALS(1UL, fs.includePaths.size());
         ASSERT_EQUALS("c:/abc/other/", fs.includePaths.front());
     }
 
@@ -111,7 +111,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("TEST1=1;TEST2=2", importer.fileSettings.begin()->defines);
     }
 
@@ -124,7 +124,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
     }
 
@@ -137,7 +137,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
     }
 
@@ -150,7 +150,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(0, importer.fileSettings.size());
+        ASSERT_EQUALS(0UL, importer.fileSettings.size());
     }
 
     void importCompileCommands5() const {
@@ -168,7 +168,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(2, importer.fileSettings.size());
+        ASSERT_EQUALS(2UL, importer.fileSettings.size());
         ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.begin()->includePaths.front());
     }
 
@@ -187,7 +187,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(2, importer.fileSettings.size());
+        ASSERT_EQUALS(2UL, importer.fileSettings.size());
         ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/second src/", importer.fileSettings.begin()->includePaths.front());
     }
 
@@ -203,9 +203,9 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("FILESDIR=\"/some/path\"", importer.fileSettings.begin()->defines);
-        ASSERT_EQUALS(1, importer.fileSettings.begin()->includePaths.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.begin()->includePaths.size());
         ASSERT_EQUALS("/home/danielm/cppcheck 2/b/lib/", importer.fileSettings.begin()->includePaths.front());
         // TODO ASSERT_EQUALS("/home/danielm/cppcheck 2/externals/", importer.fileSettings.begin()->includePaths.back());
     }
@@ -221,9 +221,9 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("FILESDIR=\"C:\\Program Files\\Cppcheck\"", importer.fileSettings.begin()->defines);
-        ASSERT_EQUALS(2, importer.fileSettings.begin()->includePaths.size());
+        ASSERT_EQUALS(2UL, importer.fileSettings.begin()->includePaths.size());
         ASSERT_EQUALS("C:/Users/danielm/cppcheck/build/lib/", importer.fileSettings.begin()->includePaths.front());
         ASSERT_EQUALS("C:/Users/danielm/cppcheck/lib/", importer.fileSettings.begin()->includePaths.back());
     }
@@ -235,7 +235,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(1, importer.fileSettings.size());
+        ASSERT_EQUALS(1UL, importer.fileSettings.size());
         ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
     }
 
@@ -245,7 +245,7 @@ private:
         std::istringstream istr(json);
         TestImporter importer;
         importer.importCompileCommands(istr);
-        ASSERT_EQUALS(0, importer.fileSettings.size());
+        ASSERT_EQUALS(0UL, importer.fileSettings.size());
     }
 
     void importCppcheckGuiProject() const {
@@ -268,9 +268,9 @@ private:
         Settings s;
         TestImporter project;
         ASSERT_EQUALS(true, project.importCppcheckGuiProject(istr, &s));
-        ASSERT_EQUALS(1, project.guiProject.pathNames.size());
+        ASSERT_EQUALS(1UL, project.guiProject.pathNames.size());
         ASSERT_EQUALS("cli/", project.guiProject.pathNames[0]);
-        ASSERT_EQUALS(1, s.includePaths.size());
+        ASSERT_EQUALS(1UL, s.includePaths.size());
         ASSERT_EQUALS("lib/", s.includePaths.front());
     }
 
@@ -282,14 +282,14 @@ private:
         project.fileSettings = {fs1, fs2};
 
         project.ignorePaths({"*foo", "bar*"});
-        ASSERT_EQUALS(2, project.fileSettings.size());
+        ASSERT_EQUALS(2UL, project.fileSettings.size());
 
         project.ignorePaths({"foo/*"});
-        ASSERT_EQUALS(1, project.fileSettings.size());
+        ASSERT_EQUALS(1UL, project.fileSettings.size());
         ASSERT_EQUALS("qwe/rty", project.fileSettings.front().filename);
 
         project.ignorePaths({ "*e/r*" });
-        ASSERT_EQUALS(0, project.fileSettings.size());
+        ASSERT_EQUALS(0UL, project.fileSettings.size());
     }
 };
 

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -115,7 +115,7 @@ private:
 
         Library library;
         ASSERT_EQUALS(true, Library::OK == (readLibrary(library, xmldata)).errorcode);
-        ASSERT_EQUALS(library.functions.size(), 1U);
+        ASSERT_EQUALS(1UL, library.functions.size());
         ASSERT(library.functions.at("foo").argumentChecks.empty());
         ASSERT(library.isnotnoreturn(tokenList.front()));
     }
@@ -483,7 +483,7 @@ private:
         // arg1: type=strlen arg2
         const std::vector<Library::ArgumentChecks::MinSize> *minsizes = library.argminsizes(tokenList.front(),1);
         ASSERT_EQUALS(true, minsizes != nullptr);
-        ASSERT_EQUALS(1U, minsizes ? minsizes->size() : 1U);
+        ASSERT_EQUALS(1UL, minsizes ? minsizes->size() : 1U);
         if (minsizes && minsizes->size() == 1U) {
             const Library::ArgumentChecks::MinSize &m = minsizes->front();
             ASSERT_EQUALS(Library::ArgumentChecks::MinSize::STRLEN, m.type);
@@ -493,7 +493,7 @@ private:
         // arg2: type=argvalue arg3
         minsizes = library.argminsizes(tokenList.front(), 2);
         ASSERT_EQUALS(true, minsizes != nullptr);
-        ASSERT_EQUALS(1U, minsizes ? minsizes->size() : 1U);
+        ASSERT_EQUALS(1UL, minsizes ? minsizes->size() : 1U);
         if (minsizes && minsizes->size() == 1U) {
             const Library::ArgumentChecks::MinSize &m = minsizes->front();
             ASSERT_EQUALS(Library::ArgumentChecks::MinSize::ARGVALUE, m.type);
@@ -503,11 +503,11 @@ private:
         // arg4: type=value
         minsizes = library.argminsizes(tokenList.front(), 4);
         ASSERT_EQUALS(true, minsizes != nullptr);
-        ASSERT_EQUALS(1U, minsizes ? minsizes->size() : 1U);
+        ASSERT_EQUALS(1UL, minsizes ? minsizes->size() : 1U);
         if (minsizes && minsizes->size() == 1U) {
             const Library::ArgumentChecks::MinSize &m = minsizes->front();
             ASSERT_EQUALS(Library::ArgumentChecks::MinSize::VALUE, m.type);
-            ASSERT_EQUALS(500, m.value);
+            ASSERT_EQUALS(500LL, m.value);
         }
     }
 
@@ -521,7 +521,7 @@ private:
 
         Library library;
         ASSERT_EQUALS(true, Library::OK == (readLibrary(library, xmldata)).errorcode);
-        ASSERT_EQUALS(library.functions.size(), 2U);
+        ASSERT_EQUALS(2UL, library.functions.size());
         ASSERT(library.functions.at("Foo::foo").argumentChecks.empty());
         ASSERT(library.functions.at("bar").argumentChecks.empty());
 
@@ -550,7 +550,7 @@ private:
 
         Library library;
         ASSERT_EQUALS(true, Library::OK == (readLibrary(library, xmldata)).errorcode);
-        ASSERT_EQUALS(library.functions.size(), 1U);
+        ASSERT_EQUALS(1UL, library.functions.size());
 
         {
             Tokenizer tokenizer(&settings, nullptr);
@@ -614,7 +614,7 @@ private:
         const Library::WarnInfo* a = library.getWarnInfo(tokenList.front());
         const Library::WarnInfo* b = library.getWarnInfo(tokenList.front()->tokAt(4));
 
-        ASSERT_EQUALS(2, library.functionwarn.size());
+        ASSERT_EQUALS(2UL, library.functionwarn.size());
         ASSERT(a && b);
         if (a && b) {
             ASSERT_EQUALS("Message", a->message);

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -251,116 +251,116 @@ private:
 
     void toLongNumber() const {
         // from hex
-        ASSERT_EQUALS(0,      MathLib::toLongNumber("0x0"));
-        ASSERT_EQUALS(0,      MathLib::toLongNumber("-0x0"));
-        ASSERT_EQUALS(0,      MathLib::toLongNumber("+0x0"));
-        ASSERT_EQUALS(10,     MathLib::toLongNumber("0xa"));
-        ASSERT_EQUALS(10995,  MathLib::toLongNumber("0x2AF3"));
-        ASSERT_EQUALS(-10,    MathLib::toLongNumber("-0xa"));
-        ASSERT_EQUALS(-10995, MathLib::toLongNumber("-0x2AF3"));
-        ASSERT_EQUALS(10,     MathLib::toLongNumber("+0xa"));
-        ASSERT_EQUALS(10995,  MathLib::toLongNumber("+0x2AF3"));
+        ASSERT_EQUALS(0LL,      MathLib::toLongNumber("0x0"));
+        ASSERT_EQUALS(0LL,      MathLib::toLongNumber("-0x0"));
+        ASSERT_EQUALS(0LL,      MathLib::toLongNumber("+0x0"));
+        ASSERT_EQUALS(10LL,     MathLib::toLongNumber("0xa"));
+        ASSERT_EQUALS(10995LL,  MathLib::toLongNumber("0x2AF3"));
+        ASSERT_EQUALS(-10LL,    MathLib::toLongNumber("-0xa"));
+        ASSERT_EQUALS(-10995LL, MathLib::toLongNumber("-0x2AF3"));
+        ASSERT_EQUALS(10LL,     MathLib::toLongNumber("+0xa"));
+        ASSERT_EQUALS(10995LL,  MathLib::toLongNumber("+0x2AF3"));
 
         // from octal
-        ASSERT_EQUALS(8,    MathLib::toLongNumber("010"));
-        ASSERT_EQUALS(8,    MathLib::toLongNumber("+010"));
-        ASSERT_EQUALS(-8,   MathLib::toLongNumber("-010"));
-        ASSERT_EQUALS(125,  MathLib::toLongNumber("0175"));
-        ASSERT_EQUALS(125,  MathLib::toLongNumber("+0175"));
-        ASSERT_EQUALS(-125, MathLib::toLongNumber("-0175"));
+        ASSERT_EQUALS(8LL,    MathLib::toLongNumber("010"));
+        ASSERT_EQUALS(8LL,    MathLib::toLongNumber("+010"));
+        ASSERT_EQUALS(-8LL,   MathLib::toLongNumber("-010"));
+        ASSERT_EQUALS(125LL,  MathLib::toLongNumber("0175"));
+        ASSERT_EQUALS(125LL,  MathLib::toLongNumber("+0175"));
+        ASSERT_EQUALS(-125LL, MathLib::toLongNumber("-0175"));
 
         // from binary
-        ASSERT_EQUALS(0,    MathLib::toLongNumber("0b0"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1U"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1L"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1LU"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1LL"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("0b1LLU"));
-        ASSERT_EQUALS(1,    MathLib::toLongNumber("+0b1"));
-        ASSERT_EQUALS(-1,   MathLib::toLongNumber("-0b1"));
-        ASSERT_EQUALS(215,  MathLib::toLongNumber("0b11010111"));
-        ASSERT_EQUALS(-215, MathLib::toLongNumber("-0b11010111"));
-        ASSERT_EQUALS(215,  MathLib::toLongNumber("0B11010111"));
+        ASSERT_EQUALS(0LL,    MathLib::toLongNumber("0b0"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1U"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1L"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1LU"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1LL"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("0b1LLU"));
+        ASSERT_EQUALS(1LL,    MathLib::toLongNumber("+0b1"));
+        ASSERT_EQUALS(-1LL,   MathLib::toLongNumber("-0b1"));
+        ASSERT_EQUALS(215LL,  MathLib::toLongNumber("0b11010111"));
+        ASSERT_EQUALS(-215LL, MathLib::toLongNumber("-0b11010111"));
+        ASSERT_EQUALS(215LL,  MathLib::toLongNumber("0B11010111"));
 
         // from base 10
-        ASSERT_EQUALS(10,  MathLib::toLongNumber("10"));
-        ASSERT_EQUALS(10,  MathLib::toLongNumber("10."));
-        ASSERT_EQUALS(10,  MathLib::toLongNumber("10.0"));
-        ASSERT_EQUALS(100, MathLib::toLongNumber("10E+1"));
-        ASSERT_EQUALS(1,   MathLib::toLongNumber("10E-1"));
-        ASSERT_EQUALS(100, MathLib::toLongNumber("+10E+1"));
-        ASSERT_EQUALS(-1,  MathLib::toLongNumber("-10E-1"));
-        ASSERT_EQUALS(100, MathLib::toLongNumber("+10.E+1"));
-        ASSERT_EQUALS(-1,  MathLib::toLongNumber("-10.E-1"));
-        ASSERT_EQUALS(100, MathLib::toLongNumber("+10.0E+1"));
-        ASSERT_EQUALS(-1,  MathLib::toLongNumber("-10.0E-1"));
+        ASSERT_EQUALS(10LL,  MathLib::toLongNumber("10"));
+        ASSERT_EQUALS(10LL,  MathLib::toLongNumber("10."));
+        ASSERT_EQUALS(10LL,  MathLib::toLongNumber("10.0"));
+        ASSERT_EQUALS(100LL, MathLib::toLongNumber("10E+1"));
+        ASSERT_EQUALS(1LL,   MathLib::toLongNumber("10E-1"));
+        ASSERT_EQUALS(100LL, MathLib::toLongNumber("+10E+1"));
+        ASSERT_EQUALS(-1LL,  MathLib::toLongNumber("-10E-1"));
+        ASSERT_EQUALS(100LL, MathLib::toLongNumber("+10.E+1"));
+        ASSERT_EQUALS(-1LL,  MathLib::toLongNumber("-10.E-1"));
+        ASSERT_EQUALS(100LL, MathLib::toLongNumber("+10.0E+1"));
+        ASSERT_EQUALS(-1LL,  MathLib::toLongNumber("-10.0E-1"));
 
         // from char
-        ASSERT_EQUALS((int)('A'),    MathLib::toLongNumber("'A'"));
-        ASSERT_EQUALS((int)('\x10'), MathLib::toLongNumber("'\\x10'"));
-        ASSERT_EQUALS((int)('\100'), MathLib::toLongNumber("'\\100'"));
-        ASSERT_EQUALS((int)('\200'), MathLib::toLongNumber("'\\200'"));
-        ASSERT_EQUALS((int)(L'A'),   MathLib::toLongNumber("L'A'"));
+        ASSERT_EQUALS((MathLib::bigint)('A'),    MathLib::toLongNumber("'A'"));
+        ASSERT_EQUALS((MathLib::bigint)('\x10'), MathLib::toLongNumber("'\\x10'"));
+        ASSERT_EQUALS((MathLib::bigint)('\100'), MathLib::toLongNumber("'\\100'"));
+        ASSERT_EQUALS((MathLib::bigint)('\200'), MathLib::toLongNumber("'\\200'"));
+        ASSERT_EQUALS((MathLib::bigint)(L'A'),   MathLib::toLongNumber("L'A'"));
 #ifdef __GNUC__
         // BEGIN Implementation-specific results
-        ASSERT_EQUALS((int)('AB'),    MathLib::toLongNumber("'AB'"));
-        ASSERT_EQUALS((int)('ABC'),    MathLib::toLongNumber("'ABC'"));
-        ASSERT_EQUALS((int)('ABCD'),    MathLib::toLongNumber("'ABCD'"));
-        ASSERT_EQUALS((int)('ABCDE'),    MathLib::toLongNumber("'ABCDE'"));
+        ASSERT_EQUALS((MathLib::bigint)('AB'),    MathLib::toLongNumber("'AB'"));
+        ASSERT_EQUALS((MathLib::bigint)('ABC'),    MathLib::toLongNumber("'ABC'"));
+        ASSERT_EQUALS((MathLib::bigint)('ABCD'),    MathLib::toLongNumber("'ABCD'"));
+        ASSERT_EQUALS((MathLib::bigint)('ABCDE'),    MathLib::toLongNumber("'ABCDE'"));
         // END Implementation-specific results
 #endif
-        ASSERT_EQUALS((int)('\0'),   MathLib::toLongNumber("'\\0'"));
-        ASSERT_EQUALS(0x1B,   MathLib::toLongNumber("'\\e'"));
-        ASSERT_EQUALS((int)('\r'),   MathLib::toLongNumber("'\\r'"));
-        ASSERT_EQUALS((int)('\x12'), MathLib::toLongNumber("'\\x12'"));
+        ASSERT_EQUALS((MathLib::bigint)('\0'),   MathLib::toLongNumber("'\\0'"));
+        ASSERT_EQUALS((MathLib::bigint)(0x1B),   MathLib::toLongNumber("'\\e'"));
+        ASSERT_EQUALS((MathLib::bigint)('\r'),   MathLib::toLongNumber("'\\r'"));
+        ASSERT_EQUALS((MathLib::bigint)('\x12'), MathLib::toLongNumber("'\\x12'"));
         // may cause some compile problems: ASSERT_EQUALS((int)('\x123'), MathLib::toLongNumber("'\\x123'"));
         // may cause some compile problems: ASSERT_EQUALS((int)('\x1234'), MathLib::toLongNumber("'\\x1234'"));
-        ASSERT_EQUALS((int)('\3'),  MathLib::toLongNumber("'\\3'"));
-        ASSERT_EQUALS((int)('\34'),  MathLib::toLongNumber("'\\34'"));
-        ASSERT_EQUALS((int)('\034'), MathLib::toLongNumber("'\\034'"));
-        ASSERT_EQUALS((int)('\x34'), MathLib::toLongNumber("'\\x34'"));
-        ASSERT_EQUALS((int)('\134'), MathLib::toLongNumber("'\\134'"));
-        ASSERT_EQUALS((int)('\134t'), MathLib::toLongNumber("'\\134t'")); // Ticket #7452
+        ASSERT_EQUALS((MathLib::bigint)('\3'),  MathLib::toLongNumber("'\\3'"));
+        ASSERT_EQUALS((MathLib::bigint)('\34'),  MathLib::toLongNumber("'\\34'"));
+        ASSERT_EQUALS((MathLib::bigint)('\034'), MathLib::toLongNumber("'\\034'"));
+        ASSERT_EQUALS((MathLib::bigint)('\x34'), MathLib::toLongNumber("'\\x34'"));
+        ASSERT_EQUALS((MathLib::bigint)('\134'), MathLib::toLongNumber("'\\134'"));
+        ASSERT_EQUALS((MathLib::bigint)('\134t'), MathLib::toLongNumber("'\\134t'")); // Ticket #7452
         ASSERT_THROW(MathLib::toLongNumber("'\\9'"), InternalError);
         ASSERT_THROW(MathLib::toLongNumber("'\\934'"), InternalError);
         // that is not gcc/clang encoding
-        ASSERT_EQUALS(959657011, MathLib::toLongNumber("'\\u9343'"));
-        ASSERT_EQUALS(1714631779, MathLib::toLongNumber("'\\U0001f34c'"));
+        ASSERT_EQUALS(959657011LL, MathLib::toLongNumber("'\\u9343'"));
+        ASSERT_EQUALS(1714631779LL, MathLib::toLongNumber("'\\U0001f34c'"));
         {
             // some unit-testing for a utility function
-            ASSERT_EQUALS(0, MathLib::characterLiteralToLongNumber(std::string()));
-            ASSERT_EQUALS(32, MathLib::characterLiteralToLongNumber(std::string(" ")));
-            ASSERT_EQUALS(538976288, MathLib::characterLiteralToLongNumber(std::string("          ")));
+            ASSERT_EQUALS(0LL, MathLib::characterLiteralToLongNumber(std::string()));
+            ASSERT_EQUALS(32LL, MathLib::characterLiteralToLongNumber(std::string(" ")));
+            ASSERT_EQUALS(538976288LL, MathLib::characterLiteralToLongNumber(std::string("          ")));
             ASSERT_THROW(MathLib::characterLiteralToLongNumber(std::string("\\u")), InternalError);
         }
 
-        ASSERT_EQUALS(-8552249625308161526, MathLib::toLongNumber("0x89504e470d0a1a0a"));
-        ASSERT_EQUALS(-8481036456200365558, MathLib::toLongNumber("0x8a4d4e470d0a1a0a"));
+        ASSERT_EQUALS(-8552249625308161526LL, MathLib::toLongNumber("0x89504e470d0a1a0a"));
+        ASSERT_EQUALS(-8481036456200365558LL, MathLib::toLongNumber("0x8a4d4e470d0a1a0a"));
         ASSERT_EQUALS(9894494448401390090ULL, MathLib::toULongNumber("0x89504e470d0a1a0a"));
         ASSERT_EQUALS(9965707617509186058ULL, MathLib::toULongNumber("0x8a4d4e470d0a1a0a"));
 
         // zero input
-        ASSERT_EQUALS(0,  MathLib::toULongNumber("0"));
-        ASSERT_EQUALS(0,  MathLib::toULongNumber("-0"));
-        ASSERT_EQUALS(0,  MathLib::toULongNumber("+0"));
-        ASSERT_EQUALS(0U, MathLib::toULongNumber("0U"));
-        ASSERT_EQUALS(0,  MathLib::toULongNumber("-0x0"));
+        ASSERT_EQUALS(0ULL,  MathLib::toULongNumber("0"));
+        ASSERT_EQUALS(0ULL,  MathLib::toULongNumber("-0"));
+        ASSERT_EQUALS(0ULL,  MathLib::toULongNumber("+0"));
+        ASSERT_EQUALS(0ULL, MathLib::toULongNumber("0U"));
+        ASSERT_EQUALS(0ULL,  MathLib::toULongNumber("-0x0"));
 
-        ASSERT_EQUALS(1U,     MathLib::toULongNumber("1U"));
-        ASSERT_EQUALS(10000U, MathLib::toULongNumber("1e4"));
-        ASSERT_EQUALS(10000U, MathLib::toULongNumber("1e4"));
-        ASSERT_EQUALS(0xFF00000000000000UL, MathLib::toULongNumber("0xFF00000000000000UL"));
-        ASSERT_EQUALS(0x0A00000000000000UL, MathLib::toULongNumber("0x0A00000000000000UL"));
-        ASSERT_EQUALS(0,  MathLib::toULongNumber("0b0"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1U"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1L"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1LU"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1LL"));
-        ASSERT_EQUALS(1,  MathLib::toULongNumber("0b1LLU"));
-        ASSERT_EQUALS(9U, MathLib::toULongNumber("011"));
-        ASSERT_EQUALS(5U, MathLib::toULongNumber("0b101"));
+        ASSERT_EQUALS(1ULL,     MathLib::toULongNumber("1U"));
+        ASSERT_EQUALS(10000ULL, MathLib::toULongNumber("1e4"));
+        ASSERT_EQUALS(10000ULL, MathLib::toULongNumber("1e4"));
+        ASSERT_EQUALS(0xFF00000000000000ULL, MathLib::toULongNumber("0xFF00000000000000UL"));
+        ASSERT_EQUALS(0x0A00000000000000ULL, MathLib::toULongNumber("0x0A00000000000000UL"));
+        ASSERT_EQUALS(0ULL,  MathLib::toULongNumber("0b0"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1U"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1L"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1LU"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1LL"));
+        ASSERT_EQUALS(1ULL,  MathLib::toULongNumber("0b1LLU"));
+        ASSERT_EQUALS(9ULL, MathLib::toULongNumber("011"));
+        ASSERT_EQUALS(5ULL, MathLib::toULongNumber("0b101"));
 
         // from long long
         /*

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -3194,7 +3194,7 @@ private:
 
             std::list<const Token *> null;
             CheckNullPointer::parseFunctionCall(*xtok, null, &library);
-            ASSERT_EQUALS(0U, null.size());
+            ASSERT_EQUALS(0UL, null.size());
         }
 
         // for 1st parameter null pointer is not ok..
@@ -3208,7 +3208,7 @@ private:
 
             std::list<const Token *> null;
             CheckNullPointer::parseFunctionCall(*xtok, null, &library);
-            ASSERT_EQUALS(1U, null.size());
+            ASSERT_EQUALS(1UL, null.size());
             ASSERT_EQUALS("a", null.front()->str());
         }
     }

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -300,7 +300,7 @@ private:
             preprocess(filedata, actual, "file.cpp");
 
             // Compare results..
-            ASSERT_EQUALS(1U, actual.size());
+            ASSERT_EQUALS(1UL, actual.size());
             ASSERT_EQUALS("\ncpp", actual[""]);
         }
 
@@ -311,7 +311,7 @@ private:
             preprocess(filedata, actual, "file.c");
 
             // Compare results..
-            ASSERT_EQUALS(1U, actual.size());
+            ASSERT_EQUALS(1UL, actual.size());
             ASSERT_EQUALS("\n\n\nc", actual[""]);
         }
     }
@@ -490,7 +490,7 @@ private:
         preprocess(filedata, actual);
 
         // Expected configurations: "" and "ABC"
-        ASSERT_EQUALS(2, actual.size());
+        ASSERT_EQUALS(2UL, actual.size());
         ASSERT_EQUALS("\n\n\nint main ( ) { }", actual[""]);
         ASSERT_EQUALS("\n#line 1 \"abc.h\"\nclass A { } ;\n#line 4 \"file.c\"\n int main ( ) { }", actual["ABC"]);
     }
@@ -1145,7 +1145,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("int main ( ) { const char * a = \"#define A\" ; }", actual[""]);
     }
 
@@ -1248,7 +1248,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("int main ( )\n{\nconst char * a = \"#include <string>\" ;\nreturn 0 ;\n}", actual[""]);
     }
 
@@ -1312,7 +1312,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("\nint main ( )\n{\nif ( $'ABCD' == 0 ) ;\nreturn 0 ;\n}", actual[""]);
     }
 
@@ -1376,7 +1376,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("\nvoid f ( )\n{\n}", actual[""]);
     }
 
@@ -1395,7 +1395,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("asm ( )\n;\n\naaa\nasm ( ) ;\n\n\nbbb", actual[""]);
     }
 
@@ -1410,7 +1410,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("asm ( )\n;\n\nbbb", actual[""]);
     }
 
@@ -1425,7 +1425,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(2, actual.size());
+        ASSERT_EQUALS(2UL, actual.size());
         const std::string expected("void f ( ) {\n\n\n}");
         ASSERT_EQUALS(expected, actual[""]);
         ASSERT_EQUALS(expected, actual["A"]);
@@ -1536,7 +1536,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("\nvoid f ( ) {\n$g $( ) ;\n}", actual[""]);
         ASSERT_EQUALS("", errout.str());
     }
@@ -1554,7 +1554,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(2, actual.size());
+        ASSERT_EQUALS(2UL, actual.size());
         ASSERT_EQUALS("\n\n\n\n\n$20", actual[""]);
         ASSERT_EQUALS("\n\n\n\n\n$10", actual["A"]);
         ASSERT_EQUALS("", errout.str());
@@ -1575,7 +1575,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("", actual[""]);
         ASSERT_EQUALS("[file.c:6]: (error) failed to expand 'BC', Wrong number of parameters for macro 'BC'.\n", errout.str());
     }
@@ -1592,7 +1592,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("\nvoid f ( )\n{\n$printf $( \"\\n\" $) ;\n}", actual[""]);
         ASSERT_EQUALS("", errout.str());
     }
@@ -1612,7 +1612,7 @@ private:
         // Compare results..
         ASSERT_EQUALS("", actual[""]);
         ASSERT_EQUALS("\nA\n\n\nA", actual["ABC"]);
-        ASSERT_EQUALS(2, actual.size());
+        ASSERT_EQUALS(2UL, actual.size());
     }
 
     void define_if1() {
@@ -1795,7 +1795,7 @@ private:
         preprocess(filedata, actual);
 
         // Compare results..
-        ASSERT_EQUALS(1U, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("", actual[""]);
     }
 
@@ -1823,7 +1823,7 @@ private:
         std::map<std::string, std::string> actual;
         preprocess(filedata, actual);
 
-        ASSERT_EQUALS(1U, actual.size());
+        ASSERT_EQUALS(1UL, actual.size());
         ASSERT_EQUALS("\n\n\n123 ;", actual[""]);
     }
 
@@ -1897,7 +1897,7 @@ private:
 
         // B will always be defined if A is defined; the following test
         // cases should be fixed whenever this other bug is fixed
-        ASSERT_EQUALS(2U, actual.size());
+        ASSERT_EQUALS(2UL, actual.size());
 
         ASSERT_EQUALS_MSG(true, (actual.find("A") != actual.end()), "A is expected to be checked but it was not checked");
 
@@ -1932,7 +1932,7 @@ private:
         errout.str("");
         preprocessor.preprocess(src, processedFile, cfg, "test.c", paths);
         ASSERT_EQUALS("", errout.str());
-        ASSERT_EQUALS(false, Preprocessor::missingIncludeFlag);
+        ASSERT_EQUALS(false, Preprocessor::missingIncludeFlag.load());
     }
 
     void predefine1() {

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -5257,7 +5257,7 @@ private:
         ASSERT_EQUALS(expected, tok(code));
     }
 
-    unsigned int instantiateMatch(const char code[], const std::size_t numberOfArguments, const char patternAfter[]) {
+    bool instantiateMatch(const char code[], const std::size_t numberOfArguments, const char patternAfter[]) {
         Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -565,28 +565,28 @@ private:
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId]", &errMsg);
-        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS(1UL, suppressions.size());
         ASSERT_EQUALS("errorId", suppressions[0].errorId);
         ASSERT_EQUALS("", suppressions[0].symbolName);
         ASSERT_EQUALS("", errMsg);
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId symbolName=arr]", &errMsg);
-        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS(1UL, suppressions.size());
         ASSERT_EQUALS("errorId", suppressions[0].errorId);
         ASSERT_EQUALS("arr", suppressions[0].symbolName);
         ASSERT_EQUALS("", errMsg);
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId symbolName=]", &errMsg);
-        ASSERT_EQUALS(1, suppressions.size());
+        ASSERT_EQUALS(1UL, suppressions.size());
         ASSERT_EQUALS("errorId", suppressions[0].errorId);
         ASSERT_EQUALS("", suppressions[0].symbolName);
         ASSERT_EQUALS("", errMsg);
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(2UL, suppressions.size());
         ASSERT_EQUALS("errorId1", suppressions[0].errorId);
         ASSERT_EQUALS("", suppressions[0].symbolName);
         ASSERT_EQUALS("errorId2", suppressions[1].errorId);
@@ -595,32 +595,32 @@ private:
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[]", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress errorId", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1 errorId2 symbolName=arr]", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbol=arr]", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(false, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("// cppcheck-suppress[errorId1, errorId2 symbolName]", &errMsg);
-        ASSERT_EQUALS(0, suppressions.size());
+        ASSERT_EQUALS(0UL, suppressions.size());
         ASSERT_EQUALS(false, errMsg.empty());
     }
 
@@ -631,17 +631,17 @@ private:
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//cppcheck-suppress[errorId1, errorId2 symbolName=arr]", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(2UL, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("//cppcheck-suppress[errorId1, errorId2 symbolName=arr] some text", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(2UL, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
 
         errMsg = "";
         suppressions=ss.parseMultiSuppressComment("/*cppcheck-suppress[errorId1, errorId2 symbolName=arr]*/", &errMsg);
-        ASSERT_EQUALS(2, suppressions.size());
+        ASSERT_EQUALS(2UL, suppressions.size());
         ASSERT_EQUALS(true, errMsg.empty());
     }
 
@@ -654,7 +654,7 @@ private:
         settings.exitCode = 1;
 
         const char code[] = "int f() { int a; return a; }";
-        ASSERT_EQUALS(0, cppCheck.check("test.c", code)); // <- no unsuppressed error is seen
+        ASSERT_EQUALS(0U, cppCheck.check("test.c", code)); // <- no unsuppressed error is seen
         ASSERT_EQUALS("[test.c:1]: (error) Uninitialized variable: a\n", errout.str()); // <- report error so ThreadExecutor can suppress it and make sure the global suppression is matched.
     }
 
@@ -763,28 +763,28 @@ private:
     }
 
     void unusedFunction() {
-        ASSERT_EQUALS(0, checkSuppression("void f() {}", "unusedFunction"));
+        ASSERT_EQUALS(0U, checkSuppression("void f() {}", "unusedFunction"));
     }
 
     void suppressingSyntaxErrorAndExitCode() {
         std::map<std::string, std::string> files;
         files["test.cpp"] = "fi if;";
 
-        ASSERT_EQUALS(0, checkSuppression(files, "*:test.cpp"));
+        ASSERT_EQUALS(0U, checkSuppression(files, "*:test.cpp"));
         ASSERT_EQUALS("", errout.str());
 
         // multi files, but only suppression one
         std::map<std::string, std::string> mfiles;
         mfiles["test.cpp"] = "fi if;";
         mfiles["test2.cpp"] = "fi if";
-        ASSERT_EQUALS(1, checkSuppression(mfiles, "*:test.cpp"));
+        ASSERT_EQUALS(1U, checkSuppression(mfiles, "*:test.cpp"));
         ASSERT_EQUALS("[test2.cpp:1]: (error) syntax error\n", errout.str());
 
         // multi error in file, but only suppression one error
         std::map<std::string, std::string> file2;
         file2["test.cpp"] = "fi fi\n"
                             "if if;";
-        ASSERT_EQUALS(1, checkSuppression(file2, "*:test.cpp:1"));  // suppress all error at line 1 of test.cpp
+        ASSERT_EQUALS(1U, checkSuppression(file2, "*:test.cpp:1"));  // suppress all error at line 1 of test.cpp
         ASSERT_EQUALS("[test.cpp:2]: (error) syntax error\n", errout.str());
 
         // multi error in file, but only suppression one error (2)
@@ -794,7 +794,7 @@ private:
                             "    int b = y/0;\n"
                             "}\n"
                             "f(0, 1);\n";
-        ASSERT_EQUALS(1, checkSuppression(file3, "zerodiv:test.cpp:3"));  // suppress 'errordiv' at line 3 of test.cpp
+        ASSERT_EQUALS(1U, checkSuppression(file3, "zerodiv:test.cpp:3"));  // suppress 'errordiv' at line 3 of test.cpp
     }
 
 };

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -467,34 +467,34 @@ private:
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(12U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(12LL, v->dimension(0));
     }
 
     void stlarray1() {
         GET_SYMBOL_DB("std::array<int, 16 + 4> arr;");
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(2, db->variableList().size()); // the first one is not used
+        ASSERT_EQUALS(2UL, db->variableList().size()); // the first one is not used
         const Variable * v = db->getVariableFromVarId(1);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(20U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(20LL, v->dimension(0));
     }
 
     void stlarray2() {
         GET_SYMBOL_DB("constexpr int sz = 16; std::array<int, sz + 4> arr;");
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(3, db->variableList().size()); // the first one is not used
+        ASSERT_EQUALS(3UL, db->variableList().size()); // the first one is not used
         const Variable * v = db->getVariableFromVarId(2);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(20U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(20LL, v->dimension(0));
     }
 
     void test_isVariableDeclarationCanHandleNull() {
@@ -1185,7 +1185,7 @@ private:
         ASSERT(db != nullptr);
 
         ASSERT(db->scopeList.back().type == Scope::eFor);
-        ASSERT_EQUALS(2, db->variableList().size());
+        ASSERT_EQUALS(2UL, db->variableList().size());
 
         const Variable* e = db->getVariableFromVarId(1);
         ASSERT(e && e->isReference() && e->isLocal());
@@ -1302,7 +1302,7 @@ private:
                       "const decltype(x) b;\n"
                       "decltype(x) *c;\n");
         ASSERT(db);
-        ASSERT_EQUALS(4, db->scopeList.front().varlist.size());
+        ASSERT_EQUALS(4UL, db->scopeList.front().varlist.size());
 
         const Variable *a = Token::findsimplematch(tokenizer.tokens(), "a")->variable();
         ASSERT(a);
@@ -1683,7 +1683,7 @@ private:
 
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(10, db->variableList().size() - 1);
+        ASSERT_EQUALS(10UL, db->variableList().size() - 1);
         ASSERT_EQUALS(true, db->getVariableFromVarId(1) && db->getVariableFromVarId(1)->dimensions().size() == 1);
         ASSERT_EQUALS(true, db->getVariableFromVarId(2) != nullptr);
         ASSERT_EQUALS(true, db->getVariableFromVarId(3) && db->getVariableFromVarId(3)->dimensions().size() == 0);
@@ -1702,7 +1702,7 @@ private:
 
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(1, db->variableList().size() - 1);
+        ASSERT_EQUALS(1UL, db->variableList().size() - 1);
         ASSERT_EQUALS(true, db->getVariableFromVarId(1) != nullptr);
 
         ASSERT_EQUALS("pFun", db->getVariableFromVarId(1)->name());
@@ -1964,7 +1964,7 @@ private:
         ASSERT(db != nullptr);
 
         // 3 scopes: Global, function, if
-        ASSERT_EQUALS(3, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->scopeList.size());
 
         ASSERT(findFunctionByName("func", &db->scopeList.back()) != nullptr);
         ASSERT(findFunctionByName("if", &db->scopeList.back()) == nullptr);
@@ -2068,9 +2068,9 @@ private:
         ASSERT(db && db->functionScopes.size()==1U);
 
         const Function * const f = db->functionScopes.front()->function;
-        ASSERT_EQUALS(1U, f->argCount());
-        ASSERT_EQUALS(0U, f->initializedArgCount());
-        ASSERT_EQUALS(1U, f->minArgCount());
+        ASSERT_EQUALS(1, f->argCount());
+        ASSERT_EQUALS(0, f->initializedArgCount());
+        ASSERT_EQUALS(1, f->minArgCount());
         const Variable * const arg1 = f->getArgumentVar(0);
         ASSERT_EQUALS("char", arg1->typeStartToken()->str());
         ASSERT_EQUALS("char", arg1->typeEndToken()->str());
@@ -2097,7 +2097,7 @@ private:
     void functionArgs1() {
         {
             GET_SYMBOL_DB("void f(std::vector<std::string>, const std::vector<int> & v) { }");
-            ASSERT_EQUALS(1+1, db->variableList().size());
+            ASSERT_EQUALS(1UL+1UL, db->variableList().size());
             const Variable* v = db->getVariableFromVarId(1);
             ASSERT(v && v->isReference() && v->isConst() && v->isArgument());
             const Scope* f = db->findScopeByName("f");
@@ -2108,7 +2108,7 @@ private:
         }
         {
             GET_SYMBOL_DB("void g(std::map<std::string, std::vector<int> > m) { }");
-            ASSERT_EQUALS(1+1, db->variableList().size());
+            ASSERT_EQUALS(1UL+1UL, db->variableList().size());
             const Variable* m = db->getVariableFromVarId(1);
             ASSERT(m && !m->isReference() && !m->isConst() && m->isArgument() && m->isClass());
             const Scope* g = db->findScopeByName("g");
@@ -2146,9 +2146,9 @@ private:
         const Variable *a = db->getVariableFromVarId(1);
         ASSERT_EQUALS("a", a->nameToken()->str());
         ASSERT_EQUALS(2UL, a->dimensions().size());
-        ASSERT_EQUALS(0UL, a->dimension(0));
+        ASSERT_EQUALS(0LL, a->dimension(0));
         ASSERT_EQUALS(false, a->dimensions()[0].known);
-        ASSERT_EQUALS(4UL, a->dimension(1));
+        ASSERT_EQUALS(4LL, a->dimension(1));
         ASSERT_EQUALS(true, a->dimensions()[1].known);
     }
 
@@ -2161,11 +2161,11 @@ private:
         const Variable *first = &func->argumentList.front();
         ASSERT_EQUALS(0UL, first->name().size());
         ASSERT_EQUALS(1UL, first->dimensions().size());
-        ASSERT_EQUALS(10UL, first->dimension(0));
+        ASSERT_EQUALS(10LL, first->dimension(0));
         const Variable *second = &func->argumentList.back();
         ASSERT_EQUALS(0UL, second->name().size());
         ASSERT_EQUALS(1UL, second->dimensions().size());
-        ASSERT_EQUALS(10UL, second->dimension(0));
+        ASSERT_EQUALS(10LL, second->dimension(0));
     }
 
     void functionArgs5() { // #7650
@@ -2302,11 +2302,11 @@ private:
                       "};\n"
                       "Fred::Fred(Whitespace whitespace) { }");
         ASSERT_EQUALS(true, db != nullptr);
-        ASSERT_EQUALS(3, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->scopeList.size());
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
-        ASSERT_EQUALS(1, scope->functionList.size());
+        ASSERT_EQUALS(1UL, scope->functionList.size());
         ASSERT(scope->functionList.begin()->functionScope != nullptr);
         const Scope * functionScope = scope->functionList.begin()->functionScope;
         ++scope;
@@ -2320,11 +2320,11 @@ private:
                       "};\n"
                       "void Fred::foo(char b[16]) { }");
         ASSERT_EQUALS(true, db != nullptr);
-        ASSERT_EQUALS(3, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->scopeList.size());
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
-        ASSERT_EQUALS(1, scope->functionList.size());
+        ASSERT_EQUALS(1UL, scope->functionList.size());
         ASSERT(scope->functionList.begin()->functionScope != nullptr);
         const Scope * functionScope = scope->functionList.begin()->functionScope;
         ++scope;
@@ -2399,11 +2399,11 @@ private:
             "};\n";
         GET_SYMBOL_DB(code);
         ASSERT(db);
-        ASSERT_EQUALS(2, db->scopeList.size());
+        ASSERT_EQUALS(2UL, db->scopeList.size());
         const Scope& classScope = db->scopeList.back();
         ASSERT_EQUALS(Scope::eClass, classScope.type);
         ASSERT_EQUALS("Class", classScope.className);
-        ASSERT_EQUALS(1, classScope.functionList.size());
+        ASSERT_EQUALS(1UL, classScope.functionList.size());
         const Function& method = classScope.functionList.front();
         ASSERT_EQUALS("Method", method.name());
         ASSERT_EQUALS(1, method.argCount());
@@ -2440,7 +2440,7 @@ private:
                       "class derived : base { void f(); };\n"
                       "void derived::f() {}");
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(4, db->scopeList.size());
+        ASSERT_EQUALS(4UL, db->scopeList.size());
         const Function *function = db->scopeList.back().function;
         ASSERT_EQUALS(true, function && function->isImplicitlyVirtual(false));
     }
@@ -2477,7 +2477,7 @@ private:
         ASSERT_EQUALS("X", scope->className);
 
         // The class has a constructor but the implementation _is not_ seen
-        ASSERT_EQUALS(1U, scope->functionList.size());
+        ASSERT_EQUALS(1UL, scope->functionList.size());
         const Function *function = &(scope->functionList.front());
         ASSERT_EQUALS(false, function->hasBody());
     }
@@ -2511,7 +2511,7 @@ private:
         ASSERT_EQUALS("X", scope->className);
 
         // The class has a constructor and the implementation _is_ seen
-        ASSERT_EQUALS(1U, scope->functionList.size());
+        ASSERT_EQUALS(1UL, scope->functionList.size());
         const Function *function = &(scope->functionList.front());
         ASSERT_EQUALS("X", function->tokenDef->str());
         ASSERT_EQUALS(true, function->hasBody());
@@ -2520,7 +2520,7 @@ private:
     void namespaces3() { // #3854 - namespace with unknown macro
         GET_SYMBOL_DB("namespace fred UNKNOWN_MACRO(default) {\n"
                       "}");
-        ASSERT_EQUALS(2U, db->scopeList.size());
+        ASSERT_EQUALS(2UL, db->scopeList.size());
         ASSERT_EQUALS(Scope::eGlobal, db->scopeList.front().type);
         ASSERT_EQUALS(Scope::eNamespace, db->scopeList.back().type);
     }
@@ -2532,7 +2532,7 @@ private:
         const Variable *fredA = db->getVariableFromVarId(2U);
         ASSERT_EQUALS("fredA", fredA->name());
         const Type *fredAType = fredA->type();
-        ASSERT_EQUALS(2U, fredAType->classDef->linenr());
+        ASSERT_EQUALS(2, fredAType->classDef->linenr());
     }
 
     void tryCatch1() {
@@ -2765,9 +2765,9 @@ private:
     // ticket 3435 (std::vector)
     void symboldatabase23() {
         GET_SYMBOL_DB("class A { std::vector<int*> ints; };");
-        ASSERT_EQUALS(2U, db->scopeList.size());
+        ASSERT_EQUALS(2UL, db->scopeList.size());
         const Scope &scope = db->scopeList.back();
-        ASSERT_EQUALS(1U, scope.varlist.size());
+        ASSERT_EQUALS(1UL, scope.varlist.size());
         const Variable &var = scope.varlist.front();
         ASSERT_EQUALS(std::string("ints"), var.name());
         ASSERT_EQUALS(true, var.isClass());
@@ -2782,7 +2782,7 @@ private:
                       "Fred::Fred() { }\n"
                       "Fred::~Fred() { }");
         // Global scope, Fred, Fred::Fred, Fred::~Fred
-        ASSERT_EQUALS(4U, db->scopeList.size());
+        ASSERT_EQUALS(4UL, db->scopeList.size());
 
         // Find the scope for the Fred struct..
         const Scope *fredScope = nullptr;
@@ -2793,7 +2793,7 @@ private:
         ASSERT(fredScope != nullptr);
 
         // The struct Fred has two functions, a constructor and a destructor
-        ASSERT_EQUALS(2U, fredScope->functionList.size());
+        ASSERT_EQUALS(2UL, fredScope->functionList.size());
 
         // Get linenumbers where the bodies for the constructor and destructor are..
         unsigned int constructor = 0;
@@ -3002,7 +3002,7 @@ private:
         ASSERT(db != nullptr);
         const Scope * const fscope = db ? db->findScopeByName("f") : nullptr;
         ASSERT(fscope != nullptr);
-        ASSERT_EQUALS(0U, fscope ? fscope->varlist.size() : ~0U);  // "x" is not a variable
+        ASSERT_EQUALS(0UL, fscope ? fscope->varlist.size() : ~0U);  // "x" is not a variable
     }
 
     void symboldatabase43() { // ticket #4738
@@ -3020,8 +3020,8 @@ private:
                       "    int l ( 1 );\n"
                       "}");
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(4U, db->variableList().size() - 1);
-        ASSERT_EQUALS(2U, db->scopeList.size());
+        ASSERT_EQUALS(4UL, db->variableList().size() - 1);
+        ASSERT_EQUALS(2UL, db->scopeList.size());
         for (std::size_t i = 1U; i < db->variableList().size(); i++)
             ASSERT(db->getVariableFromVarId(i) != nullptr);
     }
@@ -3042,11 +3042,11 @@ private:
                       "}");
 
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(4U, db->variableList().size() - 1);
+        ASSERT_EQUALS(4UL, db->variableList().size() - 1);
         for (std::size_t i = 1U; i < db->variableList().size(); i++)
             ASSERT(db->getVariableFromVarId(i) != nullptr);
 
-        ASSERT_EQUALS(4U, db->scopeList.size());
+        ASSERT_EQUALS(4UL, db->scopeList.size());
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
@@ -3064,7 +3064,7 @@ private:
                       "}");
 
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(4U, db->scopeList.size());
+        ASSERT_EQUALS(4UL, db->scopeList.size());
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
@@ -3169,8 +3169,8 @@ private:
                       "}");
 
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(2, db->scopeList.size());
-        ASSERT_EQUALS(2, db->variableList().size()-1);
+        ASSERT_EQUALS(2UL, db->scopeList.size());
+        ASSERT_EQUALS(2UL, db->variableList().size()-1);
         ASSERT(db->getVariableFromVarId(1) != nullptr);
         ASSERT(db->getVariableFromVarId(2) != nullptr);
     }
@@ -3194,7 +3194,7 @@ private:
                       "};");
 
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(1U, db->functionScopes.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
         ASSERT_EQUALS("getReg", db->functionScopes.front()->className);
         ASSERT_EQUALS(true, db->functionScopes.front()->function->hasOverrideSpecifier());
     }
@@ -3205,7 +3205,7 @@ private:
                       "}");
 
         ASSERT(db != nullptr);
-        ASSERT_EQUALS(1U, db->functionScopes.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
         ASSERT_EQUALS("testfunc", db->functionScopes.front()->className);
     }
 
@@ -3220,7 +3220,7 @@ private:
                           "}");
 
             ASSERT(db != nullptr);
-            ASSERT_EQUALS(0U, db->functionScopes.size());
+            ASSERT_EQUALS(0UL, db->functionScopes.size());
             ASSERT(db->scopeList.back().type == Scope::eClass && db->scopeList.back().className == "NestedClass");
             ASSERT(db->scopeList.back().functionList.size() == 1U && !db->scopeList.back().functionList.front().hasBody());
         }
@@ -3231,7 +3231,7 @@ private:
                           "}");
 
             ASSERT(db != nullptr);
-            ASSERT_EQUALS(1U, db->functionScopes.size());
+            ASSERT_EQUALS(1UL, db->functionScopes.size());
             ASSERT(db->scopeList.back().type == Scope::eFunction && db->scopeList.back().className == "f2");
             ASSERT(db->scopeList.back().function && db->scopeList.back().function->hasBody());
         }
@@ -3240,8 +3240,8 @@ private:
                             "friend f2() { }\n");
 
             ASSERT(db != nullptr);
-            ASSERT_EQUALS(2U, db->scopeList.size());
-            ASSERT_EQUALS(2U, db->scopeList.begin()->functionList.size());
+            ASSERT_EQUALS(2UL, db->scopeList.size());
+            ASSERT_EQUALS(2UL, db->scopeList.begin()->functionList.size());
         }
     }
 
@@ -4318,8 +4318,8 @@ private:
         GET_SYMBOL_DB("class Base { virtual int f() const = 0; };\n"
                       "class Derived : Base { virtual int f() const final { return 6; } };");
 
-        ASSERT_EQUALS(4, db->scopeList.size());
-        ASSERT_EQUALS(1, db->functionScopes.size());
+        ASSERT_EQUALS(4UL, db->scopeList.size());
+        ASSERT_EQUALS(1UL, db->functionScopes.size());
 
         const Scope *f1 = db->functionScopes[0];
         ASSERT(f1->function->hasFinalSpecifier());
@@ -4340,8 +4340,8 @@ private:
                       "auto optional<T>::value() const & -> T const & {}\n"
                       "optional<int> i;");
 
-        ASSERT_EQUALS(5, db->scopeList.size());
-        ASSERT_EQUALS(3, db->functionScopes.size());
+        ASSERT_EQUALS(5UL, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->functionScopes.size());
 
         const Scope *f = db->functionScopes[0];
         ASSERT(f->function->hasBody());
@@ -4367,7 +4367,7 @@ private:
                       "  using namespace bar::baz;\n"
                       "  auto func(int arg) -> bar::quux {}\n"
                       "}");
-        ASSERT_EQUALS(2, db->mVariableList.size());
+        ASSERT_EQUALS(2UL, db->mVariableList.size());
     }
 
     void symboldatabase77() { // #8663
@@ -4376,7 +4376,7 @@ private:
                       "  using T3 = typename T1::template T3<T2>;\n"
                       "  T3 t;\n"
                       "}");
-        ASSERT_EQUALS(2, db->mVariableList.size());
+        ASSERT_EQUALS(2UL, db->mVariableList.size());
     }
 
     void symboldatabase78() { // #9147
@@ -4692,7 +4692,7 @@ private:
                       "enum MyEnums { E1=O1+1, E2, E3=O3+1 };");
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(3U, db->scopeList.size());
+        ASSERT_EQUALS(3UL, db->scopeList.size());
 
         // Assert that all enum values are known
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
@@ -4700,7 +4700,7 @@ private:
         // Offsets
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eEnum, (unsigned int)scope->type);
-        ASSERT_EQUALS(4U, scope->enumeratorList.size());
+        ASSERT_EQUALS(4UL, scope->enumeratorList.size());
 
         ASSERT(scope->enumeratorList[0].name->enumerator() == &scope->enumeratorList[0]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[0].name->tokType());
@@ -4709,7 +4709,7 @@ private:
         ASSERT(scope->enumeratorList[0].start == nullptr);
         ASSERT(scope->enumeratorList[0].end == nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[0].value_known);
-        ASSERT_EQUALS(0, scope->enumeratorList[0].value);
+        ASSERT_EQUALS(0LL, scope->enumeratorList[0].value);
 
         ASSERT(scope->enumeratorList[1].name->enumerator() == &scope->enumeratorList[1]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[1].name->tokType());
@@ -4718,7 +4718,7 @@ private:
         ASSERT(scope->enumeratorList[1].start == nullptr);
         ASSERT(scope->enumeratorList[1].end == nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[1].value_known);
-        ASSERT_EQUALS(1, scope->enumeratorList[1].value);
+        ASSERT_EQUALS(1LL, scope->enumeratorList[1].value);
 
         ASSERT(scope->enumeratorList[2].name->enumerator() == &scope->enumeratorList[2]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[2].name->tokType());
@@ -4727,7 +4727,7 @@ private:
         ASSERT(scope->enumeratorList[2].start != nullptr);
         ASSERT(scope->enumeratorList[2].end != nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[2].value_known);
-        ASSERT_EQUALS(5, scope->enumeratorList[2].value);
+        ASSERT_EQUALS(5LL, scope->enumeratorList[2].value);
 
         ASSERT(scope->enumeratorList[3].name->enumerator() == &scope->enumeratorList[3]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[3].name->tokType());
@@ -4736,12 +4736,12 @@ private:
         ASSERT(scope->enumeratorList[3].start == nullptr);
         ASSERT(scope->enumeratorList[3].end == nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[3].value_known);
-        ASSERT_EQUALS(6, scope->enumeratorList[3].value);
+        ASSERT_EQUALS(6LL, scope->enumeratorList[3].value);
 
         // MyEnums
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eEnum, (unsigned int)scope->type);
-        ASSERT_EQUALS(3U, scope->enumeratorList.size());
+        ASSERT_EQUALS(3UL, scope->enumeratorList.size());
 
         ASSERT(scope->enumeratorList[0].name->enumerator() == &scope->enumeratorList[0]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[0].name->tokType());
@@ -4750,7 +4750,7 @@ private:
         ASSERT(scope->enumeratorList[0].start != nullptr);
         ASSERT(scope->enumeratorList[0].end != nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[0].value_known);
-        ASSERT_EQUALS(1, scope->enumeratorList[0].value);
+        ASSERT_EQUALS(1LL, scope->enumeratorList[0].value);
 
         ASSERT(scope->enumeratorList[1].name->enumerator() == &scope->enumeratorList[1]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[1].name->tokType());
@@ -4759,7 +4759,7 @@ private:
         ASSERT(scope->enumeratorList[1].start == nullptr);
         ASSERT(scope->enumeratorList[1].end == nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[1].value_known);
-        ASSERT_EQUALS(2, scope->enumeratorList[1].value);
+        ASSERT_EQUALS(2LL, scope->enumeratorList[1].value);
 
         ASSERT(scope->enumeratorList[2].name->enumerator() == &scope->enumeratorList[2]);
         ASSERT_EQUALS((unsigned int)Token::eEnumerator, (unsigned int)scope->enumeratorList[2].name->tokType());
@@ -4768,7 +4768,7 @@ private:
         ASSERT(scope->enumeratorList[2].start != nullptr);
         ASSERT(scope->enumeratorList[2].end != nullptr);
         ASSERT_EQUALS(true, scope->enumeratorList[2].value_known);
-        ASSERT_EQUALS(6, scope->enumeratorList[2].value);
+        ASSERT_EQUALS(6LL, scope->enumeratorList[2].value);
     }
 
     void enum5() {
@@ -4780,50 +4780,50 @@ private:
                       "int e[A + B];\n");
         ASSERT(db != nullptr);
 
-        ASSERT_EQUALS(2U, db->scopeList.size());
+        ASSERT_EQUALS(2UL, db->scopeList.size());
 
         // Assert that all enum values are known
         std::list<Scope>::const_iterator scope = db->scopeList.begin();
 
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eEnum, (unsigned int)scope->type);
-        ASSERT_EQUALS(2U, scope->enumeratorList.size());
+        ASSERT_EQUALS(2UL, scope->enumeratorList.size());
         ASSERT_EQUALS(true, scope->enumeratorList[0].value_known);
-        ASSERT_EQUALS(10, scope->enumeratorList[0].value);
+        ASSERT_EQUALS(10LL, scope->enumeratorList[0].value);
         ASSERT_EQUALS(true, scope->enumeratorList[1].value_known);
-        ASSERT_EQUALS(2, scope->enumeratorList[1].value);
+        ASSERT_EQUALS(2LL, scope->enumeratorList[1].value);
 
         ASSERT(db->variableList().size() == 6); // the first one is not used
         const Variable * v = db->getVariableFromVarId(1);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(12U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(12LL, v->dimension(0));
         v = db->getVariableFromVarId(2);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(10U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(10LL, v->dimension(0));
         v = db->getVariableFromVarId(3);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(12U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(12LL, v->dimension(0));
         v = db->getVariableFromVarId(4);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(12U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(12LL, v->dimension(0));
         v = db->getVariableFromVarId(5);
         ASSERT(v != nullptr);
 
         ASSERT(v->isArray());
-        ASSERT_EQUALS(1U, v->dimensions().size());
-        ASSERT_EQUALS(12U, v->dimension(0));
+        ASSERT_EQUALS(1UL, v->dimensions().size());
+        ASSERT_EQUALS(12LL, v->dimension(0));
     }
 
     void enum6() {
@@ -4850,8 +4850,8 @@ private:
         v = db->getVariableFromVarId(id++); \
         ASSERT(v != nullptr); \
         ASSERT(v->isArray()); \
-        ASSERT_EQUALS(1U, v->dimensions().size()); \
-        ASSERT_EQUALS(S, v->dimension(0))
+        ASSERT_EQUALS(1UL, v->dimensions().size()); \
+        ASSERT_EQUALS(S * 1LL, v->dimension(0))
 
     void enum7() {
         GET_SYMBOL_DB("enum E { X };\n"
@@ -4903,11 +4903,11 @@ private:
         const Enumerator *X2 = db->scopeList.back().findEnumerator("X2");
         ASSERT(X2);
         ASSERT(X2->value_known);
-        ASSERT_EQUALS(X2->value, 2);
+        ASSERT_EQUALS(2LL, X2->value);
         const Enumerator *X3 = db->scopeList.back().findEnumerator("X3");
         ASSERT(X3);
         ASSERT(X3->value_known);
-        ASSERT_EQUALS(X3->value, 3);
+        ASSERT_EQUALS(3LL, X3->value);
         const Enumerator *X4 = db->scopeList.back().findEnumerator("X4");
         ASSERT(X4);
         ASSERT(!X4->value_known);
@@ -4922,11 +4922,11 @@ private:
         const Enumerator *X0 = db->scopeList.back().findEnumerator("X0");
         ASSERT(X0);
         ASSERT(X0->value_known);
-        ASSERT_EQUALS(X0->value, 7);
+        ASSERT_EQUALS(7LL, X0->value);
         const Enumerator *X1 = db->scopeList.back().findEnumerator("X1");
         ASSERT(X1);
         ASSERT(X1->value_known);
-        ASSERT_EQUALS(X1->value, 8);
+        ASSERT_EQUALS(8LL, X1->value);
     }
 
     void sizeOfType() {
@@ -5030,7 +5030,7 @@ private:
                           "   }\n"
                           "};");
             ASSERT(db && db->findScopeByName("Bar") && !db->findScopeByName("Bar")->functionList.empty() && !db->findScopeByName("Bar")->functionList.front().isImplicitlyVirtual(false));
-            ASSERT_EQUALS(1, db->findScopeByName("Bar")->functionList.size());
+            ASSERT_EQUALS(1UL, db->findScopeByName("Bar")->functionList.size());
         }
 
         // #5590

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -38,7 +38,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data) {
+    void check(unsigned int jobs, int files, unsigned int result, const std::string &data) {
         errout.str("");
         output.str("");
         if (!ThreadExecutor::isEnabled()) {

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -395,16 +395,16 @@ private:
         Settings settings;
 
         tok.str("\"\"");
-        ASSERT_EQUALS(sizeof(""), Token::getStrSize(&tok, &settings));
+        ASSERT_EQUALS(sizeof(""), static_cast<size_t>(Token::getStrSize(&tok, &settings)));
 
         tok.str("\"abc\"");
-        ASSERT_EQUALS(sizeof("abc"), Token::getStrSize(&tok, &settings));
+        ASSERT_EQUALS(sizeof("abc"),  static_cast<size_t>(Token::getStrSize(&tok, &settings)));
 
         tok.str("\"\\0abc\"");
-        ASSERT_EQUALS(sizeof("\0abc"), Token::getStrSize(&tok, &settings));
+        ASSERT_EQUALS(sizeof("\0abc"),  static_cast<size_t>(Token::getStrSize(&tok, &settings)));
 
         tok.str("\"\\\\\"");
-        ASSERT_EQUALS(sizeof("\\"), Token::getStrSize(&tok, &settings));
+        ASSERT_EQUALS(sizeof("\\"),  static_cast<size_t>(Token::getStrSize(&tok, &settings)));
     }
 
     void getCharAt() const {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5935,7 +5935,7 @@ private:
         std::istringstream istr(code);
         tokenizer.tokenize(istr, "test.cpp");
         const Token *x = Token::findsimplematch(tokenizer.tokens(), "x");
-        ASSERT_EQUALS(1, x->bits());
+        ASSERT_EQUALS(static_cast<unsigned char>(1), x->bits());
     }
 
     void simplifyNamespaceStd() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -400,22 +400,22 @@ private:
     }
 
     void valueFlowNumber() {
-        ASSERT_EQUALS(123, valueOfTok("x=123;", "123").intvalue);
+        ASSERT_EQUALS(123LL, valueOfTok("x=123;", "123").intvalue);
         ASSERT_EQUALS_DOUBLE(192.0, valueOfTok("x=0x0.3p10;", "0x0.3p10").floatValue, 1e-5); // 3 * 16^-1 * 2^10 = 192
         ASSERT(std::fabs(valueOfTok("x=0.5;", "0.5").floatValue - 0.5f) < 0.1f);
-        ASSERT_EQUALS(10, valueOfTok("enum {A=10,B=15}; x=A+0;", "+").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("x=false;", "false").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("x=true;", "true").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("x(NULL);", "NULL").intvalue);
-        ASSERT_EQUALS((int)('a'), valueOfTok("x='a';", "'a'").intvalue);
-        ASSERT_EQUALS((int)('\n'), valueOfTok("x='\\n';", "'\\n'").intvalue);
-        ASSERT_EQUALS(0xFFFFFFFF00000000, valueOfTok("x=0xFFFFFFFF00000000;","0xFFFFFFFF00000000").intvalue); // #7701
+        ASSERT_EQUALS(10LL, valueOfTok("enum {A=10,B=15}; x=A+0;", "+").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("x=false;", "false").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("x=true;", "true").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("x(NULL);", "NULL").intvalue);
+        ASSERT_EQUALS((long long)('a'), valueOfTok("x='a';", "'a'").intvalue);
+        ASSERT_EQUALS((long long)('\n'), valueOfTok("x='\\n';", "'\\n'").intvalue);
+        ASSERT_EQUALS(static_cast<long long>(0xFFFFFFFF00000000), valueOfTok("x=0xFFFFFFFF00000000;","0xFFFFFFFF00000000").intvalue); // #7701
 
         // scope
         {
             const char code[] = "namespace N { enum E {e0,e1}; }\n"
                                 "void foo() { x = N::e1; }";
-            ASSERT_EQUALS(1, valueOfTok(code, "::").intvalue);
+            ASSERT_EQUALS(1LL, valueOfTok(code, "::").intvalue);
         }
     }
 
@@ -548,13 +548,13 @@ private:
                 "    const char *x = \"abcd\";\n"
                 "    return x[0];\n"
                 "}";
-        ASSERT_EQUALS((int)('a'), valueOfTok(code, "[").intvalue);
+        ASSERT_EQUALS((long long)('a'), valueOfTok(code, "[").intvalue);
 
         code  = "char f() {\n"
                 "    const char *x = \"\";\n"
                 "    return x[0];\n"
                 "}";
-        ASSERT_EQUALS(0, valueOfTok(code, "[").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok(code, "[").intvalue);
     }
 
     void valueFlowMove() {
@@ -658,26 +658,26 @@ private:
         const char *code;
 
         // Different operators
-        ASSERT_EQUALS(5, valueOfTok("3 +  (a ? b : 2);", "+").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("3 -  (a ? b : 2);", "-").intvalue);
-        ASSERT_EQUALS(6, valueOfTok("3 *  (a ? b : 2);", "*").intvalue);
-        ASSERT_EQUALS(6, valueOfTok("13 / (a ? b : 2);", "/").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("13 % (a ? b : 2);", "%").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("3 == (a ? b : 2);", "==").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("3 != (a ? b : 2);", "!=").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("3 >  (a ? b : 2);", ">").intvalue);
-        ASSERT_EQUALS(1, valueOfTok("3 >= (a ? b : 2);", ">=").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("3 <  (a ? b : 2);", "<").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("3 <= (a ? b : 2);", "<=").intvalue);
+        ASSERT_EQUALS(5LL, valueOfTok("3 +  (a ? b : 2);", "+").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("3 -  (a ? b : 2);", "-").intvalue);
+        ASSERT_EQUALS(6LL, valueOfTok("3 *  (a ? b : 2);", "*").intvalue);
+        ASSERT_EQUALS(6LL, valueOfTok("13 / (a ? b : 2);", "/").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("13 % (a ? b : 2);", "%").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("3 == (a ? b : 2);", "==").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("3 != (a ? b : 2);", "!=").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("3 >  (a ? b : 2);", ">").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("3 >= (a ? b : 2);", ">=").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("3 <  (a ? b : 2);", "<").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("3 <= (a ? b : 2);", "<=").intvalue);
 
-        ASSERT_EQUALS(1, valueOfTok("(UNKNOWN_TYPE)1;","(").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok("(UNKNOWN_TYPE)1;","(").intvalue);
         ASSERT(tokenValues("(UNKNOWN_TYPE)1000;","(").empty()); // don't know if there is truncation, sign extension
-        ASSERT_EQUALS(255, valueOfTok("(unsigned char)~0;", "(").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("(int)0;", "(").intvalue);
-        ASSERT_EQUALS(3, valueOfTok("(int)(1+2);", "(").intvalue);
-        ASSERT_EQUALS(0, valueOfTok("(UNKNOWN_TYPE*)0;","(").intvalue);
-        ASSERT_EQUALS(100, valueOfTok("(int)100.0;", "(").intvalue);
-        ASSERT_EQUALS(10, valueOfTok("x = static_cast<int>(10);", "( 10 )").intvalue);
+        ASSERT_EQUALS(255LL, valueOfTok("(unsigned char)~0;", "(").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("(int)0;", "(").intvalue);
+        ASSERT_EQUALS(3LL, valueOfTok("(int)(1+2);", "(").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok("(UNKNOWN_TYPE*)0;","(").intvalue);
+        ASSERT_EQUALS(100LL, valueOfTok("(int)100.0;", "(").intvalue);
+        ASSERT_EQUALS(10LL, valueOfTok("x = static_cast<int>(10);", "( 10 )").intvalue);
 
         // Don't calculate if there is UB
         ASSERT(tokenValues(";-1<<10;","<<").empty());
@@ -692,19 +692,19 @@ private:
                 "    a = x+456;\n"
                 "    if (x==123) {}"
                 "}";
-        ASSERT_EQUALS(579, valueOfTok(code, "+").intvalue);
+        ASSERT_EQUALS(579LL, valueOfTok(code, "+").intvalue);
 
         code  = "void f(int x, int y) {\n"
                 "    a = x+y;\n"
                 "    if (x==123 || y==456) {}"
                 "}";
-        ASSERT_EQUALS(0, valueOfTok(code, "+").intvalue);
+        ASSERT_EQUALS(0LL, valueOfTok(code, "+").intvalue);
 
         code  = "void f(int x) {\n"
                 "    a = x+x;\n"
                 "    if (x==123) {}"
                 "}";
-        ASSERT_EQUALS(246, valueOfTok(code, "+").intvalue);
+        ASSERT_EQUALS(246LL, valueOfTok(code, "+").intvalue);
 
         code  = "void f(int x, int y) {\n"
                 "    a = x*x;\n"
@@ -712,15 +712,15 @@ private:
                 "    if (x==4) {}\n"
                 "}";
         std::list<ValueFlow::Value> values = tokenValues(code,"*");
-        ASSERT_EQUALS(2U, values.size());
-        ASSERT_EQUALS(4, values.front().intvalue);
-        ASSERT_EQUALS(16, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(4LL, values.front().intvalue);
+        ASSERT_EQUALS(16LL, values.back().intvalue);
 
         code  = "void f(int x) {\n"
                 "    if (x == 3) {}\n"
                 "    a = x * (1 - x - 1);\n"
                 "}";
-        ASSERT_EQUALS(-9, valueOfTok(code, "*").intvalue);
+        ASSERT_EQUALS(-9LL, valueOfTok(code, "*").intvalue);
 
         // addition of different variables with known values
         code = "int f(int x) {\n"
@@ -728,30 +728,30 @@ private:
                "  while (x!=3) { x+=a; }\n"
                "  return x/a;\n"
                "}\n";
-        ASSERT_EQUALS(3, valueOfTok(code, "/").intvalue);
+        ASSERT_EQUALS(3LL, valueOfTok(code, "/").intvalue);
 
         // ? :
         code = "x = y ? 2 : 3;\n";
         values = tokenValues(code,"?");
-        ASSERT_EQUALS(2U, values.size());
-        ASSERT_EQUALS(2, values.front().intvalue);
-        ASSERT_EQUALS(3, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(2LL, values.front().intvalue);
+        ASSERT_EQUALS(3LL, values.back().intvalue);
 
         code = "void f(int a) { x = a ? 2 : 3; }\n";
         values = tokenValues(code,"?");
-        ASSERT_EQUALS(2U, values.size());
-        ASSERT_EQUALS(2, values.front().intvalue);
-        ASSERT_EQUALS(3, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(2LL, values.front().intvalue);
+        ASSERT_EQUALS(3LL, values.back().intvalue);
 
         code = "x = (2<5) ? 2 : 3;\n";
         values = tokenValues(code, "?");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(2, values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(2LL, values.front().intvalue);
 
         code = "x = 123 ? : 456;\n";
         values = tokenValues(code, "?");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(123, values.empty() ? 0 : values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(123LL, values.empty() ? 0 : values.front().intvalue);
 
         code  = "int f() {\n"
                 "    const int i = 1;\n"
@@ -764,8 +764,8 @@ private:
         code  = "x = ~0U;";
         settings.platform(cppcheck::Platform::Native); // ensure platform is native
         values = tokenValues(code,"~");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(~0U, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(static_cast<long long>(~0U), values.back().intvalue);
 
         // !
         code  = "void f(int x) {\n"
@@ -773,8 +773,8 @@ private:
                 "    if (x==0) {}\n"
                 "}";
         values = tokenValues(code,"!");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(1, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(1LL, values.back().intvalue);
 
         // unary minus
         code  = "void f(int x) {\n"
@@ -782,8 +782,8 @@ private:
                 "    if (x==10) {}\n"
                 "}";
         values = tokenValues(code,"-");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(-10, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(-10LL, values.back().intvalue);
 
         // Logical and
         code = "void f(bool b) {\n"
@@ -841,11 +841,11 @@ private:
                "    return a || b;\n"
                "}\n";
         values = tokenValues(code, "%oror%");
-        ASSERT_EQUALS(1, values.size());
+        ASSERT_EQUALS(1UL, values.size());
         if (!values.empty()) {
             ASSERT_EQUALS(true, values.front().isIntValue());
             ASSERT_EQUALS(true, values.front().isKnown());
-            ASSERT_EQUALS(1, values.front().intvalue);
+            ASSERT_EQUALS(1LL, values.front().intvalue);
         }
 
         // function call => calculation
@@ -860,30 +860,30 @@ private:
         ASSERT_EQUALS(true, values.empty());
         if (!values.empty()) {
             /* todo.. */
-            ASSERT_EQUALS(2U, values.size());
-            ASSERT_EQUALS(2, values.front().intvalue);
-            ASSERT_EQUALS(22, values.back().intvalue);
+            ASSERT_EQUALS(2UL, values.size());
+            ASSERT_EQUALS(2LL, values.front().intvalue);
+            ASSERT_EQUALS(22LL, values.back().intvalue);
         }
 
         // Comparison of string
         values = tokenValues("f(\"xyz\" == \"xyz\");", "=="); // implementation defined
-        ASSERT_EQUALS(0U, values.size()); // <- no value
+        ASSERT_EQUALS(0UL, values.size()); // <- no value
 
         values = tokenValues("f(\"xyz\" == 0);", "==");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(0, values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(0LL, values.front().intvalue);
 
         values = tokenValues("f(0 == \"xyz\");", "==");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(0, values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(0LL, values.front().intvalue);
 
         values = tokenValues("f(\"xyz\" != 0);", "!=");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(1, values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(1LL, values.front().intvalue);
 
         values = tokenValues("f(0 != \"xyz\");", "!=");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(1, values.front().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(1LL, values.front().intvalue);
     }
 
     void valueFlowSizeof() {
@@ -896,14 +896,14 @@ private:
                 "    x = sizeof(*a);\n"
                 "}";
         values = tokenValues(code,"( *");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(1, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(1LL, values.back().intvalue);
 
         code = "enum testEnum : uint32_t { a };\n"
                "sizeof(testEnum);";
         values = tokenValues(code,"( testEnum");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(4, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(4LL, values.back().intvalue);
 
 #define CHECK3(A, B, C)                          \
         do {                                     \
@@ -911,8 +911,8 @@ private:
                "    x = sizeof(" A ");\n"        \
                "}";                              \
         values = tokenValues(code,"( " C " )");  \
-        ASSERT_EQUALS(1U, values.size());        \
-        ASSERT_EQUALS(B, values.back().intvalue);\
+        ASSERT_EQUALS(1UL, values.size());        \
+        ASSERT_EQUALS(B * 1LL, values.back().intvalue);\
         } while(false)
 #define CHECK(A, B) CHECK3(A, B, A)
 
@@ -949,8 +949,8 @@ private:
                 "    x = sizeof(a) / sizeof(a[0]);\n"
                 "}";
         values = tokenValues(code,"/");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(10, values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(10LL, values.back().intvalue);
 
 #define CHECK(A, B, C, D)                         \
         do {                                      \
@@ -959,8 +959,8 @@ private:
                "    x = sizeof(" C ");\n"         \
                "}";                               \
         values = tokenValues(code,"( " C " )");   \
-        ASSERT_EQUALS(1U, values.size());         \
-        ASSERT_EQUALS(D, values.back().intvalue); \
+        ASSERT_EQUALS(1UL, values.size());         \
+        ASSERT_EQUALS(D * 1LL, values.back().intvalue); \
         } while(false)
 
         // enums
@@ -1035,8 +1035,8 @@ private:
                "    x = sizeof(arrE);\n"              \
                "}";                                   \
         values = tokenValues(code,"( arrE )");        \
-        ASSERT_EQUALS(1U, values.size());             \
-        ASSERT_EQUALS(B * 2U, values.back().intvalue);\
+        ASSERT_EQUALS(1UL, values.size());             \
+        ASSERT_EQUALS(B * 2LL, values.back().intvalue);\
         } while(false)
 
         // enum array
@@ -1070,8 +1070,8 @@ private:
                "    x = sizeof(arrE);\n"              \
                "}";                                   \
         values = tokenValues(code,"( arrE )");        \
-        ASSERT_EQUALS(1U, values.size());             \
-        ASSERT_EQUALS(B * 2U, values.back().intvalue);\
+        ASSERT_EQUALS(1UL, values.size());             \
+        ASSERT_EQUALS(B * 2LL, values.back().intvalue);\
         } while(false)
 
         // enum array
@@ -1100,8 +1100,8 @@ private:
         code = "uint16_t arr[10];\n"
                "x = sizeof(arr);";
         values = tokenValues(code,"( arr )");
-        ASSERT_EQUALS(1U, values.size());
-        ASSERT_EQUALS(10 * sizeof(std::uint16_t), values.back().intvalue);
+        ASSERT_EQUALS(1UL, values.size());
+        ASSERT_EQUALS(static_cast<long long>(10 * sizeof(std::uint16_t)), values.back().intvalue);
     }
 
     void valueFlowErrorPath() {
@@ -2165,7 +2165,7 @@ private:
                "}\n"
                "Fred::Fred(std::unique_ptr<Wilma> wilma)\n"
                "    : mWilma(std::move(wilma)) {}\n";
-        ASSERT_EQUALS(0, tokenValues(code, "mWilma (").size());
+        ASSERT_EQUALS(0UL, tokenValues(code, "mWilma (").size());
 
         code = "void g(unknown*);\n"
                "int f() {\n"
@@ -3039,10 +3039,10 @@ private:
                "  x = 0 + foo.x;\n" // <- foo.x is 1
                "}";
         values = tokenValues(code, "+");
-        ASSERT_EQUALS(1U, values.size());
+        ASSERT_EQUALS(1UL, values.size());
         ASSERT_EQUALS(true, values.front().isKnown());
         ASSERT_EQUALS(true, values.front().isIntValue());
-        ASSERT_EQUALS(1, values.front().intvalue);
+        ASSERT_EQUALS(1LL, values.front().intvalue);
 
         code = "void f() {\n"
                "  S s;\n"
@@ -3052,9 +3052,9 @@ private:
                "    s.x++;\n"
                "}";
         values = tokenValues(code, "<");
-        ASSERT_EQUALS(1, values.size());
+        ASSERT_EQUALS(1UL, values.size());
         ASSERT(values.front().isPossible());
-        ASSERT_EQUALS(true, values.front().intvalue);
+        ASSERT_EQUALS(1LL, values.front().intvalue);
 
         code = "void f() {\n"
                "  S s;\n"
@@ -3092,9 +3092,9 @@ private:
                "  }\n"
                "}";
         values = tokenValues(code, ">");
-        ASSERT_EQUALS(1, values.size());
+        ASSERT_EQUALS(1UL, values.size());
         ASSERT(values.front().isPossible());
-        ASSERT_EQUALS(true, values.front().intvalue);
+        ASSERT_EQUALS(1LL, values.front().intvalue);
 
         code = "void foo() {\n"
                "    struct ISO_PVD_s pvd;\n"
@@ -3130,7 +3130,7 @@ private:
         TODO_ASSERT_EQUALS(true, false, testConditionalValueOfX(code, 6U, 14));
 
         ValueFlow::Value value1 = valueOfTok(code, "-");
-        ASSERT_EQUALS(13, value1.intvalue);
+        ASSERT_EQUALS(13LL, value1.intvalue);
         ASSERT(!value1.isKnown());
 
         ValueFlow::Value value2 = valueOfTok(code, "+");
@@ -3407,7 +3407,7 @@ private:
                "}\n";
         value = valueOfTok(code, "x <");
         ASSERT(value.isPossible());
-        ASSERT_EQUALS(value.intvalue, 0);
+        ASSERT_EQUALS(0LL, value.intvalue);
 
         code = "void f() {\n"
                "    unsigned int x = 0;\n"
@@ -3415,7 +3415,7 @@ private:
                "}\n";
         value = valueOfTok(code, "x <");
         ASSERT(value.isPossible());
-        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT_EQUALS(0LL, value.intvalue);
 
         code = "void f() {\n"
                "    unsigned int x = 1;\n"
@@ -3423,7 +3423,7 @@ private:
                "}\n";
         value = valueOfTok(code, "x <");
         ASSERT(value.isPossible());
-        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT_EQUALS(0LL, value.intvalue);
     }
 
     void valueFlowSubFunction() {
@@ -3482,7 +3482,7 @@ private:
                "void f2() {\n"
                "    x = 10 - f1(2);\n"
                "}";
-        ASSERT_EQUALS(7, valueOfTok(code, "-").intvalue);
+        ASSERT_EQUALS(7LL, valueOfTok(code, "-").intvalue);
         ASSERT_EQUALS(true, valueOfTok(code, "-").isKnown());
 
         code = "int add(int x, int y) {\n"
@@ -3491,12 +3491,12 @@ private:
                "void f2() {\n"
                "    x = 1 * add(10+1,4);\n"
                "}";
-        ASSERT_EQUALS(15, valueOfTok(code, "*").intvalue);
+        ASSERT_EQUALS(15LL, valueOfTok(code, "*").intvalue);
         ASSERT_EQUALS(true, valueOfTok(code, "*").isKnown());
 
         code = "int one() { return 1; }\n"
                "void f() { x = 1 * one(); }";
-        ASSERT_EQUALS(1, valueOfTok(code, "*").intvalue);
+        ASSERT_EQUALS(1LL, valueOfTok(code, "*").intvalue);
         ASSERT_EQUALS(true, valueOfTok(code, "*").isKnown());
 
         code = "int add(int x, int y) {\n"
@@ -3505,7 +3505,7 @@ private:
                "void f2() {\n"
                "    x = 1 * add(1,add(2,3));\n"
                "}";
-        ASSERT_EQUALS(6, valueOfTok(code, "*").intvalue);
+        ASSERT_EQUALS(6LL, valueOfTok(code, "*").intvalue);
         ASSERT_EQUALS(true, valueOfTok(code, "*").isKnown());
 
         code = "int f(int i, X x) {\n"
@@ -3525,7 +3525,7 @@ private:
                "        x = 10 - f1(2);\n"
                "    }\n"
                "};";
-        ASSERT_EQUALS(7, valueOfTok(code, "-").intvalue);
+        ASSERT_EQUALS(7LL, valueOfTok(code, "-").intvalue);
         ASSERT_EQUALS(true, valueOfTok(code, "-").isKnown());
 
         code = "class A\n"
@@ -3537,7 +3537,7 @@ private:
                "        x = 10 - f1(2);\n"
                "    }\n"
                "};";
-        ASSERT_EQUALS(7, valueOfTok(code, "-").intvalue);
+        ASSERT_EQUALS(7LL, valueOfTok(code, "-").intvalue);
         ASSERT_EQUALS(false, valueOfTok(code, "-").isKnown());
     }
 
@@ -3570,7 +3570,7 @@ private:
                "  return x + 2;\n" // <- known value
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(3, value.intvalue);
+        ASSERT_EQUALS(3LL, value.intvalue);
         ASSERT(value.isKnown());
 
         {
@@ -3579,7 +3579,7 @@ private:
                    "  if (x == 15) { x += 7; }\n" // <- condition is true
                    "}";
             value = valueOfTok(code, "==");
-            ASSERT_EQUALS(1, value.intvalue);
+            ASSERT_EQUALS(1LL, value.intvalue);
             ASSERT(value.isKnown());
 
             code = "int f() {\n"
@@ -3599,7 +3599,7 @@ private:
                "  return x + 2;\n" // <- possible value
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(9, value.intvalue);
+        ASSERT_EQUALS(9LL, value.intvalue);
         ASSERT(value.isPossible());
 
         code = "void f(int c) {\n"
@@ -3644,7 +3644,7 @@ private:
                "  if (x < 0) {}\n"
                "}\n";
         value = valueOfTok(code, "<");
-        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT_EQUALS(0LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "void dostuff(int & x);\n"
@@ -3662,7 +3662,7 @@ private:
                "  if (x < 0) {}\n"
                "}\n";
         value = valueOfTok(code, "<");
-        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT_EQUALS(0LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "void f() {\n"
@@ -3717,7 +3717,7 @@ private:
                "  }\n"
                "}";
         value = valueOfTok(code, "!");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "void f() {\n"
@@ -3749,7 +3749,7 @@ private:
                "  }\n"
                "}";
         value = valueOfTok(code, "!");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isPossible());
 
         code = "void f() {\n"
@@ -3763,7 +3763,7 @@ private:
                "  return x + 1;\n" // <- known value
                "}\n";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "void f() {\n"
@@ -3772,7 +3772,7 @@ private:
                "  a = x + 1;\n" // <- possible value
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isPossible());
 
         // in conditional code
@@ -3782,7 +3782,7 @@ private:
                "  }\n"
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "void f(int x) {\n"
@@ -3791,7 +3791,7 @@ private:
                "  }\n"
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(16, value.intvalue);
+        ASSERT_EQUALS(16LL, value.intvalue);
         ASSERT(value.isKnown());
 
         // after condition
@@ -3800,7 +3800,7 @@ private:
                "  return x + 1;\n" // <- possible value
                "}";
         value = valueOfTok(code, "+");
-        ASSERT_EQUALS(5, value.intvalue);
+        ASSERT_EQUALS(5LL, value.intvalue);
         ASSERT(value.isPossible());
 
         code = "int f(int x) {\n"
@@ -3808,7 +3808,7 @@ private:
                "  else if (x >= 2) {}\n" // <- known value
                "}";
         value = valueOfTok(code, ">=");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT(value.isKnown());
 
         code = "int f(int x) {\n"
@@ -3829,14 +3829,14 @@ private:
         // calculation with known result
         code = "int f(int x) { a = x & 0; }"; // <- & is 0
         value = valueOfTok(code, "&");
-        ASSERT_EQUALS(0, value.intvalue);
+        ASSERT_EQUALS(0LL, value.intvalue);
         ASSERT(value.isKnown());
 
         // template parameters are not known
         code = "template <int X> void f() { a = X; }\n"
                "f<1>();";
         value = valueOfTok(code, "1");
-        ASSERT_EQUALS(1, value.intvalue);
+        ASSERT_EQUALS(1LL, value.intvalue);
         ASSERT_EQUALS(false, value.isKnown());
     }
 
@@ -4006,7 +4006,7 @@ private:
                "    y += 10;\n"
                "    x = dostuff(sizeof(*x)*y);\n"
                "}";
-        ASSERT_EQUALS(0U, tokenValues(code, "x )").size());
+        ASSERT_EQUALS(0UL, tokenValues(code, "x )").size());
 
         // #8036
         code = "void foo() {\n"
@@ -4147,7 +4147,7 @@ private:
                "  d = szHdr;\n"
                "}";
         values = tokenValues(code, "szHdr ; }");
-        ASSERT_EQUALS(0, values.size());
+        ASSERT_EQUALS(0UL, values.size());
 
         // #9933
         code = "struct MyStruct { size_t value; }\n"
@@ -4158,7 +4158,7 @@ private:
                "    if (x.value < 432) {}\n"
                "}";
         values = tokenValues(code, "x . value");
-        ASSERT_EQUALS(0, values.size());
+        ASSERT_EQUALS(0UL, values.size());
     }
 
     void valueFlowTerminatingCond() {
@@ -4653,7 +4653,7 @@ private:
                "    ptr->getMessage (&v);\n"
                "    if (v.size () > 0) {}\n" // <- v has unknown size!
                "}";
-        ASSERT_EQUALS(0U, tokenValues(code, "v . size ( )").size());
+        ASSERT_EQUALS(0UL, tokenValues(code, "v . size ( )").size());
 
         // if
         code = "bool f(std::vector<int>&) {\n" // #9532
@@ -4665,20 +4665,20 @@ private:
                "        return 0;\n"
                "    return v[0];\n"
                "}\n";
-        ASSERT_EQUALS(0U, tokenValues(code, "v [ 0 ]").size());
+        ASSERT_EQUALS(0UL, tokenValues(code, "v [ 0 ]").size());
 
         // container size => yields
         code = "void f() {\n"
                "  std::string s = \"abcd\";\n"
                "  s.size();\n"
                "}";
-        ASSERT_EQUALS(4, tokenValues(code, "( ) ;").front().intvalue);
+        ASSERT_EQUALS(4LL, tokenValues(code, "( ) ;").front().intvalue);
 
         code = "void f() {\n"
                "  std::string s;\n"
                "  s.empty();\n"
                "}";
-        ASSERT_EQUALS(1, tokenValues(code, "( ) ;").front().intvalue);
+        ASSERT_EQUALS(1LL, tokenValues(code, "( ) ;").front().intvalue);
 
         // Calculations
         code = "void f() {\n"
@@ -4734,7 +4734,7 @@ private:
                "        return str.front();\n"
                "    }\n"
                "}\n";
-        ASSERT_EQUALS(0U, tokenValues(code, "str . front").size());
+        ASSERT_EQUALS(0UL, tokenValues(code, "str . front").size());
 
         code = "void f() {\n"
                "  std::vector<int> ints{};\n"
@@ -4824,23 +4824,23 @@ private:
                "  return x + 0;\n"
                "}";
         values = tokenValues(code, "+", &s);
-        ASSERT_EQUALS(2, values.size());
-        ASSERT_EQUALS(-0x8000, values.front().intvalue);
-        ASSERT_EQUALS(0x7fff, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(-0x8000LL, values.front().intvalue);
+        ASSERT_EQUALS(0x7fffLL, values.back().intvalue);
 
         code = "short f(std::string x) {\n"
                "  return x[10];\n"
                "}";
         values = tokenValues(code, "x [", &s);
-        ASSERT_EQUALS(2, values.size());
-        ASSERT_EQUALS(0, values.front().intvalue);
-        ASSERT_EQUALS(1000000, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(0LL, values.front().intvalue);
+        ASSERT_EQUALS(1000000LL, values.back().intvalue);
 
         code = "int f(float x) {\n"
                "  return x;\n"
                "}";
         values = tokenValues(code, "x ;", &s);
-        ASSERT_EQUALS(2, values.size());
+        ASSERT_EQUALS(2UL, values.size());
         ASSERT(values.front().floatValue < -1E20);
         ASSERT(values.back().floatValue > 1E20);
 
@@ -4848,17 +4848,17 @@ private:
                "  return x + 0;\n"
                "}";
         values = tokenValues(code, "+", &s);
-        ASSERT_EQUALS(2, values.size());
-        ASSERT_EQUALS(0, values.front().intvalue);
-        ASSERT_EQUALS(100, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(0LL, values.front().intvalue);
+        ASSERT_EQUALS(100LL, values.back().intvalue);
 
         code = "unsigned short f(unsigned short x) [[expects: x <= 100]] {\n"
                "  return x + 0;\n"
                "}";
         values = tokenValues(code, "+", &s);
-        ASSERT_EQUALS(2, values.size());
-        ASSERT_EQUALS(0, values.front().intvalue);
-        ASSERT_EQUALS(100, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(0LL, values.front().intvalue);
+        ASSERT_EQUALS(100LL, values.back().intvalue);
     }
 
 
@@ -4871,9 +4871,9 @@ private:
 
         code = "x = rand();";
         values = tokenValues(code, "(", &s);
-        ASSERT_EQUALS(2, values.size());
-        ASSERT_EQUALS(INT_MIN, values.front().intvalue);
-        ASSERT_EQUALS(INT_MAX, values.back().intvalue);
+        ASSERT_EQUALS(2UL, values.size());
+        ASSERT_EQUALS(static_cast<long long>(INT_MIN), values.front().intvalue);
+        ASSERT_EQUALS(static_cast<long long>(INT_MAX), values.back().intvalue);
     }
 
     void valueFlowPointerAliasDeref() {


### PR DESCRIPTION
Extracted from #2922 since that needs more work regarding older Visual Studio versions.

There's probably some compiler warnings which would point these out at compile-time. But that's something for a later date.