### PR TITLE
fixed/excluded some shellcheck warnings and actually fail the build when something is found

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -26,7 +26,7 @@ jobs:
           
       - name: run Shellcheck
         run: |
-          find . -name "*.sh" | xargs shellcheck
+          find . -name "*.sh" | xargs shellcheck --exclude SC2002,SC2013,SC2034,SC2035,SC2043,SC2046,SC2086,SC2089,SC2090,SC2129,SC2211,SC2231
 
       - name: run pylint
         run: |

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -26,7 +26,7 @@ jobs:
           
       - name: run Shellcheck
         run: |
-          find . -name "*.sh" | xargs shellcheck || true
+          find . -name "*.sh" | xargs shellcheck
 
       - name: run pylint
         run: |

--- a/cve-test-suite/download.sh
+++ b/cve-test-suite/download.sh
@@ -3,7 +3,7 @@
 
 echo "CVE" > cve.txt
 
-for i in `seq 1 20`;
+for i in $(seq 1 20);
 do
   echo "page $i"
   # CVE 119 issues:

--- a/man/build-pdf.sh
+++ b/man/build-pdf.sh
@@ -25,7 +25,7 @@ pandoc $1.md -o $1.pdf -s --number-sections --toc \
     --listings \
     -f markdown \
     -V mainfont="$MainFont" \
-    -V monofont="$Consolas" \
+    -V monofont="$MonoFont" \
     -V geometry:a4paper \
     -V geometry:margin=2.4cm \
     -V subparagraph \

--- a/test/cfg/generate-cfg-tests.sh
+++ b/test/cfg/generate-cfg-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd ~/cppcheck
+cd ~/cppcheck || exit 1
 make generate_cfg_tests
 ./generate_cfg_tests cfg/avr.cfg > test/cfg/generated-cfg-tests-avr.cpp
 ./generate_cfg_tests cfg/bsd.cfg > test/cfg/generated-cfg-tests-bsd.cpp

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -401,11 +401,7 @@ set -e
 if [ $PKGCONFIG_RETURNCODE -ne 0 ]; then
     echo "pkg-config needed to retrieve cppunit configuration is not available, skipping syntax check."
 else
-    set +e
-    CPPUNIT=$(pkg-config cppunit)
-    CPPUNIT_RETURNCODE=$?
-    set -e
-    if [ $CPPUNIT_RETURNCODE -ne 0 ]; then
+    if pkg-config cppunit; then
         echo "cppunit not found, skipping syntax check for cppunit"
     else
         echo "cppunit found, checking syntax with ${CXX} now."

--- a/test/synthetic/run-clang.sh
+++ b/test/synthetic/run-clang.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ~/llvm/build/bin/clang -cc1 -analyze -analyzer-checker=alpha.security controlflow.c data.c functions.c 2>&1 /dev/null | grep warning
 ~/llvm/build/bin/clang -cc1 -analyze -analyzer-checker=alpha.security,core ub.c 2>&1 /dev/null | grep warning
 

--- a/tools/daca2-logs2git.sh
+++ b/tools/daca2-logs2git.sh
@@ -8,7 +8,7 @@ base_url="http://cppcheck.sourceforge.net/devinfo/daca2-report/"
 echo ${base_url}daca2.html
 
 
