### PR TITLE
Fix library data platform type

### DIFF
--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -283,8 +283,7 @@ static CppcheckLibraryData::PlatformType loadPlatformType(QXmlStreamReader &xmlR
         if (type != QXmlStreamReader::StartElement)
             continue;
         const QString elementName = xmlReader.name().toString();
-        if (elementName == "unsigned" || elementName == "long" || elementName == "pointer" ||
-            elementName == "const_ptr" || elementName == "ptr_ptr") {
+        if (QStringList({"unsigned", "long", "pointer", "const_ptr", "ptr_ptr"}).contains(elementName)) {
             platformType.types.append(elementName);
         } else if (elementName == "platform") {
             platformType.platforms.append(xmlReader.attributes().value("type").toString());

--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -271,6 +271,30 @@ static CppcheckLibraryData::PodType loadPodType(const QXmlStreamReader &xmlReade
     return podtype;
 }
 
+static CppcheckLibraryData::PlatformType loadPlatformType(QXmlStreamReader &xmlReader)
+{
+    CppcheckLibraryData::PlatformType platformType;
+    platformType.name = xmlReader.attributes().value("name").toString();
+    platformType.value = xmlReader.attributes().value("value").toString();
+
+    QXmlStreamReader::TokenType type;
+    while ((type = xmlReader.readNext()) != QXmlStreamReader::EndElement ||
+           xmlReader.name().toString() != "platformtype") {
+        if (type != QXmlStreamReader::StartElement)
+            continue;
+        const QString elementName = xmlReader.name().toString();
+        if (elementName == "unsigned" || elementName == "long" || elementName == "pointer" ||
+            elementName == "const_ptr" || elementName == "ptr_ptr") {
+            platformType.types.append(elementName);
+        } else if (elementName == "platform") {
+            platformType.platforms.append(xmlReader.attributes().value("type").toString());
+        } else {
+            unhandledElement(xmlReader);
+        }
+    }
+    return platformType;
+}
+
 QString CppcheckLibraryData::open(QIODevice &file)
 {
     clear();
@@ -305,6 +329,8 @@ QString CppcheckLibraryData::open(QIODevice &file)
                     smartPointers.append(loadSmartPointer(xmlReader));
                 else if (elementName == "type-checks")
                     typeChecks.append(loadTypeChecks(xmlReader));
+                else if (elementName == "platformtype")
+                    platformTypes.append(loadPlatformType(xmlReader));
                 else
                     unhandledElement(xmlReader);
             } catch (std::runtime_error &e) {
@@ -545,6 +571,25 @@ static void writeTypeChecks(QXmlStreamWriter &xmlWriter, const CppcheckLibraryDa
     xmlWriter.writeEndElement();
 }
 
+static void writePlatformType (QXmlStreamWriter &xmlWriter, const CppcheckLibraryData::PlatformType &pt)
+{
+    xmlWriter.writeStartElement("platformtype");
+    xmlWriter.writeAttribute("name", pt.name);
+    xmlWriter.writeAttribute("value", pt.value);
+    foreach (const QString type, pt.types) {
+        xmlWriter.writeStartElement(type);
+        xmlWriter.writeEndElement();
+    }
+    foreach (const QString platform, pt.platforms) {
+        xmlWriter.writeStartElement("platform");
+        if (!platform.isEmpty()) {
+            xmlWriter.writeAttribute("type", platform);
+        }
+        xmlWriter.writeEndElement();
+    }
+    xmlWriter.writeEndElement();
+}
+
 QString CppcheckLibraryData::toString() const
 {
     QString outputString;
@@ -600,6 +645,10 @@ QString CppcheckLibraryData::toString() const
         xmlWriter.writeStartElement("smart-pointer");
         xmlWriter.writeAttribute("class-name", smartPtr);
         xmlWriter.writeEndElement();
+    }
+
+    foreach (const PlatformType &pt, platformTypes) {
+        writePlatformType(xmlWriter, pt);
     }
 
     xmlWriter.writeEndElement();

--- a/gui/cppchecklibrarydata.h
+++ b/gui/cppchecklibrarydata.h
@@ -171,6 +171,13 @@ public:
         QString sign;
     };
 
+    struct PlatformType {
+        QString name;
+        QString value;
+        QStringList types;      // Keeps element names w/o attribute (e.g. unsigned)
+        QStringList platforms;  // Keeps "type" attribute of each "platform" element
+    };
+
     using TypeChecks = QList<QPair<QString, QString>>;
 
     void clear() {
@@ -182,6 +189,7 @@ public:
         podtypes.clear();
         smartPointers.clear();
         typeChecks.clear();
+        platformTypes.clear();
     }
 
     void swap(CppcheckLibraryData &other) {
@@ -193,6 +201,7 @@ public:
         podtypes.swap(other.podtypes);
         smartPointers.swap(other.smartPointers);
         typeChecks.swap(other.typeChecks);
+        platformTypes.swap(other.platformTypes);
     }
 
     QString open(QIODevice &file);
@@ -204,6 +213,7 @@ public:
     QList<struct MemoryResource> memoryresource;
     QList<struct PodType> podtypes;
     QList<TypeChecks> typeChecks;
+    QList<struct PlatformType> platformTypes;
     QStringList undefines;
     QStringList smartPointers;
 };

--- a/gui/test/cppchecklibrarydata/files/memory_resource_unhandled_element.cfg
+++ b/gui/test/cppchecklibrarydata/files/memory_resource_unhandled_element.cfg
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<def format="2">
+  <memory>
+    <alloc init="false" buffer-size="malloc">malloc</alloc>
+	<!-- error: invalid element aloc -->
+    <aloc init="true" buffer-size="calloc">calloc</alloc>
+    <alloc init="false" buffer-size="malloc:2">aligned_alloc</alloc>
+    <realloc init="false" buffer-size="malloc:2">realloc</realloc>
+    <realloc init="false" buffer-size="calloc:2,3">reallocarray</realloc>
+    <dealloc>free</dealloc>
+  </memory>
+</def>

--- a/gui/test/cppchecklibrarydata/files/memory_resource_valid.cfg
+++ b/gui/test/cppchecklibrarydata/files/memory_resource_valid.cfg
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<def format="2">
+  <memory>	
+    <alloc init="false" buffer-size="malloc">malloc</alloc>
+    <alloc init="true" buffer-size="calloc">calloc</alloc>
+	<realloc init="false" buffer-size="malloc:2">realloc</realloc> 
+	<alloc arg="2">UuidToString</alloc>
+	<dealloc arg="3">HeapFree</dealloc>
+  </memory>
+
+  <resource>
+    <dealloc>fclose</dealloc>
+	<alloc init="true" arg="1">_wfopen_s</alloc>
+  </resource>
+</def>

--- a/gui/test/cppchecklibrarydata/files/platform_type_unhandled_element.cfg
+++ b/gui/test/cppchecklibrarydata/files/platform_type_unhandled_element.cfg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<def format="2">
+  <platformtype name="unhandled element" value="">
+    <!-- error: invalid element ptr --> 
+	<ptr/>
+	<platform type="win32"/>	
+  </platformtype>
+</def>

--- a/gui/test/cppchecklibrarydata/files/platform_type_valid.cfg
+++ b/gui/test/cppchecklibrarydata/files/platform_type_valid.cfg
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<def format="2">
+  <platformtype name="platform" value="with attribute and empty">
+    <platform type="win64"/>
+	<platform/>
+  </platformtype>
+  <platformtype name="types" value="all">
+    <unsigned/>
+    <long/>
+	<pointer/>
+	<const_ptr/>
+	<ptr_ptr/>
+  </platformtype> 
+  <platformtype name="types and platform" value="">        
+	<pointer/>
+	<platform type="win32"/>
+	<ptr_ptr/>
+  </platformtype>
+</def>

--- a/gui/test/cppchecklibrarydata/resources.qrc
+++ b/gui/test/cppchecklibrarydata/resources.qrc
@@ -9,5 +9,6 @@
         <file>files/platform_type_valid.cfg</file>
         <file>files/platform_type_unhandled_element.cfg</file>
         <file>files/memory_resource_unhandled_element.cfg</file>
+        <file>files/memory_resource_valid.cfg</file>
     </qresource>
 </RCC>

--- a/gui/test/cppchecklibrarydata/resources.qrc
+++ b/gui/test/cppchecklibrarydata/resources.qrc
@@ -6,5 +6,8 @@
         <file>files/typechecks_valid.cfg</file>
         <file>files/podtype_valid.cfg</file>
         <file>files/smartptr_valid.cfg</file>
+        <file>files/platform_type_valid.cfg</file>
+        <file>files/platform_type_unhandled_element.cfg</file>
+        <file>files/memory_resource_unhandled_element.cfg</file>
     </qresource>
 </RCC>

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -39,6 +39,14 @@ void TestCppcheckLibraryData::unhandledElement()
     loadCfgFile(":/files/unhandled_element.cfg", fileLibraryData, result);
     QCOMPARE(result.isNull(), false);
     qDebug() << result;
+
+    loadCfgFile(":/files/platform_type_unhandled_element.cfg", fileLibraryData, result);
+    QCOMPARE(result.isNull(), false);
+    qDebug() << result;
+
+    loadCfgFile(":/files/memory_resource_unhandled_element.cfg", fileLibraryData, result);
+    QCOMPARE(result.isNull(), false);
+    qDebug() << result;
 }
 
 void TestCppcheckLibraryData::mandatoryAttributeMissing()
@@ -134,11 +142,8 @@ void TestCppcheckLibraryData::typechecksValid()
     for (int idx=0; idx < libraryData.typeChecks.size(); idx++) {
         CppcheckLibraryData::TypeChecks lhs = libraryData.typeChecks[idx];
         CppcheckLibraryData::TypeChecks rhs = fileLibraryData.typeChecks[idx];
-        QCOMPARE(lhs.size(), lhs.size());
-        for (int num=0; num < lhs.size(); num++) {
-            QCOMPARE(lhs[num].first, rhs[num].first);
-            QCOMPARE(lhs[num].second, rhs[num].second);
-        }
+        QCOMPARE(lhs.size(), rhs.size());
+        QCOMPARE(lhs, rhs);
     }
 }
 
