### PR TITLE
donate_cpu_lib.py: improved timeout reporting and process handling

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -38,6 +38,7 @@ jobs:
           python -m pip install pytest
           python -m pip install pygments
           python -m pip install requests
+          python -m pip install psutil
 
       - name: run Shellcheck
         if: matrix.python-version == '3.8'

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.8"
+CLIENT_VERSION = "1.3.9"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -255,14 +255,18 @@ def has_include(path, includes):
 def run_command(cmd):
     print(cmd)
     startTime = time.time()
+    comm = None
     p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=os.setsid)
     try:
         comm = p.communicate(timeout=CPPCHECK_TIMEOUT)
         return_code = p.returncode
+        p = None
     except subprocess.TimeoutExpired:
-        os.killpg(os.getpgid(p.pid), signal.SIGTERM)  # Send the signal to all the process groups
-        comm = p.communicate()
         return_code = RETURN_CODE_TIMEOUT
+    finally:
+        if p:
+            os.killpg(os.getpgid(p.pid), signal.SIGTERM)  # Send the signal to all the process groups
+            comm = p.communicate()
     stop_time = time.time()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore')


### PR DESCRIPTION
We will now just terminate all the child processes (which are the hanging files) - in case we are actually using multiple threads - so we get errors for the actual hanging files. I will evaluate the case with `-j1` later.

A result now looks like this:
```
cppcheck-options: --library=posix --library=gnu --library=openssl --library=zlib -j6 --showtime=top5 --check-library --inconclusive --enable=style,information --template=daca2 -rp=temp -D__GNUC__ --platform=unix64 temp
platform: Linux-4.4.0-19041-Microsoft-x86_64-with-glibc2.31
python: 3.9.1+
client-version: 1.3.9
cppcheck: head 2.3
head-info: bc8eb164a (2021-02-26 18:30:17 +0100)
count: TO! TO!
elapsed-time: 60.0 60.0
head-timing-info:

old-timing-info:

head results:
temp/httrack-3.49.2/src/htsparse.c:0:0: error: Internal error: Child process crashed with signal 15 [cppcheckError]
```

We can probably clean up some of the error detection but I need to test that in detail with actual test cases.

This also adds `psutil` as dependency for the script. I will do adjustments to the `requirements.txt` (which is not properly maintained and used anyways) later.