### PR TITLE
Fix #10187 (memleak open with fd >= 0)

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -52,8 +52,8 @@ static const CWE CWE415(415U);
 static const int NEW_ARRAY = -2;
 static const int NEW = -1;
 
-static const std::vector<std::pair<std::string, std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
-static const std::vector<std::pair<std::string, std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
+static const std::vector<std::pair<std::string, std::string>> alloc_failed_conds {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
+static const std::vector<std::pair<std::string, std::string>> alloc_success_conds {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
 
 /**
  * @brief Is variable type some class with automatic deallocation?
@@ -80,7 +80,7 @@ static bool isAutoDealloc(const Variable *var)
 static bool isVarTokComparison(const Token * tok, const Token ** vartok,
                                const std::vector<std::pair<std::string, std::string>>& ops)
 {
-    for (auto op : ops) {
+    for (const auto & op : ops) {
         if (astIsVariableComparison(tok, op.first, op.second, vartok))
             return true;
     }
@@ -484,8 +484,8 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                             if (!par->isComparisonOp())
                                 continue;
                             const Token *vartok = nullptr;
-                            if (isVarTokComparison(par, &vartok, var2_fail_conds) ||
-                               (isVarTokComparison(par, &vartok, var1_fail_conds))) {
+                            if (isVarTokComparison(par, &vartok, alloc_success_conds) ||
+                                (isVarTokComparison(par, &vartok, alloc_failed_conds))) {
                                 varInfo1.erase(vartok->varId());
                                 varInfo2.erase(vartok->varId());
                             }
@@ -494,13 +494,13 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     }
 
                     const Token *vartok = nullptr;
-                    if (isVarTokComparison(tok3, &vartok, var2_fail_conds)) {
+                    if (isVarTokComparison(tok3, &vartok, alloc_success_conds)) {
                         varInfo2.reallocToAlloc(vartok->varId());
                         varInfo2.erase(vartok->varId());
                         if (astIsVariableComparison(tok3, "!=", "0", &vartok) &&
                             (notzero.find(vartok->varId()) != notzero.end()))
                             varInfo2.clear();
-                    } else if (isVarTokComparison(tok3, &vartok, var1_fail_conds)) {
+                    } else if (isVarTokComparison(tok3, &vartok, alloc_failed_conds)) {
                         varInfo1.reallocToAlloc(vartok->varId());
                         varInfo1.erase(vartok->varId());
                     }

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -52,8 +52,8 @@ static const CWE CWE415(415U);
 static const int NEW_ARRAY = -2;
 static const int NEW = -1;
 
-static const std::vector<std::pair<const std::string, const std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
-static const std::vector<std::pair<const std::string, const std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
+static const std::vector<std::pair<std::string, std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
+static const std::vector<std::pair<std::string, std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
 
 /**
  * @brief Is variable type some class with automatic deallocation?
@@ -78,7 +78,7 @@ static bool isAutoDealloc(const Variable *var)
 }
 
 static bool isVarTokComparison(const Token * tok, const Token ** vartok,
-                               const std::vector<std::pair<const std::string, const std::string>>& ops)
+                               const std::vector<std::pair<std::string, std::string>>& ops)
 {
     for (auto op : ops) {
         if (astIsVariableComparison(tok, op.first, op.second, vartok))

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -52,8 +52,8 @@ static const CWE CWE415(415U);
 static const int NEW_ARRAY = -2;
 static const int NEW = -1;
 
-static const std::vector<std::pair<const std::string, const std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}};
-static const std::vector<std::pair<const std::string, const std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}};
+static const std::vector<std::pair<const std::string, const std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
+static const std::vector<std::pair<const std::string, const std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
 
 /**
  * @brief Is variable type some class with automatic deallocation?

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -52,6 +52,8 @@ static const CWE CWE415(415U);
 static const int NEW_ARRAY = -2;
 static const int NEW = -1;
 
+static const std::vector<std::pair<const std::string, const std::string>> var1_fail_conds = {{"==", "0"}, {"<", "0"}, {"==", "-1"}};
+static const std::vector<std::pair<const std::string, const std::string>> var2_fail_conds = {{"!=", "0"}, {">", "0"}, {"!=", "-1"}};
 
 /**
  * @brief Is variable type some class with automatic deallocation?
@@ -73,6 +75,16 @@ static bool isAutoDealloc(const Variable *var)
         return false;
 
     return true;
+}
+
+static bool isVarTokComparison(const Token * tok, const Token ** vartok,
+                               const std::vector<std::pair<const std::string, const std::string>>& ops)
+{
+    for (auto op : ops) {
+        if (astIsVariableComparison(tok, op.first, op.second, vartok))
+            return true;
+    }
+    return false;
 }
 
 //---------------------------------------------------------------------------
@@ -472,12 +484,8 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                             if (!par->isComparisonOp())
                                 continue;
                             const Token *vartok = nullptr;
-                            if (astIsVariableComparison(par, "!=", "0", &vartok) ||
-                                astIsVariableComparison(par, "==", "0", &vartok) ||
-                                astIsVariableComparison(par, "<", "0", &vartok) ||
-                                astIsVariableComparison(par, ">", "0", &vartok) ||
-                                astIsVariableComparison(par, "==", "-1", &vartok) ||
-                                astIsVariableComparison(par, "!=", "-1", &vartok)) {
+                            if (isVarTokComparison(par, &vartok, var2_fail_conds) ||
+                               (isVarTokComparison(par, &vartok, var1_fail_conds))) {
                                 varInfo1.erase(vartok->varId());
                                 varInfo2.erase(vartok->varId());
                             }
@@ -486,26 +494,15 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     }
 
                     const Token *vartok = nullptr;
-                    if (astIsVariableComparison(tok3, "!=", "0", &vartok)) {
+                    if (isVarTokComparison(tok3, &vartok, var2_fail_conds)) {
                         varInfo2.reallocToAlloc(vartok->varId());
                         varInfo2.erase(vartok->varId());
-                        if (notzero.find(vartok->varId()) != notzero.end())
+                        if (astIsVariableComparison(tok3, "!=", "0", &vartok) &&
+                            (notzero.find(vartok->varId()) != notzero.end()))
                             varInfo2.clear();
-                    } else if (astIsVariableComparison(tok3, "==", "0", &vartok)) {
+                    } else if (isVarTokComparison(tok3, &vartok, var1_fail_conds)) {
                         varInfo1.reallocToAlloc(vartok->varId());
                         varInfo1.erase(vartok->varId());
-                    } else if (astIsVariableComparison(tok3, "<", "0", &vartok)) {
-                        varInfo1.reallocToAlloc(vartok->varId());
-                        varInfo1.erase(vartok->varId());
-                    } else if (astIsVariableComparison(tok3, ">", "0", &vartok)) {
-                        varInfo2.reallocToAlloc(vartok->varId());
-                        varInfo2.erase(vartok->varId());
-                    } else if (astIsVariableComparison(tok3, "==", "-1", &vartok)) {
-                        varInfo1.reallocToAlloc(vartok->varId());
-                        varInfo1.erase(vartok->varId());
-                    } else if (astIsVariableComparison(tok3, "!=", "-1", &vartok)) {
-                        varInfo2.reallocToAlloc(vartok->varId());
-                        varInfo2.erase(vartok->varId());
                     }
                     return ChildrenToVisit::none;
                 });

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -147,6 +147,7 @@ private:
         TEST_CASE(ifelse19);
         TEST_CASE(ifelse20); // #10182
         TEST_CASE(ifelse21);
+        TEST_CASE(ifelse22); // #10187
 
         // switch
         TEST_CASE(switch1);
@@ -1644,6 +1645,24 @@ private:
               "    return;\n"
               "}");
         ASSERT_EQUALS("[test.c:6]: (error) Memory leak: p\n",  errout.str());
+    }
+
+    void ifelse22() { // #10187
+        check("int f(const char * pathname, int flags) {\n"
+              "    int fd = socket(pathname, flags);\n"
+              "    if (fd >= 0)\n"
+              "        return fd;\n"
+              "    return -1;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("int f(const char * pathname, int flags) {\n"
+              "    int fd = socket(pathname, flags);\n"
+              "    if (fd <= -1)\n"
+              "        return -1;\n"
+              "    return fd;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void switch1() {


### PR DESCRIPTION
Fix FPs where the return value of `open()` (and other functions returning non-negative values on success) was checked like this: `fd >= 0` (and also the perhaps less common check for failure: `fd <= -1`). On 100 packages with `test-my-pr`, 3 fewer FP were reported (and no FN were added).