### PR TITLE
cppcheckdata: Use instance attributes in CppcheckData class

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -852,15 +852,14 @@ class CppcheckData:
     @endcode
     """
 
-    rawTokens = []
-    platform = None
-    suppressions = []
-
     def __init__(self, filename):
         """
         :param filename: Path to Cppcheck dump file
         """
         self.filename = filename
+        self.rawTokens = []
+        self.platform = None
+        self.suppressions = []
 
         files = []  # source files for elements occurred in this configuration
         platform_done = False


### PR DESCRIPTION
Since class attributes are mutable (list), when you append to them, they don't promote to instance variable which means when you call `parsedump()` multiple times data just gets appended to them.

Found by samed on the forum: https://sourceforge.net/p/cppcheck/discussion/general/thread/c6e1210ec2/