### PR TITLE
oss-fuzz: Only use tinyxml2_objs if bundled tinyxml2 is used

### DIFF
--- a/oss-fuzz/CMakeLists.txt
+++ b/oss-fuzz/CMakeLists.txt
@@ -3,7 +3,6 @@ if (ENABLE_OSS_FUZZ AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
             main.cpp
             type2.cpp
             $<TARGET_OBJECTS:simplecpp_objs>
-            $<TARGET_OBJECTS:tinyxml2_objs>
             $<TARGET_OBJECTS:lib_objs>)
     target_include_directories(fuzz-client PRIVATE ${CMAKE_SOURCE_DIR}/lib ${CMAKE_SOURCE_DIR}/externals/simplecpp ${CMAKE_SOURCE_DIR}/externals/tinyxml2 ${CMAKE_SOURCE_DIR}/externals)
     target_compile_options(fuzz-client PRIVATE -fsanitize=fuzzer)
@@ -15,6 +14,9 @@ if (ENABLE_OSS_FUZZ AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif()
     if (USE_Z3)
         target_link_libraries(fuzz-client PRIVATE ${Z3_LIBRARIES})
+    endif()
+    if (USE_BUNDLED_TINYXML2)
+        target_link_libraries(fuzz-client PRIVATE $<TARGET_OBJECTS:tinyxml2_objs>)
     endif()
 
     add_executable(translate EXCLUDE_FROM_ALL


### PR DESCRIPTION
The build would previously fail if clang was used in combination with a
system-wide installation of tinyxml2.