### PR TITLE
addons: Fix arguments parser when running pytest

### DIFF
--- a/addons/cert.py
+++ b/addons/cert.py
@@ -379,13 +379,14 @@ def api01(data):
             token = token.next
 
 
-def get_args():
+def get_args_parser():
     parser = cppcheckdata.ArgumentParser()
     parser.add_argument("-verify", help=argparse.SUPPRESS, action="store_true")
-    return parser.parse_args()
+    return parser
 
 if __name__ == '__main__':
-    args = get_args()
+    parser = get_args_parser()
+    args = parser.parse_args()
 
     if args.verify:
         VERIFY = True

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -3377,7 +3377,7 @@ and 20.13, run:
 '''
 
 
-def get_args():
+def get_args_parser():
     """Generates list of command-line arguments acceptable by misra.py script."""
     parser = cppcheckdata.ArgumentParser()
     parser.add_argument("--rule-texts", type=str, help=RULE_TEXTS_HELP)
@@ -3391,11 +3391,12 @@ def get_args():
     parser.add_argument("-generate-table", help=argparse.SUPPRESS, action="store_true")
     parser.add_argument("-verify", help=argparse.SUPPRESS, action="store_true")
     parser.add_argument("--severity", type=str, help="Set a custom severity string, for example 'error' or 'warning'. ")
-    return parser.parse_args()
+    return parser
 
 
 def main():
-    args = get_args()
+    parser = get_args_parser()
+    args = parser.parse_args()
     settings = MisraSettings(args)
     checker = MisraChecker(settings)
 

--- a/addons/test/test-cert.py
+++ b/addons/test/test-cert.py
@@ -18,18 +18,20 @@ def test_arguments_regression():
     # Arguments with expected SystemExit
     args_exit = ["--non-exists", "--non-exists-param=42", "-h", "--help"]
 
-    from addons.cert import get_args
+    from addons.cert import get_args_parser
 
     for arg in args_exit:
         sys.argv.append(arg)
         with pytest.raises(SystemExit):
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         sys.argv.remove(arg)
 
     for arg in args_ok:
         sys.argv.append(arg)
         try:
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         except SystemExit:
             pytest.fail("Unexpected SystemExit with '%s'" % arg)
         sys.argv.remove(arg)

--- a/addons/test/test-misra.py
+++ b/addons/test/test-misra.py
@@ -29,8 +29,9 @@ def teardown_module(module):
 
 @pytest.fixture(scope="function")
 def checker():
-    from addons.misra import MisraChecker, MisraSettings, get_args
-    args = get_args()
+    from addons.misra import MisraChecker, MisraSettings, get_args_parser
+    parser = get_args_parser()
+    args = parser.parse_args([])
     settings = MisraSettings(args)
     return MisraChecker(settings)
 
@@ -135,18 +136,20 @@ def test_arguments_regression():
     # Arguments with expected SystemExit
     args_exit = ["--non-exists", "--non-exists-param=42", "-h", "--help"]
 
-    from addons.misra import get_args
+    from addons.misra import get_args_parser
 
     for arg in args_exit:
         sys.argv.append(arg)
         with pytest.raises(SystemExit):
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         sys.argv.remove(arg)
 
     for arg in args_ok:
         sys.argv.append(arg)
         try:
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         except SystemExit:
             pytest.fail("Unexpected SystemExit with '%s'" % arg)
         sys.argv.remove(arg)

--- a/addons/test/test-y2038.py
+++ b/addons/test/test-y2038.py
@@ -113,18 +113,20 @@ def test_arguments_regression():
     # Arguments with expected SystemExit
     args_exit = ["--non-exists", "--non-exists-param=42", "-h", "--help"]
 
-    from addons.y2038 import get_args
+    from addons.y2038 import get_args_parser
 
     for arg in args_exit:
         sys.argv.append(arg)
         with pytest.raises(SystemExit):
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         sys.argv.remove(arg)
 
     for arg in args_ok:
         sys.argv.append(arg)
         try:
-            get_args()
+            parser = get_args_parser()
+            parser.parse_args()
         except SystemExit:
             pytest.fail("Unexpected SystemExit with '%s'" % arg)
         sys.argv.remove(arg)

--- a/addons/y2038.py
+++ b/addons/y2038.py
@@ -226,13 +226,14 @@ def check_y2038_safe(dumpfile, quiet=False):
     return y2038safe
 
 
-def get_args():
+def get_args_parser():
     parser = cppcheckdata.ArgumentParser()
-    return parser.parse_args()
+    return parser
 
 
 if __name__ == '__main__':
-    args = get_args()
+    parser = get_args_parser()
+    args = parser.parse_args()
 
     exit_code = 0
     quiet = not any((args.quiet, args.cli))


### PR DESCRIPTION
The problem is if we call argparse functions through pytest, the addon will treat pytest options from sysv as its own options and will fail.

For example, if we run a specific test with the following command:
```
PYTHONPATH=addons python3 -m pytest addons/test/test-misra.py -k test_loadRuleTexts_structure
```

The MISRA addon will fail because it considers `-k` as an argument for misra.py.

This commit decouples parser initialization and `parser.get_args()` logic from the implementation in addons.