### PR TITLE
Fix FP unknownEvaluationOrder on  __builtin_bswap*.

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -25,15 +25,45 @@
     <alloc init="false" buffer-size="malloc">pvalloc</alloc>
     <dealloc>free</dealloc>
   </memory>
-  <define name="bswap_16(x)" value="((unsigned short int) ((((x) &gt;&gt; 8) &amp; 0xff) | (((x) &amp; 0xff) &lt;&lt; 8)))"/>
+  <function name="bswap_16">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="uint16_t"/>
+    <leak-ignore/>
+    <const/>
+    <arg nr="1" direction="in">
+        <not-uninit/>
+        <not-bool/>
+    </arg>
+  </function>
   <define name="__bswap_constant_16(x)" value="bswap_16(x)"/>
   <define name="__builtin_bswap16(x)" value="bswap_16(x)"/>
   <define name="__bswap_16(x)" value="bswap_16(x)"/>
-  <define name="bswap_32(x)" value="((((x) &amp; 0xff000000) &gt;&gt; 24) | (((x) &amp; 0x00ff0000) &gt;&gt; 8) | (((x) &amp; 0x0000ff00) &lt;&lt; 8) | (((x) &amp; 0x000000ff) &lt;&lt; 24))"/>
+  <function name="bswap_32">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="uint32_t"/>
+    <leak-ignore/>
+    <const/>
+    <arg nr="1" direction="in">
+        <not-uninit/>
+        <not-bool/>
+    </arg>
+  </function>
   <define name="__bswap_constant_32(x)" value="bswap_32(x)"/>
   <define name="__builtin_bswap32(x)" value="bswap_32(x)"/>
   <define name="__bswap_32(x)" value="bswap_32(x)"/>
-  <define name="bswap_64(x)" value="((((x) &amp; 0xff00000000000000ull) &gt;&gt; 56) | (((x) &amp; 0x00ff000000000000ull) &gt;&gt; 40) | (((x) &amp; 0x0000ff0000000000ull) &gt;&gt; 24) | (((x) &amp; 0x000000ff00000000ull) &gt;&gt; 8) | (((x) &amp; 0x00000000ff000000ull) &lt;&lt; 8) | (((x) &amp; 0x0000000000ff0000ull) &lt;&lt; 24) | (((x) &amp; 0x000000000000ff00ull) &lt;&lt; 40) | (((x) &amp; 0x00000000000000ffull) &lt;&lt; 56))"/>
+  <function name="bswap_64">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="uint64_t"/>
+    <leak-ignore/>
+    <const/>
+    <arg nr="1" direction="in">
+        <not-uninit/>
+        <not-bool/>
+    </arg>
+  </function>
   <define name="__bswap_constant_64(x)" value="bswap_64(x)"/>
   <define name="__builtin_bswap64(x)" value="bswap_64(x)"/>
   <define name="__bswap_64(x)" value="bswap_64(x)"/>


### PR DESCRIPTION
`gnu.cfg` defines `__builtin_bswap*` as macros which evaluate arguments
multiple times. As a result side effects in arguments, e.g.
`__builtin_bswap64(x++)`, lead to a bunch of false positive
`unknownEvaluationOrder` reports with `--library=gnu`.

This replaces the macro definitions with function definitions.

To use macro definitions instead without this issue, it would, as far as I am aware, be necessary to use a compiler extension such as GCC's statement expressions.