### PR TITLE
Added case to not increase error counter in case of use --inline-suppr

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2963,7 +2963,7 @@ class MisraChecker:
 
         if self.settings.verify:
             self.verify_actual.append('%s:%d %d.%d' % (location.file, location.linenr, num1, num2))
-        elif self.isRuleSuppressed(location.file, location.linenr, ruleNum):
+        elif (self.isRuleSuppressed(location.file, location.linenr, ruleNum) or cppcheckdata.is_suppressed(location, '',  'misra-c2012-'+str(num1)+'.'+str(num2))):
             # Error is suppressed. Ignore
             self.suppressionStats.setdefault(ruleNum, 0)
             self.suppressionStats[ruleNum] += 1


### PR DESCRIPTION
Added case to not increase error counter in case of use --inline-suppr option.

More in the forum discussion: https://sourceforge.net/p/cppcheck/discussion/development/thread/d1dd5402db/?limit=25#1933