### PR TITLE
Fix test case for #10186

### DIFF
--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -429,13 +429,7 @@ private:
     void assign21() { // #10186
         check("void f(int **x) {\n"
               "    void *p = malloc(10);\n"
-              "    *x = p;\n"
-              "}", true);
-        ASSERT_EQUALS("", errout.str());
-
-        check("void f(struct str *d) {\n"
-              "    void *p = malloc(10);\n"
-              "    d->a = p;\n"
+              "    *x = (int*)p;\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
     }


### PR DESCRIPTION
When #10186 was fixed, the test case added didn't actually test what was
described in the ticket. Fix this by adding a cast and remove a
duplicated test case (essentially equal to TestLeakAutoVar::assign7).

Spotted when answering https://sourceforge.net/p/cppcheck/discussion/general/thread/cba4e2d026/