### PR TITLE
Support function level try blocks

### DIFF
--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -511,6 +511,12 @@ public:
      */
     void simplifyFunctionParameters();
 
+    /** Simplify function level try blocks:
+     *  Convert "void f() try {} catch (int) {}"
+     *  to "void f() { try {} catch (int) {} }"
+     */
+    void simplifyFunctionTryCatch();
+
     /**
      * Simplify templates
      */


### PR DESCRIPTION
Currently Cppcheck emits "syntax error: keyword 'try' is not allowed in global scope" on valid code like this:
```
void foo() try {} catch (int) {}
```
and skips the whole file where such code was found.

When function level try blocks are used with all functions except constructors and destructors they act as if the function body consisted of the following try-catch block. So additional simplification step is added that performs this transformation.

My main goal is to fix the syntax error that prevents analysis of the file.