### PR TITLE
Fix build warnings and checkcfg errors with musl and libc++.

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -179,7 +179,7 @@ bool FileLister::fileExists(const std::string &path)
 
 #include <dirent.h>
 #include <sys/stat.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 
 static std::string addFiles2(std::map<std::string, std::size_t> &files,

--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -179,7 +179,7 @@ bool FileLister::fileExists(const std::string &path)
 
 #include <dirent.h>
 #include <sys/stat.h>
-#include <errno.h>
+#include <cerrno>
 
 
 static std::string addFiles2(std::map<std::string, std::size_t> &files,

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -12,6 +12,8 @@
 #include <dirent.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <dlfcn.h>
 #include <fcntl.h>
 // unavailable on some linux systems #include <ndbm.h>

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <cctype>
+#include <clocale>
 #include <complex>
 #include <cassert>
 #include <cwchar>


### PR DESCRIPTION
The first commit fixes the following warning when building with musl:

```
In file included from cli/filelister.cpp:182:                                  
/usr/include/sys/errno.h:1:2: warning: redirecting incorrect #include <sys/errno.h> to <errno.h> [-W#warnings]
#warning redirecting incorrect #include <sys/errno.h> to <errno.h>                                                                                            
 ^     
```

The second commit fixes some compilation errors occurring during `make checkcfg` with musl and libc++ instead of glibc and libstdc++.