### PR TITLE
Report an error if analysis becomes cyclic

### DIFF
--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -385,8 +385,12 @@ struct ForwardTraversal {
     Progress updateRange(Token* start, const Token* end, int depth = 20) {
         if (depth < 0)
             return Break(Terminate::Bail);
+        std::size_t i = 0;
         for (Token* tok = start; tok && tok != end; tok = tok->next()) {
             Token* next = nullptr;
+            if (tok->index() <= i)
+                throw InternalError(tok, "Cyclic forward analysis.");
+            i = tok->index();
 
             if (tok->link()) {
                 // Skip casts..

--- a/lib/reverseanalyzer.cpp
+++ b/lib/reverseanalyzer.cpp
@@ -1,6 +1,7 @@
 #include "reverseanalyzer.h"
 #include "analyzer.h"
 #include "astutils.h"
+#include "errortypes.h"
 #include "forwardanalyzer.h"
 #include "settings.h"
 #include "symboldatabase.h"
@@ -119,7 +120,11 @@ struct ReverseTraversal {
     void traverse(Token* start, const Token* end = nullptr) {
         if (start == end)
             return;
+        std::size_t i = start->index();
         for (Token* tok = start->previous(); tok != end; tok = tok->previous()) {
+            if (tok->index() >= i)
+                throw InternalError(tok, "Cyclic reverse analysis.");
+            i = tok->index();
             if (tok == start || (tok->str() == "{" && (tok->scope()->type == Scope::ScopeType::eFunction ||
                                  tok->scope()->type == Scope::ScopeType::eLambda))) {
                 break;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5281,6 +5281,8 @@ bool Tokenizer::simplifyTokenList2()
 
     Token::assignProgressValues(list.front());
 
+    list.front()->assignIndexes();
+
     list.createAst();
     // needed for #7208 (garbage code) and #7724 (ast max depth limit)
     list.validateAst();


### PR DESCRIPTION
Sometimes when analysis traverses to the next token using the AST, it can sometimes move in the wrong direction, which means it will repeat the token again causing a hang. This will now report an error instead of hanging which should help in diagnosing the issue. 