### PR TITLE
New check for rethrow without current handled exception

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -340,6 +340,8 @@ void CheckExceptionSafety::rethrowNoCurrentException()
 
 void CheckExceptionSafety::rethrowNoCurrentExceptionError(const Token *tok) {
     reportError(tok, Severity::error, "rethrowNoCurrentException",
-                "Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().",
+                "Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow."
+                " If there is no current exception this calls std::terminate()."
+                " More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object",
                 CWE480, Certainty::normal);
 }

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -315,6 +315,13 @@ void CheckExceptionSafety::rethrowNoCurrentException()
         const Function* function = scope->function;
         if (!function)
             continue;
+
+        // Rethrow can be used in 'exception dispatcher' idiom which is FP in such case
+        // https://isocpp.org/wiki/faq/exceptions#throw-without-an-object
+        // We check the beggining of the function with idiom pattern
+        if (Token::simpleMatch(function->functionScope->bodyStart->next(), "try { throw ; } catch (" ))
+            continue;
+
         for (const Token *tok = function->functionScope->bodyStart->next();
             tok != function->functionScope->bodyEnd; tok = tok->next()) {
             if (Token::simpleMatch(tok, "catch (")) {

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -141,11 +141,7 @@ private:
     }
 
     /** Rethrow without currently handled exception */
-    void rethrowNoCurrentExceptionError(const Token *tok) {
-        reportError(tok, Severity::error, "rethrowNoCurrentException",
-                    "Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()",
-                    CWE480, Certainty::normal);
-    }
+    void rethrowNoCurrentExceptionError(const Token *tok);
 
     /** Generate all possible errors (for --errorlist) */
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -36,6 +36,7 @@ class ErrorLogger;
 // CWE ID used:
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 static const struct CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
+static const struct CWE CWE480(480U);   // Use of Incorrect Operator
 
 
 /// @addtogroup Checks
@@ -72,6 +73,7 @@ public:
         checkExceptionSafety.checkCatchExceptionByValue();
         checkExceptionSafety.nothrowThrows();
         checkExceptionSafety.unhandledExceptionSpecification();
+        checkExceptionSafety.rethrowNoCurrentException();
     }
 
     /** Don't throw exceptions in destructors */
@@ -91,6 +93,9 @@ public:
 
     /** @brief %Check for unhandled exception specification */
     void unhandledExceptionSpecification();
+
+    /** @brief %Check for rethrow not from catch scope */
+    void rethrowNoCurrentException();
 
 private:
     /** Don't throw exceptions in destructors */
@@ -135,6 +140,13 @@ private:
                     "Either use a try/catch around the function call, or add a exception specification for " + funcname + "() also.", CWE703, Certainty::inconclusive);
     }
 
+    /** Rethrow without currently handled exception */
+    void rethrowNoCurrentExceptionError(const Token *tok) {
+        reportError(tok, Severity::error, "rethrowNoCurrentException",
+                    "Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()",
+                    CWE480, Certainty::normal);
+    }
+
     /** Generate all possible errors (for --errorlist) */
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckExceptionSafety c(nullptr, settings, errorLogger);
@@ -144,6 +156,7 @@ private:
         c.catchExceptionByValueError(nullptr);
         c.noexceptThrowError(nullptr);
         c.unhandledExceptionSpecificationError(nullptr, nullptr, "funcname");
+        c.rethrowNoCurrentExceptionError(nullptr);
     }
 
     /** Short description of class (for --doc) */
@@ -159,7 +172,8 @@ private:
                "- Throwing a copy of a caught exception instead of rethrowing the original exception\n"
                "- Exception caught by value instead of by reference\n"
                "- Throwing exception in noexcept, nothrow(), __attribute__((nothrow)) or __declspec(nothrow) function\n"
-               "- Unhandled exception specification when calling function foo()\n";
+               "- Unhandled exception specification when calling function foo()\n"
+               "- Rethrow without currently handled exception\n";
     }
 };
 /// @}

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -51,6 +51,7 @@ private:
         TEST_CASE(nothrowAttributeThrow);
         TEST_CASE(nothrowAttributeThrow2); // #5703
         TEST_CASE(nothrowDeclspecThrow);
