### PR TITLE
Fix Failed to load translation for English

### DIFF
--- a/gui/translationhandler.cpp
+++ b/gui/translationhandler.cpp
@@ -86,8 +86,8 @@ bool TranslationHandler::setLanguage(const QString &code)
     bool failure = false;
     QString error;
 
-    //If English is the language
-    if (code == "en") {
+    //If English is the language. Code can be e.g. en_US
+    if (code.indexOf("en") == 0) {
         //Just remove all extra translators
         if (mTranslator) {
             qApp->removeTranslator(mTranslator);


### PR DESCRIPTION
Upon the first start of cppcheck-gui, the following message appears,
if the language of the OS is English:
```
  Failed to load the user interface language:
  Failed to load translation for language English from file
  cppcheck_en.qm
  The user interface language has been reset to English.
```
- Update translationhandler.cpp and check if the language code starts
  with "en". The code can be e.g. "en_US"
