### PR TITLE
Remove mirror option from install-qt-action

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           version: '5.15.2'
           modules: 'qtcharts qthelp'
-          mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
 
       - name: Create .qm
         run: |


### PR DESCRIPTION
The mirror option has been removed from the
[jurplel/install-qt-action](https://github.com/jurplel/install-qt-action) [1]
- Fixes warning in release-windows GitHub Action:
  `build`
  `Unexpected input(s) 'mirror'`

[1] https://github.com/jurplel/install-qt-action/commit/49465b8