### PR TITLE
Matchcompiler parse all Match|simpleMatch on the same line

### DIFF
--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -92,7 +92,7 @@ class MatchCompiler:
         elif tok == '%bool%':
             return 'tok->isBoolean()'
         elif tok == '%char%':
-            return '(tok->tokType()==Token::eChar)'
+            return '(tok->tokType() == Token::eChar)'
         elif tok == '%comp%':
             return 'tok->isComparisonOp()'
         elif tok == '%num%':
@@ -102,24 +102,24 @@ class MatchCompiler:
         elif tok == '%op%':
             return 'tok->isOp()'
         elif tok == '%or%':
-            return '(tok->tokType() == Token::eBitOp && tok->str()==MatchCompiler::makeConstString("|") )'
+            return '(tok->tokType() == Token::eBitOp && tok->str() == MatchCompiler::makeConstString("|") )'
         elif tok == '%oror%':
-            return '(tok->tokType() == Token::eLogicalOp && tok->str()==MatchCompiler::makeConstString("||"))'
+            return '(tok->tokType() == Token::eLogicalOp && tok->str() == MatchCompiler::makeConstString("||"))'
         elif tok == '%str%':
-            return '(tok->tokType()==Token::eString)'
+            return '(tok->tokType() == Token::eString)'
         elif tok == '%type%':
-            return '(tok->isName() && tok->varId()==0U && (tok->str() != "delete" || !tok->isKeyword()))'
+            return '(tok->isName() && tok->varId() == 0U && (tok->str() != "delete" || !tok->isKeyword()))'
         elif tok == '%name%':
             return 'tok->isName()'
         elif tok == '%var%':
             return '(tok->varId() != 0)'
         elif tok == '%varid%':
-            return '(tok->isName() && tok->varId()==varid)'
+            return '(tok->isName() && tok->varId() == varid)'
         elif (len(tok) > 2) and (tok[0] == "%"):
             print("unhandled:" + tok)
 
         return (
-            '(tok->str()==MatchCompiler::makeConstString("' + tok + '"))'
+            '(tok->str() == MatchCompiler::makeConstString("' + tok + '"))'
         )
 
     def _compilePattern(self, pattern, nr, varid,
@@ -155,7 +155,7 @@ class MatchCompiler:
 
             # [abc]
             if (len(tok) > 2) and (tok[0] == '[') and (tok[-1] == ']'):
-                ret += '    if (!tok || tok->str().size()!=1U || !strchr("' + tok[1:-1] + '", tok->str()[0]))\n'
+                ret += '    if (!tok || tok->str().size() != 1U || !strchr("' + tok[1:-1] + '", tok->str()[0]))\n'
                 ret += '        ' + returnStatement
 
             # a|b|c

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -330,8 +330,8 @@ class MatchCompiler:
         # ret += '            std::cout << "tok: " << tok->str();\n'
         # ret += '        if (tok->next())\n'
         # ret += '            std::cout << "tok next: " << tok->next()->str();\n'
-        ret += '        throw InternalError(tok, "Internal error.' +\
-            'compiled match returned different result than parsed match: ' + pattern + '");\n'
+        ret += '        throw InternalError(tok, "Internal error. ' +\
+            'Compiled match returned different result than parsed match: ' + pattern + '");\n'
         ret += '    }\n'
         ret += '    return res_compiled_match;\n'
         ret += '}\n'
@@ -459,7 +459,7 @@ class MatchCompiler:
         # We also need to verify builds in 'release' mode
         ret += '    if (res_parsed_findmatch != res_compiled_findmatch) {\n'
         ret += '        throw InternalError(tok, "Internal error. ' +\
-            'compiled findmatch returned different result than parsed findmatch: ' + pattern + '");\n'
+            'Compiled findmatch returned different result than parsed findmatch: ' + pattern + '");\n'
         ret += '    }\n'
         ret += '    return res_compiled_findmatch;\n'
         ret += '}\n'

--- a/tools/test_matchcompiler.py
+++ b/tools/test_matchcompiler.py
@@ -39,6 +39,10 @@ class MatchCompilerTest(unittest.TestCase):
         output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
         self.assertEqual(output, 'if (match1(tok)) {')
 
+        input = 'if (Token::simpleMatch(tok, "foobar")) {'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, 'if (match1(tok)) {')
+
         input = 'if (Token::Match(tok->next()->next(), "foobar %type% %num%")) {'
         output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
         self.assertEqual(output, 'if (match2(tok->next()->next())) {')
@@ -59,6 +63,25 @@ class MatchCompilerTest(unittest.TestCase):
         output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
         self.assertEqual(
             output, 'if (Token::Match(tok, "extern \"C\" " + varname)) {')
+
+        # test that multiple patterns on the same line are replaced
+        input = 'if (Token::Match(tok, "foo") && Token::Match(tok->next(), "baz")) {'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, 'if (match4(tok) && match5(tok->next())) {')
+
+        # test that second pattern is replaced, even if there is a bailout on the first pattern
+        input = 'if (Token::Match(tok, foo) && Token::Match(tok->next(), "foobaz")) {'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, 'if (Token::Match(tok, foo) && match6(tok->next())) {')
+
+        # test mixing Match and simpleMatch on the same line
+        input = 'if (Token::Match(tok, "a") && Token::simpleMatch(tok->next(), "b")) {'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, 'if (match7(tok) && match8(tok->next())) {')
+
+        input = 'if (Token::simpleMatch(tok, "a") && Token::Match(tok->next(), "b")) {'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, 'if (match7(tok) && match8(tok->next())) {')
 
     def test_replaceTokenMatchWithVarId(self):
         input = 'if (Token::Match(tok, "foobar %varid%", 123)) {'


### PR DESCRIPTION
Previously, Matchcompiler stopped processing the line in case it found a match it could not process, which meant other matches on the same line were not processed, even though they might be simplified (also, due to the implementation, all 
`Token::Match` on the line were processed first, so if the line contained one Match that could not be simplified, no simpleMatches would be simplified).  Fix this by not bailing out and check all matches. Due to indentation changes (I put the relevant lines of code in a for loop), the diff look larger than it really is (compare without whitespace changes and you'll see).

Also, while at it, fix some whitespace formatting in the generated code, and neaten some error messages slightly (I actually looked at the code and error messages when debugging, and the minor changes actually improved readability for me).

Also, it can be noted that current cppcheck main branch do not contain any such lines at the moment.