+        TEST_CASE(rethrowNoCurrentException);
     }
 
     void check(const char code[], bool inconclusive = false) {
@@ -406,6 +407,15 @@ private:
         // avoid false positives
         check("const char *func() __attribute((nothrow)); void func1() { return 0; }");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void rethrowNoCurrentException() {
+        check("void func1() { try{ throw; } catch (int&) { ; } }\n"
+              "void func2() { try{ ; } catch (const int&) { throw; } ; }\n"
+              "void func3() { try{ ; } catch (...) { ; } throw; }\n"
+              "void func4() { throw 0; }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()\n"
+                      "[test.cpp:3]: (error) Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()\n", errout.str());
     }
 };
 

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -412,7 +412,7 @@ private:
     }
 
     void rethrowNoCurrentException1() {
-        check("void func1() { try{ throw; } catch (int&) { ; } }");
+        check("void func1(const bool flag) { try{ if(!flag) throw; } catch (int&) { ; } }");
         ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().\n", errout.str());
     }
 
@@ -422,8 +422,9 @@ private:
     }
 
     void rethrowNoCurrentException3() {
-        check("void func1() { try{ ; } catch (const int&) { throw; } ; }\n"
-              "void func2() { throw 0; }");
+        check("void on_error() { try { throw; } catch (const int &) { ; } catch (...) { ; } }\n"      // exception dispatcher idiom
+              "void func2() { try{ ; } catch (const int&) { throw; } ; }\n"
+              "void func3() { throw 0; }");
         ASSERT_EQUALS("", errout.str());
     }
 };

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -413,12 +413,14 @@ private:
 
     void rethrowNoCurrentException1() {
         check("void func1(const bool flag) { try{ if(!flag) throw; } catch (int&) { ; } }");
-        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow."
+                      " If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object\n", errout.str());
     }
 
     void rethrowNoCurrentException2() {
         check("void func1() { try{ ; } catch (...) { ; } throw; }");
-        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow."
+                      " If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object\n", errout.str());
     }
 
     void rethrowNoCurrentException3() {

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -51,7 +51,9 @@ private:
         TEST_CASE(nothrowAttributeThrow);
         TEST_CASE(nothrowAttributeThrow2); // #5703
         TEST_CASE(nothrowDeclspecThrow);
-        TEST_CASE(rethrowNoCurrentException);
+        TEST_CASE(rethrowNoCurrentException1);
+        TEST_CASE(rethrowNoCurrentException2);
+        TEST_CASE(rethrowNoCurrentException3);
     }
 
     void check(const char code[], bool inconclusive = false) {
@@ -409,13 +411,20 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void rethrowNoCurrentException() {
-        check("void func1() { try{ throw; } catch (int&) { ; } }\n"
-              "void func2() { try{ ; } catch (const int&) { throw; } ; }\n"
-              "void func3() { try{ ; } catch (...) { ; } throw; }\n"
-              "void func4() { throw 0; }");
-        ASSERT_EQUALS("[test.cpp:1]: (error) Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()\n"
-                      "[test.cpp:3]: (error) Calling `throw;` without currently handled exception(not from catch block) calls std​::​​terminate()\n", errout.str());
+    void rethrowNoCurrentException1() {
+        check("void func1() { try{ throw; } catch (int&) { ; } }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().\n", errout.str());
+    }
+
+    void rethrowNoCurrentException2() {
+        check("void func1() { try{ ; } catch (...) { ; } throw; }");
+        ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing exception with 'throw;' outside a catch scope calls std::terminate().\n", errout.str());
+    }
+
+    void rethrowNoCurrentException3() {
+        check("void func1() { try{ ; } catch (const int&) { throw; } ; }\n"
+              "void func2() { throw 0; }");
+        ASSERT_EQUALS("", errout.str());
     }
 };
 


### PR DESCRIPTION
This check should warn user about forgotten argument for `throw`. I guess it could be quite common in case if you go to look up the right type of exception or macro for it and got distracted or something.
Possible FP can be if rethrow which located inside a function which called from a catch block. But in this case it should be one place for entire project if code in not bad shape.

Standard references:
-  https://eel.is/c++draft/expr.throw
-  https://eel.is/c++draft/except.handle#def:exception_handling,currently_handled_exception

Also similar check presented in another analyzer: https://pvs-studio.com/en/docs/warnings/v667/