### PR TITLE
split "autoNoType" and "bailoutUninitVar" from more generic "debug"

### DIFF
--- a/.travis_suppressions
+++ b/.travis_suppressions
@@ -14,6 +14,8 @@ valueFlowBailout
 valueFlowBailoutIncompleteVar
 debug
 varid0
+autoNoType
+bailoutUninitVar
 
 *:gui/test/*
 *:test/test.cxx

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -465,7 +465,7 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                             if (tok2->isName() && tok2->next()->isName())
                                 condition += ' ';
                         }
-                        reportError(tok, Severity::debug, "debug", "bailout uninitialized variable checking for '" + var.name() + "'. can't determine if this condition can be false when previous condition is false: " + condition);
+                        reportError(tok, Severity::debug, "bailoutUninitVar", "bailout uninitialized variable checking for '" + var.name() + "'. can't determine if this condition can be false when previous condition is false: " + condition);
                     }
                     return true;
                 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -6498,7 +6498,7 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
     if (reportDebugWarnings && mSettings->debugwarnings) {
         for (Token *tok = tokens; tok; tok = tok->next()) {
             if (tok->str() == "auto" && !tok->valueType())
-                debugMessage(tok, "debug", "auto token with no type.");
+                debugMessage(tok, "autoNoType", "auto token with no type.");
         }
     }
 


### PR DESCRIPTION
The idea is to unclutter the generic `debug` and move some hard to fix/unfixable things out of the warning so we can at least enable it in the self-checks.