### PR TITLE
Scratchpad uses CodeEditor class

### DIFF
--- a/gui/scratchpad.ui
+++ b/gui/scratchpad.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
+    <width>574</width>
     <height>600</height>
    </rect>
   </property>
@@ -22,7 +22,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QPlainTextEdit" name="plainTextEdit">
+    <widget class="CodeEditor" name="plainTextEdit">
      <property name="font">
       <font>
        <family>Courier New</family>
@@ -99,6 +99,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CodeEditor</class>
+   <extends>QPlainTextEdit</extends>
+   <header>codeeditor.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
It looks like we can reuse CodeEditor class instead of QPlainTextEdit in a scratchpad.
Motivation:
1. Line# showing, much easy log to source code mapping for cases with > 10 lines and/or > 1 error message
2. keywords higlighting

![image](https://user-images.githubusercontent.com/4844306/116950033-87e0fd00-ac8c-11eb-8044-2119a1eec88b.png)
