### PR TITLE
Fixed regression breaking support for Apple's C language extension

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10133,7 +10133,7 @@ void Tokenizer::findGarbageCode() const
             std::string code;
             if (Token::Match(tok->next(), ")|]|}"))
                 code = tok->str() + tok->next()->str();
-            if (Token::simpleMatch(tok->next(), "( )"))
+            if (Token::simpleMatch(tok->next(), "( )") && tok->str() != "^")
                 code = tok->str() + "()";
             if (!code.empty()) {
                 if (isC() || (tok->str() != ">" && !Token::simpleMatch(tok->previous(), "operator")))

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -1263,6 +1263,7 @@ private:
                                            "inline CImg<T> operator==(const char *const expression, const CImg<T>& img) {"
                                            "  return img == expression;"
                                            "}"));
+        ASSERT_EQUALS("f ( source , asm ( \"^(){somecode}\" ) ) ;", tokenizeAndStringify("f(source, ^(){somecode});"));
     }
 
     void ifAddBraces1() {


### PR DESCRIPTION
After upgrade from 1.88 to 2.3, we noticed that the cppcheck started reporting syntax errors on [Blocks](https://en.wikipedia.org/wiki/Blocks_(C_language_extension)) code. For example:
```
main.cpp:31:51: error: syntax error: ^() [syntaxError]
        dispatch_source_set_event_handler(source, ^() {
                                                  ^
```
The syntax here is from Apple's C language extension, which is completely valid.

It looks like 382f21a5c926368dadb4be769c4dd238b83421cb is the commit which caused this regression. It appears that since 2.1 release, syntax validation happens before asm token simplification.

The only workaround I found is to put `void` inside the brackets, which keeps cppcheck happy:
```c++
dispatch_source_set_event_handler(source, ^(void) {
```

Thanks to @PKEuS recommendation, we manage to fix this issue by adding extra check.
When recompiled the 2.3 with this patch all worked like a charm.

I hope this fix can become a part of 2.4 release.

Apologies for not creating the matching unit test but don't know enough about cppcheck to create valid test case.