### PR TITLE
some self-check suppression cleanups

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -110,12 +110,12 @@ jobs:
           make -j$(nproc) -s CPPFLAGS="-DCHECK_INTERNAL" CXXFLAGS="-g -O2" MATCHCOMPILER=yes VERIFY=1
           # self check lib/cli
           mkdir b1
-          ./cppcheck -q -j$(nproc) --template=gcc --cppcheck-build-dir=b1 -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib --addon=naming.json -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli --inconclusive --enable=style,performance,portability,warning,internal --exception-handling cli lib
+          ./cppcheck -q -j$(nproc) --template=selfcheck --cppcheck-build-dir=b1 -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib --addon=naming.json -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli --inconclusive --enable=style,performance,portability,warning,internal --exception-handling cli lib
           # check gui with qt settings
           mkdir b2
-          ./cppcheck -q -j$(nproc) --template=gcc --cppcheck-build-dir=b2 -D__CPPCHECK__ -DQT_VERSION=0x050000 --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=qt --addon=naming.json -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ --enable=style,performance,portability,warning,internal --exception-handling gui/*.cpp
+          ./cppcheck -q -j$(nproc) --template=selfcheck --cppcheck-build-dir=b2 -D__CPPCHECK__ -DQT_VERSION=0x050000 --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=qt --addon=naming.json -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ --enable=style,performance,portability,warning,internal --exception-handling gui/*.cpp
           # self check test and tools
-          ./cppcheck -q -j$(nproc) --template=gcc -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli -Igui --inconclusive --enable=style,performance,portability,warning,internal --exception-handling test/*.cpp tools
+          ./cppcheck -q -j$(nproc) --template=selfcheck -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli -Igui --inconclusive --enable=style,performance,portability,warning,internal --exception-handling test/*.cpp tools
 
       - name: Build triage on ubuntu
         if: matrix.os == 'ubuntu-20.04'

--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -15,6 +15,7 @@ duplicateBranch:lib/tokenize.cpp
 missingOverride
 redundantAssignment:lib/tokenlist.cpp
 unreachableCode:lib/checkbufferoverrun.cpp
+# disabled because of #8388
 unreachableCode:lib/checkclass.cpp
 unreachableCode:test/testother.cpp
 unusedPrivateFunction:lib/checkbufferoverrun.h

--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -1,21 +1,12 @@
 unusedPrivateFunction:test/testbufferoverrun.cpp
 unusedPrivateFunction:test/testcmdlineparser.cpp
-redundantNextPrevious:test/testtoken.cpp
-simplePatternError:test/testtoken.cpp
 shadowFunction
 functionConst
 functionStatic
 bitwiseOnBoolean
 
 # temporary suppressions - fix the warnings!
-duplicateBranch:lib/checkunusedvar.cpp
-duplicateBranch:lib/tokenize.cpp
 missingOverride
-redundantAssignment:lib/tokenlist.cpp
-unreachableCode:lib/checkbufferoverrun.cpp
-# disabled because of #8388
-unreachableCode:lib/checkclass.cpp
-unreachableCode:test/testother.cpp
 unusedPrivateFunction:lib/checkbufferoverrun.h
 unusedPrivateFunction:test/test*.cpp
 useStlAlgorithm

--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -2,12 +2,10 @@ unusedPrivateFunction:test/testbufferoverrun.cpp
 unusedPrivateFunction:test/testcmdlineparser.cpp
 redundantNextPrevious:test/testtoken.cpp
 simplePatternError:test/testtoken.cpp
-noValidConfiguration
 shadowFunction
 functionConst
 functionStatic
 bitwiseOnBoolean
-hidingInheritedPublic
 
 # temporary suppressions - fix the warnings!
 duplicateBranch:lib/checkunusedvar.cpp

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -849,6 +849,10 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     mSettings->templateFormat = "{file} +{line}: {severity}: {message}";
                 else if (mSettings->templateFormat == "cppcheck1")
                     mSettings->templateFormat = "{callstack}: ({severity}{inconclusive:, inconclusive}) {message}";
+                else if (mSettings->templateFormat == "selfcheck") {
+                    mSettings->templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}";
+                    mSettings->templateLocation = "{file}:{line}:{column}: note: {info}\\n{code}";
+                }
             }
 
             else if (std::strcmp(argv[i], "--template-location") == 0 ||

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -1169,7 +1169,7 @@ bool CppCheckExecutor::tryLoadLibrary(Library& destination, const char* basepath
 /**
  * Execute a shell command and read the output from it. Returns true if command terminated successfully.
  */
