### PR TITLE
Check if XML reader stopped because of an error.

### DIFF
--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -279,8 +279,12 @@ QString CppcheckLibraryData::open(QIODevice &file)
             break;
         }
     }
-
-    return QString();
+    if (xmlReader.hasError()) {
+        return xmlReader.errorString();
+    }
+    else {
+        return QString();
+    }
 }
 
 static void writeContainerFunctions(QXmlStreamWriter &xmlWriter, const QString &name, int extra, const QList<struct CppcheckLibraryData::Container::Function> &functions)


### PR DESCRIPTION
Member function `atEnd()` of class `QXmlStreamReader` returns `true` if an error occured and this breaks the XML reader loop.
But this error will not be visible to the user and leaves `CppcheckLibraryData` instance in incomplete state.