### PR TITLE
Fix scratchpad translation on language change.

### DIFF
--- a/gui/cppcheck_de.ts
+++ b/gui/cppcheck_de.ts
@@ -22,7 +22,7 @@
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
         <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 Cppcheck-Team.</translation>
+        <translation>Copyright © 2007-%1 Cppcheck-Team.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>
@@ -2310,7 +2310,7 @@ Legen Sie unter dem Menü Ansicht fest, welche Arten von Fehlern angezeigt werde
     <message>
         <location filename="resultsview.ui" line="196"/>
         <source>Variables</source>
-        <translation type="unfinished"></translation>
+        <translation>Variablen</translation>
     </message>
     <message>
         <location filename="resultsview.ui" line="217"/>
@@ -2345,7 +2345,7 @@ Legen Sie unter dem Menü Ansicht fest, welche Arten von Fehlern angezeigt werde
     <message>
         <location filename="scratchpad.ui" line="37"/>
         <source>Optionally enter a filename (mainly for automatic language detection) and click on &quot;Check&quot;:</source>
-        <translation>Optional einen Dateinamen (hauptsächlich für automatische Spracherkennung) eingeben und auf &quot;Check&quot; klicken:</translation>
+        <translation>Optional einen Dateinamen (hauptsächlich für automatische Spracherkennung) eingeben und auf &quot;Prüfe&quot; klicken:</translation>
     </message>
     <message>
         <location filename="scratchpad.ui" line="71"/>

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1462,6 +1462,8 @@ void MainWindow::setLanguage(const QString &code)
         mLineEditFilter->setPlaceholderText(QCoreApplication::translate("MainWindow", "Quick Filter:"));
         if (mProjectFile)
             formatAndSetTitle(tr("Project:") + ' ' + mProjectFile->getFilename());
+        if (mScratchPad)
+            mScratchPad->translate();
     }
 }
 

--- a/gui/scratchpad.cpp
+++ b/gui/scratchpad.cpp
@@ -29,6 +29,11 @@ ScratchPad::ScratchPad(MainWindow& mainWindow)
     connect(mUI.mCheckButton, &QPushButton::clicked, this, &ScratchPad::checkButtonClicked);
 }
 
+void ScratchPad::translate()
+{
+    mUI.retranslateUi(this);
+}
+
 void ScratchPad::checkButtonClicked()
 {
     QString filename = mUI.lineEdit->text();

--- a/gui/scratchpad.h
+++ b/gui/scratchpad.h
@@ -35,6 +35,11 @@ class ScratchPad : public QDialog {
 public:
     explicit ScratchPad(MainWindow& mainWindow);
 
+    /**
+    * @brief Translate dialog
+    */
+    void translate();
+
 private slots:
     /**
     * @brief Called when check button is clicked.


### PR DESCRIPTION
Scratchpad UI translation function won't be called again if object already exists.
Therefore i added `translate()` member function and call it on language change.
Added/Fixed some German translations.