-// cppcheck-suppress passedByValue
+// cppcheck-suppress passedByValue - "exe" copy needed in _WIN32 code
 bool CppCheckExecutor::executeCommand(std::string exe, std::vector<std::string> args, const std::string &redirect, std::string *output)
 {
     output->clear();

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -27,7 +27,7 @@
 #include <map>
 #include <string>
 
-#if (defined(__GNUC__) || defined(__sun)) && !defined(__MINGW32__) && !defined(__CYGWIN__)
+#if ((defined(__GNUC__) || defined(__sun)) && !defined(__MINGW32__) && !defined(__CYGWIN__)) || defined(__CPPCHECK__)
 #define THREADING_MODEL_FORK
 #elif defined(_WIN32)
 #define THREADING_MODEL_WIN

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -826,19 +826,19 @@ bool CheckBufferOverrun::analyseWholeProgram(const CTU::FileInfo *ctu, const std
         if (!fi)
             continue;
         for (const CTU::FileInfo::UnsafeUsage &unsafeUsage : fi->unsafeArrayIndex)
-            foundErrors |= analyseWholeProgram1(ctu, callsMap, unsafeUsage, 1, errorLogger);
+            foundErrors |= analyseWholeProgram1(callsMap, unsafeUsage, 1, errorLogger);
         for (const CTU::FileInfo::UnsafeUsage &unsafeUsage : fi->unsafePointerArith)
-            foundErrors |= analyseWholeProgram1(ctu, callsMap, unsafeUsage, 2, errorLogger);
+            foundErrors |= analyseWholeProgram1(callsMap, unsafeUsage, 2, errorLogger);
     }
     return foundErrors;
 }
 
