### PR TITLE
some test/CI related refactoring and cleanup

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -65,6 +65,10 @@ jobs:
         run: |
           make -j$(nproc) check HAVE_RULES=yes
 
+      - name: Run extra tests
+        run: |
+          tools/generate_and_run_more_tests.sh
+
       - name: Validate
         run: |
           make -j$(nproc) checkCWEEntries validateXML

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
       - name: Install missing software on ubuntu 18.04
         if: matrix.os == 'ubuntu-18.04'
         run: |
@@ -24,7 +29,6 @@ jobs:
           sudo apt-get install libxml2-utils
           sudo apt-get install z3 libz3-dev
           cp externals/z3_version_old.h externals/z3_version.h
-          sudo apt-get install python3-pytest
 
       - name: Install missing software on ubuntu 20.04
         if: matrix.os == 'ubuntu-20.04' 
@@ -32,13 +36,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-utils
           sudo apt-get install z3 libz3-dev
-          sudo apt-get install python3-pytest
 
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
           brew install coreutils z3
           cp externals/z3_version_old.h externals/z3_version.h
+
+      - name: Install missing Python packages
+        run: |
+          python -m pip install pip --upgrade
+          python -m pip install pytest
           
       - name: Install Qt
         if: contains(matrix.os, 'ubuntu')
@@ -78,12 +86,13 @@ jobs:
           make -j$(nproc) check USE_Z3=yes HAVE_RULES=yes
 
       - name: Run test/cli
-        if: contains(matrix.os, 'ubuntu')
         run: |
-          cd ..
-          ln -s cppcheck cpp\ check
-          cd cpp\ check/test/cli
-          pytest-3 test-*.py
+          cd test/cli
+          pytest test-*.py
+          cd ../../..
+          ln -s cppcheck 'cpp check'
+          cd 'cpp check/test/cli'
+          pytest test-*.py
 
       - name: Validate
         run: |

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -85,6 +85,12 @@ jobs:
         run: |
           make -j$(nproc) check USE_Z3=yes HAVE_RULES=yes
 
+      # the script uses sed parameters not supported by MacOS
+      - name: Run extra tests
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          tools/generate_and_run_more_tests.sh
+
       - name: Run test/cli
         run: |
           cd test/cli

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           python -m pip install pip --upgrade
           python -m pip install pytest
+          python -m pip install pytest-custom_exit_code
 
       - name: Build GUI release
         if: matrix.os == 'x64'
@@ -117,7 +118,7 @@ jobs:
           copy .\bin\cppcheck.exe .\cppcheck.exe || exit /b !errorlevel!
           copy .\bin\cppcheck-core.dll .\cppcheck-core.dll || exit /b !errorlevel!
           cd test/cli || exit /b !errorlevel!
-          python -m pytest test-clang-import.py || exit /b !errorlevel!
+          python -m pytest --suppress-no-test-exit-code test-clang-import.py || exit /b !errorlevel!
           python -m pytest test-helloworld.py || exit /b !errorlevel!
           python -m pytest test-inline-suppress.py || exit /b !errorlevel!
           python -m pytest test-more-projects.py || exit /b !errorlevel!

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -18,7 +18,7 @@ jobs:
         # windows 2016 should default to VS 2017. Not supported by setup-msbuild
         os: [windows-2019]
         arch: [x64, x86]
-      fail-fast: true
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
       - name: Setup msbuild.exe
         uses: microsoft/setup-msbuild@v1.0.2
 
@@ -61,6 +66,11 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           modules: 'qtcharts'
+
+      - name: Install missing Python packages
+        run: |
+          python -m pip install pip --upgrade
+          python -m pip install pytest
 
       - name: Build GUI release
         if: matrix.os == 'x64'
@@ -100,4 +110,16 @@ jobs:
 
       - name: Run Release test
         run: .\bin\testrunner.exe || exit /b !errorlevel!
