### PR TITLE
Fix noCopyConstructor with multiple inheritance

### DIFF
--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -71,6 +71,7 @@ private:
         TEST_CASE(copyConstructor2); // ticket #4458
         TEST_CASE(copyConstructor3); // defaulted/deleted
         TEST_CASE(copyConstructor4); // base class with private constructor
+        TEST_CASE(copyConstructor5); // multiple inheritance
         TEST_CASE(noOperatorEq); // class with memory management should have operator eq
         TEST_CASE(noDestructor); // class with memory management should have destructor
 
@@ -906,6 +907,30 @@ private:
                              "    int* m_ptr;\n"
                              "};");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void copyConstructor5() {
+         checkCopyConstructor("class Copyable {};\n"
+                              "\n"
+                              "class Foo : public Copyable, public UnknownType {\n"
+                              "public:\n"
+                              "    Foo() : m_ptr(new int) {}\n"
+                              "    ~Foo() { delete m_ptr; }\n"
+                              "private:\n"
+                              "    int* m_ptr;\n"
+                              "};");
+         ASSERT_EQUALS("", errout.str());
+
+         checkCopyConstructor("class Copyable {};\n"
+                              "\n"
+                              "class Foo : public UnknownType, public Copyable {\n"
+                              "public:\n"
+                              "    Foo() : m_ptr(new int) {}\n"
+                              "    ~Foo() { delete m_ptr; }\n"
+                              "private:\n"
+                              "    int* m_ptr;\n"
+                              "};");
+         ASSERT_EQUALS("", errout.str());
     }
 
     void noOperatorEq() {


### PR DESCRIPTION
The bug was that `isNonCopyable` (now renamed to
`hasNonCopyableBase`) "forgot" that it found an
unknown class in the list if a known copyable
class was found later in the list.

As discussed on the Development mailing list: https://sourceforge.net/p/cppcheck/discussion/development/thread/223ac3df06/#5a8d

