### PR TITLE
Remove a false positive - main function has no return value

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -257,6 +257,8 @@ void CheckFunctions::checkMissingReturn()
         const Function *function = scope->function;
         if (!function || !function->hasBody())
             continue;
+        if (function->name() == "main" && !(mSettings->standards.c < Standards::C99 && mTokenizer->isC()))
+            continue;
         if (function->type != Function::Type::eFunction && function->type != Function::Type::eOperatorEqual)
             continue;
         if (Token::Match(function->retDef, "%name% (") && function->retDef->isUpperCaseName())

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1373,6 +1373,9 @@ private:
         check("int f() {}");
         ASSERT_EQUALS("[test.cpp:1]: (error) Found a exit path from function with non-void return type that has missing return statement\n", errout.str());
 
+        check("int main(void) {}");
+        ASSERT_EQUALS("", errout.str());
+
         check("F(A,B) { x=1; }");
         ASSERT_EQUALS("", errout.str());
 

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1373,8 +1373,20 @@ private:
         check("int f() {}");
         ASSERT_EQUALS("[test.cpp:1]: (error) Found a exit path from function with non-void return type that has missing return statement\n", errout.str());
 
-        check("int main(void) {}");
-        ASSERT_EQUALS("", errout.str());
+        {
+            const char code[] = "int main(void) {}";
+            Settings s;
+
+            s.standards.c = Standards::C89;
+            check(code, "test.c", &s); // c code (c89)
+            ASSERT_EQUALS("[test.c:1]: (error) Found a exit path from function with non-void return type that has missing return statement\n", errout.str());
+
+            s.standards.c = Standards::C99; check(code, "test.c", &s); // c code (c99)
+            ASSERT_EQUALS("", errout.str());
+
+            check(code, "test.cpp", &s); // c++ code
+            ASSERT_EQUALS("", errout.str());
+        }
 
         check("F(A,B) { x=1; }");
         ASSERT_EQUALS("", errout.str());


### PR DESCRIPTION
Removed a false positive:

```
error: Found a exit path from function with non-void return type that has missing return statement [missingReturn]
int main(void) {}
                ^
```

I have kept the error for C with a standard lower than C99, as there the return value is undefined. 


ANSI C:
2.1.2.2
Program termination
...
  If the main function executes a return that
specifies no value, the termination status returned to the host
environment is undefined.

C99:
5.1.2.2.3
Program termination
If the return type of the main function is a type compatible with int, a return from the initial call to the main function is equivalent to calling the exit function with the value returned by the main function as its argument;**reaching the } that terminates the main function returns a value of 0.**