### PR TITLE
Fix UB on CTU attribute read.

### DIFF
--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -174,7 +174,7 @@ static long long readAttrInt(const tinyxml2::XMLElement *e, const char *attr, bo
     const char *value = e->Attribute(attr);
     if (!value && error)
         *error = true;
-    return value ? std::atoi(value) : 0;
+    return value ? std::strtoll(value, nullptr, 10) : 0;
 }
 
 bool CTU::FileInfo::CallBase::loadBaseFromXml(const tinyxml2::XMLElement *xmlElement)


### PR DESCRIPTION
Checking some projects with UBSan enabled and using CTU results in a report for an integer overflow in `atoi` while reading back files written by cppcheck.

Values are written to to the file as `MathLib::bigint` (`long long`) and may fall out-of-range of `int`. `atoi` has UB if the read value is not representable. Use a function without UB instead and use the correct length suffix. This still does not check the validity of the read value, though.

The UBSan report was observed with musl and probably can not be observed with glibc, since glibc seems to call `strtoi` for `atoi` internally.