### PR TITLE
Lazily compute ErrorMessage::hash

### DIFF
--- a/gui/erroritem.cpp
+++ b/gui/erroritem.cpp
@@ -51,7 +51,7 @@ ErrorItem::ErrorItem(const ErrorMessage &errmsg)
     , summary(QString::fromStdString(errmsg.shortMessage()))
     , message(QString::fromStdString(errmsg.verboseMessage()))
     , cwe(errmsg.cwe.id)
-    , hash(errmsg.hash)
+    , hash(errmsg.hash.getHash())
     , symbolNames(QString::fromStdString(errmsg.symbolNames()))
 {
     for (std::list<ErrorMessage::FileLocation>::const_iterator loc = errmsg.callStack.begin();

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -197,7 +197,7 @@ public:
     bool inconclusive;
 
     /** Warning hash */
-    std::size_t hash;
+    Hash hash;
 
     /** set short and verbose messages */
     void setmsg(const std::string &msg);

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -43,6 +43,16 @@ static bool isAcceptedErrorIdChar(char c)
     }
 }
 
+std::size_t Hash::getHash() const
+{
+    if (mComputed)
+        return mHash;
+
+    mHash = mComputation();
+    mComputed = true;
+    return mHash;
+}
+
 std::string Suppressions::parseFile(std::istream &istr)
 {
     // Change '\r' to '\n' in the istr
@@ -306,7 +316,7 @@ bool Suppressions::Suppression::parseComment(std::string comment, std::string *e
 
 bool Suppressions::Suppression::isSuppressed(const Suppressions::ErrorMessage &errmsg) const
 {
-    if (hash > 0 && hash != errmsg.hash)
+    if (hash > 0 && hash != errmsg.hash.getHash())
         return false;
     if (!errorId.empty() && !matchglob(errorId, errmsg.errorId))
         return false;

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -22,6 +22,7 @@
 
 #include "config.h"
 
+#include <functional>
 #include <istream>
 #include <list>
 #include <string>
@@ -30,12 +31,26 @@
 /// @addtogroup Core
 /// @{
 
+class Hash {
+public:
+    Hash(std::function<std::size_t()> computation): mComputation(computation), mComputed(false) {}
+
+    Hash(std::size_t hash = 0):mHash(hash), mComputed(true) {}
+
+    std::size_t getHash() const;
+private:
+    mutable std::size_t mHash;
+    std::function<std::size_t()> mComputation;
+    mutable bool mComputed;
+};
+
+
 /** @brief class for handling suppressions */
 class CPPCHECKLIB Suppressions {
 public:
 
     struct CPPCHECKLIB ErrorMessage {
-        std::size_t hash;
+        Hash hash;
         std::string errorId;
         void setFileName(const std::string &s);
         const std::string &getFileName() const {


### PR DESCRIPTION
Since the computation is quite expensive, only do it if we need it. This
uses the assumptions that tokenList and the tokens in it are still valid
at the time of computation.
I believe this is the case, but I might be wrong.

As the hash is not used very often, this is very beneficial. On a huge
codebase with many warnings (typically many missingOverride on some
protobuf generated code), the cppcheck duration is halved, and I believe
calculateWarningHash is never called.