### PR TITLE
fix #10281 (Tokenizer; Wrong simplification for 'namespace ef = ::a::…

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -12545,6 +12545,18 @@ static bool sameTokens(const Token *first, const Token *last, const Token *other
     return false;
 }
 
+static bool alreadyHasNamespace(const Token *first, const Token *last, const Token *end)
+{
+    while (end && last->str() == end->str()) {
+        if (first == last)
+            return true;
+        last = last->previous();
+        end = end->previous();
+    }
+
+    return false;
+}
+
 static Token * deleteAlias(Token * tok)
 {
     Token::eraseTokens(tok, Token::findsimplematch(tok, ";"));
@@ -12615,7 +12627,7 @@ void Tokenizer::simplifyNamespaceAliases()
                         }
                     }
 
-                    if (tok2->strAt(1) == "::") {
+                    if (tok2->strAt(1) == "::" && !alreadyHasNamespace(tokNameStart, tokNameEnd, tok2)) {
                         tok2->str(tokNameStart->str());
                         Token * tok3 = tokNameStart;
                         while (tok3 != tokNameEnd) {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -265,7 +265,8 @@ private:
         TEST_CASE(simplifyCharAt);
         TEST_CASE(simplifyOverride); // ticket #5069
         TEST_CASE(simplifyNestedNamespace);
-        TEST_CASE(simplifyNamespaceAliases);
+        TEST_CASE(simplifyNamespaceAliases1);
+        TEST_CASE(simplifyNamespaceAliases2); // ticket #10281
 
         TEST_CASE(simplifyKnownVariables1);
         TEST_CASE(simplifyKnownVariables2);
@@ -5156,7 +5157,7 @@ private:
         ASSERT_EQUALS("namespace A { namespace B { namespace C { int i ; } } }", tok("namespace A::B::C { int i; }"));
     }
 
-    void simplifyNamespaceAliases() {
+    void simplifyNamespaceAliases1() {
         ASSERT_EQUALS(";",
                       tok("namespace ios = boost::iostreams;"));
         ASSERT_EQUALS("boost :: iostreams :: istream foo ( \"foo\" ) ;",
@@ -5222,6 +5223,17 @@ private:
                           "}"));
     }
 
+    void simplifyNamespaceAliases2() {
+        ASSERT_EQUALS("void foo ( ) "
+                      "{ "
+                      "int maxResults ; maxResults = :: a :: b :: c :: d :: ef :: MAX ; "
+                      "}",
+                      tok("namespace ef = ::a::b::c::d::ef;"
+                          "void foo()"
+                          "{"
+                          "  int maxResults = ::a::b::c::d::ef::MAX;"
+                          "}"));
+    }
 
     std::string simplifyKnownVariables(const char code[]) {
         errout.str("");


### PR DESCRIPTION
…b::c::d::ef')