### PR TITLE
removed 32-bit Appveyor builds and sped up cygwin build a bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ test_script:
   - python -m pytest test-inline-suppress.py
   - python -m pytest test-proj2.py
   - python -m pytest test-suppress-syntaxError.py
-  - 'IF defined cygwin_build C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cppcheck && make clean && make -j 2 && make test && make checkcfg"'
+  - 'IF defined cygwin_build C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cppcheck && make clean && make -j 2 test checkcfg"'
 
 artifacts:
   - path: bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,17 +8,6 @@ matrix:
 environment:
   matrix:
     - VisualStudioVersion: 12.0
-      platform: Win32
-      configuration: Debug
-      vcvarsall_platform: x86
-      PlatformToolset: v120
-    - VisualStudioVersion: 12.0
-      platform: Win32
-      configuration: Release
-      vcvarsall_platform: x86
-      PlatformToolset: v120
-      MYQTDIR: C:\Qt\5.6\msvc2013
-    - VisualStudioVersion: 12.0
       platform: x64
       configuration: Debug
       vcvarsall_platform: x64
@@ -31,17 +20,6 @@ environment:
       PlatformToolset: v120
       MYQTDIR: C:\Qt\5.6\msvc2013_64
 # FIXME: These are disabled for now. They were broken by ae8653612802b41b70424ec9a5eefe8a1178f6d1
-#    - VisualStudioVersion: 14.0
-#      platform: Win32
-#      configuration: Debug
-#      vcvarsall_platform: x86
-#      PlatformToolset: v140
-#    - VisualStudioVersion: 14.0
-#      platform: Win32
-#      configuration: Release
-#      vcvarsall_platform: x86
-#      PlatformToolset: v140
-#      MYQTDIR: C:\Qt\5.11\msvc2015
 #    - VisualStudioVersion: 14.0
 #      platform: x64
 #      configuration: Debug
@@ -58,8 +36,7 @@ environment:
 install:
   - python -m pip install --user pip --upgrade
   - python -m pip install --user pytest
-  - SET p=x86
-  - IF "%platform%"=="x64" SET p=x64
+  - SET p=x64
   - curl -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-%p%-win.zip -o z3-4.8.9-win.zip
   - 7z x z3-4.8.9-win.zip -oexternals -r -y
   - move externals\z3-4.8.9-%p%-win externals\z3


### PR DESCRIPTION
Wo do not build for 32-bit in any of the other builds and Appveyor is our slowest (and mostly discarded because of that) build so it doesn't really make sense to do that. We should limit to a bare necessities build just to make sure it compiles and test for basic functionality since these are legacy compilers. It is quite unlikely some code will just be broken for a single configuration. We will move a few more things in upcoming PRs.

It might also make sense to not do release builds since we don't do that for most other platforms either but Visual Studio projects configurations for Debug/Release are completely separate and might be accidentally broken by incomplete changes so unfortunately we cannot really do that. I think having a single Release build on Visual Studio should be fine. So if we just do that for the latest available version we could just drop those for older ones.

Also the cygwin build was not using all threads for building the tests.