### PR TITLE
testrunner: Allow to specify testcases with regex

### DIFF
--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <regex>
 #include <string>
 
 std::ostringstream errout;
@@ -88,7 +89,7 @@ bool TestFixture::prepareTest(const char testname[])
     mTemplateLocation.clear();
 
     // Check if tests should be executed
-    if (testToRun.empty() || testToRun == testname) {
+    if (testToRun.empty() || std::regex_match(testname, std::regex(testToRun))) {
         // Tests will be executed - prepare them
         mTestname = testname;
         ++countTests;
@@ -292,6 +293,8 @@ void TestFixture::printHelp()
               "        testrunner TestClass::TestCase\n"
               "    run all test cases in TestClass1 and TestClass2::TestCase:\n"
               "        testrunner TestClass1 TestClass2::TestCase\n"
+	      "\n"
+	      "    Regex may be used for TestClasses and TestCases.\n"
               "\n"
               "Options:\n"
               "    -q                   Do not print the test cases that have run.\n"
@@ -327,7 +330,7 @@ std::size_t TestFixture::runTests(const options& args)
         }
 
         for (TestFixture * test : TestRegistry::theInstance().tests()) {
-            if (classname.empty() || test->classname == classname) {
+            if (classname.empty() || std::regex_match(test->classname, std::regex(classname))) {
                 test->processOptions(args);
                 test->run(testname);
             }


### PR DESCRIPTION
Allow to specify which tests to run using a regex. In addition to the
currently existing ways of running tests, this makes it possible to
specify the tests to run using a regex. For example (depending on your
shell, you might have to quote the wildcard expressions):

Run all Memleak tests (`TestMemleak`, `TestMemleakInFunction`, etc)

	./testrunner TestMemleak.*

Run all `simplifyOperatorName` tests in `TestTokenizer`:

	./testrunner TestTokenizer::simplifyOperatorName.*

All tests containing 'const' or 'Const' (ok, this one is probably not very useful, also, some of these tests do not pass when run separately).

	make testrunner && ./testrunner .*::.*[C|c]onst.*

Tested on Linux only, `std::regex` is c++11, but I don't know if all old compilers support them.