### PR TITLE
misra: Allow zero-initializers in any form in rule 9.3

### DIFF
--- a/addons/misra_9.py
+++ b/addons/misra_9.py
@@ -1,3 +1,5 @@
+import re
+
 # Holds information about an array, struct or union's element definition.
 class ElementDef:
     def __init__(self, elementType, name, valueType, dimensions = None):
@@ -300,7 +302,7 @@ class InitializerParser:
                     if not isDesignated and len(self.rootStack) > 0 and self.rootStack[-1][1] == self.root:
                         self.rootStack[-1][0].markStuctureViolation(self.token)
 
-                    if isFirstElement and self.token.str == '0' and self.token.next.str == '}':
+                    if isFirstElement and re.match(r'^0([xb\.]0+)?[uUlL]*$', self.token.str) and self.token.next.str == '}':
                         # Zero initializer causes recursive initialization
                         self.root.initializeChildren()
                     elif self.token.isString and self.ed.valueType and self.ed.valueType.pointer > 0:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -380,6 +380,10 @@ void misra_9_empty_or_zero_initializers(void) {
     int k[2][2] = { [0] = { 1 , 2 }, { 0 } };
     int l[1][2] = { { 0 }, [0] = { 1 } };      // 9.3 9.4
 
+    int m[2]    = { 0u };
+    int n[2]    = { 0x00 };
+    int o[2]    = { 0x00ULL };
+
     typedef struct {
         int a;
         int b;


### PR DESCRIPTION
The MISRA document has the exception for rule 9.3, which says that an initialzier _of the form { 0 }_ doesn't violate that rule.

We should consider not only the `{ 0 }` initializer, but also similar ones with initial values like `{ 0.0 }`, `{ 0ULL }`, etc. This makes sense because we can initialize not only the integer arrays but the other types too.

Reported in the forum: https://sourceforge.net/p/cppcheck/discussion/development/thread/801dc07e59/#a1a8/d3e9/c455/8915/747c/2525/0eb8/0f7d