### PR TITLE
Fix #10182 (FN memory leak with if-statement)

### DIFF
--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -149,7 +149,7 @@ private:
     void changeAllocStatusIfRealloc(std::map<int, VarInfo::AllocInfo> &alloctype, const Token *fTok, const Token *retTok);
 
     /** return. either "return" or end of variable scope is seen */
-    void ret(const Token *tok, const VarInfo &varInfo);
+    void ret(const Token *tok, VarInfo &varInfo, const bool isEndOfScope = false);
 
     /** if variable is allocated then there is a leak */
     void leakIfAllocated(const Token *vartok, const VarInfo &varInfo);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -145,6 +145,8 @@ private:
         TEST_CASE(ifelse17); //  if (!!(!p))
         TEST_CASE(ifelse18);
         TEST_CASE(ifelse19);
+        TEST_CASE(ifelse20); // #10182
+        TEST_CASE(ifelse21);
 
         // switch
         TEST_CASE(switch1);
@@ -1609,6 +1611,39 @@ private:
               "    a = b;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void ifelse20() {
+        check("void f() {\n"
+              "    if (x > 0)\n"
+              "        void * p1 = malloc(5);\n"
+              "    else\n"
+              "        void * p2 = malloc(2);\n"
+              "    return;\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p1\n"
+                      "[test.c:5]: (error) Memory leak: p2\n", errout.str());
+
+        check("void f() {\n"
+              "    if (x > 0)\n"
+              "        void * p1 = malloc(5);\n"
+              "    else\n"
+              "        void * p2 = malloc(2);\n"
+              "}");
+        ASSERT_EQUALS("[test.c:3]: (error) Memory leak: p1\n"
+                      "[test.c:5]: (error) Memory leak: p2\n", errout.str());
+    }
+
+    void ifelse21() {
+        check("void f() {\n"
+              "    if (y) {\n"
+              "        void * p;\n"
+              "        if (x > 0)\n"
+              "            p = malloc(5);\n"
+              "    }\n"
+              "    return;\n"
+              "}");
+        ASSERT_EQUALS("[test.c:6]: (error) Memory leak: p\n",  errout.str());
     }
 
     void switch1() {


### PR DESCRIPTION
Improve leak detections in if-statements. This is done by checking for
leaks every time a scope is left. This allows cppcheck to catch more
memory leaks, as well as improve some error messages which now contain
the line where the variable goes out of scope, instead of the end of
the function. 