### PR TITLE
New check: [perf] Copy elision optimization can't be applied for `return std::move(local)`

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -568,7 +568,7 @@ void CheckFunctions::returnLocalStdMove()
                 copyElisionError(retval);
             }
             // NRVO
-            if (Token::Match(matchToken, "std :: move ( %var% ) ;") && retval->variable()->isLocal()) {
+            if (Token::Match(matchToken, "std :: move ( %var% ) ;") && retval->variable()->isLocal() && !retval->variable()->isVolatile()) {
                 copyElisionError(retval);
             }
         }

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -74,6 +74,7 @@ public:
         checkFunctions.checkMathFunctions();
         checkFunctions.memsetZeroBytes();
         checkFunctions.memsetInvalid2ndParam();
+        checkFunctions.returnLocalStdMove();
     }
 
     /** Check for functions that should not be used */
@@ -101,6 +102,9 @@ public:
     /** @brief %Check for invalid 2nd parameter of memset() */
     void memsetInvalid2ndParam();
 
+    /** @brief %Check for copy elision by RVO|NRVO */
+    void returnLocalStdMove();
+
     /** @brief --check-library: warn for unconfigured function calls */
     void checkLibraryMatchFunctions();
 
@@ -119,6 +123,7 @@ private:
     void memsetFloatError(const Token *tok, const std::string &var_value);
     void memsetValueOutOfRangeError(const Token *tok, const std::string &value);
     void missingReturnError(const Token *tok);
+    void copyElisionError(const Token *tok);
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckFunctions c(nullptr, settings, errorLogger);
@@ -137,6 +142,7 @@ private:
         c.memsetFloatError(nullptr,  "varname");
         c.memsetValueOutOfRangeError(nullptr,  "varname");
         c.missingReturnError(nullptr);
+        c.copyElisionError(nullptr);
     }
 
     static std::string myName() {
@@ -151,7 +157,8 @@ private:
                "- Warn if a function is called whose usage is discouraged\n"
                "- memset() third argument is zero\n"
                "- memset() with a value out of range as the 2nd parameter\n"
-               "- memset() with a float as the 2nd parameter\n";
+               "- memset() with a float as the 2nd parameter\n"
+               "- copy elision optimization for returning value affected by std::move\n";
     }
 };
 /// @}

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -83,16 +83,16 @@ private:
         TEST_CASE(memsetZeroBytes);
         TEST_CASE(memsetInvalid2ndParam);
 
-<<<<<<< HEAD
         // missing "return"
         TEST_CASE(checkMissingReturn);
-=======
+
         // std::move for locar variable
         TEST_CASE(returnLocalStdMove1);
         TEST_CASE(returnLocalStdMove2);
         TEST_CASE(returnLocalStdMove3);
         TEST_CASE(returnLocalStdMove4);
->>>>>>> 7126f65dd (New check; F.48: Don’t return std::move(local))
+
+        TEST_CASE(returnLocalStdMove5);
     }
 
     void check(const char code[], const char filename[]="test.cpp", const Settings* settings_=nullptr) {
@@ -1414,6 +1414,7 @@ private:
               "    else\n"
               "        return {1, 2};\n"
               "}");
+    }
     // NRVO check
     void returnLocalStdMove1() {
         check("struct A{}; A f() { A var; return std::move(var); }");
@@ -1435,7 +1436,14 @@ private:
                       " More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local\n", errout.str());
     }
 
+    // Function argument
     void returnLocalStdMove4() {
+        check("struct A{}; A f(A a) { return std::move(A{}); }");
+        ASSERT_EQUALS("[test.cpp:1]: (performance) Using std::move for returning object by-value from function will affect copy elision optimization."
+                      " More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local\n", errout.str());
+    }
+
+    void returnLocalStdMove5() {
         check("struct A{} a; A f1() { return std::move(a); }\n"
               "A f2() { volatile A var; return std::move(var); }");
         ASSERT_EQUALS("", errout.str());

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1436,7 +1436,8 @@ private:
     }
 
     void returnLocalStdMove4() {
-        check("struct A{} a; A f() { return std::move(a); }");
+        check("struct A{} a; A f1() { return std::move(a); }\n"
+              "A f2() { volatile A var; return std::move(var); }");
         ASSERT_EQUALS("", errout.str());
     }
 };

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -37,6 +37,7 @@ private:
     void run() OVERRIDE {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::performance);
         settings.severity.enable(Severity::portability);
         settings.libraries.emplace_back("posix");
         settings.standards.c = Standards::C11;
@@ -82,8 +83,16 @@ private:
         TEST_CASE(memsetZeroBytes);
         TEST_CASE(memsetInvalid2ndParam);
 
+<<<<<<< HEAD
         // missing "return"
         TEST_CASE(checkMissingReturn);
+=======
+        // std::move for locar variable
+        TEST_CASE(returnLocalStdMove1);
+        TEST_CASE(returnLocalStdMove2);
+        TEST_CASE(returnLocalStdMove3);
+        TEST_CASE(returnLocalStdMove4);
+>>>>>>> 7126f65dd (New check; F.48: Don’t return std::move(local))
     }
 
     void check(const char code[], const char filename[]="test.cpp", const Settings* settings_=nullptr) {
@@ -1405,6 +1414,29 @@ private:
               "    else\n"
               "        return {1, 2};\n"
               "}");
+    // NRVO check
+    void returnLocalStdMove1() {
+        check("struct A{}; A f() { A var; return std::move(var); }");
+        ASSERT_EQUALS("[test.cpp:1]: (performance) Using std::move for returning object by-value from function will affect copy elision optimization."
+                      " More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local\n", errout.str());
+    }
+
+    // RVO, C++03 ctor style
+    void returnLocalStdMove2() {
+        check("struct A{}; A f() { return std::move( A() ); }");
+        ASSERT_EQUALS("[test.cpp:1]: (performance) Using std::move for returning object by-value from function will affect copy elision optimization."
+                      " More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local\n", errout.str());
+    }
+
+    // RVO, new ctor style
+    void returnLocalStdMove3() {
+        check("struct A{}; A f() { return std::move(A{}); }");
+        ASSERT_EQUALS("[test.cpp:1]: (performance) Using std::move for returning object by-value from function will affect copy elision optimization."
+                      " More: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local\n", errout.str());
+    }
+
+    void returnLocalStdMove4() {
+        check("struct A{} a; A f() { return std::move(a); }");
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
Returning objects by-value from function could[2] be optimized by Return Value Optimization by compiler. Using `std::move` could affect compiler behaviour in this case. [1] has general recommendation to avoid such expressions.

As an other optimizations it has a lot of vary from version to version, from platform to platform, e.g. *mandatory* case came with C++17. But as a motivation for adding this 

[1] https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-return-move-local
[2] https://en.cppreference.com/w/cpp/language/copy_elision
https://pvs-studio.com/en/docs/warnings/v828/
