### PR TITLE
Add description of setup for development in VS Code.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,72 @@ Use the cppcheck.sln file. The file is configured for Visual Studio 2019, but th
 
 To compile with rules, select "Release-PCRE" or "Debug-PCRE" configuration. pcre.lib (pcre64.lib for x64 builds) and pcre.h are expected to be in /externals then. A current version of PCRE for Visual Studio can be obtained using [vcpkg](https://github.com/microsoft/vcpkg).
 
+### VS Code (on Windows)
+
+Install MSYS2 to get GNU toolchain with g++ and gdb (https://www.msys2.org/).
+Create a settings.json file in the .vscode folder with the following content (adjust path as necessary):
+
+```
+{
+    "terminal.integrated.shell.windows": "C:\\msys64\\usr\\bin\\bash.exe",
+    "terminal.integrated.shellArgs.windows": [
+        "--login",
+    ],
+    "terminal.integrated.env.windows": {
+        "CHERE_INVOKING": "1",
+        "MSYSTEM": "MINGW64",
+    }
+}
+```
+
+Run "make" in the terminal to build cppcheck.
+
+For debugging create a launch.json file in the .vscode folder with the following content, which covers configuration for debugging cppcheck and misra.py:
+
+```
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "cppcheck",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/cppcheck.exe",
+            "args": [
+                "--dump",
+                "${workspaceFolder}/addons/test/misra/misra-test.c"
+            ],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": true,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:/msys64/mingw64/bin/gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "misra.py",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/addons/misra.py",
+            "console": "integratedTerminal",
+            "args": [
+                "${workspaceFolder}/addons/test/misra/misra-test.c.dump"
+            ]
+        }
+    ]
+}
+```
+
 ### Qt Creator + MinGW
 
 The PCRE dll is needed to build the CLI. It can be downloaded here:


### PR DESCRIPTION
Description on how to setup VS Code (https://code.visualstudio.com/) for building and debugging cppcheck using GNU toolchain from MSYS2 (https://www.msys2.org/).