### PR TITLE
misra: Don't consider variadic arguments as the violation of rule 2.7

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1123,7 +1123,10 @@ class MisraChecker:
             # Setup list of function parameters
             func_param_list = list()
             for arg in func.argument:
-                func_param_list.append(func.argument[arg])
+                func_arg = func.argument[arg]
+                if func_arg.typeStartToken and func_arg.typeStartToken.str == '...':
+                    continue
+                func_param_list.append(func_arg)
             # Search for scope of current function
             for scope in data.scopes:
                 if (scope.type == "Function") and (scope.function == func):

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -65,6 +65,9 @@ void misra_2_7_used_params (int *param1, int param2, int param3)
     *param1 = param2;
 }
 
+void misra_2_7_vararg(int a, ...) { (void)a; }
+void misra_2_7_unnamed_arg(int) { } // 2.7 8.2
+
 void misra_3_2(int enable)
 {
     // This won't generate a violation because of subsequent blank line \


### PR DESCRIPTION
The MISRA 2012 standard does not say anything about variadic functions in the definition of rule 2.7. Therefore, these cases should be considered as false positives.