### PR TITLE
Made missing comparison in loop check more generic

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1729,8 +1729,6 @@ void CheckStl::missingComparison()
             }
 
             const Token *incrementToken = nullptr;
-            MathLib::bigint comparedInAdvance = 0;
-
             // Parse loop..
             for (const Token *tok3 = scope.bodyStart; tok3 != scope.bodyEnd; tok3 = tok3->next()) {
                 if (tok3->varId() == iteratorId) {
@@ -1739,20 +1737,13 @@ void CheckStl::missingComparison()
                         tok3 = tok3->linkAt(6);
                         if (!tok3)
                             break;
-                    } else if (Token::simpleMatch(tok3->astParent(), "++")) {
-                        if (comparedInAdvance == 0)
+                    } else if (Token::simpleMatch(tok3->astParent(), "++"))
                             incrementToken = tok3;
-                        else
-                            comparedInAdvance -= 1;
-                    } else if (Token::simpleMatch(tok3->astParent(), "+")) {
+                    else if (Token::simpleMatch(tok3->astParent(), "+")) {
                         if (Token::Match(tok3->astSibling(), "%num%")) {
                             const Token* tokenGrandParent = tok3->astParent()->astParent();
                             if (Token::Match(tokenGrandParent, "==|!="))
-                            {
-                                auto incrNum = MathLib::toLongNumber(tok3->astSibling()->str());
-                                if (incrNum > comparedInAdvance)
-                                    comparedInAdvance = incrNum;
-                            }
+                                break;
                         }
                     } else if (Token::Match(tok3->astParent(), "==|!="))
                         incrementToken = nullptr;

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1729,7 +1729,7 @@ void CheckStl::missingComparison()
             }
 
             const Token *incrementToken = nullptr;
-            bool bComparedInAdvance = false;
+            MathLib::bigint comparedInAdvance = 0;
 
             // Parse loop..
             for (const Token *tok3 = scope.bodyStart; tok3 != scope.bodyEnd; tok3 = tok3->next()) {
@@ -1740,15 +1740,19 @@ void CheckStl::missingComparison()
                         if (!tok3)
                             break;
                     } else if (Token::simpleMatch(tok3->astParent(), "++")) {
-                        if (!bComparedInAdvance)
+                        if (comparedInAdvance == 0)
                             incrementToken = tok3;
                         else
-                            bComparedInAdvance = false;
+                            comparedInAdvance -= 1;
                     } else if (Token::simpleMatch(tok3->astParent(), "+")) {
-                        if (Token::simpleMatch(tok3->astSibling(), "1")) {
+                        if (Token::Match(tok3->astSibling(), "%num%")) {
                             const Token* tokenGrandParent = tok3->astParent()->astParent();
                             if (Token::Match(tokenGrandParent, "==|!="))
-                                bComparedInAdvance = true;
+                            {
+                                auto incrNum = MathLib::toLongNumber(tok3->astSibling()->str());
+                                if (incrNum > comparedInAdvance)
+                                    comparedInAdvance = incrNum;
+                            }
                         }
                     } else if (Token::Match(tok3->astParent(), "==|!="))
                         incrementToken = nullptr;

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3004,8 +3004,11 @@ private:
 
         check("void f(const std::vector<std::string> &v) {\n"
               "    for(std::vector<std::string>::const_iterator it = v.begin(); it != v.end(); ++it) {\n"
-              "        if(it+1 != v.end())\n"
+              "        if(it+2 != v.end())\n"
+              "        {\n"
               "            ++it;\n"
+              "            ++it;\n"
+              "        }\n"
               "    }\n"
               "}");
         ASSERT_EQUALS("", errout.str());


### PR DESCRIPTION
Considering new use case added to issue 9938 (https://trac.cppcheck.net/ticket/9938) enhanced earlier fix to consider increment number in comparison check