### PR TITLE
misra: Improve warning messages for rule 8.2 when the missing arguments are on the next line

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1500,7 +1500,10 @@ class MisraChecker:
                         break
                     voidArg = voidArg.next
                 if not voidArg.str == 'void':
-                    self.reportError(func.tokenDef, 8, 2)
+                    if func.tokenDef.next:
+                        self.reportError(func.tokenDef.next, 8, 2)
+                    else:
+                        self.reportError(func.tokenDef, 8, 2)
 
         def checkDeclarationArgumentsViolations(func, startCall, endCall):
             # Collect the tokens for the arguments in function definition
@@ -1528,7 +1531,10 @@ class MisraChecker:
                 startCall = startCall.next
 
             if len(argNameTokens) != foundVariables:
-                self.reportError(func.tokenDef, 8, 2)
+                if func.tokenDef.next:
+                    self.reportError(func.tokenDef.next, 8, 2)
+                else:
+                    self.reportError(func.tokenDef, 8, 2)
 
         def checkDefinitionArgumentsViolations(func, startCall, endCall):
             for arg in func.argument:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -354,6 +354,8 @@ int misra_8_2_p(
     const uint32_t a1,
     const uint8_t *const a2
 );
+int misra_8_2_q
+(); // 8.2
 
 extern int a811[]; // 8.11
 


### PR DESCRIPTION
This makes it easier for the user to find the violation.

Suggested in the forum: https://sourceforge.net/p/cppcheck/discussion/development/thread/801dc07e59/#a1a8/d3e9/c455/8915/747c/2525/0eb8/0f7d