### PR TITLE
appveyor.yml: avoid duplicated debug builds and removed artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,39 +13,40 @@ environment:
       vcvarsall_platform: x64
       PlatformToolset: v120
       cygwin_build: yes
+      MYQTDIR: C:\Qt\5.6\msvc2013_64
     - VisualStudioVersion: 12.0
       platform: x64
       configuration: Release
       vcvarsall_platform: x64
       PlatformToolset: v120
-      MYQTDIR: C:\Qt\5.6\msvc2013_64
 # FIXME: These are disabled for now. They were broken by ae8653612802b41b70424ec9a5eefe8a1178f6d1
 #    - VisualStudioVersion: 14.0
 #      platform: x64
 #      configuration: Debug
 #      vcvarsall_platform: x64
 #      PlatformToolset: v140
+#      MYQTDIR: C:\Qt\5.11\msvc2015_64
 # That platform causes frequent errors on appveyor due to an unknown infrastructure failure
 #    - VisualStudioVersion: 14.0
 #      platform: x64
 #      configuration: Release
 #      vcvarsall_platform: x64
 #      PlatformToolset: v140
-#      MYQTDIR: C:\Qt\5.11\msvc2015_64
 
 install:
   - python -m pip install --user pip --upgrade
   - python -m pip install --user pytest
-  - SET p=x64
-  - curl -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-%p%-win.zip -o z3-4.8.9-win.zip
+  - curl -fsSL https://github.com/Z3Prover/z3/releases/download/z3-4.8.9/z3-4.8.9-%platform%-win.zip -o z3-4.8.9-win.zip
   - 7z x z3-4.8.9-win.zip -oexternals -r -y
-  - move externals\z3-4.8.9-%p%-win externals\z3
+  - move externals\z3-4.8.9-%platform%-win externals\z3
 
 build_script:
   - ECHO Building %configuration% %platform% with MSVC %VisualStudioVersion% using %PlatformToolset% PlatformToolset
   - 'CALL "C:\Program Files (x86)\Microsoft Visual Studio %VisualStudioVersion%\VC\vcvarsall.bat" %vcvarsall_platform%'
   # Visual studio project..
   - msbuild "cppcheck.sln" /consoleloggerparameters:Verbosity=minimal /target:Build /property:Configuration="%configuration%";Platform=%platform% /p:PlatformToolset=%PlatformToolset% /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  # the following builds are Debug ones so do not perform them in Release jobs
+  - 'IF "%configuration%" == "Release" exit /b 0'
   # cmake..
   - mkdir build
   - cd build
@@ -72,11 +73,3 @@ test_script:
   - python -m pytest test-proj2.py
   - python -m pytest test-suppress-syntaxError.py
   - 'IF defined cygwin_build C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cppcheck && make clean && make -j 2 test checkcfg"'
-
-artifacts:
-  - path: bin
-    name: CLI binaries
-    type: zip
-  - path: Build\gui
-    name: GUI binaries
-    type: zip


### PR DESCRIPTION
The non-msbuild builds were always debug once so there's no need to run them in the release build.

The artifacts were not used at all and the GUI ones were also always debug ones.

I would also like to remove the Release build completely since we do this build in GitHub actions and that would be mainly done to see if the Visual Studio configuration is correct which the ones on the latest compiler already provide.