- 
+
+      - name: Run test/cli
+        run: |
+          :: since FILESDIR is not set copy the binary to the root so the addons are found
+          copy .\bin\cppcheck.exe .\cppcheck.exe || exit /b !errorlevel!
+          copy .\bin\cppcheck-core.dll .\cppcheck-core.dll || exit /b !errorlevel!
+          cd test/cli || exit /b !errorlevel!
+          python -m pytest test-clang-import.py || exit /b !errorlevel!
+          python -m pytest test-helloworld.py || exit /b !errorlevel!
+          python -m pytest test-inline-suppress.py || exit /b !errorlevel!
+          python -m pytest test-more-projects.py || exit /b !errorlevel!
+          python -m pytest test-proj2.py || exit /b !errorlevel!
+          python -m pytest test-suppress-syntaxError.py || exit /b !errorlevel!

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -77,6 +77,10 @@ jobs:
         run: |
           python -m compileall ./addons
 
+      - name: test matchcompiler
+        run: |
+          python tools/test_matchcompiler.py
+
       - name: test addons
         run: |
           make -j$(nproc) -s

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install missing software on ubuntu (Python 3)
         if: matrix.python-version != '2.7'
         run: |
+          sudo apt-get update
           sudo apt-get install shellcheck libxml2-utils
           python -m pip install pip --upgrade
           python -m pip install natsort

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyc
 cppcheck
 cppcheck.exe
+cppcheck-core.dll
 dmake
 dmake.exe
 reduce

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,9 +74,6 @@ matrix:
         - /usr/bin/cppcheck ./cli
 # check if showtime=top5 works
         - ./tools/test_showtimetop5.sh
-# check matchcompiler
-        - python2 tools/test_matchcompiler.py
-        - python3 tools/test_matchcompiler.py
 # check --dump
         - ${CPPCHECK} test/testpreprocessor.cpp --dump
         - xmllint --noout test/testpreprocessor.cpp.dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,8 @@ matrix:
         - make -j$(nproc) -s
 # run extra tests
         - tools/generate_and_run_more_tests.sh
-# check for missing CWE entries
-        - make checkCWEEntries
 # check cfg files
         - make checkcfg
-# Validate Result XML
-        - make validateXML
 # check htmlreport stuff
         - python2 htmlreport/test_htmlreport.py
         - python3 htmlreport/test_htmlreport.py
@@ -148,6 +144,3 @@ script:
 # compile cppcheck, default build
   - echo $CXXFLAGS
   - make -s check -j$(nproc)
-# Testing addons (disabled 2020-11-24 because Travis fails, TODO try to enable these)
-#  - PYTHONPATH=./addons python -m pytest addons/test/test-*.py
-#  - PYTHONPATH=./addons python3 -m pytest addons/test/test-*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,7 @@ matrix:
       compiler: clang
       script:
         - make -j$(nproc) -s
-# run extra tests
-        - tools/generate_and_run_more_tests.sh
-# check cfg files
+        # check cfg files
         - make checkcfg
 # check htmlreport stuff
         - python2 htmlreport/test_htmlreport.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,9 +67,4 @@ test_script:
   - build\bin\testrunner.exe -q
   - IF EXIST bin\debug\testrunner.exe bin\debug\testrunner.exe -q
   - IF EXIST bin\testrunner.exe bin\testrunner.exe -q
-  - cd test\cli
-  - python -m pytest test-helloworld.py
-  - python -m pytest test-inline-suppress.py
-  - python -m pytest test-proj2.py
-  - python -m pytest test-suppress-syntaxError.py
   - 'IF defined cygwin_build C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cppcheck && make clean && make -j 2 test checkcfg"'

--- a/test/cli/test-clang-import.py
+++ b/test/cli/test-clang-import.py
@@ -4,7 +4,13 @@
 import os
 import re
 import subprocess
+import pytest
 from testutils import cppcheck
+
+try:
+    subprocess.call(['clang', '--version'])
+except OSError:
+    pytest.skip("'clang' does not exist", allow_module_level=True)
 
 
 def get_debug_section(title, stdout):
@@ -31,12 +37,6 @@ def get_debug_section(title, stdout):
 
 
 def check_symbol_database(code):
