### PR TITLE
Add more ValueFlow info in the xml dumps

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1740,12 +1740,15 @@ void Token::printValueFlow(bool xml, std::ostream &out) const
                     break;
                 case ValueFlow::Value::ValueType::LIFETIME:
                     out << "lifetime=\"" << value.tokvalue << '\"';
+                    out << " lifetime-scope=\"" << ValueFlow::Value::toString(value.lifetimeScope) << "\"";
+                    out << " lifetime-kind=\"" << ValueFlow::Value::toString(value.lifetimeKind) << "\"";
                     break;
                 case ValueFlow::Value::ValueType::SYMBOLIC:
-                    out << "tokvalue=\"" << value.tokvalue << '\"';
-                    out << " intvalue=\"" << value.intvalue << '\"';
+                    out << "symbolic=\"" << value.tokvalue << '\"';
+                    out << " symbolic-delta=\"" << value.intvalue << '\"';
                     break;
                 }
+                out << " bound=\"" << ValueFlow::Value::toString(value.bound) << "\"";
                 if (value.condition)
                     out << " condition-line=\"" << value.condition->linenr() << '\"';
                 if (value.isKnown())
@@ -1756,6 +1759,7 @@ void Token::printValueFlow(bool xml, std::ostream &out) const
                     out << " impossible=\"true\"";
                 else if (value.isInconclusive())
                     out << " inconclusive=\"true\"";
+                out << " path=\"" << value.path << "\"";
                 out << "/>" << std::endl;
             }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7091,6 +7091,31 @@ const char* ValueFlow::Value::toString(LifetimeKind lifetimeKind)
     return "";
 }
 
+const char* ValueFlow::Value::toString(LifetimeScope lifetimeScope)
+{
+    switch (lifetimeScope) {
+    case ValueFlow::Value::LifetimeScope::Local:
+        return "Local";
+    case ValueFlow::Value::LifetimeScope::Argument:
+        return "Argument";
+    case ValueFlow::Value::LifetimeScope::SubFunction:
+        return "SubFunction";
+    }
+    return "";
+}
+const char* ValueFlow::Value::toString(Bound bound)
+{
+    switch (bound) {
+    case ValueFlow::Value::Bound::Point:
+        return "Point";
+    case ValueFlow::Value::Bound::Upper:
+        return "Upper";
+    case ValueFlow::Value::Bound::Lower:
+        return "Lower";
+    }
+    return "";
+}
+
 const ValueFlow::Value *ValueFlow::valueFlowConstantFoldAST(Token *expr, const Settings *settings)
 {
     if (expr && expr->values().empty()) {

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -366,6 +366,8 @@ namespace ValueFlow {
 
         static const char* toString(MoveKind moveKind);
         static const char* toString(LifetimeKind lifetimeKind);
+        static const char* toString(LifetimeScope lifetimeScope);
+        static const char* toString(Bound bound);
 
         /** How known is this value */
         enum class ValueKind {


### PR DESCRIPTION
- Provide the value bound
- Provide the lifetime scopes and kinds
- Provide the path id
- Rename symbolic values to avoid conflicts with `intvalue`