### PR TITLE
Fix compilation with recent glibc where SIGSTKSZ is not constant.

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -335,7 +335,11 @@ static void print_stacktrace(FILE* output, bool demangling, int maxdepth, bool l
 #endif
 }
 
+#ifdef __USE_DYNAMIC_STACK_SIZE
+static const size_t MYSTACKSIZE = 16*1024+32768; // wild guess about a reasonable buffer
+#else
 static const size_t MYSTACKSIZE = 16*1024+SIGSTKSZ; // wild guess about a reasonable buffer
+#endif
 static char mytstack[MYSTACKSIZE]= {0}; // alternative stack for signal handler
 static bool bStackBelowHeap=false; // lame attempt to locate heap vs. stack address space. See CppCheckExecutor::check_wrapper()
 


### PR DESCRIPTION
Compilation error encountered on Fedora Rawhide.