### PR TITLE
gui: Handle errors when creating a build directory

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1590,13 +1590,21 @@ void MainWindow::analyzeProject(const ProjectFile *projectFile, const bool check
         if (!QDir::isAbsolutePath(buildDir))
             buildDir = inf.canonicalPath() + '/' + buildDir;
         if (!QDir(buildDir).exists()) {
-            QMessageBox msg(QMessageBox::Critical,
+            QMessageBox msg(QMessageBox::Question,
                             tr("Cppcheck"),
                             tr("Build dir '%1' does not exist, create it?").arg(buildDir),
                             QMessageBox::Yes | QMessageBox::No,
                             this);
             if (msg.exec() == QMessageBox::Yes) {
                 QDir().mkpath(buildDir);
+            } else if (!projectFile->getAddons().isEmpty()) {
+                QMessageBox m(QMessageBox::Critical,
+                              tr("Cppcheck"),
+                              tr("To check the project using addons, you need a build directory."),
+                              QMessageBox::Ok,
+                              this);
+                m.exec();
+                return;
             }
         }
     }


### PR DESCRIPTION
If user doesn't create a build directory, it is not possible to run add-ons, because they are trying to check dump files in non-existent build directory.

This commit also makes the icon of the 'Create build directory' dialog less confusing.

Before:
![q1](https://user-images.githubusercontent.com/12023585/121291011-38779780-c8f0-11eb-97f7-b2446f29b46b.png)

After:
![q2](https://user-images.githubusercontent.com/12023585/121290981-2dbd0280-c8f0-11eb-8c9c-10bdac561df0.png)
