### PR TITLE
moved cygwin build from appveyor to GitHub action

### DIFF
--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -1,0 +1,41 @@
+# Some convenient links:
+# - https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
+#
+
+name: CI-cygwin
+
+on: [push,pull_request]
+
+defaults:
+  run:
+    shell: cmd
+
+jobs:
+  build_cygwin:
+    strategy:
+      matrix:
+        os: [windows-2019]
+        arch: [x64, x86]
+      fail-fast: true
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@v3
+        with:
+          platform: ${{ matrix.arch }}
+
+      - name: Build cppcheck
+        run: |
+          C:\tools\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2
+
+      - name: Build test
+        run: |
+          C:\tools\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2 testrunner
+
+      - name: Run test
+        run: |
+          C:\tools\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2 check

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
       configuration: Debug
       vcvarsall_platform: x64
       PlatformToolset: v120
-      cygwin_build: yes
       MYQTDIR: C:\Qt\5.6\msvc2013_64
     - VisualStudioVersion: 12.0
       platform: x64
@@ -69,4 +68,3 @@ test_script:
   - build\bin\testrunner.exe -q
   - IF EXIST bin\debug\testrunner.exe bin\debug\testrunner.exe -q
   - IF EXIST bin\testrunner.exe bin\testrunner.exe -q
-  - 'IF defined cygwin_build C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cppcheck && make clean && make -j 2 test checkcfg"'


### PR DESCRIPTION
Unfortunately it is much slower than in appveyor but we were only piggy-backing it on the Visual Studio ones. I think we should use Appveyor just for legacy Visual Studio compilers.