### PR TITLE
gtk: Mark g_thread_join as a dealloc for g_thread_new

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -193,6 +193,7 @@
     <alloc init="true">g_thread_try_new</alloc>
     <use>g_thread_ref</use>
     <dealloc>g_thread_unref</dealloc>
+    <dealloc>g_thread_join</dealloc>
   </memory>
   <memory>
     <alloc init="true">g_variant_iter_copy</alloc>


### PR DESCRIPTION
g_thread_join() consumes the reference to the passed-in thread .
This will usually cause the GThread struct and associated resources to be freed.