### PR TITLE
misra: Emit more accurate warnings for unused arguments in rule 2.7

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1133,9 +1133,19 @@ class MisraChecker:
                         if token.variable is not None and token.variable in func_param_list:
                             func_param_list.remove(token.variable)
                         token = token.next
-                    if len(func_param_list) > 0:
-                        # At least one parameter has not been referenced in function body
-                        self.reportError(func.tokenDef, 2, 7)
+                    # Emit a warning for each unused variable, but no more that one warning per line
+                    reported_linenrs = set()
+                    for func_param in func_param_list:
+                        if func_param.nameToken:
+                            linenr = func_param.nameToken
+                            if linenr not in reported_linenrs:
+                                self.reportError(func_param.nameToken, 2, 7)
+                                reported_linenrs.add(linenr)
+                        else:
+                            linenr = func.tokenDef.linenr
+                            if linenr not in reported_linenrs:
+                                self.reportError(func.tokenDef, 2, 7)
+                                reported_linenrs.add(linenr)
 
     def misra_3_1(self, rawTokens):
         for token in rawTokens:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -65,6 +65,20 @@ void misra_2_7_used_params (int *param1, int param2, int param3)
     *param1 = param2;
 }
 
+void misra_2_7_a(int a,
+                 int b, // 2.7
+                 int c,
+                 int d) // 2.7
+{
+    (void)a;
+    (void)c;
+}
+void misra_2_7_b(int a, int b, int c, // 2.7
+                 int d)               // 2.7
+{
+    (void)a;
+}
+
 void misra_3_2(int enable)
 {
     // This won't generate a violation because of subsequent blank line \


### PR DESCRIPTION
Make the MISRA addon emit extra warnings for unused arguments placed in lines other than the function definition. This makes it easier for the user to find violations.