-for site in `curl -s --compressed ${base_url}daca2.html | grep "^<tr" | grep -o "\".*\"" | sed s/\"//g` ; do
+for site in $(curl -s --compressed ${base_url}daca2.html | grep "^<tr" | grep -o "\".*\"" | sed s/\"//g) ; do
     echo ${site} ;  curl -s --compressed ${base_url}${site} | sort -n --parallel=4 | sed 's/^ *//; s/ *$//; /^$/d; s/^M$//; s/\r$//'  | sed -e 's/\[[0-9][0-9]:[0-9][0-9]\]$//' | sed '/^$/d' | sed 's/\&amp\;/\&/g; s/&lt;/</g; s/&gt;/>/g;' > ${site}
 done
 
@@ -24,37 +24,37 @@ grep "^-.*" /tmp/daca_tmp_diff > /tmp/daca_tmp_minus
 
 
 
-plus_glob=`wc -l /tmp/daca_tmp_plus | cut -d' ' -f1`
+plus_glob=$(wc -l /tmp/daca_tmp_plus | cut -d' ' -f1)
 
-plus_error=`grep -c ":\ \(inconclusive\ \)\?error: "  /tmp/daca_tmp_plus`
-plus_warning=`grep -c ":\ \(inconclusive\ \)\?warning: "  /tmp/daca_tmp_plus`
-plus_style=`grep -c ":\ \(inconclusive\ \)\?style: "  /tmp/daca_tmp_plus`
-plus_performance=`grep -c ":\ \(inconclusive\ \)\?performance: "  /tmp/daca_tmp_plus`
-plus_portability=`grep -c ":\ \(inconclusive\ \)\?portability: "   /tmp/daca_tmp_plus`
-#plus_information=`grep -c "]: (information)"   /tmp/daca_tmp_plus`
-plus_crash=`grep -c "\ Crash?$" /tmp/daca_tmp_plus`
-plus_varid=`grep -c "called with varid 0\." /tmp/daca_tmp_plus`
-
-
-minus_glob=`wc -l /tmp/daca_tmp_minus | cut -d' ' -f1`
-
-minus_error=`grep -c ":\ \(inconclusive\ \)\?error: "  /tmp/daca_tmp_minus`
-minus_warning=`grep -c ":\ \(inconclusive\ \)\?warning: "  /tmp/daca_tmp_minus`
-minus_style=`grep -c ":\ \(inconclusive\ \)\?style: "  /tmp/daca_tmp_minus`
-minus_performance=`grep -c ":\ \(inconclusive\ \)\?performance: "  /tmp/daca_tmp_minus`
-minus_portability=`grep -c ":\ \(inconclusive\ \)\?portability: "   /tmp/daca_tmp_minus`
-#minus_information=`grep -c "]: (information)"   /tmp/daca_tmp_minus`
-minus_crash=`grep -c "\ Crash?$" /tmp/daca_tmp_minus`
-minus_varid=`grep -c "called with varid 0\." /tmp/daca_tmp_minus`
+plus_error=$(grep -c ":\ \(inconclusive\ \)\?error: "  /tmp/daca_tmp_plus)
+plus_warning=$(grep -c ":\ \(inconclusive\ \)\?warning: "  /tmp/daca_tmp_plus)
+plus_style=$(grep -c ":\ \(inconclusive\ \)\?style: "  /tmp/daca_tmp_plus)
+plus_performance=$(grep -c ":\ \(inconclusive\ \)\?performance: "  /tmp/daca_tmp_plus)
+plus_portability=$(grep -c ":\ \(inconclusive\ \)\?portability: "   /tmp/daca_tmp_plus)
+#plus_information=$(grep -c "]: (information)"   /tmp/daca_tmp_plus)
+plus_crash=$(grep -c "\ Crash?$" /tmp/daca_tmp_plus)
+plus_varid=$(grep -c "called with varid 0\." /tmp/daca_tmp_plus)
 
 
+minus_glob=$(wc -l /tmp/daca_tmp_minus | cut -d' ' -f1)
 
-files=`git ls-files`
+minus_error=$(grep -c ":\ \(inconclusive\ \)\?error: "  /tmp/daca_tmp_minus)
+minus_warning=$(grep -c ":\ \(inconclusive\ \)\?warning: "  /tmp/daca_tmp_minus)
+minus_style=$(grep -c ":\ \(inconclusive\ \)\?style: "  /tmp/daca_tmp_minus)
+minus_performance=$(grep -c ":\ \(inconclusive\ \)\?performance: "  /tmp/daca_tmp_minus)
+minus_portability=$(grep -c ":\ \(inconclusive\ \)\?portability: "   /tmp/daca_tmp_minus)
+#minus_information=$(grep -c "]: (information)"   /tmp/daca_tmp_minus)
+minus_crash=$(grep -c "\ Crash?$" /tmp/daca_tmp_minus)
+minus_varid=$(grep -c "called with varid 0\." /tmp/daca_tmp_minus)
 
-ID_stats=`awk '{ print $NF }' $files | grep "^\[.*\]$"  | sort -n | uniq --count | sort -n`
 
-echo "Update `date`" >> /tmp/daca_msg
-echo "Updated: `git status  --porcelain   | grep daca | cut -d' ' -f3 | sed s/daca2-// | sed s/\.html// | tr '\n' ' '`"  >> /tmp/daca_msg
+
+files=$(git ls-files)
+
+ID_stats=$(awk '{ print $NF }' $files | grep "^\[.*\]$"  | sort -n | uniq --count | sort -n)
+
+echo "Update $(date)" >> /tmp/daca_msg
+echo "Updated: $(git status  --porcelain   | grep daca | cut -d' ' -f3 | sed s/daca2-// | sed s/\.html// | tr '\n' ' ')"  >> /tmp/daca_msg
 echo "all:           new: $plus_glob   gone: $minus_glob =   $((plus_glob-minus_glob))" >> /tmp/daca_msg
 echo "error:         new: $plus_error   gone: $minus_error =   $((plus_error-minus_error))" >> /tmp/daca_msg
 echo "warning:       new: $plus_warning   gone: $minus_warning =   $((plus_warning-minus_warning))" >> /tmp/daca_msg

--- a/tools/extract_and_run_more_tests.sh
+++ b/tools/extract_and_run_more_tests.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-cd ~/cppcheck
+cd ~/cppcheck || exit 1
 rm -rf test1
 python tools/extracttests.py --code=test1 test/testleakautovar.cpp
-cd ~/cppcheck/test1
+cd ~/cppcheck/test1 || exit 1
 ~/cppcheck/tools/run_more_tests.sh
 

--- a/tools/run-coverity.sh
+++ b/tools/run-coverity.sh
@@ -15,7 +15,7 @@ curl --insecure \
   --form token=e74RRnWR6BVsn5LKdclfcA \
   --form email=daniel.marjamaki@gmail.com \
   --form file=@cppcheck.tgz \
-  --form version=`git log -1 --format=oneline | sed -r 's/([a-f0-9]{7}).*/\1/'` \
+  --form version=$(git log -1 --format=oneline | sed -r 's/([a-f0-9]{7}).*/\1/') \
   --form description="Development" \
   https://scan.coverity.com/builds?project=cppcheck
 

--- a/tools/run-coverity.sh
+++ b/tools/run-coverity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PATH=$PATH:/home/danielmarjamaki/cov-analysis-linux64-2019.03/bin
-cd /home/danielmarjamaki/cppcheck-devinfo
+cd /home/danielmarjamaki/cppcheck-devinfo || exit 1
 git pull
 
 echo Analyze

--- a/webreport.sh
+++ b/webreport.sh
@@ -10,7 +10,7 @@ mv coverage_report devinfo/
 doxygen 2> devinfo/doxygen-errors.txt
 mv doxyoutput/html devinfo/doxyoutput
 
-cd addons
+cd addons || exit 1
 doxygen cppcheckdata.doxyfile
 mv html ../devinfo/cppcheckdata
 cd ..


### PR DESCRIPTION
I excluded several warnings so we at least have a baseline to start with. These should all be enabled again.

Some of the findings might actually break the scripts if fixed so those need more work or suppressions.