### PR TITLE
gui: Set signed int type for the error lines

### DIFF
--- a/gui/erroritem.h
+++ b/gui/erroritem.h
@@ -110,7 +110,7 @@ Q_DECLARE_METATYPE(ErrorItem)
 class ErrorLine {
 public:
     QString file;
-    unsigned int line;
+    int line;
     QString file0;
     QString errorId;
     bool incomplete;

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -138,7 +138,7 @@ QStandardItem *ResultsTree::createCheckboxItem(bool checked)
 QStandardItem *ResultsTree::createLineNumberItem(const QString &linenumber)
 {
     QStandardItem *item = new QStandardItem();
-    item->setData(QVariant(linenumber.toULongLong()), Qt::DisplayRole);
+    item->setData(QVariant(linenumber.toInt()), Qt::DisplayRole);
     item->setToolTip(linenumber);
     item->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
     item->setEditable(false);
@@ -1318,7 +1318,7 @@ void ResultsTree::readErrorItem(const QStandardItem *error, ErrorItem *item) con
 
         QErrorPathItem e;
         e.file = stripPath(child_data[FILENAME].toString(), true);
-        e.line = child_data[LINE].toUInt();
+        e.line = child_data[LINE].toInt();
         e.info = child_data[MESSAGE].toString();
         item->errorPath << e;
     }


### PR DESCRIPTION
This is required because Cppcheck can return -1 as line number if the warning has no line. For example, `unmatchedSuppression` warnings behave this way.

Before:

![image](https://user-images.githubusercontent.com/12023585/126614463-405596cb-4d68-4452-ba9d-db7c3c4a00c1.png)

After:

![image](https://user-images.githubusercontent.com/12023585/126614444-26b1f61c-200e-4f2c-bbfd-12cba0540795.png)
