### PR TITLE
misra: Add support for expected suppressions in header files in `-verify` mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ matrix:
         # We'll force C89 standard to enable an additional verification for
         # rules 5.4 and 5.5 which have standard-dependent options.
         - ${CPPCHECK} --dump --suppress=uninitvar --suppress=uninitStructMember --std=c89 misra/misra-test.c
+        - ${CPPCHECK} --dump --suppress=uninitvar --suppress=uninitStructMember --std=c89 misra/misra-test.h
         - python3 ../misra.py -verify misra/misra-test.c.dump
         - ${CPPCHECK} --dump misra/misra-test.cpp
         - python3 ../misra.py -verify misra/misra-test.cpp.dump

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1,4 +1,5 @@
 // To test:
+// ~/cppcheck/cppcheck --dump misra/misra-test.h --std=c89
 // ~/cppcheck/cppcheck --dump --suppress=uninitvar --suppress=uninitStructMember misra/misra-test.c --std=c89 && python3 ../misra.py -verify misra/misra-test.c.dump
 
 #include "path\file.h" // 20.2

--- a/addons/test/misra/misra-test.h
+++ b/addons/test/misra/misra-test.h
@@ -1,5 +1,6 @@
 #ifndef MISRA_TEST_H
 #define MISRA_TEST_H
 struct misra_h_s { int foo; };
-bool test(char *a);
+bool test(char *); // 8.2
+bool test(char *a); // OK
 #endif // MISRA_TEST_H


### PR DESCRIPTION
This allows to specify expected suppressions in the included header files.

This is necessary to verify MISRA checkers, which make requirements for header files. For example, Rule 8.2 requires adding
prototypes for each function to the header files.

Merging this PR also allows to test the regressions in #3227.