### PR TITLE
Remove unnecessary use-retval from wxString::erase

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -8302,7 +8302,6 @@
   <function name="wxString::erase">
     <noreturn>false</noreturn>
     <leak-ignore/>
-    <use-retval/>
     <arg nr="1" direction="in" default="0">
       <not-uninit/>
       <not-bool/>


### PR DESCRIPTION
I could see use-retval potentially making since in a loop if I'm using the iterator version, but using the version that returns a ref to itself there's no reason to use that return value.

Simple example that reproduces this:
```c++
int main()
{
  wxString str = GetString();
  if (str.size() > 2)
    str.erase(0, 2);

  return str.size();
}
```

Output:
```
cppcheck.exe --enable=all --inconclusive --library=wxwidgets.cfg test.cpp
Checking test.cpp ...
test.cpp:5:9: warning: Return value of function str.erase() is not used. [ignoredReturnValue]
    str.erase(0, 2);
        ^
```