### PR TITLE
Refactor: Remove extra analysis of container sizes in conditions

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6425,50 +6425,6 @@ static void valueFlowContainerSize(TokenList *tokenlist, SymbolDatabase* symbold
             }
         }
     }
-
-    // conditional conditionSize
-    for (const Scope &scope : symboldatabase->scopeList) {
-        if (scope.type != Scope::ScopeType::eIf) // TODO: while
-            continue;
-        for (const Token *tok = scope.classDef; tok && tok->str() != "{"; tok = tok->next()) {
-            if (!tok->isName() || !tok->valueType() || tok->valueType()->type != ValueType::CONTAINER || !tok->valueType()->container)
-                continue;
-
-            const Token *conditionToken;
-            MathLib::bigint intval;
-
-            if (Token::Match(tok, "%name% . %name% (")) {
-                if (tok->valueType()->container->getYield(tok->strAt(2)) == Library::Container::Yield::SIZE) {
-                    const Token *parent = tok->tokAt(3)->astParent();
-                    if (!parent || !parent->isComparisonOp() || !parent->astOperand2())
-                        continue;
-                    if (parent->astOperand1()->hasKnownIntValue())
-                        intval = parent->astOperand1()->values().front().intvalue;
-                    else if (parent->astOperand2()->hasKnownIntValue())
-                        intval = parent->astOperand2()->values().front().intvalue;
-                    else
-                        continue;
-                    conditionToken = parent;
-                } else if (tok->valueType()->container->getYield(tok->strAt(2)) == Library::Container::Yield::EMPTY) {
-                    conditionToken = tok->tokAt(3);
-                    intval = 0;
-                } else {
-                    continue;
-                }
-            } else if (tok->valueType()->container->stdStringLike && Token::Match(tok, "%name% ==|!= %str%") && tok->next()->astOperand2() == tok->tokAt(2)) {
-                intval = Token::getStrLength(tok->tokAt(2));
-                conditionToken = tok->next();
-            } else {
-                continue;
-            }
-
-            ValueFlow::Value value(conditionToken, intval);
-            value.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
-
-            // possible value before condition
-            valueFlowContainerReverse(const_cast<Token*>(scope.classDef), tok, {value}, tokenlist, settings);
-        }
-    }
 }
 
 struct ContainerConditionHandler : ConditionHandler {


### PR DESCRIPTION
This is already handled by `valueFlowCondition`.