### PR TITLE
Ticket #10028: Properly simplify auto variables' initialization.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7493,7 +7493,7 @@ Token * Tokenizer::initVar(Token * tok)
             return tok;
 
         tok = tok->next();
-    } else if (!tok->isStandardType() && tok->next()->str() != "*")
+    } else if (!tok->isStandardType() && tok->str() != "auto" && tok->next()->str() != "*")
         return tok;
 
     // goto variable name..

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -5013,6 +5013,9 @@ private:
               "}\n",
               true);
         ASSERT_EQUALS("", errout.str());
+
+        check("void foo() { int f = 0; auto g(f); g = g; }");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
This fixes an infinite recursion in ``CheckStl::checkMutexes`` by handling auto variables in ``Tokenizer::initVar``.