### PR TITLE
improve cppunit macros

### DIFF
--- a/cfg/cppunit.cfg
+++ b/cfg/cppunit.cfg
@@ -5,13 +5,13 @@
   <define name="CPPUNIT_TEST(test)" value=""/>
   <define name="CPPUNIT_TEST_SUITE_END()" value=""/>
   <!-- Macros see http://cppunit.sourceforge.net/doc/cvs/group___assertions.html  -->
-  <define name="CPPUNIT_ASSERT(condition)" value="if (!(condition)) throw false;"/>
-  <define name="CPPUNIT_ASSERT_MESSAGE(message, condition)" value="if (!(condition)) throw message;"/>
+  <define name="CPPUNIT_ASSERT(condition)" value="{if (!(condition)) throw false;}"/>
+  <define name="CPPUNIT_ASSERT_MESSAGE(message, condition)" value="{if (!(condition)) throw message;}"/>
   <define name="CPPUNIT_FAIL(message)" value="throw message;"/>
-  <define name="CPPUNIT_ASSERT_EQUAL(expected, actual)" value="if ((expected) != (actual)) throw false;"/>
-  <define name="CPPUNIT_ASSERT_EQUAL_MESSAGE(message, expected, actual)" value="if ((expected) != (actual)) throw message;"/>
-  <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual, delta)" value="if (std::abs((expected) - (actual)) &gt; delta) throw false;"/>
-  <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE(message, expected, actual, delta)" value="if (std::abs((expected) - (actual)) &gt; delta) throw message;"/>
+  <define name="CPPUNIT_ASSERT_EQUAL(expected, actual)" value="{if ((expected) != (actual)) throw false;}"/>
+  <define name="CPPUNIT_ASSERT_EQUAL_MESSAGE(message, expected, actual)" value="{if ((expected) != (actual)) throw message;}"/>
+  <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, actual, delta)" value="{if (std::abs((expected) - (actual)) &gt; delta) throw false;}"/>
+  <define name="CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE(message, expected, actual, delta)" value="{if (std::abs((expected) - (actual)) &gt; delta) throw message;}"/>
   <define name="CPPUNIT_ASSERT_THROW(expression, ExceptionType)" value=""/>
   <define name="CPPUNIT_ASSERT_THROW_MESSAGE(message, expression, ExceptionType)" value=""/>
   <define name="CPPUNIT_ASSERT_NO_THROW(expression)" value=""/>


### PR DESCRIPTION
Addresses issue described here: https://github.com/danmar/cppcheck/commit/fe4657f2185f9bb3fb169aa17534947d48427758#r43715649

specifically the code
```
if (checkA)
   CPPUNIT_ASSERT(a);
else
   CPPUNIT_ASSERT(b);
```
will expand to
```
if (checkA)
{
   if (!(condition))
      throw false;
   else if (!(condition))
      throw false;
}
```

which doesn't match the behavior of the actual cppunit macros or, presumably the authors intent. Fix surrounds the whole expression in braces to make it look like a single statement as far as the if statement is concerned.

Not sure how to test this other than making sure nothing weird happens on my own code. I've had a very similar fix locally for a while but it's not identical.