### PR TITLE
Check for libc++ instead of clang to workaround a libc++ bug.

### DIFF
--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -603,7 +603,7 @@ double MathLib::toDoubleNumber(const std::string &str)
     // nullcheck
     if (isNullValue(str))
         return 0.0;
-#ifdef __clang__
+#ifdef _LIBCPP_VERSION
     if (isFloat(str)) // Workaround libc++ bug at http://llvm.org/bugs/show_bug.cgi?id=17782
         // TODO : handle locale
         return std::strtod(str.c_str(), nullptr);


### PR DESCRIPTION
The original fix will fail if building cppcheck with gcc and libc++.