### PR TITLE
gui: Set the correct names for coding standards in UI elements. NFC.

### DIFF
--- a/gui/cppcheck_de.ts
+++ b/gui/cppcheck_de.ts
@@ -1415,8 +1415,8 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
-        <translation>Misra-Regeltexte</translation>
+        <source>MISRA rule texts</source>
+        <translation>MISRA-Regeltexte</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="826"/>
@@ -1695,8 +1695,8 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
-        <translation>Cert</translation>
+        <source>CERT</source>
+        <translation>CERT</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="858"/>
@@ -1793,7 +1793,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation>MISRA-Regeltext-Datei</translation>
     </message>
 </context>
@@ -2451,12 +2451,12 @@ Legen Sie unter dem Menü Ansicht fest, welche Arten von Fehlern angezeigt werde
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation>MISRA-Addon</translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation>MISRA-Regeltext-Datei</translation>
     </message>
     <message>

--- a/gui/cppcheck_es.ts
+++ b/gui/cppcheck_es.ts
@@ -1565,7 +1565,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1821,7 +1821,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1923,7 +1923,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2599,12 +2599,12 @@ Para cambiar el tipo de comportamiento, abra el menú Ver.</translation>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_fi.ts
+++ b/gui/cppcheck_fi.ts
@@ -1407,7 +1407,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1667,7 +1667,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1765,7 +1765,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2432,12 +2432,12 @@ Määrittääksesi minkä tyyppisiä virheitä näytetään, avaa näkymä valik
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_fr.ts
+++ b/gui/cppcheck_fr.ts
@@ -1604,7 +1604,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1705,7 +1705,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1815,7 +1815,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2589,12 +2589,12 @@ Pour configurer les erreurs affichées, ouvrez le menu d&apos;affichage.</transl
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_it.ts
+++ b/gui/cppcheck_it.ts
@@ -1582,7 +1582,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1834,7 +1834,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1932,7 +1932,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2631,12 +2631,12 @@ Per vedere il tipo di errori che sono mostrati, apri il menu Visualizza.</transl
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_ja.ts
+++ b/gui/cppcheck_ja.ts
@@ -1619,8 +1619,8 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
-        <translation>Misra ルールテキスト</translation>
+        <source>MISRA rule texts</source>
+        <translation>MISRA ルールテキスト</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="826"/>
@@ -1927,7 +1927,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation>CERT</translation>
     </message>
     <message>
@@ -2045,8 +2045,8 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
-        <translation>Misraルールテキストファイル (%1)</translation>
+        <source>MISRA rule texts file (%1)</source>
+        <translation>MISRAルールテキストファイル (%1)</translation>
     </message>
 </context>
 <context>
@@ -2749,13 +2749,13 @@ To toggle what kind of errors are shown, open view menu.</source>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
-        <translation>Misraアドオン</translation>
+        <source>MISRA addon</source>
+        <translation>MISRAアドオン</translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
-        <translation>Misra ルールテキストファイル</translation>
+        <source>MISRA rule texts file</source>
+        <translation>MISRA ルールテキストファイル</translation>
     </message>
     <message>
         <location filename="settings.ui" line="338"/>

--- a/gui/cppcheck_ko.ts
+++ b/gui/cppcheck_ko.ts
@@ -1687,7 +1687,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1788,7 +1788,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1898,7 +1898,7 @@ Do you want to proceed?</source>
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2688,12 +2688,12 @@ To toggle what kind of errors are shown, open view menu.</source>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_nl.ts
+++ b/gui/cppcheck_nl.ts
@@ -1564,7 +1564,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1816,7 +1816,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1914,7 +1914,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2615,12 +2615,12 @@ Gebruik het uitzicht menu om te selecteren welke fouten getoond worden.</transla
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_ru.ts
+++ b/gui/cppcheck_ru.ts
@@ -1697,7 +1697,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation>Файл с текстами правил MISRA</translation>
     </message>
     <message>
@@ -1934,8 +1934,8 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
-        <translation>Cert</translation>
+        <source>CERT</source>
+        <translation>CERT</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="858"/>
@@ -2032,7 +2032,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation>Файл текстов правил MISRA (%1)</translation>
     </message>
 </context>
@@ -2732,12 +2732,12 @@ To toggle what kind of errors are shown, open view menu.</source>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation>Дополнение MISRA</translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation>Файл с текстами правил MISRA: </translation>
     </message>
     <message>

