### PR TITLE
Remove unnecessary null check

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -1373,7 +1373,7 @@ void CheckStl::if_find()
             continue;
 
         const Token *conditionStart = scope.classDef->next();
-        if (conditionStart && Token::simpleMatch(conditionStart->astOperand2(), ";"))
+        if (Token::simpleMatch(conditionStart->astOperand2(), ";"))
             conditionStart = conditionStart->astOperand2();
 
         for (const Token *tok = conditionStart; tok->str() != "{"; tok = tok->next()) {


### PR DESCRIPTION
Spotted by coverity (conditionStart is assigned to tok which is
dereferenced in the loop).