### PR TITLE
cppcheckdata: Fix crash on a nested union

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -404,7 +404,9 @@ class Scope:
         self.nestedIn = IdMap[self.nestedInId]
         self.function = IdMap[self.functionId]
         for v in self.varlistId:
-            self.varlist.append(IdMap[v])
+            value = IdMap.get(v)
+            if value:
+                self.varlist.append(value)
 
 
 class Function:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -41,6 +41,16 @@
 #include <tgmath.h> // 21.11
 #include <fenv.h>
 
+// Check that the addon doesn't crash
+typedef struct {
+  union { // 19.2
+    struct {
+      unsigned a : 2;
+      unsigned : 14;
+    };
+    uint16_t value;
+  };
+} STRUCT_BITS;
 
 typedef unsigned char      u8;
 typedef unsigned short     u16;


### PR DESCRIPTION
The problem is that the variables from the anonymous union nested in a struct don't appear in the dump file. It doesn't matter, since they are not used in the analysis.

Reported in the forum: https://sourceforge.net/p/cppcheck/discussion/development/thread/fe109ee48f/?page=2&limit=25#ff97