### PR TITLE
minor simplifyUsing optimizations

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -559,6 +559,9 @@ Token *Tokenizer::processFunc(Token *tok2, bool inOperator) const
 
 void Tokenizer::simplifyUsingToTypedef()
 {
+    if (!isCPP() || mSettings->standards.cpp < Standards::CPP11)
+        return;
+
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         // using a::b;  =>   typedef  a::b  b;
         if ((Token::Match(tok, "[;{}] using %name% :: %name% ::|;") && !tok->tokAt(2)->isKeyword()) ||
@@ -2180,6 +2183,9 @@ static bool scopesMatch(const std::string &scope1, const std::string &scope2, co
 
 bool Tokenizer::simplifyUsing()
 {
+    if (!isCPP() || mSettings->standards.cpp < Standards::CPP11)
+        return false;
+
     bool substitute = false;
     ScopeInfo3 scopeInfo;
     ScopeInfo3 *currentScope = &scopeInfo;
@@ -2325,7 +2331,7 @@ bool Tokenizer::simplifyUsing()
         const ScopeInfo3 * memberFuncScope = nullptr;
         const Token * memberFuncEnd = nullptr;
         bool skip = false; // don't erase type aliases we can't parse
-        for (Token* tok1 = startToken; tok1 && tok1 != endToken; tok1 = tok1->next()) {
+        for (Token* tok1 = startToken; !skip && tok1 && tok1 != endToken; tok1 = tok1->next()) {
             if ((Token::Match(tok1, "{|}|namespace|class|struct|union") && tok1->strAt(-1) != "using") ||
                 Token::Match(tok1, "using namespace %name% ;|::")) {
                 setScopeInfo(tok1, &currentScope1);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1831,7 +1831,7 @@ namespace {
 
         const ScopeInfo3 * findInChildren(const std::string & scope) const {
             for (const auto & child : children) {
-                if (child.name == scope || child.fullName == scope)
+                if (child.type == Record && (child.name == scope || child.fullName == scope))
                     return &child;
                 else {
                     const ScopeInfo3 * temp = child.findInChildren(scope);

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -66,6 +66,7 @@ private:
         TEST_CASE(simplifyUsing17);
         TEST_CASE(simplifyUsing18);
         TEST_CASE(simplifyUsing19);
+        TEST_CASE(simplifyUsing20);
 
         TEST_CASE(simplifyUsing8970);
         TEST_CASE(simplifyUsing8971);
@@ -473,6 +474,50 @@ private:
                             "   using b = float;\n"
                             "}\n"
                             "}";
+        tok(code, false); // don't hang
+    }
+
+    void simplifyUsing20() {
+        const char code[] = "namespace a {\n"
+                            "namespace b {\n"
+                            "namespace c {\n"
+                            "namespace d {\n"
+                            "namespace e {\n"
+                            "namespace f {\n"
+                            "namespace g {\n"
+                            "using Changeset = ::IAdaptionCallback::Changeset;\n"
+                            "using EProperty = searches::EProperty;\n"
+                            "using ChangesetValueType = Changeset::value_type;\n"
+                            "namespace {\n"
+                            "   template <class T>\n"
+                            "   auto modify(std::shared_ptr<T>& p) -> boost::optional<decltype(p->modify())> {\n"
+                            "      return nullptr;\n"
+                            "   }\n"
+                            "   template <class T>\n"
+                            "   std::list<T> getValidElements() {\n"
+                            "      return nullptr;\n"
+                            "   }\n"
+                            "}\n"
+                            "std::shared_ptr<ResourceConfiguration>\n"
+                            "foo::getConfiguration() {\n"
+                            "   return nullptr;\n"
+                            "}\n"
+                            "void\n"
+                            "foo::doRegister(const Input & Input) {\n"
+                            "   UNUSED( Input );\n"
+                            "}\n"
+                            "foo::MicroServiceReturnValue\n"
+                            "foo::post(SearchesPtr element, const Changeset& changeset)\n"
+                            "{\n"
+                            "   using EProperty = ab::ep;\n"
+                            "   static std::map<EProperty, std::pair<ElementPropertyHandler, CheckComponentState>> updateHandlers =\n"
+                            "   {\n"
+                            "      {EProperty::Needle, {&RSISearchesResource::updateNeedle,         &RSISearchesResource::isSearcherReady}},\n"
+                            "      {EProperty::SortBy, {&RSISearchesResource::updateResultsSorting, &RSISearchesResource::isSearcherReady}}\n"
+                            "   };\n"
+                            "   return nullptr;\n"
+                            "}\n"
+                            "}}}}}}}";
         tok(code, false); // don't hang
     }
 


### PR DESCRIPTION
The using type aliases are a C++ 11 feature so only check for them in
C++ 11 or later.

Don't try to simplify a type alias when it can't be parsed.