### PR TITLE
Fix FP leakNoVarFunctionCall with passthrough returns

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -996,7 +996,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
         const Token* tok2 = tok->next()->astParent();
         while (tok2 && tok2->isCast())
             tok2 = tok2->astParent();
-        if (tok2 && (tok2->isAssignmentOp() || tok2->str() == "return"))
+        if (Token::Match(tok2, "%assign%|return"))
             continue;
 
         const std::string& functionName = tok->str();

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -996,7 +996,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
         const Token* tok2 = tok->next()->astParent();
         while (tok2 && tok2->isCast())
             tok2 = tok2->astParent();
-        if (tok2 && tok2->isAssignmentOp())
+        if (tok2 && (tok2->isAssignmentOp() || tok2->str() == "return"))
             continue;
 
         const std::string& functionName = tok->str();

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2173,6 +2173,11 @@ private:
               "    return ret;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+        
+        check("char *x() {\n"
+              "    return strcpy(malloc(10), \"abc\");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
 
         check("void x() {\n"
               "    free(malloc(10));\n"


### PR DESCRIPTION
This fixes the following false positive leakNoVarFunctionCall:

void* f(size_t s) { return memset(xmalloc(s), 0, s); }

When assigning the pointer returned from memset, there already was no
report. This adds return statements to the excluded patterns.

---

The rule currently doesn't seem to care whether the function used is actually passing through the pointer. Maybe the `returnValue` function attribute can be used to limit the exclusion to functions that actually pass through the argument?