### PR TITLE
Another gcc11 fix

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -35,6 +35,7 @@
 #include <cassert>
 #include <climits>
 #include <cstring>
+#include <limits>
 #include <iomanip>
 #include <iostream>
 #include <unordered_map>


### PR DESCRIPTION
```
/home/tkloczko/rpmbuild/BUILD/cppcheck-2.4/lib/symboldatabase.cpp: In member function ‘void SymbolDatabase::createSymbolDatabaseExprIds()’:
/home/tkloczko/rpmbuild/BUILD/cppcheck-2.4/lib/symboldatabase.cpp:1443:32: error: ‘numeric_limits’ is not a member of ‘std’
 1443 |                 if (id == std::numeric_limits<nonneg int>::max()) {
      |                                ^~~~~~~~~~~~~~
/home/tkloczko/rpmbuild/BUILD/cppcheck-2.4/lib/symboldatabase.cpp:1443:54: error: expected primary-expression before ‘int’
 1443 |                 if (id == std::numeric_limits<nonneg int>::max()) {
      |                                                      ^~~
/home/tkloczko/rpmbuild/BUILD/cppcheck-2.4/lib/symboldatabase.cpp:1443:47: error: expected ‘)’ before ‘int’
 1443 |                 if (id == std::numeric_limits<nonneg int>::max()) {
      |                    ~                          ^      ~~~
      |                                               )
```
This patch adds missing `include #include <limits>`