-    # Only compare symboldatabases if clang is found in PATH
-    try:
-        subprocess.call(['clang', '--version'])
-    except OSError:
-        return
-
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)
@@ -49,12 +49,6 @@ def check_symbol_database(code):
 
 
 def check_ast(code):
-    # Only compare syntax trees if clang is found in PATH
-    try:
-        subprocess.call(['clang', '--version'])
-    except OSError:
-        return
-
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)
@@ -67,12 +61,6 @@ def check_ast(code):
 
 
 def todo_check_ast(code):
-    # Only compare syntax trees if clang is found in PATH
-    try:
-        subprocess.call(['clang', '--version'])
-    except OSError:
-        return
-
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)

--- a/test/cli/test-clang-import.py
+++ b/test/cli/test-clang-import.py
@@ -21,7 +21,7 @@ def get_debug_section(title, stdout):
         s = re.sub(r"return '[a-zA-Z0-9: *]+'", "return", s)
 
     pos1 = s.find(title)
-    assert pos1 > 0
+    assert pos1 > 0, 'title not found'
     pos1 = s.find('\n', pos1) + 1
     assert pos1 > 0
     pos2 = s.find("\n##", pos1)
@@ -40,9 +40,11 @@ def check_symbol_database(code):
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)
-    ret1, stdout1, stderr1 = cppcheck(['--clang', '--debug', '-v', testfile])
-    ret2, stdout2, stderr2 = cppcheck(['--debug', '-v', testfile])
+    ret1, stdout1, _ = cppcheck(['--clang', '--debug', '-v', testfile])
+    ret2, stdout2, _ = cppcheck(['--debug', '-v', testfile])
     os.remove(testfile)
+    assert 0 == ret1, stdout1
+    assert 0 == ret2, stdout2
     assert get_debug_section('### Symbol database', stdout1) == get_debug_section('### Symbol database', stdout2)
 
 
@@ -56,9 +58,11 @@ def check_ast(code):
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)
-    ret1, stdout1, stderr1 = cppcheck(['--clang', '--debug', '-v', testfile])
-    ret2, stdout2, stderr2 = cppcheck(['--debug', '-v', testfile])
+    ret1, stdout1, _ = cppcheck(['--clang', '--debug', '-v', testfile])
+    ret2, stdout2, _ = cppcheck(['--debug', '-v', testfile])
     os.remove(testfile)
+    assert 0 == ret1, stdout1
+    assert 0 == ret2, stdout1
     assert get_debug_section('##AST', stdout1) == get_debug_section('##AST', stdout2)
 
 
@@ -72,9 +76,11 @@ def todo_check_ast(code):
     testfile = 'test.cpp'
     with open(testfile, 'w+t') as f:
         f.write(code)
-    ret1, stdout1, stderr1 = cppcheck(['--clang', '--debug', '-v', testfile])
-    ret2, stdout2, stderr2 = cppcheck(['--debug', '-v', testfile])
+    ret1, stdout1, _ = cppcheck(['--clang', '--debug', '-v', testfile])
+    ret2, stdout2, _ = cppcheck(['--debug', '-v', testfile])
     os.remove(testfile)
+    assert 0 == ret1, stdout1
+    assert 0 == ret2, stdout2
     assert get_debug_section('##AST', stdout1) != get_debug_section('##AST', stdout2)
 
 

