### PR TITLE
remove cleanupAfterSimplify from the template simplifier

### DIFF
--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -296,7 +296,7 @@ void CheckSizeof::sizeofCalculation()
         if (tok->isExpandedMacro() && tok->previous()) {
             const Token *cast_end = (tok->previous()->str() == "(") ? tok->previous() : tok;
             if (Token::simpleMatch(cast_end->tokAt(-3), "( void )") ||
-                Token::simpleMatch(cast_end->previous(), "static_cast<void>")) {
+                Token::simpleMatch(cast_end->tokAt(-4), "static_cast < void >")) {
                 continue;
             }
         }
@@ -337,7 +337,7 @@ void CheckSizeof::sizeofFunction()
             if (tok->isExpandedMacro() && tok->previous()) {
                 const Token *cast_end = (tok->previous()->str() == "(") ? tok->previous() : tok;
                 if (Token::simpleMatch(cast_end->tokAt(-3), "( void )") ||
-                    Token::simpleMatch(cast_end->previous(), "static_cast<void>")) {
+                    Token::simpleMatch(cast_end->tokAt(-4), "static_cast < void >")) {
                     continue;
                 }
             }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -245,58 +245,6 @@ TemplateSimplifier::~TemplateSimplifier()
 {
 }
 
-void TemplateSimplifier::cleanupAfterSimplify()
-{
-    bool goback = false;
-    for (Token *tok = mTokenList.front(); tok; tok = tok->next()) {
-        if (goback) {
-            tok = tok->previous();
-            goback = false;
-        }
-        if (tok->str() == "(")
-            tok = tok->link();
-
-        else if (Token::Match(tok, "template < > %name%")) {
-            const Token *end = tok;
-            while (end) {
-                if (end->str() == ";")
-                    break;
-                if (end->str() == "{") {
-                    end = end->link()->next();
-                    break;
-                }
-                if (!Token::Match(end, "%name%|::|<|>|,")) {
-                    end = nullptr;
-                    break;
-                }
-                end = end->next();
-            }
-            if (end) {
-                Token::eraseTokens(tok,end);
-                tok->deleteThis();
-            }
-        }
-
-        else if (Token::Match(tok, "%type% <") &&
-                 (!tok->previous() || tok->previous()->str() == ";")) {
-            const Token *tok2 = tok->tokAt(2);
-            std::string type;
-            while (Token::Match(tok2, "%type%|%num% ,")) {
-                type += tok2->str() + ",";
-                tok2 = tok2->tokAt(2);
-            }
-            if (Token::Match(tok2, "%type%|%num% > (")) {
-                type += tok2->str();
-                tok->str(tok->str() + "<" + type + ">");
-                Token::eraseTokens(tok, tok2->tokAt(2));
-                if (tok == mTokenList.front())
-                    goback = true;
-            }
-        }
-    }
-}
-
-
 void TemplateSimplifier::checkComplicatedSyntaxErrorsInTemplates()
 {
     // check for more complicated syntax errors when using templates..

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -48,13 +48,6 @@ public:
     ~TemplateSimplifier();
 
     /**
-     * Used after simplifyTemplates to perform a little cleanup.
-     * Sometimes the simplifyTemplates isn't fully successful and then
-     * there are function calls etc with "wrong" syntax.
-     */
-    void cleanupAfterSimplify();
-
-    /**
      */
     void checkComplicatedSyntaxErrorsInTemplates();
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4747,11 +4747,7 @@ bool Tokenizer::simplifyTokenList1(const char FileName[])
         if (Settings::terminated())
             return false;
 
-        // sometimes the "simplifyTemplates" fail and then unsimplified
-        // function calls etc remain. These have the "wrong" syntax. So
-        // this function will just fix so that the syntax is corrected.
         validate(); // #6847 - invalid code
-        mTemplateSimplifier->cleanupAfterSimplify();
     }
 
     // Simplify pointer to standard types (C only)

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -997,8 +997,8 @@ private:
     }
 
     void template_unhandled() {
-        // An unhandled template usage should be simplified..
-        ASSERT_EQUALS("x<int> ( ) ;", tok("x<int>();"));
+        // An unhandled template usage should not be simplified..
+        ASSERT_EQUALS("x < int > ( ) ;", tok("x<int>();"));
     }
 
     void template38() { // #4832 - Crash on C++11 right angle brackets

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -4315,13 +4315,13 @@ private:
     void unsigned3() {
         {
             const char code[] = "; foo<unsigned>();";
-            const char expected[] = "; foo<int> ( ) ;";
+            const char expected[] = "; foo < unsigned int > ( ) ;";
             ASSERT_EQUALS(expected, tokenizeAndStringify(code));
         }
 
         {
             const char code[] = "; foo<unsigned int>();";
-            const char expected[] = "; foo<int> ( ) ;";
+            const char expected[] = "; foo < unsigned int > ( ) ;";
             ASSERT_EQUALS(expected, tokenizeAndStringify(code));
         }
     }


### PR DESCRIPTION
The template simplifier works well enough now so cleanupAfterSimplify is
no longer necessary.  In fact cleanupAfterSimplify was introducing a bug
which improperly simplified C++ style casts.

Bugs should be exposed and fixed properly rather than just hiding them.