### PR TITLE
travis_suppressions: Remove some temporary suppressions

### DIFF
--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -6,8 +6,6 @@ functionStatic
 bitwiseOnBoolean
 
 # temporary suppressions - fix the warnings!
-missingOverride
-unusedPrivateFunction:lib/checkbufferoverrun.h
 unusedPrivateFunction:test/test*.cpp
 useStlAlgorithm
 


### PR DESCRIPTION
There are no such warnings any longer, so lets remove them.