### PR TITLE
Fix crash in checkclass.cpp

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -170,7 +170,7 @@ void CheckClass::constructors()
                 if (usage[count].assign || usage[count].init || var.isStatic())
                     continue;
 
-                if (var.valueType()->pointer == 0 && var.type() && var.type()->needInitialization == Type::NeedInitialization::False && var.type()->derivedFrom.empty())
+                if (var.valueType() && var.valueType()->pointer == 0 && var.type() && var.type()->needInitialization == Type::NeedInitialization::False && var.type()->derivedFrom.empty())
                     continue;
 
                 if (var.isConst() && func.isOperator()) // We can't set const members in assignment operator


### PR DESCRIPTION
Spotted  by daca:
http://cppcheck1.osuosl.org:8000/kactivities-stats

```
2021-01-26 16:31
ftp://ftp.de.debian.org/debian/pool/main/k/kactivities-stats/kactivities-stats_5.78.0.orig.tar.xz
cppcheck-options: --library=posix --library=gnu --library=boost --library=qt -j1 --showtime=top5 --check-library --inconclusive --enable=style,information --template=daca2 -rp=temp -D__GNUC__ --platform=unix64 temp
platform: Linux-4.4.180-102-default-x86_64-with-SuSE-42.3-x86_64
python: 3.4.6
client-version: 1.3.7
cppcheck: head 2.3
head-info: 987c8a854 (2021-01-25 22:51:50 +0100)
count: Crash! Crash!
elapsed-time: -11.0 -11.0
head-timing-info:

old-timing-info:

head results:
Checking temp/kactivities-stats-5.78.0/src/resultwatcher.cpp: __GNUC__=1...

Program received signal SIGSEGV, Segmentation fault.
0x00000000004c5e03 in CheckClass::constructors (this=this@entry=0x7fffffffbbc0) at build/checkclass.cpp:1387
1387	                if (var.valueType()->pointer == 0 && var.type() && var.type()->needInitialization == Type::NeedInitialization::False && var.type()->derivedFrom.empty())
 #0  0x00000000004c5e03 in CheckClass::constructors (this=this@entry=0x7fffffffbbc0) at build/checkclass.cpp:1387
 #1  0x00000000004cc7eb in CheckClass::runChecks (this=<optimized out>, tokenizer=<optimized out>, settings=<optimized out>, errorLogger=<optimized out>) at lib/checkclass.h:66
 #2  0x000000000058a0d8 in CppCheck::checkNormalTokens (this=this@entry=0x7fffffffd2a0, tokenizer=...) at build/cppcheck.cpp:968
 #3  0x00000000005909f9 in CppCheck::checkFile (this=this@entry=0x7fffffffd2a0, filename=..., cfgname=..., fileStream=...) at build/cppcheck.cpp:769
 #4  0x0000000000594769 in CppCheck::check (this=this@entry=0x7fffffffd2a0, path=...) at build/cppcheck.cpp:409
 #5  0x0000000000727b7d in CppCheckExecutor::check_internal (this=0x7fffffffdfc0, cppcheck=..., argv=<optimized out>) at cli/cppcheckexecutor.cpp:923
 #6  0x0000000000728f0d in CppCheckExecutor::check (this=this@entry=0x7fffffffdfc0, argc=argc@entry=16, argv=argv@entry=0x7fffffffe348) at cli/cppcheckexecutor.cpp:232
 #7  0x000000000047fe87 in main (argc=16, argv=0x7fffffffe348) at cli/main.cpp:95

DONE
```