### PR TITLE
Fix #9139 (leak when variable has const qualifier)

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -316,6 +316,9 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
         if (!tok || tok == endToken)
             break;
 
+        if (Token::Match(tok, "const %type%"))
+            tok = tok->tokAt(2);
+
         // parse statement, skip to last member
         const Token *varTok = tok;
         while (Token::Match(varTok, "%name% ::|. %name% !!("))

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -41,7 +41,7 @@ private:
         settings.library.setalloc("malloc", id, -1);
         settings.library.setrealloc("realloc", id, -1);
         settings.library.setdealloc("free", id, 1);
-        while (!Library::ismemory(++id));
+        while (!Library::isresource(++id));
         settings.library.setalloc("socket", id, -1);
         settings.library.setdealloc("close", id, 1);
         while (!Library::isresource(++id));
@@ -81,6 +81,7 @@ private:
         TEST_CASE(assign19);
         TEST_CASE(assign20); // #9187
         TEST_CASE(assign21); // #10186
+        TEST_CASE(assign22); // #9139
 
         TEST_CASE(isAutoDealloc);
 
@@ -436,6 +437,18 @@ private:
               "    d->a = p;\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void assign22() { // #9139
+        check("void f(char tempFileName[256]) {\n"
+              "    const int fd = socket(AF_INET, SOCK_PACKET, 0 );\n"
+              "}", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Resource leak: fd\n", errout.str());
+
+        check("void f() {\n"
+              "    const void * const p = malloc(10);\n"
+              "}", true);
+        ASSERT_EQUALS("[test.cpp:3]: (error) Memory leak: p\n", errout.str());
     }
 
     void isAutoDealloc() {


### PR DESCRIPTION
It's a little strange how this `const`-assignments are tokenized/simplified differently for pointers and for non-pointers. For example,
```
int x = mkstemp(tempFileName);
const int y = mkstemp(tempFileName);
const void * const p = malloc(5);
```
gets tokenized/simplified to
```
int x; x = mkstemp(tempFileName); // Simplified to declaration and assignment
const int y = mkstemp(tempFileName); // No change, this is why it previously failed
const void * const p; p = malloc(5); // Simplified to declaration and assignment despite the const, this is why memleaks like this are detected
```

Not sure it is a problem, but that's why `const int fd = mkstemp(f);` previously wasn't detected while `const void * const p = malloc(10);` was.