### PR TITLE
Increase max AST depth and throw error if exceeded

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -35,7 +35,7 @@
 // How many compileExpression recursions are allowed?
 // For practical code this could be endless. But in some special torture test
 // there needs to be a limit.
-static const int AST_MAX_DEPTH = 50;
+static const int AST_MAX_DEPTH = 100;
 
 
 TokenList::TokenList(const Settings* settings) :
@@ -705,7 +705,9 @@ static void compileUnaryOp(Token *&tok, AST_state& state, void(*f)(Token *&tok, 
     if (f) {
         tok = tok->next();
         state.depth++;
-        if (tok && state.depth <= AST_MAX_DEPTH)
+        if (state.depth > AST_MAX_DEPTH)
+            throw InternalError(tok, "maximum AST depth exceeded", InternalError::AST);
+        if (tok)
             f(tok, state);
         state.depth--;
     }
@@ -1313,7 +1315,7 @@ static void compileComma(Token *&tok, AST_state& state)
 static void compileExpression(Token *&tok, AST_state& state)
 {
     if (state.depth > AST_MAX_DEPTH)
-        return; // ticket #5592
+        throw InternalError(tok, "maximum AST depth exceeded", InternalError::AST); // ticket #5592
     if (tok)
         compileComma(tok, state);
 }


### PR DESCRIPTION
While testing gzip's sources on my system, I got a an internalAstError saying `AST broken, ternary operator missing operand(s)`.

It turns out that a file from gnulib exceeds the limit of `AST_MAX_DEPTH`, specifically [float+.h](https://git.savannah.gnu.org/gitweb/?p=gnulib.git;f=lib/float%2B.h;hb=HEAD) has a macro with deeply nested ternary operators.

This PR doubles the value of `AST_MAX_DEPTH` and makes the code throw immediately with a clearer error message if it is exceeded instead of causing hard-to-follow errors down the line. If this behavior is not desired I would suggest at least maintaining a flag indicating whether the maximum depth was exceeded which can then be reported with other internalAstErrors to help diagnosis.