### PR TITLE
Fix tokenizing of x[i](0) (Fixes #8875)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8741,11 +8741,11 @@ bool Tokenizer::simplifyRedundantParentheses()
             ret = true;
         }
 
-        // Simplify "!!operator !!%name%|)|>|>> ( %num%|%bool% ) %op%|;|,|)"
+        // Simplify "!!operator !!%name%|)|]|>|>> ( %num%|%bool% ) %op%|;|,|)"
         if (Token::Match(tok, "( %bool%|%num% ) %cop%|;|,|)") &&
             tok->strAt(-2) != "operator" &&
             tok->previous() &&
-            !Token::Match(tok->previous(), "%name%|)") &&
+            !Token::Match(tok->previous(), "%name%|)|]") &&
             (!(isCPP() && Token::Match(tok->previous(),">|>>")))) {
             tok->link()->deleteThis();
             tok->deleteThis();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -171,6 +171,7 @@ private:
         TEST_CASE(removeParentheses23);      // Ticket #6103 - Infinite loop upon valid input
         TEST_CASE(removeParentheses24);      // Ticket #7040
         TEST_CASE(removeParentheses25);      // daca@home - a=(b,c)
+        TEST_CASE(removeParentheses26);      // Ticket #8875 a[0](0)
 
         TEST_CASE(tokenize_double);
         TEST_CASE(tokenize_strings);
@@ -1673,6 +1674,12 @@ private:
     void removeParentheses25() { // daca@home - a=(b,c)
         static char code[] = "a=(b,c);";
         static char  exp[] = "a = ( b , c ) ;";
+        ASSERT_EQUALS(exp, tokenizeAndStringify(code));
+    }
+
+    void removeParentheses26() { // Ticket #8875 a[0](0)
+        static char code[] = "a[0](0);";
+        static char  exp[] = "a [ 0 ] ( 0 ) ;";
         ASSERT_EQUALS(exp, tokenizeAndStringify(code));
     }
 

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -204,6 +204,12 @@ private:
               "    return -(y << (x-1));\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("bool f() {\n"
+              "    std::ofstream outfile;\n"
+              "    outfile << vec_points[0](0) << static_cast<int>(d) << ' ';\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkIntegerOverflow() {


### PR DESCRIPTION
Fix faulty removal of parenthesis when "]" is followed by parenthesis
with a number inside, for example when calling a function pointer in
an array or (perhaps more common) in c++, calling operator ( on an
element in an array.

Fixes #8875 where such wrong simplification lead to a FP with too many
bits shifted due to "<<" was interpreted like a shift operator rather
than a stream output.

There was no change in warnings after trying 500 packages in `test-my-pr.py`.