### PR TITLE
SunOs 11 needs alternative macro for NAME_MAX

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -181,6 +181,12 @@ bool FileLister::fileExists(const std::string &path)
 #include <sys/stat.h>
 #include <cerrno>
 
+#ifndef NAME_MAX
+#ifdef MAXNAMLEN
+#define NAME_MAX MAXNAMLEN
+#endif
+#endif
+
 
 static std::string addFiles2(std::map<std::string, std::size_t> &files,
                              const std::string &path,


### PR DESCRIPTION
When compiling on SunOs 11 with g++ (GCC) 10.2.0 NAME_MAX is not defined.
Use alternative MAXNAMLEN if it is defined