### PR TITLE
fix NAME_MAX not found on macOS GCC8.1

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <limits.h>
 
 #ifdef _WIN32
 


### PR DESCRIPTION
add `limits.h` header file to `filelister.cpp`