### PR TITLE
misra: Fixed a crash in rule 8.2

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1477,7 +1477,7 @@ class MisraChecker:
                             break
                         following.append(rawToken)
 
-                    return following
+            return following
 
         # Check arguments in function declaration
         for func in data.functions:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -8,6 +8,8 @@
 #include <file,.h> // 20.2
 #include "file,.h" // 20.2
 
+#include "misra-test.h"
+
 #include /*abc*/ "file.h" // no warning
 /*foo*/#include "file.h" // no warning
 #include "./file.h" // no warning

--- a/addons/test/misra/misra-test.h
+++ b/addons/test/misra/misra-test.h
@@ -1,4 +1,5 @@
 #ifndef MISRA_TEST_H
 #define MISRA_TEST_H
 struct misra_h_s { int foo; };
+bool test(char *a);
 #endif // MISRA_TEST_H


### PR DESCRIPTION
Due to incorrect indentation, we return "None" instead of an empty list, which causes the crash.
The problem was reported on the forum: https://sourceforge.net/p/cppcheck/discussion/general/thread/e146b8d779/