### PR TITLE
Fix assertion failure in errorlogger.cpp

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -272,8 +272,10 @@ static std::string executeAddon(const AddonInfo &addonInfo,
     std::istringstream istr(result);
     std::string line;
     while (std::getline(istr, line)) {
-        if (line.compare(0,9,"Checking ", 0, 9) != 0 && !line.empty() && line[0] != '{')
+        if (line.compare(0,9,"Checking ", 0, 9) != 0 && !line.empty() && line[0] != '{') {
+            result.erase(std::remove(result.begin(), result.end(), '\n'), result.end()); // Remove trailing newlines
             throw InternalError(nullptr, "Failed to execute '" + pythonExe + " " + args + "'. " + result);
+        }
     }
 
     // Valid results

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -273,7 +273,7 @@ static std::string executeAddon(const AddonInfo &addonInfo,
     std::string line;
     while (std::getline(istr, line)) {
         if (line.compare(0,9,"Checking ", 0, 9) != 0 && !line.empty() && line[0] != '{') {
-            result.erase(std::remove(result.begin(), result.end(), '\n'), result.end()); // Remove trailing newlines
+            result.erase(result.find_last_not_of('\n') + 1, std::string::npos); // Remove trailing newlines
             throw InternalError(nullptr, "Failed to execute '" + pythonExe + " " + args + "'. " + result);
         }
     }


### PR DESCRIPTION
The offending code can (and does) result in newlines at the end of InternalError messages, which are asserted to never happen.