### PR TITLE
donate-cpu-server.py: fixed daca crash report

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -22,7 +22,7 @@ import operator
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.9"
+SERVER_VERSION = "1.3.10"
 
 OLD_VERSION = '2.3'
 
@@ -186,7 +186,7 @@ def crashReport(results_path: str) -> str:
                         break
                 if line.find(' received signal ') != -1:
                     crash_line = next(file_, '').strip()
-                    location_index = crash_line.rindex(' at ')
+                    location_index = crash_line.rfind(' at ')
                     if location_index > 0:
                         code_line = next(file_, '').strip()
                         stack_trace = []


### PR DESCRIPTION
`rindex()` raises an exception when the substring is not found - `rfind()` returns -1.

Fixes `ERR_CONNECTION_RESET` error when currently trying to view the crash report.