### PR TITLE
Remove unnecessary null checks

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1068,7 +1068,7 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
                 do {
                     instantiationArgs[index].push_back(tok1);
                     tok1 = tok1->next();
-                } while (tok1 && tok1 != endLink);
+                } while (tok1 != endLink);
                 instantiationArgs[index].push_back(tok1);
             } else if (tok1->str() == "<" &&
                        (tok1->strAt(1) == ">" || (tok1->previous()->isName() &&
@@ -1077,7 +1077,7 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
                 do {
                     instantiationArgs[index].push_back(tok1);
                     tok1 = tok1->next();
-                } while (tok1 && tok1 != endLink);
+                } while (tok1 != endLink);
                 instantiationArgs[index].push_back(tok1);
             } else if (tok1->str() == ",") {
                 ++index;


### PR DESCRIPTION
Spotted by coverity, as tok1->next() is called in the loop iteration.
In any case, tok1 can't be null here, as we are going up to
tok1->link().