### PR TITLE
donate_cpu_lib.py: reduced daca timeout to 1800 seconds

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,10 +15,10 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.7"
+CLIENT_VERSION = "1.3.8"
 
 # Timeout for analysis with Cppcheck in seconds
-CPPCHECK_TIMEOUT = 60 * 60
+CPPCHECK_TIMEOUT = 30 * 60
 
 # Return code that is used to mark a timed out analysis
 RETURN_CODE_TIMEOUT = -999


### PR DESCRIPTION
The additional report I added in https://github.com/danmar/cppcheck/pull/3139 shows the following:

```
Time report (slowest)
Package                                  Date        Time     2.3    Head 
kfreebsd-11                              2021-02-18 01:29  3600.1  3254.1
ngspice                                  2021-02-18 16:46  3344.1  2927.0
openjdk-11                               2021-02-18 19:04  2963.2  2770.4
mrboom                                   2021-02-18 14:12  2769.3  2724.7
zvmcloudconnector                        2021-02-16 17:56    10.3  2705.0
votca-xtp                                2021-02-16 13:34  1313.1  2649.8
blender                                  2021-02-16 23:48  2817.8  2529.1
wine-gecko-2.24                          2021-02-16 15:37  2577.1  2366.3
samba                                    2021-02-20 01:28  2434.5  2333.4
niceshaper                               2021-02-18 15:40     3.4  2306.8
pythonqt                                 2021-02-19 09:58  3077.5  2225.8
rnahybrid                                2021-02-19 21:38   278.1  2222.0
root-system                              2021-02-19 22:29  2583.6  2163.5
ukui-menu                                2021-02-16 11:42   818.8  2113.0
libntlm                                  2021-02-18 08:13  3600.0  2079.0
libsbml                                  2021-02-18 09:40  3600.1  1999.1
httrack                                  2021-02-17 21:00   160.5  1970.7
qemu                                     2021-02-19 11:07  2026.4  1891.1
ergo                                     2021-02-17 12:52  3600.2  1797.3
symmetrica                               2021-02-16 07:50  3242.0  1787.8
foobillardplus                           2021-02-17 14:26  1029.5  1779.8
gauche                                   2021-02-17 15:39  1073.4  1730.8
mirrormagic                              2021-02-18 11:57   260.9  1636.7
libpreludedb                             2021-02-18 08:09  1861.6  1626.8
faumachine                               2021-02-17 12:42  1390.1  1601.8
aflplusplus                              2021-02-16 18:26   486.6  1576.5
flint                                    2021-02-17 13:46  1585.7  1560.5
webkit2gtk                               2021-02-16 14:19  1512.3  1460.4
opencascade                              2021-02-18 17:48  1476.5  1398.7
openjfx                                  2021-02-18 18:41  1646.2  1359.8
re2c                                     2021-02-19 20:45  2713.5  1324.2
godot                                    2021-02-17 17:59  1485.9  1314.0
qgis                                     2021-02-19 10:40   779.2  1284.6
spatialite-tools                         2021-02-20 07:10    10.4  1244.9
indelible                                2021-02-17 22:26  3600.1  1234.9
mesa                                     2021-02-18 11:57  2120.4  1194.0
mongodb                                  2021-02-18 12:47  1556.9  1148.1
suitesparse                              2021-02-16 06:21  3600.1  1130.4
wpewebkit                                2021-02-16 15:54  1531.2  1112.8
openmm                                   2021-02-18 18:33   570.6  1022.7
libunistring                             2021-02-18 09:21  1087.6   996.0
ffmpeg                                   2021-02-17 12:38   857.3   966.3
libtgowt                                 2021-02-18 09:14  1248.0   912.9
onednn                                   2021-02-18 17:19   941.2   900.1
photoflow                                2021-02-18 23:51   800.9   895.2
psi4                                     2021-02-19 05:38   671.2   894.4
prodigal                                 2021-02-19 04:50   500.2   828.3
firebird3.0                              2021-02-17 12:43   728.3   800.0
crawl                                    2021-02-17 08:11  1485.2   796.4
vtk6                                     2021-02-16 13:14   910.4   781.9
zapping                                  2021-02-16 17:25   769.1   771.6
efl                                      2021-02-17 11:06   847.8   718.0
gambc                                    2021-02-17 15:11   684.5   689.3
gocr                                     2021-02-17 17:44  1288.2   682.5
insighttoolkit                           2021-02-17 22:29  3600.0   669.2
libsass                                  2021-02-18 08:29   817.8   663.9
libqalculate                             2021-02-18 07:34   257.2   657.5
openjdk-11-jre-dcevm                     2021-02-18 17:52   620.4   641.1
visualboyadvance                         2021-02-16 12:40  1491.5   639.3
lammps                                   2021-02-18 02:24  2098.2   635.2
android-platform-art                     2021-02-16 19:10  1712.5   634.3
intelrdfpmath                            2021-02-17 22:01   420.8   620.8
bibledit-cloud                           2021-02-16 20:36   103.1   618.3
libwpd                                   2021-02-18 09:22   412.2   617.4
imagemagick                              2021-02-17 21:14   362.4   606.8
snd                                      2021-02-20 05:25  1018.6   605.4
dart                                     2021-02-17 08:55   227.9   595.3
simbody                                  2021-02-20 04:03   338.9   594.0
gmic                                     2021-02-17 16:51   797.6   578.7
postgresql-9.6                           2021-02-19 02:19   708.2   564.9
quantlib                                 2021-02-15 18:11   493.8   559.9
webkitgtk                                2021-02-16 14:08  1774.9   555.8
gnulib                                   2021-02-17 17:24   729.4   529.6
mldemos                                  2021-02-18 11:52   242.1   524.6
quickfix                                 2021-02-19 16:41  3600.1   521.5
fossil                                   2021-02-17 13:58    89.2   521.3
aom                                      2021-02-16 18:57    81.0   507.3
libreoffice                              2021-02-18 08:11   809.7   501.9
goo                                      2021-02-17 19:12  2491.9   495.8
bpfcc                                    2021-02-16 23:35   493.3   492.8
vxl                                      2021-02-16 13:26   507.2   491.0
indigo                                   2021-02-17 21:19   268.2   489.4
mozjs60                                  2021-02-18 12:30   574.4   466.0
renderdoc                                2021-02-19 20:44   497.8   449.8
openbabel                                2021-02-18 18:04  3600.1   449.6
afnix                                    2021-02-16 18:05   306.2   435.8
itksnap                                  2021-02-17 22:43   103.8   430.3
socnetv                                  2021-02-20 05:18   388.9   427.8
inkscape                                 2021-02-17 21:33   619.7   427.1
berkeley-abc                             2021-02-16 20:31   567.2   427.0
searchandrescue                          2021-02-20 02:28    23.4   416.9
openttd                                  2021-02-18 19:37   726.3   415.4
rbdoom3bfg                               2021-02-19 19:23  1529.1   403.4
alliance                                 2021-02-16 18:25   334.2   403.1
flint-arb                                2021-02-17 13:06   404.2   401.4
libdfp                                   2021-02-18 05:08   256.4   399.4
bibledit                                 2021-02-16 20:32    88.3   398.6
texlive-bin                              2021-02-16 08:19   577.6   397.6
bandage                                  2021-02-16 20:22   808.8   392.9
cegui-mk2                                2021-02-17 01:38   796.1   390.2
```

As you can see there is not a lot of packages which take longer than 1800 seconds (beside those which already timeout) so I think adding an whole hour of run-time for packages timeouts isn't justified. We might even want to lower the timeout.