### PR TITLE
Remove incorrect use-retvals in wxwidgets.cfg

### DIFF
--- a/cfg/wxwidgets.cfg
+++ b/cfg/wxwidgets.cfg
@@ -5466,7 +5466,6 @@
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="wxString &amp;"/>
-    <use-retval/>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_string.html#ab20a87ca731a52c36ec674dae2213ad8 -->
   <!-- wxString& wxString::MakeLower()-->
@@ -5474,7 +5473,6 @@
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="wxString &amp;"/>
-    <use-retval/>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_string.html#ab20a87ca731a52c36ec674dae2213ad8 -->
   <!-- wxString& wxString::MakeUpper()-->
@@ -5482,7 +5480,6 @@
     <noreturn>false</noreturn>
     <leak-ignore/>
     <returnValue type="wxString &amp;"/>
-    <use-retval/>
   </function>
   <!-- http://docs.wxwidgets.org/trunk/classwx_string.html#ab20a87ca731a52c36ec674dae2213ad8 -->
   <!-- bool wxString::Matches(const wxString & mask) const -->


### PR DESCRIPTION
These functions return a self ref and are not const so you shouldn't need to use the return value.