### PR TITLE
misra: Fix crash on rule 8.2

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1471,7 +1471,7 @@ class MisraChecker:
                     for _ in range(count):
                         rawToken = rawToken.next
                         # Skip comments
-                        while rawTokens and (rawToken.str.startswith('/*') or rawToken.str.startswith('//')):
+                        while rawToken and (rawToken.str.startswith('/*') or rawToken.str.startswith('//')):
                             rawToken = rawToken.next
                         if rawToken is None:
                             break


### PR DESCRIPTION
Example of the source file used to reproduce this crash:

```c
int misra_8_2_o(
    const uint32_t a1,
    const uint8_t *const a2
)
{ return *a2 + a1; }
int misra_8_2_p(
    const uint32_t a1,
    const uint8_t *const a2
);
```

```
Traceback (most recent call last):
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 3474, in <module>
    main()
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 3418, in main
    checker.parseDump(item)
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 3244, in parseDump
    self.executeCheck(802, self.misra_8_2, cfg, data.rawTokens)
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 3179, in executeCheck
    check_function(*args)
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 1579, in misra_8_2
    rawTokensFollowingPtr = getFollowingRawTokens(rawTokens, var.nameToken, 3)
  File "/home/jubnzv/Dev/cppcheck/addons/misra.py", line 1474, in getFollowingRawTokens
    while rawTokens and (rawToken.str.startswith('/*') or rawToken.str.startswith('//')):
AttributeError: 'NoneType' object has no attribute 'str'
```

The unit test was not added because it looks like a typo and regressions are unlikely.