--- a/gui/cppcheck_sr.ts
+++ b/gui/cppcheck_sr.ts
@@ -1432,7 +1432,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1692,7 +1692,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1790,7 +1790,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2453,12 +2453,12 @@ To toggle what kind of errors are shown, open view menu.</translation>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_sv.ts
+++ b/gui/cppcheck_sv.ts
@@ -1817,7 +1817,7 @@ Sökvägar och defines importeras.</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1970,8 +1970,8 @@ Sökvägar och defines importeras.</translation>
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
-        <translation>Cert</translation>
+        <source>CERT</source>
+        <translation>CERT</translation>
     </message>
     <message>
         <source>Extra Tools</source>
@@ -2050,7 +2050,7 @@ Sökvägar och defines importeras.</translation>
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2795,12 +2795,12 @@ För att ställa in vilka fel som skall visas använd visa menyn.</translation>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_zh_CN.ts
+++ b/gui/cppcheck_zh_CN.ts
@@ -1581,7 +1581,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="819"/>
-        <source>Misra rule texts</source>
+        <source>MISRA rule texts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1833,7 +1833,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.ui" line="803"/>
-        <source>Cert</source>
+        <source>CERT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1931,7 +1931,7 @@ Options:
     </message>
     <message>
         <location filename="projectfiledialog.cpp" line="831"/>
-        <source>Misra rule texts file (%1)</source>
+        <source>MISRA rule texts file (%1)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2632,12 +2632,12 @@ To toggle what kind of errors are shown, open view menu.</source>
     </message>
     <message>
         <location filename="settings.ui" line="323"/>
-        <source>Misra addon</source>
+        <source>MISRA addon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="settings.ui" line="331"/>
-        <source>Misra rule texts file</source>
+        <source>MISRA rule texts file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/help/preferences.html
+++ b/gui/help/preferences.html
@@ -49,9 +49,9 @@ warnings on the screen will not have the full path.</p>
 where python is. Unless you configure something, Cppcheck will try to execute
 python in your PATH.</p>
 
-<p><b>Misra rule texts</b><br>Only needed if you want to use the Misra addon.
-Cppcheck is not legally allowed to distribute the Misra rule texts and these
-must be provided by users. The Misra rule texts are proprietary. An example
+<p><b>MISRA rule texts</b><br>Only needed if you want to use the MISRA addon.
+Cppcheck is not legally allowed to distribute the MISRA rule texts and these
+must be provided by users. The MISRA rule texts are proprietary. An example
 rule text file:
 <blockquote><pre>Appendix A Summary of guidelines
 Rule 1.1

--- a/gui/help/projectfiledialog.html
+++ b/gui/help/projectfiledialog.html
@@ -167,9 +167,9 @@ overflow in year 2038. Check that the code does not use such timers.</p>
 
 <p><b>Thread safety</b><br>Check that the code is thread safe</p>
 
-<p><b>Cert</b><br>Ensure that the Cert coding standard is followed</p>
+<p><b>CERT</b><br>Ensure that the CERT coding standard is followed</p>
 
-<p><b>Misra</b><br>Ensure that the Misra coding standard is followed. Please
+<p><b>MISRA</b><br>Ensure that the MISRA coding standard is followed. Please
 note you need to have a textfile with the misra rule texts to get proper
 warning messages. Cppcheck is not legally allowed to distribute the misra
 rule texts.</p>

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -822,7 +822,7 @@ void ProjectFileDialog::browseMisraFile()
     const QString fileName = QFileDialog::getOpenFileName(this,
                              tr("Select MISRA rule texts file"),
                              QDir::homePath(),
-                             tr("Misra rule texts file (%1)").arg("*.txt"));
+                             tr("MISRA rule texts file (%1)").arg("*.txt"));
     if (!fileName.isEmpty()) {
         QSettings settings;
         mUI.mEditMisraFile->setText(fileName);

--- a/gui/projectfiledialog.ui
+++ b/gui/projectfiledialog.ui
@@ -800,7 +800,7 @@
           <item>
            <widget class="QCheckBox" name="mAddonCert">
             <property name="text">
-             <string>Cert</string>
+             <string>CERT</string>
             </property>
            </widget>
           </item>
@@ -816,7 +816,7 @@
             <item>
              <widget class="QLabel" name="label_2">
               <property name="text">
-               <string>Misra rule texts</string>
+               <string>MISRA rule texts</string>
               </property>
              </widget>
             </item>

--- a/gui/settings.ui
+++ b/gui/settings.ui
@@ -320,7 +320,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
-          <string>Misra addon</string>
+          <string>MISRA addon</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
@@ -328,7 +328,7 @@
             <item>
              <widget class="QLabel" name="label_4">
               <property name="text">
-               <string>Misra rule texts file</string>
+               <string>MISRA rule texts file</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Names of MISRA and CERT should be written is uppercase, because they are abbrevations.