### PR TITLE
try to find pcre.h for HAVE_RULES in any case

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -11,7 +11,7 @@ if (HAVE_RULES)
     find_library(PCRE_LIBRARY pcre)
     if (NOT PCRE_LIBRARY OR NOT PCRE_INCLUDE)
         message(FATAL_ERROR "pcre dependency for RULES has not been found")
-    else
+    else()
         include_directories(${PCRE_INCLUDE})
     endif()
 endif()

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -7,9 +7,12 @@ if (BUILD_GUI)
 endif()
 
 if (HAVE_RULES)
+    find_path(PCRE_INCLUDE pcre.h)
     find_library(PCRE_LIBRARY pcre)
-    if (NOT PCRE_LIBRARY)
+    if (NOT PCRE_LIBRARY OR NOT PCRE_INCLUDE)
         message(FATAL_ERROR "pcre dependency for RULES has not been found")
+    else
+        include_directories(${PCRE_INCLUDE})
     endif()
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,11 +8,6 @@ include_directories(${PROJECT_SOURCE_DIR}/externals/simplecpp/)
 file(GLOB_RECURSE hdrs "*.h")
 file(GLOB_RECURSE srcs "*.cpp")
 
-if (HAVE_RULES)
-    find_path(PCRE_INCLUDE pcre.h)
-    include_directories(${PCRE_INCLUDE})
-endif()
-
 function(build_src output filename)
     get_filename_component(file ${filename} NAME)
     set(outfile ${CMAKE_CURRENT_BINARY_DIR}/build/mc_${file})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,6 +8,11 @@ include_directories(${PROJECT_SOURCE_DIR}/externals/simplecpp/)
 file(GLOB_RECURSE hdrs "*.h")
 file(GLOB_RECURSE srcs "*.cpp")
 
+if (HAVE_RULES)
+    find_path(PCRE_INCLUDE pcre.h)
+    include_directories(${PCRE_INCLUDE})
+endif()
+
 function(build_src output filename)
     get_filename_component(file ${filename} NAME)
     set(outfile ${CMAKE_CURRENT_BINARY_DIR}/build/mc_${file})


### PR DESCRIPTION
pcre.h may not be available using default system search paths (e.g. during cross-compilation),
thus have to be bootstrapped using CMAKE_STAGING_PREFIX/CMAKE_FIND_ROOT_PATH