### PR TITLE
Test for return address of reference

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2742,7 +2742,8 @@ std::vector<LifetimeToken> getLifetimeTokens(const Token* tok, bool escape, Valu
             } else if (Token::simpleMatch(var->declEndToken(), "=")) {
                 errorPath.emplace_back(var->declEndToken(), "Assigned to reference.");
                 const Token *vartok = var->declEndToken()->astOperand2();
-                const bool temporary = isTemporary(true, vartok, nullptr, true);
+                const bool temporaryDefault = false; //If we can't tell then assume the value is not temporary as this will result in fewer false positives.
+                const bool temporary = isTemporary(true, vartok, nullptr, temporaryDefault);
                 const bool nonlocal = var->isStatic() || var->isGlobal();
                 if (vartok == tok || (nonlocal && temporary) || (!escape && (var->isConst() || var->isRValueReference()) && temporary))
                     return {{tok, true, std::move(errorPath)}};

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -2563,6 +2563,20 @@ private:
               "        f(std::move(w));\n"
               "    }\n"
               "};\n");
+
+        //Make sure we can still take the address of a reference without warning
+        check("int* foo() {\n"
+              "  int& x = getX();\n"
+              "  return &x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+        check("struct C {\n"
+              "  int* m_x;\n"
+              "  void foo() {\n"
+              "    const int& x = getX();\n"
+              "    m_x = &x;\n"
+              "  }\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -2563,6 +2563,7 @@ private:
               "        f(std::move(w));\n"
               "    }\n"
               "};\n");
+        ASSERT_EQUALS("", errout.str());
 
         //Make sure we can still take the address of a reference without warning
         check("int* foo() {\n"


### PR DESCRIPTION
When storing the address of a local variable in a class field cppcheck will issue a warning even if that local variable is a reference whose value was returned from a function. Unless more is known about the function it is a reasonable assumption that the reference it returns will outlive the function call. It appears that when cppcheck encounters an unknown function it makes the opposite assumption. 