### PR TITLE
Fix false positive invalidFunctionArg for zero arguments to calloc.

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -945,7 +945,7 @@
     <returnValue type="void *"/>
     <arg nr="1" direction="in">
       <not-uninit/>
-      <valid>1:</valid>
+      <valid>0:</valid>
     </arg>
     <arg nr="2" direction="in">
       <not-uninit/>

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -433,11 +433,10 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (error) Invalid memset() argument nr 3. A non-boolean value is required.\n", errout.str());
 
-        check("void boolArgZeroIsInvalidButOneIsValid(int param) {\n"
-              "  void* buffer = calloc(param > 0, 10);\n"
-              "  free(buffer);\n"
+        check("int boolArgZeroIsInvalidButOneIsValid(int a, int param) {\n"
+              "  return div(a, param > 0);\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:2]: (error) Invalid calloc() argument nr 1. The value is 0 or 1 (boolean) but the valid values are '1:'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (error) Invalid div() argument nr 2. The value is 0 or 1 (boolean) but the valid values are ':-1,1:'.\n", errout.str());
 
         check("void boolArgZeroIsValidButOneIsInvalid(int param) {\n"
               "  strtol(a, b, param > 0);\n"


### PR DESCRIPTION
The following program results in a false positive invalid argument
report for the first argument of calloc:

void f() { auto x = calloc(0,0); }

But calloc has (implementation-)defined behavior analogously to
malloc/realloc if either argument is zero. Modify the valid range
for the first argument to match that of the second and the other
allocation functions.