### PR TITLE
Better handling functions with try block for throwInNoexceptFunction

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -208,8 +208,10 @@ static const Token * functionThrowsRecursive(const Function * function, std::set
     for (const Token *tok = function->functionScope->bodyStart->next();
          tok != function->functionScope->bodyEnd; tok = tok->next()) {
         if (tok->str() == "try") {
-            // just bail for now
-            break;
+            tok = tok->next();
+            if (function->functionScope->bodyEnd == tok || tok->str() != "{")
+                break;
+            tok = tok->link();  // skip till start of catch clauses
         }
         if (tok->str() == "throw") {
             return tok;
@@ -232,7 +234,7 @@ static const Token * functionThrowsRecursive(const Function * function, std::set
 
 static const Token * functionThrows(const Function * function)
 {
-    std::set<const Function *>  recursive;
+    std::set<const Function *> recursive;
 
     return functionThrowsRecursive(function, recursive);
 }
@@ -306,4 +308,3 @@ void CheckExceptionSafety::unhandledExceptionSpecification()
         }
     }
 }
-

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -207,12 +207,8 @@ static const Token * functionThrowsRecursive(const Function * function, std::set
 
     for (const Token *tok = function->functionScope->bodyStart->next();
          tok != function->functionScope->bodyEnd; tok = tok->next()) {
-        if (tok->str() == "try") {
-            tok = tok->next();
-            if (function->functionScope->bodyEnd == tok || tok->str() != "{")
-                break;
-            tok = tok->link();  // skip till start of catch clauses
-        }
+        if (Token::simpleMatch(tok, "try {"))
+            tok = tok->linkAt(1);  // skip till start of catch clauses
         if (tok->str() == "throw") {
             return tok;
         } else if (tok->function()) {

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -321,7 +321,7 @@ private:
     }
 
     void noexceptThrow() {
-        check("void func1() noexcept(false) { try {;} catch(...) {;} throw 1; }\n"
+        check("void func1() noexcept(false) { try {} catch(...) {;} throw 1; }\n"
               "void func2() noexcept { throw 1; }\n"
               "void func3() noexcept(true) { throw 1; }\n"
               "void func4() noexcept(false) { throw 1; }\n"

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -321,7 +321,7 @@ private:
     }
 
     void noexceptThrow() {
-        check("void func1() noexcept(false) { throw 1; }\n"
+        check("void func1() noexcept(false) { try {;} catch(...) {;} throw 1; }\n"
               "void func2() noexcept { throw 1; }\n"
               "void func3() noexcept(true) { throw 1; }\n"
               "void func4() noexcept(false) { throw 1; }\n"
@@ -332,12 +332,13 @@ private:
                       "[test.cpp:5]: (error) Exception thrown in function declared not to throw exceptions.\n", errout.str());
 
         // avoid false positives
-        check("const char *func() noexcept { return 0; }");
+        check("const char *func() noexcept { return 0; }\n"
+              "const char *func1() noexcept { try { throw 1; } catch(...) {} return 0; }");
         ASSERT_EQUALS("", errout.str());
     }
 
     void nothrowThrow() {
-        check("void func1() throw(int) { throw 1; }\n"
+        check("void func1() throw(int) { try {;} catch(...) { throw 1; } ; }\n"
               "void func2() throw() { throw 1; }\n"
               "void func3() throw(int) { throw 1; }\n"
               "void func4() throw() { func1(); }\n"


### PR DESCRIPTION
Previous implementation of recursive function analysis just give up in case of meeting `try` token.
This patch should improve handling such cases. Still it has gap in lack of analysis of try scope (which types can be thrown and can be catched)
Testing for this incorporated in current test cases to avoid duplication