### PR TITLE
added docker builds for legacy/cutting edge platforms

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -1,0 +1,86 @@
+# Syntax reference https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# Environment reference https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+name: CI-unixish-docker
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        image: ["centos:7", "ubuntu:14.04", "ubuntu:21.04"]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ubuntu-20.04
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install missing software on CentOS 7
+        if: matrix.image == 'centos:7'
+        run: |
+          yum install -y cmake gcc-c++ make
+          yum install -y pcre-devel
+
+      - name: Install missing software on ubuntu
+        if: matrix.image != 'centos:7'
+        run: |
+          apt-get update
+          apt-get install -y cmake g++ make
+          apt-get install -y libpcre3-dev
+
+      # tests require CMake 3.4
+      - name: Test CMake build (no tests)
+        if: matrix.image != 'ubuntu:21.04'
+        run: |
+          mkdir cmake.output
+          cd cmake.output
+          cmake -G "Unix Makefiles" -DHAVE_RULES=On ..
+          make -j$(nproc)
+          cd ..
+
+      - name: Test CMake build
+        if: matrix.image == 'ubuntu:21.04'
+        run: |
+          mkdir cmake.output
+          cd cmake.output
+          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On ..
+          make -j$(nproc) check
+          cd ..
+
+      - name: Build cppcheck
+        run: |
+          make clean
+          make -j$(nproc) HAVE_RULES=yes
+
+      - name: Build test
+        run: |
+          make -j$(nproc) testrunner HAVE_RULES=yes
+
+      - name: Run test
+        run: |
+          make -j$(nproc) check HAVE_RULES=yes
+
+      - name: Test addons
+        run: |
+          ./cppcheck --addon=threadsafety addons/test/threadsafety
+          ./cppcheck --addon=threadsafety --std=c++03 addons/test/threadsafety
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cppcheck_cli
+          path: ./cppcheck
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cppcheck_cli
+          path: ./**/cfg/*.cfg
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cppcheck_cli
+          path: ./**/platforms/*.xml

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           mkdir cmake.output
           cd cmake.output
-          cmake -G "Unix Makefiles" -DBUILD_TESTS=On ..
+          cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On ..
           make -j$(nproc) check
           cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,17 +172,6 @@ matrix:
         - make -s dmake -j$(nproc)
         - make -s run-dmake
         - git diff --exit-code
-# check if cppcheck builds on trusty
-    - name: "make ubuntu 14.04 trusty"
-      compiler: gcc
-      dist: trusty
-      before_install:
-        - travis_retry sudo apt-get update -qq
-        - travis_retry sudo apt-get install libxml2-utils libpcre3
-      script:
-        - CXX=g++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck check -j$(nproc) -s
-        - make clean
-        - CXX=clang++ CXXFLAGS="${ORIGINAL_CXXFLAGS}" make cppcheck check -j $(nproc) -s
 
 script:
 # fail the entire job as soon as one of the subcommands exits non-zero to save time and resources


### PR DESCRIPTION
I omitted z3 from the docker builds for now and removed the build-agnostic validate step for now. There's more CI refactorings/cleanups coming which address that.

At some point we might also be able to merge the actual steps of `CI-unixish.yml` and `CI-unixish-docker.yml`