### PR TITLE
Fix varId assignment for uses of variables declared in the if condition

### DIFF
--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -179,6 +179,7 @@ private:
         TEST_CASE(localvarInvert);      // Usage with inverted variable
         TEST_CASE(localvarIf);          // Usage in if
         TEST_CASE(localvarIfElse);      // return tmp1 ? tmp2 : tmp3;
+        TEST_CASE(localvarDeclaredInIf);
         TEST_CASE(localvarOpAssign);    // a |= b;
         TEST_CASE(localvarFor);         // for ( ; var; )
         TEST_CASE(localvarForEach);     // #4155 - BOOST_FOREACH, hlist_for_each, etc
@@ -4589,6 +4590,35 @@ private:
                               "    int tmp2 = 2;\n"
                               "    int tmp3 = 3;\n"
                               "    return tmp1 ? tmp2 : tmp3;\n"
+                              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void localvarDeclaredInIf() {
+        functionVariableUsage("int foo(int x)\n"
+                              "{\n"
+                              "    if (int y = x % 2)\n"
+                              "        return 2;\n"
+                              "    else\n"
+                              "        return 1;\n"
+                              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (style) Variable 'y' is assigned a value that is never used.\n", errout.str());
+
+        functionVariableUsage("int foo(int x)\n"
+                              "{\n"
+                              "    if (int y = x % 2)\n"
+                              "        return y;\n"
+                              "    else\n"
+                              "        return 1;\n"
+                              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        functionVariableUsage("int foo(int x)\n"
+                              "{\n"
+                              "    if (int y = x % 2)\n"
+                              "        return 2;\n"
+                              "    else\n"
+                              "        return y;\n"
                               "}");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -173,6 +173,7 @@ private:
         TEST_CASE(varid_parameter_pack); // #9383
         TEST_CASE(varid_for_auto_cpp17);
         TEST_CASE(varid_not); // #9689 'not x'
+        TEST_CASE(varid_declInIfCondition);
 
         TEST_CASE(varidclass1);
         TEST_CASE(varidclass2);
@@ -2696,6 +2697,53 @@ private:
                             "2: if ( ! x@1 ) { }\n"
                             "3: }\n";
         ASSERT_EQUALS(exp1, tokenize(code1));
+    }
+
+    void varid_declInIfCondition() {
+        // if
+        ASSERT_EQUALS("1: void f ( int x@1 ) {\n"
+                      "2: if ( int x@2 = 0 ) { x@2 ; }\n"
+                      "3: x@1 ;\n"
+                      "4: }\n",
+                      tokenize("void f(int x) {\n"
+                               "  if (int x = 0) { x; }\n"
+                               "  x;\n"
+                               "}"));
+        // if, else
+        ASSERT_EQUALS("1: void f ( int x@1 ) {\n"
+                      "2: if ( int x@2 = 0 ) { x@2 ; }\n"
+                      "3: else { x@2 ; }\n"
+                      "4: x@1 ;\n"
+                      "5: }\n",
+                      tokenize("void f(int x) {\n"
+                               "  if (int x = 0) { x; }\n"
+                               "  else { x; }\n"
+                               "  x;\n"
+                               "}"));
+        // if, else if
+        ASSERT_EQUALS("1: void f ( int x@1 ) {\n"
+                      "2: if ( int x@2 = 0 ) { x@2 ; }\n"
+                      "3: else { if ( void * x@3 = & x@3 ) { x@3 ; } }\n"
+                      "4: x@1 ;\n"
+                      "5: }\n",
+                      tokenize("void f(int x) {\n"
+                               "  if (int x = 0) x;\n"
+                               "  else if (void* x = &x) x;\n"
+                               "  x;\n"
+                               "}"));
+        // if, else if, else
+        ASSERT_EQUALS("1: void f ( int x@1 ) {\n"
+                      "2: if ( int x@2 = 0 ) { x@2 ; }\n"
+                      "3: else { if ( void * x@3 = & x@3 ) { x@3 ; }\n"
+                      "4: else { x@3 ; } }\n"
+                      "5: x@1 ;\n"
+                      "6: }\n",
+                      tokenize("void f(int x) {\n"
+                               "  if (int x = 0) x;\n"
+                               "  else if (void* x = &x) x;\n"
+                               "  else x;\n"
+                               "  x;\n"
+                               "}"));
     }
 
     void varidclass1() {


### PR DESCRIPTION
Variables declared in the `if` condition (or in C++17 init-statement) are visible not only in the `if` body but also in the `else` body. But logic in `Tokenizer::setVarIdPass1()` handled such variables as if they were declared in the `if` body.

As the result they were removed from `variablesMap` by the time the `else` block was parsed and their uses in the `else` block were either given an incorrect `varId` from variables in some outer scope or not given a `varId` at all.

This then resulted in false positive unreadVariable errors for variables declared in the `if` condition (or init-statement) and used only in the `else` block.