### PR TITLE
Revert "Formatted the code [ci skip]"

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2605,13 +2605,13 @@ static Analyzer::Result valueFlowForward(Token* top,
                                          const std::list<ValueFlow::Value>& values,
                                          TokenList* const tokenlist,
                                          const Settings* settings)
-// *INDENT-ON* {
-Analyzer::Result result{};
-for (const ValueFlow::Value& v : values)
+// *INDENT-ON*
 {
-    result.update(valueFlowGenericForward(top, makeAnalyzer(exprTok, v, tokenlist), settings));
-}
-return result;
+    Analyzer::Result result{};
+    for (const ValueFlow::Value& v : values) {
+        result.update(valueFlowGenericForward(top, makeAnalyzer(exprTok, v, tokenlist), settings));
+    }
+    return result;
 }
 
 static void valueFlowReverse(Token* tok,
@@ -6246,9 +6246,10 @@ static Analyzer::Result valueFlowContainerForwardRecursive(Token* top,
                                                            const Token* exprTok,
                                                            const ValueFlow::Value& value,
                                                            TokenList* tokenlist)
-// *INDENT-ON* {
-ContainerExpressionAnalyzer a(exprTok, value, tokenlist);
-return valueFlowGenericForward(top, a, tokenlist->getSettings());
+// *INDENT-ON*
+{
+    ContainerExpressionAnalyzer a(exprTok, value, tokenlist);
+    return valueFlowGenericForward(top, a, tokenlist->getSettings());
 }
 
 static Analyzer::Result valueFlowContainerForward(Token* startToken,

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -4322,7 +4322,7 @@ private:
               "  }\n"
               "  return name;\n"
               "}\n");
-        ASSERT_EQUALS("", errout.str());
+      ASSERT_EQUALS("", errout.str());
     }
 
     void bufferNotZeroTerminated() {


### PR DESCRIPTION
This reverts commit 7a6d7f7c2de9846bd12a4bc5aab6c3bb2aba61ec. The formatting change makes cppcheck uncompilable and it breaks CI.