### PR TITLE
10110: Fix FP knownConditionTrueFalse

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1024,6 +1024,73 @@ static bool isZeroBoundCond(const Token * const cond)
     return false;
 }
 
+static bool isForLoopCondition(const Token * const tok)
+{
+    if (!tok)
+        return false;
+    const Token *const parent = tok->astParent();
+    return Token::simpleMatch(parent, ";") && parent->astOperand1() == tok &&
+           Token::simpleMatch(parent->astParent(), ";") &&
+           Token::simpleMatch(parent->astParent()->astParent(), "(") &&
+           parent->astParent()->astParent()->astOperand1()->str() == "for";
+}
+
+/**
+ * Is token used a boolean (cast to a bool, or used as a condition somewhere)
+ * @param tok
+ * @param checkingParent true if we are checking a parent. This is used to know
+ * what we are checking. For instance in `if (i == 2)`, isUsedAsBool("==") is
+ * true whereas isUsedAsBool("i") is false, but it might call
+ * isUsedAsBool_internal("==") which must not return true
+ */
+static bool isUsedAsBool_internal(const Token * const tok, bool checkingParent)
+{
+    if (!tok)
+        return false;
+    const Token::Type type = tok->tokType();
+    if (type == Token::eBitOp || type == Token::eIncDecOp || (type == Token::eArithmeticalOp && !tok->isUnaryOp("*")))
+        // those operators don't return a bool
+        return false;
+    if (type == Token::eComparisonOp) {
+        if (!checkingParent)
+            // this operator returns a bool
+            return true;
+        if (Token::Match(tok, "==|!="))
+            return astIsBool(tok->astOperand1()) || astIsBool(tok->astOperand2());
+        return false;
+    }
+    if (type == Token::eLogicalOp)
+        return true;
+    if (astIsBool(tok))
+        return true;
+
+    const Token * const parent = tok->astParent();
+    if (!parent)
+        return false;
+    if (parent->str() == "(" && parent->astOperand2() == tok) {
+        if (Token::Match(parent->astOperand1(), "if|while"))
+            return true;
+
+        if (!parent->isCast()) { // casts are handled via the recursive call, as astIsBool will be true
+            // is it a call to a function ?
+            int argnr;
+            const Token *const func = getTokenArgumentFunction(tok, argnr);
+            if (!func || !func->function())
+                return false;
+            const Variable *var = func->function()->getArgumentVar(argnr);
+            return var && (var->getTypeName() == "bool");
+        }
+    } else if (isForLoopCondition(tok))
+        return true;
+
+    return isUsedAsBool_internal(parent, true);
+}
+
+bool isUsedAsBool(const Token * const tok)
+{
+    return isUsedAsBool_internal(tok, false);
+}
+
 bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
 {
     if (!cond1 || !cond2)
@@ -1051,6 +1118,8 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
             if (cond2->astOperand2() && cond2->astOperand2()->str() == "0")
                 return isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors);
         }
+        if (!isUsedAsBool(cond2))
+            return false;
         return isSameExpression(cpp, true, cond1->astOperand1(), cond2, library, pure, followVar, errors);
     }
 

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -142,6 +142,11 @@ bool isEqualKnownValue(const Token * const tok1, const Token * const tok2);
 bool isDifferentKnownValues(const Token * const tok1, const Token * const tok2);
 
 /**
+ * Is token used a boolean, that is to say cast to a bool, or used as a condition in a if/while/for
+ */
+bool isUsedAsBool(const Token * const tok);
+
+/**
  * Are two conditions opposite
  * @param isNot  do you want to know if cond1 is !cond2 or if cond1 and cond2 are non-overlapping. true: cond1==!cond2  false: cond1==true => cond2==false
  * @param cpp    c++ file

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2340,6 +2340,8 @@ struct OppositeExpressionAnalyzer : ExpressionAnalyzer {
     {}
 
     virtual bool match(const Token* tok) const OVERRIDE {
+        if (tok->isName() && !tok->isBoolean())
+            return false;
         return isOppositeCond(isNot, isCPP(), expr, tok, getSettings()->library, true, true);
     }
 };

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2340,8 +2340,6 @@ struct OppositeExpressionAnalyzer : ExpressionAnalyzer {
     {}
 
     virtual bool match(const Token* tok) const OVERRIDE {
-        if (tok->isName() && !tok->isBoolean())
-            return false;
         return isOppositeCond(isNot, isCPP(), expr, tok, getSettings()->library, true, true);
     }
 };

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -4305,6 +4305,73 @@ private:
                "}\n";
         ASSERT_EQUALS(true, valueOfTok(code, "> 0").isKnown());
         ASSERT_EQUALS(true, valueOfTok(code, "> 0").intvalue == 1);
+
+        //  FP #10110
+        code = "enum FENUMS { NONE = 0, CB = 8 };\n"
+               "bool calc(int x) {\n"
+               "    if (!x) {\n"
+               "        return false;\n"
+               "    }\n"
+               "\n"
+               "    if (x & CB) {\n"
+               "        return true;\n"
+               "    }\n"
+               "    return false;\n"
+               "}\n";
+        ASSERT_EQUALS(false, valueOfTok(code, "& CB").isKnown());
+        ASSERT_EQUALS(true, testValueOfXImpossible(code, 7U, 0));
+
+        code = "enum FENUMS { NONE = 0, CB = 8 };\n"
+               "bool calc(int x) {\n"
+               "    if (x) {\n"
+               "        return false;\n"
+               "    }\n"
+               "\n"
+               "    if ((!x) & CB) {\n"
+               "        return true;\n"
+               "    }\n"
+               "    return false;\n"
+               "}\n";
+        ASSERT_EQUALS(true, valueOfTok(code, "& CB").isKnown());
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 7U, 0));
+
+        code = "enum FENUMS { NONE = 0, CB = 8 };\n"
+               "bool calc(int x) {\n"
+               "    if (!!x) {\n"
+               "        return false;\n"
+               "    }\n"
+               "\n"
+               "    if (x & CB) {\n"
+               "        return true;\n"
+               "    }\n"
+               "    return false;\n"
+               "}\n";
+        ASSERT_EQUALS(true, valueOfTok(code, "& CB").isKnown());
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 7U, 0));
+
+        code = "bool calc(bool x) {\n"
+               "    if (!x) {\n"
+               "        return false;\n"
+               "    }\n"
+               "\n"
+               "    if (x) {\n"
+               "        return true;\n"
+               "    }\n"
+               "    return false;\n"
+               "}\n";
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 6U, 1));
+
+        code = "bool calc(bool x) {\n"
+               "    if (x) {\n"
+               "        return false;\n"
+               "    }\n"
+               "\n"
+               "    if (!x) {\n"
+               "        return true;\n"
+               "    }\n"
+               "    return false;\n"
+               "}\n";
+        ASSERT_EQUALS(true, testValueOfXKnown(code, 6U, 0));
     }
 
     static std::string isPossibleContainerSizeValue(const std::list<ValueFlow::Value> &values, MathLib::bigint i) {


### PR DESCRIPTION
With
```
enum FENUMS { NONE = 0, CB = 8 };

bool calc(int flag) {
    if (!flag) {
        return false;
    }

    if (flag & CB) {
        return true;
    }
    return false;
}
```

Since flag is not a bool, we can't know its value in the second if.
However, isOppositeCond would still return true (since `!flag` and
`flag` really are opposite condition), and we would update flag with a
known value of `1`. This patch adds an additional check to prevent that
when we don't deal with a bool.