### PR TITLE
misra: Fix 8.2 false positives

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1512,7 +1512,9 @@ class MisraChecker:
                     self.reportError(typeStartToken, 8, 2)
 
                 # Type declaration on next line (old style declaration list) is not allowed
-                if (typeStartToken.linenr > endCall.linenr) or (typeStartToken.column > endCall.column):
+                if ((typeStartToken.file == endCall.file) and
+                    ((typeStartToken.linenr > endCall.linenr) or
+                     (typeStartToken.column > endCall.column))):
                     self.reportError(typeStartToken, 8, 2)
 
         # Check arguments in pointer declarations

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -322,6 +322,10 @@ static int misra_8_2_l ( // 8.2
 int16_t ( *misra_8_2_p_a ) (); // 8.2
 int16_t ( *misra_8_2_p_b ) (void);
 int16_t ( *misra_8_2_p_c ) (int);
+int misra_8_2_no_fp (int a)
+{
+    return a + 42;
+}
 
 extern int a811[]; // 8.11
 

--- a/addons/test/misra/misra-test.h
+++ b/addons/test/misra/misra-test.h
@@ -3,4 +3,5 @@
 struct misra_h_s { int foo; };
 bool test(char *); // 8.2
 bool test(char *a); // OK
+int misra_8_2_no_fp(int a);
 #endif // MISRA_TEST_H


### PR DESCRIPTION
Type declaration on the next line is not allowed in rule 8.2. But we need to make sure that the files of the checked files are the same.

Reported on the forum: https://sourceforge.net/p/cppcheck/discussion/development/thread/801dc07e59/#32c3/e90b/293e/39df/85b3/b821/e0c3