### PR TITLE
Add return value config for tolower()/toupper()

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -2848,7 +2848,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="towlower,std::towlower">
     <use-retval/>
     <pure/>
-    <returnValue type="wint_t"/>
+    <returnValue type="wint_t">arg1 &lt; 'A' || arg1 &gt; 'Z' ? arg1 : arg1 + 32</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="in">
@@ -2859,7 +2859,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="towupper,std::towupper">
     <use-retval/>
     <pure/>
-    <returnValue type="wint_t"/>
+    <returnValue type="wint_t">arg1 &lt; 'a' || arg1 &gt; 'z' ? arg1 : arg1 - 32</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="in">
@@ -5512,7 +5512,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- int tolower(int c); -->
   <function name="tolower,std::tolower">
     <use-retval/>
-    <returnValue type="int"/>
+    <returnValue type="int">arg1 &lt; 'A' || arg1 &gt; 'Z' ? arg1 : arg1 + 32</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="in">
@@ -5524,7 +5524,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- int toupper(int c); -->
   <function name="toupper,std::toupper">
     <use-retval/>
-    <returnValue type="int"/>
+    <returnValue type="int">arg1 &lt; 'a' || arg1 &gt; 'z' ? arg1 : arg1 - 32</returnValue>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="in">


### PR DESCRIPTION
Technically, these are locale dependent, but since for example `islower()` and `isupper()` were configured as if it is the "C" locale, I figured these probably can be configured like this too?