### PR TITLE
misra: Fixed crash with struct fields containing unknown types on 9.x rules

### DIFF
--- a/addons/misra_9.py
+++ b/addons/misra_9.py
@@ -303,7 +303,7 @@ class InitializerParser:
                     if isFirstElement and self.token.str == '0' and self.token.next.str == '}':
                         # Zero initializer causes recursive initialization
                         self.root.initializeChildren()
-                    elif self.token.isString and self.ed.valueType.pointer > 0:
+                    elif self.token.isString and self.ed.valueType and self.ed.valueType.pointer > 0:
                         if self.ed.valueType.pointer - self.ed.getEffectiveLevel() == 1:
                             if self.ed.parent != self.root:
                                 self.root.markStuctureViolation(self.token)

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -432,6 +432,12 @@ void misra_9_struct_initializers(void) {
         struct1 s[2][2];
     } struct3;
 
+    typedef struct {
+        unknown_field_type f1;
+        unknown_field_type f2[2];
+        int f3[2];
+    } struct_with_unknown_fields;
+
     struct3 sa[2]  = { [1].s[1][0].i1 = 3, 4 };         // 9.2
 
     struct1 sa          = 1;                            // 9.2
@@ -482,6 +488,19 @@ void misra_9_struct_initializers(void) {
     dummy_struct dsf[]     = { [0] = 1 };                     // 9.5
     dummy_struct dsg       = { .a = {0}, .b = {0} };
     dummy_struct dsh[2][2] = { { {.a = 0, .b = {0}}, { 0 } }, { { 0 }, {.a = 0, .b = {0}}} };
+
+    // Struct with fields of unknown type
+    struct_with_unknown_fields ufa       = { 1, { 1, 2 }, { 1, 2 } };
+    struct_with_unknown_fields ufb       = { 1, 1, 2 };                     // 9.2
+    struct_with_unknown_fields[2] ufc    = { {1, { 1, 2 }, { 1, 2 } },
+                                             { 2, { 1, 2 }, { 1, 2 } } };
+    struct_with_unknown_fields[2][2] ufd = { {1, { 1, 2 }, { 1, 2 } },
+                                             { 2, { 1, 2 }, { 1, 2 } } };
+    struct_with_unknown_fields[2] ufe    = { 1, { 1, 2 }, { 1, 2 },         // TODO: 9.2
+                                             2, { 1, 2 }, { 1, 2 } };
+    struct_with_unknown_fields[3] uff    = { { 1, { 1, 2 }, { 1, 2 }},      // TODO: 9.3 9.4
+                                             {2, { 1, 2 }, { 1, 2 }},
+                                             [1] = { 2, { 1, 2 }, { 1, 2 }} };
 
     // Obsolete initialization syntax for GCC
     struct1 os1 = { i1: 1, i2: 2 }; // 10.4 13.4


### PR DESCRIPTION
This fixes the crash on with struct fields containing unknown types reported on the forum: https://sourceforge.net/p/cppcheck/discussion/general/thread/d64551cc55/#5f0f.

The suggested patch doesn't handle the cases when there are struct fields with arrays containing unknown types. So the addon will not generate warnings in these cases. The problem is that Cppcheck doesn't generate `valueType-pointer` information for unknown types in the dump file. When adding this in *symboldatabase.cpp*, MISRA addon will generate a lot of false positives because we depend on the null value of `valueType`.

So I suppose it better to left this as is, to don't break the addon for such rare cases.