### PR TITLE
Add how to install pcre by using homebrew

### DIFF
--- a/build-pcre.txt
+++ b/build-pcre.txt
@@ -59,10 +59,18 @@ Mac OSX
 
 Install PCRE:
 
+homebre
+  brew install pcre
+
+or macport
   sudo port install pcre
 
 Ensure /path/to/pcre.h is in CXXFLAGS, e.g:
 
+for homebrew
+  export CXXFLAGS=${CXXFLAGS}:/usr/local/include
+
+or macport
   export CXXFLAGS=${CXXFLAGS}:/opt/local/include
 
 Or for MSVC copy pcre.lib and pcre.h in /externals directory.


### PR DESCRIPTION
Previously macport is famous on macOS. but these days,
homebrew is more famous and popular than macport.
So I add how to install pcre by using homwbrew.
That's all