### PR TITLE
Symboldatabase: Improve valuetypes for containers, iterators, and smart pointers

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -73,6 +73,8 @@ static bool isRaiiClass(const ValueType *valueType, bool cpp, bool defaultReturn
             return true;
         return defaultReturn;
 
+    case ValueType::Type::SMART_POINTER:
+        return true;
     case ValueType::Type::CONTAINER:
     case ValueType::Type::ITERATOR:
     case ValueType::Type::VOID:

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -74,7 +74,6 @@ static bool isRaiiClass(const ValueType *valueType, bool cpp, bool defaultReturn
         return defaultReturn;
 
     case ValueType::Type::SMART_POINTER:
-        return true;
     case ValueType::Type::CONTAINER:
     case ValueType::Type::ITERATOR:
     case ValueType::Type::VOID:

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -500,6 +500,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
             if (!className)
                 return Error(ErrorCode::MISSING_ATTRIBUTE, "class-name");
             SmartPointer& smartPointer = smartPointers[className];
+            smartPointer.name = className;
             for (const tinyxml2::XMLElement* smartPointerNode = node->FirstChildElement(); smartPointerNode;
                  smartPointerNode = smartPointerNode->NextSiblingElement()) {
                 const std::string smartPointerNodeName = smartPointerNode->Name();

--- a/lib/library.h
+++ b/lib/library.h
@@ -431,6 +431,7 @@ public:
     std::vector<std::string> defines; // to provide some library defines
 
     struct SmartPointer {
+        std::string name = "";
         bool unique = false;
     };
 

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5857,6 +5857,16 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
             return;
         }
     }
+    // Dereference smart pointer
+    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::SMART_POINTER && valuetype.smartPointerTypeToken) {
+        ValueType vt;
+        if (parsedecl(valuetype.smartPointerTypeToken, &vt, mDefaultSignedness, mSettings)) {
+            if (vt.constness == 0)
+                vt.constness = valuetype.constness;
+            setValueType(parent, vt);
+            return;
+        }
+    }
     if (parent->str() == "*" && Token::simpleMatch(parent->astOperand2(), "[") && valuetype.pointer > 0U) {
         const Token *op1 = parent->astOperand2()->astOperand1();
         while (op1 && op1->str() == "[")

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -6112,7 +6112,7 @@ static const Token * parsedecl(const Token *type, ValueType * const valuetype, V
     if (!valuetype->typeScope && !valuetype->smartPointerType)
         valuetype->type = ValueType::Type::UNKNOWN_TYPE;
     else if (valuetype->smartPointerType)
-        valuetype->type = ValueType::Type::NONSTD;
+        valuetype->type = ValueType::Type::SMART_POINTER;
     else if (valuetype->typeScope->type == Scope::eEnum) {
         const Token * enum_type = valuetype->typeScope->enumType;
         if (enum_type) {

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5748,7 +5748,7 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
             if (item.constness == 0)
                 item.constness = vt1->constness;
             if (isContainerYieldPointer(vt1->container->getYield(parent->next()->str())))
-                item.pointer = 1;
+                item.pointer += 1;
             else
                 item.reference = Reference::LValue;
             setValueType(parent->tokAt(2), item);

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5846,6 +5846,17 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
         setValueType(parent, vt);
         return;
     }
+    // Dereference iterator
+    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::ITERATOR && valuetype.containerTypeToken) {
+        ValueType vt;
+        if (parsedecl(valuetype.containerTypeToken, &vt, mDefaultSignedness, mSettings)) {
+            if (vt.constness == 0)
+                vt.constness = valuetype.constness;
+            vt.reference = Reference::LValue;
+            setValueType(parent, vt);
+            return;
+        }
+    }
     if (parent->str() == "*" && Token::simpleMatch(parent->astOperand2(), "[") && valuetype.pointer > 0U) {
         const Token *op1 = parent->astOperand2()->astOperand1();
         while (op1 && op1->str() == "[")

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5702,18 +5702,13 @@ static void setAutoTokenProperties(Token * const autoTok)
 
 static bool isContainerYieldElement(Library::Container::Yield yield)
 {
-    return 
-        yield == Library::Container::Yield::ITEM ||
-        yield == Library::Container::Yield::AT_INDEX ||
-        yield == Library::Container::Yield::BUFFER ||
-        yield == Library::Container::Yield::BUFFER_NT;
+    return yield == Library::Container::Yield::ITEM || yield == Library::Container::Yield::AT_INDEX ||
+           yield == Library::Container::Yield::BUFFER || yield == Library::Container::Yield::BUFFER_NT;
 }
 
 static bool isContainerYieldPointer(Library::Container::Yield yield)
 {
-    return 
-        yield == Library::Container::Yield::BUFFER ||
-        yield == Library::Container::Yield::BUFFER_NT;
+    return yield == Library::Container::Yield::BUFFER || yield == Library::Container::Yield::BUFFER_NT;
 }
 
 void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
@@ -5746,7 +5741,8 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
         return;
     }
 
-    if (vt1 && vt1->container && vt1->containerTypeToken && Token::Match(parent, ". %name% (") && isContainerYieldElement(vt1->container->getYield(parent->next()->str()))) {
+    if (vt1 && vt1->container && vt1->containerTypeToken && Token::Match(parent, ". %name% (") &&
+        isContainerYieldElement(vt1->container->getYield(parent->next()->str()))) {
         ValueType item;
         if (parsedecl(vt1->containerTypeToken, &item, mDefaultSignedness, mSettings)) {
             if (item.constness == 0)
@@ -5847,7 +5843,8 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
         return;
     }
     // Dereference iterator
-    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::ITERATOR && valuetype.containerTypeToken) {
+    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::ITERATOR &&
+        valuetype.containerTypeToken) {
         ValueType vt;
         if (parsedecl(valuetype.containerTypeToken, &vt, mDefaultSignedness, mSettings)) {
             if (vt.constness == 0)
@@ -5858,7 +5855,8 @@ void SymbolDatabase::setValueType(Token *tok, const ValueType &valuetype)
         }
     }
     // Dereference smart pointer
-    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::SMART_POINTER && valuetype.smartPointerTypeToken) {
+    if (parent->str() == "*" && !parent->astOperand2() && valuetype.type == ValueType::Type::SMART_POINTER &&
+        valuetype.smartPointerTypeToken) {
         ValueType vt;
         if (parsedecl(valuetype.smartPointerTypeToken, &vt, mDefaultSignedness, mSettings)) {
             if (vt.constness == 0)
@@ -6505,7 +6503,7 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
                         setValueType(tok, vt);
                         continue;
                     }
-                    if (const Library::SmartPointer *sp = mSettings->library.detectSmartPointer(typeStartToken)) {
+                    if (const Library::SmartPointer* sp = mSettings->library.detectSmartPointer(typeStartToken)) {
                         ValueType vt;
                         vt.type = ValueType::Type::SMART_POINTER;
                         vt.smartPointer = sp;
@@ -6530,7 +6528,6 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
                         vt.smartPointerTypeToken = tok->astOperand1()->tokAt(3);
                         setValueType(tok, vt);
                         continue;
-
                     }
 
                     ValueType podtype;
@@ -6568,7 +6565,8 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
                                 ValueType vt;
                                 vt.type = ValueType::Type::ITERATOR;
                                 vt.container = cont;
-                                vt.containerTypeToken = tok->astOperand1()->astOperand1()->valueType()->containerTypeToken;
+                                vt.containerTypeToken =
+                                    tok->astOperand1()->astOperand1()->valueType()->containerTypeToken;
                                 setValueType(tok, vt);
                             }
                         }

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1217,7 +1217,7 @@ enum class Reference {
 class CPPCHECKLIB ValueType {
 public:
     enum Sign { UNKNOWN_SIGN, SIGNED, UNSIGNED } sign;
-    enum Type { UNKNOWN_TYPE, NONSTD, RECORD, CONTAINER, ITERATOR, VOID, BOOL, CHAR, SHORT, WCHAR_T, INT, LONG, LONGLONG, UNKNOWN_INT, FLOAT, DOUBLE, LONGDOUBLE } type;
+    enum Type { UNKNOWN_TYPE, NONSTD, RECORD, SMART_POINTER, CONTAINER, ITERATOR, VOID, BOOL, CHAR, SHORT, WCHAR_T, INT, LONG, LONGLONG, UNKNOWN_INT, FLOAT, DOUBLE, LONGDOUBLE } type;
     nonneg int bits;                           ///< bitfield bitcount
     nonneg int pointer;                        ///< 0=>not pointer, 1=>*, 2=>**, 3=>***, etc
     nonneg int constness;                      ///< bit 0=data, bit 1=*, bit 2=**

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1217,7 +1217,26 @@ enum class Reference {
 class CPPCHECKLIB ValueType {
 public:
     enum Sign { UNKNOWN_SIGN, SIGNED, UNSIGNED } sign;
-    enum Type { UNKNOWN_TYPE, NONSTD, RECORD, SMART_POINTER, CONTAINER, ITERATOR, VOID, BOOL, CHAR, SHORT, WCHAR_T, INT, LONG, LONGLONG, UNKNOWN_INT, FLOAT, DOUBLE, LONGDOUBLE } type;
+    enum Type {
+        UNKNOWN_TYPE,
+        NONSTD,
+        RECORD,
+        SMART_POINTER,
+        CONTAINER,
+        ITERATOR,
+        VOID,
+        BOOL,
+        CHAR,
+        SHORT,
+        WCHAR_T,
+        INT,
+        LONG,
+        LONGLONG,
+        UNKNOWN_INT,
+        FLOAT,
+        DOUBLE,
+        LONGDOUBLE
+    } type;
     nonneg int bits;                           ///< bitfield bitcount
     nonneg int pointer;                        ///< 0=>not pointer, 1=>*, 2=>**, 3=>***, etc
     nonneg int constness;                      ///< bit 0=data, bit 1=*, bit 2=**

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -2058,7 +2058,9 @@ private:
               "    auto p = x.data();\n"
               "    return p;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning pointer to local variable 'x' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS(
+            "[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning pointer to local variable 'x' that will be invalid when returning.\n",
+            errout.str());
 
         check("auto f() {\n"
               "    std::vector<int> x;\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -2058,7 +2058,7 @@ private:
               "    auto p = x.data();\n"
               "    return p;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning object that points to local variable 'x' that will be invalid when returning.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2] -> [test.cpp:4]: (error) Returning pointer to local variable 'x' that will be invalid when returning.\n", errout.str());
 
         check("auto f() {\n"
               "    std::vector<int> x;\n"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7438,29 +7438,42 @@ private:
             vector.startPattern2 = "Vector !!::";
             vector.type_templateArgNo = 0;
             vector.arrayLike_indexOp = true;
-        vector.functions["front"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::ITEM};
-        vector.functions["data"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::BUFFER};
-        vector.functions["begin"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::START_ITERATOR};
+            vector.functions["front"] =
+                Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::ITEM};
+            vector.functions["data"] =
+                Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::BUFFER};
+            vector.functions["begin"] = Library::Container::Function{Library::Container::Action::NO_ACTION,
+                                                                     Library::Container::Yield::START_ITERATOR};
             set.library.containers["Vector"] = vector;
             Library::Container string;
             string.startPattern = "test :: string";
             string.startPattern2 = "test :: string !!::";
             string.arrayLike_indexOp = string.stdStringLike = true;
             set.library.containers["test::string"] = string;
-        ASSERT_EQUALS("signed int", typeOf("Vector<int> v; v[0]=3;", "[", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("{return test::string();}", "(", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "s", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "+", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string) &", typeOf("Vector<test::string> v; x = v.front();", "(", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string) *", typeOf("Vector<test::string> v; x = v.data();", "(", "test.cpp", &set));
-        ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = v.front();", "(", "test.cpp", &set));
-        ASSERT_EQUALS("signed int *", typeOf("Vector<int> v; x = v.data();", "(", "test.cpp", &set));
-        ASSERT_EQUALS("iterator(Vector <)", typeOf("Vector<int> v; x = v.begin();", "(", "test.cpp", &set));
-        ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = *v.begin();", "*", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return \"x\"+s;}", "+", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+\"x\";}", "+", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return 'x'+s;}", "+", "test.cpp", &set));
-        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+'x';}", "+", "test.cpp", &set));
+            ASSERT_EQUALS("signed int", typeOf("Vector<int> v; v[0]=3;", "[", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string)", typeOf("{return test::string();}", "(", "test.cpp", &set));
+            ASSERT_EQUALS(
+                "container(test :: string)",
+                typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "s", "test.cpp", &set));
+            ASSERT_EQUALS(
+                "container(test :: string)",
+                typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "+", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string) &",
+                          typeOf("Vector<test::string> v; x = v.front();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string) *",
+                          typeOf("Vector<test::string> v; x = v.data();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = v.front();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("signed int *", typeOf("Vector<int> v; x = v.data();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("iterator(Vector <)", typeOf("Vector<int> v; x = v.begin();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = *v.begin();", "*", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string)",
+                          typeOf("void foo(){test::string s; return \"x\"+s;}", "+", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string)",
+                          typeOf("void foo(){test::string s; return s+\"x\";}", "+", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string)",
+                          typeOf("void foo(){test::string s; return 'x'+s;}", "+", "test.cpp", &set));
+            ASSERT_EQUALS("container(test :: string)",
+                          typeOf("void foo(){test::string s; return s+'x';}", "+", "test.cpp", &set));
         }
 
         // new
@@ -7486,7 +7499,8 @@ private:
             Library::SmartPointer sharedPtr;
             sharedPtr.name = "std::shared_ptr";
             set.library.smartPointers["std::shared_ptr"] = sharedPtr;
-            ASSERT_EQUALS("smart-pointer(std::shared_ptr)", typeOf("class C {}; x = std::make_shared<C>();", "(","test.cpp",  &set));
+            ASSERT_EQUALS("smart-pointer(std::shared_ptr)",
+                          typeOf("class C {}; x = std::make_shared<C>();", "(", "test.cpp", &set));
         }
 
         // return
@@ -7505,7 +7519,8 @@ private:
             Library::SmartPointer myPtr;
             myPtr.name = "MyPtr";
             set.library.smartPointers["MyPtr"] = myPtr;
-            ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() { MyPtr<int> p; return p; }", "p ;", "test.cpp", &set));
+            ASSERT_EQUALS("smart-pointer(MyPtr)",
+                          typeOf("void f() { MyPtr<int> p; return p; }", "p ;", "test.cpp", &set));
             ASSERT_EQUALS("signed int", typeOf("void f() { MyPtr<int> p; return *p; }", "* p ;", "test.cpp", &set));
             ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() {return MyPtr<int>();}", "(", "test.cpp", &set));
         }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7438,22 +7438,24 @@ private:
             vector.startPattern2 = "Vector !!::";
             vector.type_templateArgNo = 0;
             vector.arrayLike_indexOp = true;
-            vector.functions["front"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::ITEM};
+        vector.functions["front"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::ITEM};
+        vector.functions["data"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::BUFFER};
             set.library.containers["Vector"] = vector;
             Library::Container string;
             string.startPattern = "test :: string";
             string.startPattern2 = "test :: string !!::";
             string.arrayLike_indexOp = string.stdStringLike = true;
             set.library.containers["test::string"] = string;
-            ASSERT_EQUALS("signed int", typeOf("Vector<int> v; v[0]=3;", "[", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("{return test::string();}", "(", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "s", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "+", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("Vector<test::string> v; x = v.front();", "(", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return \"x\"+s;}", "+", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+\"x\";}", "+", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return 'x'+s;}", "+", "test.cpp", &set));
-            ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+'x';}", "+", "test.cpp", &set));
+        ASSERT_EQUALS("signed int", typeOf("Vector<int> v; v[0]=3;", "[", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("{return test::string();}", "(", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "s", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "+", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string) &", typeOf("Vector<test::string> v; x = v.front();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string) *", typeOf("Vector<test::string> v; x = v.data();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return \"x\"+s;}", "+", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+\"x\";}", "+", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return 'x'+s;}", "+", "test.cpp", &set));
+        ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+'x';}", "+", "test.cpp", &set));
         }
 
         // new

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7464,6 +7464,7 @@ private:
                           typeOf("Vector<test::string> v; x = v.data();", "(", "test.cpp", &set));
             ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = v.front();", "(", "test.cpp", &set));
             ASSERT_EQUALS("signed int *", typeOf("Vector<int> v; x = v.data();", "(", "test.cpp", &set));
+            ASSERT_EQUALS("signed int * *", typeOf("Vector<int*> v; x = v.data();", "(", "test.cpp", &set));
             ASSERT_EQUALS("iterator(Vector <)", typeOf("Vector<int> v; x = v.begin();", "(", "test.cpp", &set));
             ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = *v.begin();", "*", "test.cpp", &set));
             ASSERT_EQUALS("container(test :: string)",

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7506,6 +7506,7 @@ private:
             myPtr.name = "MyPtr";
             set.library.smartPointers["MyPtr"] = myPtr;
             ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() { MyPtr<int> p; return p; }", "p ;", "test.cpp", &set));
+            ASSERT_EQUALS("signed int", typeOf("void f() { MyPtr<int> p; return *p; }", "* p ;", "test.cpp", &set));
             ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() {return MyPtr<int>();}", "(", "test.cpp", &set));
         }
     }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7481,7 +7481,13 @@ private:
         ASSERT_EQUALS("", typeOf("; int x[10] = { [3]=1 };", "[ 3 ]"));
 
         // std::make_shared
-        ASSERT_EQUALS("smart-pointer<C>", typeOf("class C {}; x = std::make_shared<C>();", "("));
+        {
+            Settings set;
+            Library::SmartPointer sharedPtr;
+            sharedPtr.name = "std::shared_ptr";
+            set.library.smartPointers["std::shared_ptr"] = sharedPtr;
+            ASSERT_EQUALS("smart-pointer(std::shared_ptr)", typeOf("class C {}; x = std::make_shared<C>();", "(","test.cpp",  &set));
+        }
 
         // return
         {
@@ -7492,6 +7498,15 @@ private:
             c.startPattern2 = "C !!::";
             sC.library.containers["C"] = c;
             ASSERT_EQUALS("container(C)", typeOf("C f(char *p) { char data[10]; return data; }", "return", "test.cpp", &sC));
+        }
+        // Smart pointer
+        {
+            Settings set;
+            Library::SmartPointer myPtr;
+            myPtr.name = "MyPtr";
+            set.library.smartPointers["MyPtr"] = myPtr;
+            ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() { MyPtr<int> p; return p; }", "p ;", "test.cpp", &set));
+            ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("{return MyPtr<int>();}", "(", "test.cpp", &set));
         }
     }
 

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7440,6 +7440,7 @@ private:
             vector.arrayLike_indexOp = true;
         vector.functions["front"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::ITEM};
         vector.functions["data"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::BUFFER};
+        vector.functions["begin"] = Library::Container::Function{Library::Container::Action::NO_ACTION, Library::Container::Yield::START_ITERATOR};
             set.library.containers["Vector"] = vector;
             Library::Container string;
             string.startPattern = "test :: string";
@@ -7452,6 +7453,10 @@ private:
         ASSERT_EQUALS("container(test :: string)", typeOf("void foo(Vector<test::string> v) { for (auto s: v) { x=s+s; } }", "+", "test.cpp", &set));
         ASSERT_EQUALS("container(test :: string) &", typeOf("Vector<test::string> v; x = v.front();", "(", "test.cpp", &set));
         ASSERT_EQUALS("container(test :: string) *", typeOf("Vector<test::string> v; x = v.data();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = v.front();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("signed int *", typeOf("Vector<int> v; x = v.data();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("iterator(Vector <)", typeOf("Vector<int> v; x = v.begin();", "(", "test.cpp", &set));
+        ASSERT_EQUALS("signed int &", typeOf("Vector<int> v; x = *v.begin();", "*", "test.cpp", &set));
         ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return \"x\"+s;}", "+", "test.cpp", &set));
         ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return s+\"x\";}", "+", "test.cpp", &set));
         ASSERT_EQUALS("container(test :: string)", typeOf("void foo(){test::string s; return 'x'+s;}", "+", "test.cpp", &set));

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7506,7 +7506,7 @@ private:
             myPtr.name = "MyPtr";
             set.library.smartPointers["MyPtr"] = myPtr;
             ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() { MyPtr<int> p; return p; }", "p ;", "test.cpp", &set));
-            ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("{return MyPtr<int>();}", "(", "test.cpp", &set));
+            ASSERT_EQUALS("smart-pointer(MyPtr)", typeOf("void f() {return MyPtr<int>();}", "(", "test.cpp", &set));
         }
     }
 


### PR DESCRIPTION
- Type is set when accessing an element or buffer of a container
- Type is set when dereferencing a iterator
- Improve detecting smart pointer and make it its own type
- Type is set when dereferencing a smart pointer