-bool CheckBufferOverrun::analyseWholeProgram1(const CTU::FileInfo *ctu, const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger)
+bool CheckBufferOverrun::analyseWholeProgram1(const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger)
 {
     const CTU::FileInfo::FunctionCall *functionCall = nullptr;
 
     const std::list<ErrorMessage::FileLocation> &locationList =
-        ctu->getErrorPath(CTU::FileInfo::InvalidValueType::bufferOverflow,
+        CTU::FileInfo::getErrorPath(CTU::FileInfo::InvalidValueType::bufferOverflow,
                           unsafeUsage,
                           callsMap,
                           "Using argument ARG",

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -137,7 +137,7 @@ private:
     static bool isCtuUnsafePointerArith(const Check *check, const Token *argtok, MathLib::bigint *offset);
 
     Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
-    bool analyseWholeProgram1(const CTU::FileInfo *ctu, const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger);
+    static bool analyseWholeProgram1(const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger);
 
 
     static std::string myName() {

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2497,6 +2497,7 @@ void CheckClass::checkCopyCtorAndEqOperator()
     // The message must be clarified. How is the behaviour different?
     return;
 
+    // cppcheck-suppress unreachableCode - remove when code is enabled again
     if (!mSettings->isEnabled(Settings::WARNING))
         return;
 

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -591,7 +591,7 @@ bool CheckNullPointer::analyseWholeProgram(const CTU::FileInfo *ctu, const std::
                     break;
 
                 const std::list<ErrorMessage::FileLocation> &locationList =
-                    ctu->getErrorPath(CTU::FileInfo::InvalidValueType::null,
+                    CTU::FileInfo::getErrorPath(CTU::FileInfo::InvalidValueType::null,
                                       unsafeUsage,
                                       callsMap,
                                       "Dereferencing argument ARG that is null",

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1446,7 +1446,7 @@ bool CheckUninitVar::analyseWholeProgram(const CTU::FileInfo *ctu, const std::li
             const CTU::FileInfo::FunctionCall *functionCall = nullptr;
 
             const std::list<ErrorMessage::FileLocation> &locationList =
-                ctu->getErrorPath(CTU::FileInfo::InvalidValueType::uninit,
+                CTU::FileInfo::getErrorPath(CTU::FileInfo::InvalidValueType::uninit,
                                   unsafeUsage,
                                   callsMap,
                                   "Using argument ARG",

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -521,15 +521,13 @@ static const Token* doAssignment(Variables &variables, const Token *tok, bool de
                                 if (var1->_assignments.find(scope) == var1->_assignments.end() ||
                                     scope->type == Scope::eSwitch) {
                                     // nothing to replace
+                                    // cppcheck-suppress duplicateBranch - remove when TODO below is address
                                     if (var1->_assignments.empty())
                                         replace = false;
 
                                     // this variable has previous assignments
                                     else {
-                                        /**
-                                         * @todo determine if existing aliases should be replaced or merged
-                                         */
-
+                                        // TODO: determine if existing aliases should be replaced or merged
                                         replace = false;
                                     }
                                 }

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -532,7 +532,7 @@ std::list<ErrorMessage::FileLocation> CTU::FileInfo::getErrorPath(InvalidValueTy
         const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap,
         const char info[],
         const FunctionCall * * const functionCallPtr,
-        bool warning) const
+        bool warning)
 {
     std::list<ErrorMessage::FileLocation> locationList;
 

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -116,12 +116,12 @@ namespace CTU {
         void loadFromXml(const tinyxml2::XMLElement *xmlElement);
         std::map<std::string, std::list<const CallBase *>> getCallsMap() const;
 
-        std::list<ErrorMessage::FileLocation> getErrorPath(InvalidValueType invalidValue,
+        static std::list<ErrorMessage::FileLocation> getErrorPath(InvalidValueType invalidValue,
                 const UnsafeUsage &unsafeUsage,
                 const std::map<std::string, std::list<const CallBase *>> &callsMap,
                 const char info[],
                 const FunctionCall * * const functionCallPtr,
-                bool warning) const;
+                bool warning);
     };
 
     extern int maxCtuDepth;

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -750,7 +750,7 @@ namespace {
             std::vector<std::string> constraints;
         };
 
-        void parsestr(const std::string &s, std::vector<ImportData> *importData) const {
+        static void parsestr(const std::string &s, std::vector<ImportData> *importData) {
             std::string line;
             std::istringstream istr(s);
             while (std::getline(istr, line)) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -12005,6 +12005,7 @@ void Tokenizer::simplifyNamespaceAliases()
                             continue;
                         } else {
                             // conflicting declaration (syntax error)
+                            // cppcheck-suppress duplicateBranch - remove when TODO below is addressed
                             if (endScope == scope) {
                                 // delete conflicting declaration
                                 tok2 = deleteAlias(tok2->previous());

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3182,7 +3182,7 @@ static bool setVarIdParseDeclaration(const Token **tok, const std::map<std::stri
 
 void Tokenizer::setVarIdStructMembers(Token **tok1,
                                       std::map<int, std::map<std::string, int> >& structMembers,
-                                      nonneg int *varId)
+                                      nonneg int *varId) const
 {
     Token *tok = *tok1;
 
@@ -9572,7 +9572,7 @@ static bool isCPPAttribute(const Token * tok)
     return Token::simpleMatch(tok, "[ [") && tok->link() && tok->link()->previous() == tok->linkAt(1);
 }
 
-void Tokenizer::reportUnknownMacros()
+void Tokenizer::reportUnknownMacros() const
 {
     // Report unknown macros used in expressions "%name% %num%"
     for (const Token *tok = tokens(); tok; tok = tok->next()) {

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -664,7 +664,7 @@ private:
     void validate() const;
 
     /** Detect unknown macros and throw unknownMacro */
-    void reportUnknownMacros();
+    void reportUnknownMacros() const;
 
     /** Detect garbage code and call syntaxError() if found. */
     void findGarbageCode() const;
@@ -809,7 +809,7 @@ private:
 
     void setVarIdStructMembers(Token **tok1,
                                std::map<int, std::map<std::string, int> >& structMembers,
-                               nonneg int *varId);
+                               nonneg int *varId) const;
 
     void setVarIdClassFunction(const std::string &classname,
                                Token * const startToken,

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1614,7 +1614,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
     return tok;
 }
 
-void TokenList::createAst()
+void TokenList::createAst() const
 {
     for (Token *tok = mTokensFrontBack.front; tok; tok = tok ? tok->next() : nullptr) {
         tok = createAstAtToken(tok, isCPP());

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1465,7 +1465,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
                     compileExpression(tok2, state1);
                     if (Token::Match(tok2, ";|)"))
                         break;
-                    init1 = nullptr; // cppcheck-suppress redundantAssignment ; FALSE POSITIVE
+                    init1 = nullptr;
                 }
                 if (!tok2) // #7109 invalid code
                     return nullptr;

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -156,7 +156,7 @@ public:
     /**
      * Create abstract syntax tree.
      */
-    void createAst();
+    void createAst() const;
 
     /**
      * Check abstract syntax tree.

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7518,6 +7518,7 @@ private:
         return; // FIXME: temporary hack
 
         // Simple tests
+        // cppcheck-suppress unreachableCode - remove when code is enabled again
         check("void f() {\n"
               "    char a[10];\n"
               "    memcpy(a, foo, bar);\n"

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -120,11 +120,13 @@ private:
         Token *last = token->tokAt(2);
         ASSERT_EQUALS(token->str(), "1");
         ASSERT_EQUALS(token->next()->str(), "2");
+        // cppcheck-suppress redundantNextPrevious - this is itentional
         ASSERT_EQUALS(token->tokAt(2)->str(), "3");
         ASSERT_EQUALS_MSG(true, last->next() == nullptr, "Null was expected");
 
         ASSERT_EQUALS(last->str(), "3");
         ASSERT_EQUALS(last->previous()->str(), "2");
+        // cppcheck-suppress redundantNextPrevious - this is itentional
         ASSERT_EQUALS(last->tokAt(-2)->str(), "1");
         ASSERT_EQUALS_MSG(true, token->previous() == nullptr, "Null was expected");
 
@@ -719,18 +721,24 @@ private:
 
     void matchOr() const {
         givenACodeSampleToTokenize bitwiseOr(";|;", true);
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(true,  Token::Match(bitwiseOr.tokens(), "; %or%"));
         ASSERT_EQUALS(true,  Token::Match(bitwiseOr.tokens(), "; %op%"));
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(false, Token::Match(bitwiseOr.tokens(), "; %oror%"));
 
         givenACodeSampleToTokenize bitwiseOrAssignment(";|=;");
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(false,  Token::Match(bitwiseOrAssignment.tokens(), "; %or%"));
         ASSERT_EQUALS(true,  Token::Match(bitwiseOrAssignment.tokens(), "; %op%"));
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(false, Token::Match(bitwiseOrAssignment.tokens(), "; %oror%"));
 
         givenACodeSampleToTokenize logicalOr(";||;", true);
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(false, Token::Match(logicalOr.tokens(), "; %or%"));
         ASSERT_EQUALS(true,  Token::Match(logicalOr.tokens(), "; %op%"));
+        // cppcheck-suppress simplePatternError - this is itentional
         ASSERT_EQUALS(true,  Token::Match(logicalOr.tokens(), "; %oror%"));
         ASSERT_EQUALS(true,  Token::Match(logicalOr.tokens(), "; &&|%oror%"));
         ASSERT_EQUALS(true,  Token::Match(logicalOr.tokens(), "; %oror%|&&"));


### PR DESCRIPTION
I added `--template=selfcheck` so we see the actual severity and if it is inconclusive. It would also allow us to add additional stuff (like the daca checks) for self-check in the future.

If we add any suppressions in the future I would like to have a comment which describes why and if it is a false positive it should also contain a ticket number.

I would also like to get rid of `-D__CPPCHECK__` and specify a proper configuration like `-D__GNUC__ -D__cplusplus=201103L` instead.