### PR TITLE
[triage tool] Keep UI alive while wget and tar execution

### DIFF
--- a/tools/triage/mainwindow.cpp
+++ b/tools/triage/mainwindow.cpp
@@ -13,8 +13,6 @@
 #include <ctime>
 #include <cstdlib>
 
-#include <iostream>
-
 const QString WORK_FOLDER(QDir::homePath() + "/triage");
 const QString DACA2_PACKAGES(QDir::homePath() + "/daca2-packages");
 
@@ -45,7 +43,6 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->hFilesFilter->setToolTip(hFiles.join(','));
     ui->srcFilesFilter->setToolTip(srcFiles.join(','));
-    std::cerr << "AAAAA\n";
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Downloading and untaring big files freezes triage tool. To fix this problem properly, it should be redesigned in Qt style.
However, we could dispatch events manually in loop which allow us to show pop-up window(which locks all actions with main form) and keep user in touch.
Long story short, it's a hack, but it should be good enough for internal tool

Tested on Linux KDE