### PR TITLE
Fix case ranges with single quotes and escape sequences

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3258,19 +3258,20 @@ void Tokenizer::simplifyCaseRange()
                 }
             }
         } else if (Token::Match(tok, "case %char% ... %char% :")) {
-            const char start = tok->strAt(1)[1];
-            const char end = tok->strAt(3)[1];
-            if (start < end) {
+            const MathLib::bigint start = MathLib::toLongNumber(tok->strAt(1));
+            const MathLib::bigint end = MathLib::toLongNumber(tok->strAt(3));
+            if (start < end && start >= std::numeric_limits<char>::min() && end <= std::numeric_limits<char>::max()) {
                 tok = tok->tokAt(2);
                 tok->str(":");
                 tok->insertToken("case");
                 for (char i = end - 1; i > start; i--) {
                     tok->insertToken(":");
-                    if (i == '\\') {
-                        tok->insertToken(std::string("\'\\") + i + '\'');
-                    } else {
-                        tok->insertToken(std::string(1, '\'') + i + '\'');
-                    }
+                    if (i == '\\' || i == '\'')
+                        tok->insertToken(std::string("'\\") + i + "'");
+                    else if (i == '\n')
+                        tok->insertToken("'\\n'");
+                    else
+                        tok->insertToken(std::string("'") + i + "'");
                     tok->insertToken("case");
                 }
             }

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3243,7 +3243,7 @@ void Tokenizer::simplifyLabelsCaseDefault()
 void Tokenizer::simplifyCaseRange()
 {
     for (Token* tok = list.front(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "case %num% ... %num% :")) {
+        if (Token::Match(tok, "case %num%|%char% ... %num%|%char% :")) {
             const MathLib::bigint start = MathLib::toLongNumber(tok->strAt(1));
             MathLib::bigint end = MathLib::toLongNumber(tok->strAt(3));
             end = std::min(start + 50, end); // Simplify it 50 times at maximum
@@ -3254,24 +3254,6 @@ void Tokenizer::simplifyCaseRange()
                 for (MathLib::bigint i = end-1; i > start; i--) {
                     tok->insertToken(":");
                     tok->insertToken(MathLib::toString(i));
-                    tok->insertToken("case");
-                }
-            }
-        } else if (Token::Match(tok, "case %char% ... %char% :")) {
-            const MathLib::bigint start = MathLib::toLongNumber(tok->strAt(1));
-            const MathLib::bigint end = MathLib::toLongNumber(tok->strAt(3));
-            if (start < end && start >= std::numeric_limits<char>::min() && end <= std::numeric_limits<char>::max()) {
-                tok = tok->tokAt(2);
-                tok->str(":");
-                tok->insertToken("case");
-                for (char i = end - 1; i > start; i--) {
-                    tok->insertToken(":");
-                    if (i == '\\' || i == '\'')
-                        tok->insertToken(std::string("'\\") + i + "'");
-                    else if (i == '\n')
-                        tok->insertToken("'\\n'");
-                    else
-                        tok->insertToken(std::string("'") + i + "'");
                     tok->insertToken("case");
                 }
             }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5400,13 +5400,13 @@ private:
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case 4 ... 1 : ; } }", tokenizeAndStringify("void f() { switch(x) { case 4 ... 1: } }"));
         tokenizeAndStringify("void f() { switch(x) { case 1 ... 1000000: } }"); // Do not run out of memory
 
-        ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'a' : case 'b' : case 'c' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'a' ... 'c': } }"));
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'a' : case 98 : case 'c' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'a' ... 'c': } }"));
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'c' ... 'a' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'c' ... 'a': } }"));
 
-        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '[' : case '\\\\' : case ']' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '[' ... ']': } }"));
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '[' : case 92 : case ']' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '[' ... ']': } }"));
 
-        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '&' : case '\\'' : case '(' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '&' ... '(': } }"));
-        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '\\x61' : case 'b' : case '\\x63' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '\\x61' ... '\\x63': } }"));
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '&' : case 39 : case '(' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '&' ... '(': } }"));
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '\\x61' : case 98 : case '\\x63' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '\\x61' ... '\\x63': } }"));
     }
 
     void simplifyEmptyNamespaces() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -5404,6 +5404,9 @@ private:
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case 'c' ... 'a' : ; } }", tokenizeAndStringify("void f() { switch(x) { case 'c' ... 'a': } }"));
 
         ASSERT_EQUALS("void f ( ) { switch ( x ) { case '[' : case '\\\\' : case ']' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '[' ... ']': } }"));
+
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '&' : case '\\'' : case '(' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '&' ... '(': } }"));
+        ASSERT_EQUALS("void f ( ) { switch ( x ) { case '\\x61' : case 'b' : case '\\x63' : ; } }", tokenizeAndStringify("void f() { switch(x) { case '\\x61' ... '\\x63': } }"));
     }
 
     void simplifyEmptyNamespaces() {


### PR DESCRIPTION
This fixes the following daca@home report:

```
refind-0.12.0/refind/line_edit.c:0:0: error: Internal Error. MathLib::toLongNumber: characterLiteralToLL(''') => raw single quotes and newlines not allowed in character literals [cppcheckError]
```

due to the case range `case ' ' ... '~':` and some similar issues with escape sequences in case ranges.

---

I would like better though to remove the separation between the `%num%` and `%char%` cases. The `%num%` case can take care of both if it is acceptable that the newly-inserted `case`s use integer literals instead of character literals. Then some more unusual cases, such as wide characters, will also be handled correctly. At the moment I don't see any particular reason for the distinction.