### PR TITLE
Add default parameter to next() to prevent StopIteration exception

### DIFF
--- a/addons/misra_9.py
+++ b/addons/misra_9.py
@@ -435,7 +435,11 @@ def getElementDef(nameToken, rawTokens = None):
 def createArrayChildrenDefs(ed, token, rawTokens = None):
     if token.str == '[':
         if rawTokens is not None:
-            foundToken = next(rawToken for rawToken in rawTokens if rawToken.file == token.file and rawToken.linenr == token.linenr and rawToken.column == token.column)
+            foundToken = next((rawToken for rawToken in rawTokens
+                               if rawToken.file == token.file
+                               and rawToken.linenr == token.linenr
+                               and rawToken.column == token.column
+                               ), None)
 
             if foundToken and foundToken.next and foundToken.next.str == ']':
                 ed.markAsFlexibleArray(token)


### PR DESCRIPTION
Add default parameter to next() to prevent StopIteration exception when no corresponding rawToken is found for '[' token.

Not sure why that happens since there is no code to reproduce the issue, but the rest of the code should be fine with this change.