### PR TITLE
gtk.cfg: g_strdup and g_strcmp0 allow NULL args

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -4087,12 +4087,10 @@
     <returnValue type="int"/>
     <use-retval/>
     <arg nr="1" direction="in">
-      <not-null/>
       <not-uninit/>
       <strz/>
     </arg>
     <arg nr="2" direction="in">
-      <not-null/>
       <not-uninit/>
       <strz/>
       <not-bool/>
@@ -20432,7 +20430,6 @@
     <returnValue type="gchar *"/>
     <use-retval/>
     <arg nr="1">
-      <not-null/>
       <not-uninit/>
       <not-bool/>
     </arg>


### PR DESCRIPTION
According to the documentation, both `g_strdup` and `g_strcmp0` allow for null pointer arguments. This removes the `not-null` attributes of these from `gtk.cfg`.

See https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html.