### PR TITLE
fixed #9965: handle template function names properly in stack trace o…

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -24,7 +24,7 @@ import html as html_lib
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.13"
+SERVER_VERSION = "1.3.14"
 
 OLD_VERSION = '2.3'
 
@@ -199,12 +199,12 @@ def crashReport(results_path: str) -> str:
                         if not l.strip():
                             break
                         # #0  0x00007ffff71cbf67 in raise () from /lib64/libc.so.6
-                        m = re.search(r'(?P<number>#\d+) .* (?P<function>.+)\(.*\) from (?P<binary>.*)$', l)
+                        m = re.search(r'(?P<number>#\d+) .* in (?P<function>.+)\(.*\) from (?P<binary>.*)$', l)
                         if m:
                             stack_trace.append(m.group('number') + ' ' + m.group('function') + '(...) from ' + m.group('binary'))
                             continue
                         # #11 0x00000000006f2414 in valueFlowNumber (tokenlist=tokenlist@entry=0x7fffffffc610) at build/valueflow.cpp:2503
-                        m = re.search(r'(?P<number>#\d+) .* (?P<function>.+)\(.*\) at (?P<location>.*)$', l)
+                        m = re.search(r'(?P<number>#\d+) .* in (?P<function>.+)\(.*\) at (?P<location>.*)$', l)
                         if m:
                             stack_trace.append(m.group('number') + ' ' + m.group('function') + '(...) at ' + m.group('location'))
                             continue

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -637,7 +637,7 @@ def timeReport(resultPath: str, show_gt: bool) -> str:
     html = '<html><head><title>{}</title></head><body>\n'.format(title)
     html += '<h1>{}</h1>\n'.format(title)
     html += '<pre>\n'
-    column_width = [40, 10, 10, 10, 10]
+    column_width = [40, 10, 10, 10, 10, 10]
     html += '<b>'
     html += fmt('Package', 'Date       Time', OLD_VERSION, 'Head', 'Factor', link=False, column_width=column_width)
     html += '</b>\n'
@@ -710,6 +710,7 @@ def timeReport(resultPath: str, show_gt: bool) -> str:
         total_time_factor = 0.0
     html += 'Time for all packages (not just the ones listed above):\n'
     html += fmt('Total time:',
+            '',
             '{:.1f}'.format(total_time_base),
             '{:.1f}'.format(total_time_head),
             '{:.2f}'.format(total_time_factor), link=False, column_width=column_width)


### PR DESCRIPTION
…verview of daca crash report

Fixes incomplete function names like
```
#7 int> (...) at /usr/include/c++/4.8/ext/string_conversions.h:70
```

Also includes a fix for the time report which is completely broken now - sorry for not testing it properly.