@@ -171,8 +176,64 @@ void TestCppcheckLibraryData::smartPointerValid()
     // Verify no data got lost or modified
     QCOMPARE(libraryData.smartPointers.size(), fileLibraryData.smartPointers.size());
     QCOMPARE(libraryData.smartPointers.size(), 3);
-    for (int i=0; i < libraryData.smartPointers.size(); i++) {
-        QCOMPARE(libraryData.smartPointers[i], fileLibraryData.smartPointers[i]);
+    QCOMPARE(libraryData.smartPointers, fileLibraryData.smartPointers);
+}
+
+void TestCppcheckLibraryData::platformTypeValid()
+{
+    // Load library data from file
+    loadCfgFile(":/files/platform_type_valid.cfg", fileLibraryData, result);
+    QCOMPARE(result.isNull(), true);
+
+    // Swap libray data read from file to other object
+    libraryData.swap(fileLibraryData);
+
+    // Do size and content checks against swapped data.
+    QCOMPARE(libraryData.platformTypes.size(), 3);
+
+    QCOMPARE(libraryData.platformTypes[0].name, "platform");
+    QCOMPARE(libraryData.platformTypes[0].value, "with attribute and empty");
+    QCOMPARE(libraryData.platformTypes[0].types.size(), 0);
+    QCOMPARE(libraryData.platformTypes[0].platforms.size(), 2);
+    QCOMPARE(libraryData.platformTypes[0].platforms[0], "win64");
+    QCOMPARE(libraryData.platformTypes[0].platforms[1].isEmpty(), true);
+
+    QCOMPARE(libraryData.platformTypes[1].name, "types");
+    QCOMPARE(libraryData.platformTypes[1].value, "all");
+    QCOMPARE(libraryData.platformTypes[1].types.size(), 5);
+    QCOMPARE(libraryData.platformTypes[1].types,
+            QStringList({"unsigned", "long", "pointer", "const_ptr", "ptr_ptr"}));
+    QCOMPARE(libraryData.platformTypes[1].platforms.isEmpty(), true);
+
+    QCOMPARE(libraryData.platformTypes[2].name, "types and platform");
+    QCOMPARE(libraryData.platformTypes[2].value.isEmpty(), true);
+    QCOMPARE(libraryData.platformTypes[2].types.size(), 2);
+    QCOMPARE(libraryData.platformTypes[2].types, QStringList({"pointer", "ptr_ptr"}));
+    QCOMPARE(libraryData.platformTypes[2].platforms.size(), 1);
+    QCOMPARE(libraryData.platformTypes[2].platforms[0], "win32");
+
+    // Save library data to file
+    saveCfgFile(TempCfgFile, libraryData);
+
+    fileLibraryData.clear();
+    QCOMPARE(fileLibraryData.platformTypes.size(), 0);
+
+    // Reload library data from file
+    loadCfgFile(TempCfgFile, fileLibraryData, result, true);
+    QCOMPARE(result.isNull(), true);
+
+    // Verify no data got lost or modified
+    QCOMPARE(libraryData.platformTypes.size(), fileLibraryData.platformTypes.size());
+    QCOMPARE(libraryData.platformTypes.size(), 3);
+    for (int idx=0; idx < libraryData.platformTypes.size(); idx++) {
+        CppcheckLibraryData::PlatformType lhs = libraryData.platformTypes[idx];
+        CppcheckLibraryData::PlatformType rhs = fileLibraryData.platformTypes[idx];
+        QCOMPARE(lhs.name, rhs.name);
+        QCOMPARE(lhs.value, rhs.value);
+        QCOMPARE(lhs.types.size(), rhs.types.size());
+        QCOMPARE(lhs.types, rhs.types);
+        QCOMPARE(lhs.platforms.size(), rhs.platforms.size());
+        QCOMPARE(lhs.platforms, rhs.platforms);
     }
 }
 

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -33,6 +33,7 @@ private slots:
     void typechecksValid();
     void smartPointerValid();
     void platformTypeValid();
+    void memoryResourceValid();
 
 private:
     void loadCfgFile(QString filename, CppcheckLibraryData &data, QString &result, bool removeFile = false);

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -32,6 +32,7 @@ private slots:
     void podtypeValid();
     void typechecksValid();
     void smartPointerValid();
+    void platformTypeValid();
 
 private:
     void loadCfgFile(QString filename, CppcheckLibraryData &data, QString &result, bool removeFile = false);


### PR DESCRIPTION
Add missing `platformtype` support (windows.cfg) to avoid configuration file load error.
Modify tests, add tests.