--- a/test/cli/test-helloworld.py
+++ b/test/cli/test-helloworld.py
@@ -37,25 +37,25 @@ def getVsConfigs(stdout, filename):
 def test_relative_path():
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', 'helloworld'])
     filename = os.path.join('helloworld', 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
 
 def test_local_path():
     ret, stdout, stderr = cppcheck_local(['--template=cppcheck1', '.'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == '[main.c:5]: (error) Division by zero.\n'
 
 def test_absolute_path():
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', prjpath])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
 def test_addon_local_path():
     ret, stdout, stderr = cppcheck_local(['--addon=misra', '--template=cppcheck1', '.'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ('[main.c:5]: (error) Division by zero.\n'
                       '[main.c:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n')
 
@@ -63,7 +63,7 @@ def test_addon_absolute_path():
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--addon=misra', '--template=cppcheck1', prjpath])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
                       '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n' % (filename, filename))
 
@@ -71,7 +71,7 @@ def test_addon_relative_path():
     prjpath = getRelativeProjectPath()
     ret, stdout, stderr = cppcheck(['--addon=misra', '--template=cppcheck1', prjpath])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout == ('Checking %s ...\n'
                       'Checking %s: SOME_CONFIG...\n' % (filename, filename))
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
@@ -82,7 +82,7 @@ def test_addon_with_gui_project():
     create_gui_project_file(project_file, paths=['.'], addon='misra')
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--project=' + project_file])
     filename = os.path.join('helloworld', 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout == 'Checking %s ...\n' % filename
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
                       '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n' % (filename, filename))
@@ -90,18 +90,18 @@ def test_addon_with_gui_project():
 def test_basepath_relative_path():
     prjpath = getRelativeProjectPath()
     ret, stdout, stderr = cppcheck([prjpath, '--template=cppcheck1', '-rp=' + prjpath])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == '[main.c:5]: (error) Division by zero.\n'
 
 def test_basepath_absolute_path():
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', prjpath, '-rp=' + prjpath])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == '[main.c:5]: (error) Division by zero.\n'
 
 def test_vs_project_local_path():
     ret, stdout, stderr = cppcheck_local(['--template=cppcheck1', '--project=helloworld.vcxproj'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, 'main.c') == 'Debug|Win32 Debug|x64 Release|Win32 Release|x64'
     assert stderr == '[main.c:5]: (error) Division by zero.\n'
 
@@ -109,7 +109,7 @@ def test_vs_project_relative_path():
     prjpath = getRelativeProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--project=' + os.path.join(prjpath, 'helloworld.vcxproj')])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, filename) == 'Debug|Win32 Debug|x64 Release|Win32 Release|x64'
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
@@ -117,13 +117,13 @@ def test_vs_project_absolute_path():
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--project=' + os.path.join(prjpath, 'helloworld.vcxproj')])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, filename) == 'Debug|Win32 Debug|x64 Release|Win32 Release|x64'
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
 def test_cppcheck_project_local_path():
     ret, stdout, stderr = cppcheck_local(['--template=cppcheck1', '--platform=win64', '--project=helloworld.cppcheck'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, 'main.c') == 'Debug|x64'
     assert stderr == '[main.c:5]: (error) Division by zero.\n'
 
@@ -131,7 +131,7 @@ def test_cppcheck_project_relative_path():
     prjpath = getRelativeProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--platform=win64', '--project=' + os.path.join(prjpath, 'helloworld.cppcheck')])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, filename) == 'Debug|x64'
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
@@ -139,19 +139,19 @@ def test_cppcheck_project_absolute_path():
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--platform=win64', '--project=' + os.path.join(prjpath, 'helloworld.cppcheck')])
     filename = os.path.join(prjpath, 'main.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert getVsConfigs(stdout, filename) == 'Debug|x64'
     assert stderr == '[%s:5]: (error) Division by zero.\n' % filename
 
 def test_suppress_command_line():
     prjpath = getRelativeProjectPath()
     ret, stdout, stderr = cppcheck(['--suppress=zerodiv:' + os.path.join(prjpath, 'main.c'), prjpath])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ''
 
     prjpath = getAbsoluteProjectPath()
     ret, stdout, stderr = cppcheck(['--suppress=zerodiv:' + os.path.join(prjpath, 'main.c'), prjpath])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ''
 
 def test_suppress_project():
@@ -162,18 +162,19 @@ def test_suppress_project():
 
     # Relative path
     ret, stdout, stderr = cppcheck(['--project=' + project_file])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ''
 
     # Absolute path
     ret, stdout, stderr = cppcheck(['--project=' + os.path.join(os.getcwd(), 'helloworld', 'test.cppcheck')])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ''
 
 
 def test_exclude():
     prjpath = getRelativeProjectPath()
-    ret, stdout, stderr = cppcheck(['-i' + prjpath, '--platform=win64', '--project=' + os.path.join(prjpath, 'helloworld.cppcheck')])
+    ret, stdout, _ = cppcheck(['-i' + prjpath, '--platform=win64', '--project=' + os.path.join(prjpath, 'helloworld.cppcheck')])
+    assert ret == 1
     assert stdout == 'cppcheck: No C or C++ source files found.\n'
 
 

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -19,12 +19,12 @@ def create_unused_function_compile_commands():
 
 def test1():
     ret, stdout, stderr = cppcheck(['--inline-suppr', 'proj-inline-suppress'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stderr == ''
 
 def test2():
     ret, stdout, stderr = cppcheck(['proj-inline-suppress'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert len(stderr) > 0
 
 def test_unmatched_suppression():
@@ -42,6 +42,7 @@ def test_backwards_compatibility():
     assert '[zerodiv]' in stderr
 
     ret, stdout, stderr = cppcheck(['--inline-suppr', 'proj-inline-suppress/3.cpp'])
+    assert ret == 0, stdout
     assert stderr == ''
 
 def test_compile_commands_unused_function():
@@ -53,5 +54,5 @@ def test_compile_commands_unused_function():
 def test_compile_commands_unused_function_suppression():
     create_unused_function_compile_commands()
     ret, stdout, stderr = cppcheck(['--enable=all', '--inline-suppr', '--error-exitcode=1', '--project=./proj-inline-suppress-unusedFunction/compile_commands.json'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert 'unusedFunction' not in stderr

--- a/test/cli/test-more-projects.py
+++ b/test/cli/test-more-projects.py
@@ -2,65 +2,62 @@
 # python -m pytest test-more-projects.py
 
 import os
-import tempfile
 from testutils import cppcheck
 
 
-def test_project_force_U():
+def test_project_force_U(tmpdir):
     # 10018
     # -U does not work with compile_commands.json
-    with tempfile.TemporaryDirectory('10018') as temp_folder:
-        with open(os.path.join(temp_folder, 'bug1.cpp'), 'wt') as f:
-            f.write("""
-                    int x = 123 / 0;
-                    #ifdef MACRO1
-                    int y = 1000 / 0;
-                    #endif
-                    """)
+    with open(os.path.join(tmpdir, 'bug1.cpp'), 'wt') as f:
+        f.write("""
+                int x = 123 / 0;
+                #ifdef MACRO1
+                int y = 1000 / 0;
+                #endif
+                """)
 
-        compile_commands = os.path.join(temp_folder, 'compile_commands.json')
+    compile_commands = os.path.join(tmpdir, 'compile_commands.json')
 
-        with open(compile_commands, 'wt') as f:
-            f.write('[ { "directory": "%s", "command": "c++ -o bug1.o -c bug1.cpp", "file": "bug1.cpp", "output": "bug1.o" } ]' % str(temp_folder))
+    with open(compile_commands, 'wt') as f:
+        f.write('[ { "directory": "%s", "command": "c++ -o bug1.o -c bug1.cpp", "file": "bug1.cpp", "output": "bug1.o" } ]' % str(tmpdir))
 
-        # Without -U => both bugs are found
-        ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-rp=' + temp_folder, '--template=cppcheck1'])
-        assert ret == 0, stdout
-        assert (stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
-                          '[bug1.cpp:4]: (error) Division by zero.\n')
+    # Without -U => both bugs are found
+    ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-rp=' + str(tmpdir), '--template=cppcheck1'])
+    assert ret == 0, stdout
+    assert (stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
+                      '[bug1.cpp:4]: (error) Division by zero.\n')
 
-        # With -U => only first bug is found
-        ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-UMACRO1', '-rp=' + temp_folder, '--template=cppcheck1'])
-        assert ret == 0, stdout
-        assert stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
+    # With -U => only first bug is found
+    ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-UMACRO1', '-rp=' + str(tmpdir), '--template=cppcheck1'])
+    assert ret == 0, stdout
+    assert stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
 
 
-def test_project_custom_platform():
+def test_project_custom_platform(tmpdir):
     """
     import cppcheck project that contains a custom platform file
     """
-    with tempfile.TemporaryDirectory('10018') as temp_folder:
-        project_file = os.path.join(temp_folder, 'Project.cppcheck')
+    project_file = os.path.join(tmpdir, 'Project.cppcheck')
 
-        with open(project_file, 'wt') as f:
-            f.write("""
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <project version="1">
-                      <platform>p1.xml</platform>
-                      <paths>
-                        <dir name="."/>
-                      </paths>
-                    </project>
-                    """)
+    with open(project_file, 'wt') as f:
+        f.write("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project version="1">
+                  <platform>p1.xml</platform>
+                  <paths>
+                    <dir name="."/>
+                  </paths>
+                </project>
+                """)
 
-        with open(os.path.join(temp_folder, 'p1.xml'), 'wt') as f:
-            f.write('<?xml version="1.0"?>\n<platform/>')
+    with open(os.path.join(tmpdir, 'p1.xml'), 'wt') as f:
+        f.write('<?xml version="1.0"?>\n<platform/>')
 
-        with open(os.path.join(temp_folder, '1.c'), 'wt') as f:
-            f.write("int x;")
+    with open(os.path.join(tmpdir, '1.c'), 'wt') as f:
+        f.write("int x;")
 
-        ret, stdout, stderr = cppcheck(['--project=' + project_file, '--template=cppcheck1'])
-        assert ret == 0, stdout
-        assert stderr == ''
+    ret, stdout, stderr = cppcheck(['--project=' + project_file, '--template=cppcheck1'])
+    assert ret == 0, stdout
+    assert stderr == ''
 
 

--- a/test/cli/test-more-projects.py
+++ b/test/cli/test-more-projects.py
@@ -1,6 +1,5 @@
-
 # python -m pytest test-more-projects.py
-
+import json
 import os
 from testutils import cppcheck
 
@@ -18,8 +17,15 @@ def test_project_force_U(tmpdir):
 
     compile_commands = os.path.join(tmpdir, 'compile_commands.json')
 
+    compilation_db = [
+        {"directory": str(tmpdir),
+         "command": "c++ -o bug1.o -c bug1.cpp",
+         "file": "bug1.cpp",
+         "output": "bug1.o"}
+    ]
+
     with open(compile_commands, 'wt') as f:
-        f.write('[ { "directory": "%s", "command": "c++ -o bug1.o -c bug1.cpp", "file": "bug1.cpp", "output": "bug1.o" } ]' % str(tmpdir))
+        f.write(json.dumps(compilation_db))
 
     # Without -U => both bugs are found
     ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-rp=' + str(tmpdir), '--template=cppcheck1'])
@@ -59,5 +65,3 @@ def test_project_custom_platform(tmpdir):
     ret, stdout, stderr = cppcheck(['--project=' + project_file, '--template=cppcheck1'])
     assert ret == 0, stdout
     assert stderr == ''
-
-

--- a/test/cli/test-more-projects.py
+++ b/test/cli/test-more-projects.py
@@ -25,11 +25,13 @@ def test_project_force_U():
 
         # Without -U => both bugs are found
         ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-rp=' + temp_folder, '--template=cppcheck1'])
+        assert ret == 0, stdout
         assert (stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
                           '[bug1.cpp:4]: (error) Division by zero.\n')
 
         # With -U => only first bug is found
         ret, stdout, stderr = cppcheck(['--project=' + compile_commands, '--force', '-UMACRO1', '-rp=' + temp_folder, '--template=cppcheck1'])
+        assert ret == 0, stdout
         assert stderr == '[bug1.cpp:2]: (error) Division by zero.\n'
 
 
@@ -58,6 +60,7 @@ def test_project_custom_platform():
             f.write("int x;")
 
         ret, stdout, stderr = cppcheck(['--project=' + project_file, '--template=cppcheck1'])
+        assert ret == 0, stdout
         assert stderr == ''
 
 

--- a/test/cli/test-proj2.py
+++ b/test/cli/test-proj2.py
@@ -38,7 +38,7 @@ def test_file_filter():
     assert ret == 0
     assert stdout.find('Checking %s ...' % file1) >= 0
     ret, stdout, stderr = cppcheck(['proj2/','--file-filter=proj2/b*'])
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file2) >= 0
 
 def test_local_path():
@@ -46,24 +46,20 @@ def test_local_path():
     ret, stdout, stderr = cppcheck_local(['--project=compile_commands.json'])
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
 def test_local_path_force():
     create_compile_commands()
     ret, stdout, stderr = cppcheck_local(['--project=compile_commands.json', '--force'])
-    file1 = os.path.realpath('proj2/a/a.c')
-    file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('AAA') >= 0
 
 def test_local_path_maxconfigs():
     create_compile_commands()
     ret, stdout, stderr = cppcheck_local(['--project=compile_commands.json', '--max-configs=2'])
-    file1 = os.path.realpath('proj2/a/a.c')
-    file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('AAA') >= 0
 
 def test_relative_path():
@@ -71,7 +67,7 @@ def test_relative_path():
     ret, stdout, stderr = cppcheck(['--project=proj2/' + COMPILE_COMMANDS_JSON])
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
@@ -80,7 +76,7 @@ def test_absolute_path():
     ret, stdout, stderr = cppcheck(['--project=' + os.path.realpath('proj2/' + COMPILE_COMMANDS_JSON)])
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
@@ -89,7 +85,7 @@ def test_gui_project_loads_compile_commands_1():
     ret, stdout, stderr = cppcheck(['--project=proj2/proj2.cppcheck'])
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
@@ -102,7 +98,7 @@ def test_gui_project_loads_compile_commands_2():
     ret, stdout, stderr = cppcheck(['--project=proj2/test.cppcheck'])
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c') # Excluded by test.cppcheck
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) < 0
 
@@ -112,7 +108,7 @@ def test_gui_project_loads_relative_vs_solution():
     ret, stdout, stderr = cppcheck(['--project=test.cppcheck'])
     file1 = os.path.join('proj2', 'a', 'a.c')
     file2 = os.path.join('proj2', 'b', 'b.c')
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s Debug|Win32...' % file1) >= 0
     assert stdout.find('Checking %s Debug|x64...' % file1) >= 0
     assert stdout.find('Checking %s Release|Win32...' % file1) >= 0
@@ -128,7 +124,7 @@ def test_gui_project_loads_absolute_vs_solution():
     file1 = os.path.realpath('proj2/a/a.c')
     file2 = os.path.realpath('proj2/b/b.c')
     print(stdout)
-    assert ret == 0
+    assert ret == 0, stdout
     assert stdout.find('Checking %s Debug|Win32...' % file1) >= 0
     assert stdout.find('Checking %s Debug|x64...' % file1) >= 0
     assert stdout.find('Checking %s Release|Win32...' % file1) >= 0
@@ -141,11 +137,13 @@ def test_gui_project_loads_absolute_vs_solution():
 def test_gui_project_loads_relative_vs_solution_2():
     create_gui_project_file('test.cppcheck', root_path='proj2', import_project='proj2/proj2.sln')
     ret, stdout, stderr = cppcheck(['--project=test.cppcheck'])
+    assert ret == 0, stdout
     assert stderr == ERR_A + ERR_B
 
 def test_gui_project_loads_relative_vs_solution_with_exclude():
     create_gui_project_file('test.cppcheck', root_path='proj2', import_project='proj2/proj2.sln', exclude_paths=['b'])
     ret, stdout, stderr = cppcheck(['--project=test.cppcheck'])
+    assert ret == 0, stdout
     assert stderr == ERR_A
 
 def test_gui_project_loads_absolute_vs_solution_2():
@@ -153,4 +151,5 @@ def test_gui_project_loads_absolute_vs_solution_2():
                             root_path=realpath('proj2'),
                             import_project=realpath('proj2/proj2.sln'))
     ret, stdout, stderr = cppcheck(['--project=test.cppcheck'])
+    assert ret == 0, stdout
     assert stderr == ERR_A + ERR_B


### PR DESCRIPTION
The tests should be properly named `<name>_test.py` so they are automatically picked up by pytest and we don't have to specify any filenames at all.