### PR TITLE
Fix update of some translations after application language switch.

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2020 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1459,6 +1459,9 @@ void MainWindow::setLanguage(const QString &code)
         //Translate everything that is visible here
         mUI.retranslateUi(this);
         mUI.mResults->translate();
+        mLineEditFilter->setPlaceholderText(QCoreApplication::translate("MainWindow", "Quick Filter:"));
+        if (mProjectFile)
+            formatAndSetTitle(tr("Project:") + ' ' + mProjectFile->getFilename());
     }
 }
 

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2020 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -364,6 +364,7 @@ void ResultsView::saveSettings(QSettings *settings)
 
 void ResultsView::translate()
 {
+    mUI.retranslateUi(this);
     mUI.mTree->translate();
 }
 


### PR DESCRIPTION
This PR updates translations of

- Placeholder text of toolbar filter (fix for Trac issue 8879)
- Main window title if project file has been opened
- `ResultsView` auto generated user interface class.
