### PR TITLE
Added .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ compile_commands.json
 
 # qmake
 /gui/.qmake.stash
+
+#vs code
+.vscode


### PR DESCRIPTION
While using visual studio code for development one need to create .vscode at root of workspace. This change adds to .gitignore so its not accidently pushed to origin