### PR TITLE
fix hangs from poor type lookup of base classes in derived classes

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3059,7 +3059,11 @@ const Token *Type::initBaseInfo(const Token *tok, const Token *tok1)
             base.type = classScope->check->findType(base.nameTok, classScope);
 
             // save pattern for base class name
-            derivedFrom.push_back(base);
+            if (base.type != this)
+                derivedFrom.push_back(base);
+            else if (base.name != name())
+                if (classScope && classScope->check)
+                   classScope->check-> debugMessage(base.nameTok, "debug", "Type::initBaseInfo found same type with different names");
         } else
             tok2 = tok2->next();
     }


### PR DESCRIPTION
Cppcheck is inconsistent in handling the lookoup of uninstantiated
template types and their scopes.  Sometimes the template parameters are
taken into account and sometimes they are ignored. This can cause a
circular dependency when a template type is derived from itself with
different parameters.

This patch prevents an incorrect type lookup from causing a hang. I does
not fix the underlying problem of how uninstantiated template types are
represented and looked up.  That requires auditing a lot of code and
determining the best way to address this problem.