### PR TITLE
[Perf optimization] Use boost::container::small_vector

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -26,6 +26,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <boost/container/small_vector.hpp>
 
 #include "errortypes.h"
 #include "utils.h"
@@ -35,6 +36,8 @@ class Library;
 class Settings;
 class Token;
 class Variable;
+
+using TokenVector = boost::container::small_vector<const Token*, 32>;
 
 enum class ChildrenToVisit {
     none,
@@ -57,7 +60,7 @@ const Token* findExpression(const nonneg int exprid,
                             const std::function<bool(const Token*)>& pred);
 const Token* findExpression(const Token* start, const nonneg int exprid);
 
-std::vector<const Token*> astFlatten(const Token* tok, const char* op);
+TokenVector astFlatten(const Token* tok, const char* op);
 
 bool astHasToken(const Token* root, const Token * tok);
 
@@ -264,7 +267,7 @@ int numberOfArguments(const Token *start);
 /**
  * Get arguments (AST)
  */
-std::vector<const Token *> getArguments(const Token *ftok);
+TokenVector getArguments(const Token *ftok);
 
 int getArgumentPos(const Variable* var, const Function* f);
 

--- a/lib/bughuntingchecks.cpp
+++ b/lib/bughuntingchecks.cpp
@@ -100,7 +100,7 @@ static void bufferOverflow(const Token *tok, const ExprEngine::Value &value, Exp
     if (!functionCallArguments)
         return;
 
-    const std::vector<const Token *> arguments = getArguments(tok);
+    const auto arguments = getArguments(tok);
     if (functionCallArguments->argValues.size() != arguments.size())
         // TODO investigate what to do
         return;

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -69,7 +69,7 @@ static const ValueFlow::Value *getBufferSizeValue(const Token *tok)
     return it == tokenValues.end() ? nullptr : &*it;
 }
 
-static int getMinFormatStringOutputLength(const std::vector<const Token*> &parameters, nonneg int formatStringArgNr)
+static int getMinFormatStringOutputLength(const TokenVector &parameters, nonneg int formatStringArgNr)
 {
     if (formatStringArgNr <= 0 || formatStringArgNr > parameters.size())
         return 0;
@@ -558,7 +558,7 @@ ValueFlow::Value CheckBufferOverrun::getBufferSize(const Token *bufTok) const
 }
 //---------------------------------------------------------------------------
 
-static bool checkBufferSize(const Token *ftok, const Library::ArgumentChecks::MinSize &minsize, const std::vector<const Token *> &args, const MathLib::bigint bufferSize, const Settings *settings)
+static bool checkBufferSize(const Token *ftok, const Library::ArgumentChecks::MinSize &minsize, const TokenVector &args, const MathLib::bigint bufferSize, const Settings *settings)
 {
     const Token * const arg = (minsize.arg > 0 && minsize.arg - 1 < args.size()) ? args[minsize.arg - 1] : nullptr;
     const Token * const arg2 = (minsize.arg2 > 0 && minsize.arg2 - 1 < args.size()) ? args[minsize.arg2 - 1] : nullptr;
@@ -602,7 +602,7 @@ void CheckBufferOverrun::bufferOverflow()
                 continue;
             if (!mSettings->library.hasminsize(tok))
                 continue;
-            const std::vector<const Token *> args = getArguments(tok);
+            const auto args = getArguments(tok);
             for (int argnr = 0; argnr < args.size(); ++argnr) {
                 if (!args[argnr]->valueType() || args[argnr]->valueType()->pointer == 0)
                     continue;
@@ -720,7 +720,7 @@ void CheckBufferOverrun::stringNotZeroTerminated()
         for (const Token *tok = scope->bodyStart; tok && tok != scope->bodyEnd; tok = tok->next()) {
             if (!Token::simpleMatch(tok, "strncpy ("))
                 continue;
-            const std::vector<const Token *> args = getArguments(tok);
+            const auto args = getArguments(tok);
             if (args.size() != 3)
                 continue;
             const Token *sizeToken = args[2];
@@ -778,7 +778,7 @@ void CheckBufferOverrun::argumentSize()
 
             // If argument is '%type% a[num]' then check bounds against num
             const Function *callfunc = tok->function();
-            const std::vector<const Token *> callargs = getArguments(tok);
+            const auto callargs = getArguments(tok);
             for (nonneg int paramIndex = 0; paramIndex < callargs.size() && paramIndex < callfunc->argCount(); ++paramIndex) {
                 const Variable* const argument = callfunc->getArgumentVar(paramIndex);
                 if (!argument || !argument->nameToken() || !argument->isArray())

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -102,7 +102,7 @@ void CheckFunctions::invalidFunctionUsage()
             if (!Token::Match(tok, "%name% ( !!)"))
                 continue;
             const Token * const functionToken = tok;
-            const std::vector<const Token *> arguments = getArguments(tok);
+            const auto arguments = getArguments(tok);
             for (int argnr = 1; argnr <= arguments.size(); ++argnr) {
                 const Token * const argtok = arguments[argnr-1];
 
@@ -465,7 +465,7 @@ void CheckFunctions::memsetZeroBytes()
     for (const Scope *scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (Token::Match(tok, "memset|wmemset (") && (numberOfArguments(tok)==3)) {
-                const std::vector<const Token *> &arguments = getArguments(tok);
+                const auto &arguments = getArguments(tok);
                 if (WRONG_DATA(arguments.size() != 3U, tok))
                     continue;
                 const Token* lastParamTok = arguments[2];
@@ -506,7 +506,7 @@ void CheckFunctions::memsetInvalid2ndParam()
             if (!Token::simpleMatch(tok, "memset ("))
                 continue;
 
-            const std::vector<const Token *> args = getArguments(tok);
+            const auto args = getArguments(tok);
             if (args.size() != 3)
                 continue;
 

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -480,7 +480,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                     if (tok3->str() == "(" && Token::Match(tok3->astOperand1(), "UNLIKELY|LIKELY")) {
                         return ChildrenToVisit::op2;
                     } else if (tok3->str() == "(" && Token::Match(tok3->previous(), "%name%")) {
-                        const std::vector<const Token *> params = getArguments(tok3->previous());
+                        const auto params = getArguments(tok3->previous());
                         for (const Token *par : params) {
                             if (!par->isComparisonOp())
                                 continue;

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1010,7 +1010,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
         if (!CheckMemoryLeakInFunction::test_white_list(functionName, mSettings, mTokenizer->isCPP()))
             continue;
 
-        const std::vector<const Token *> args = getArguments(tok);
+        const auto args = getArguments(tok);
         for (const Token* arg : args) {
             if (arg->isOp())
                 continue;

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -57,7 +57,7 @@ void CheckNullPointer::parseFunctionCall(const Token &tok, std::list<const Token
     if (Token::Match(&tok, "%name% ( )") || !tok.tokAt(2))
         return;
 
-    const std::vector<const Token *> args = getArguments(&tok);
+    const auto args = getArguments(&tok);
 
     if (library || tok.function() != nullptr) {
         for (int argnr = 1; argnr <= args.size(); ++argnr) {
@@ -368,7 +368,7 @@ void CheckNullPointer::nullConstantDereference()
                 nullPointerError(tok);
 
             else if (Token::Match(tok->previous(), "::|. %name% (")) {
-                const std::vector<const Token *> &args = getArguments(tok);
+                const auto &args = getArguments(tok);
                 for (int argnr = 0; argnr < args.size(); ++argnr) {
                     const Token *argtok = args[argnr];
                     if (!argtok->hasKnownIntValue())

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3490,7 +3490,7 @@ void CheckOther::checkOverlappingWrite()
                 const Library::NonOverlappingData *nonOverlappingData = mSettings->library.getNonOverlappingData(tok);
                 if (!nonOverlappingData)
                     continue;
-                const std::vector<const Token *> args = getArguments(tok);
+                const auto args = getArguments(tok);
                 if (nonOverlappingData->ptr1Arg <= 0 || nonOverlappingData->ptr1Arg > args.size())
                     continue;
                 if (nonOverlappingData->ptr2Arg <= 0 || nonOverlappingData->ptr2Arg > args.size())

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -718,7 +718,7 @@ void CheckStl::mismatchingContainers()
                 continue;
             const Token * const ftok = tok;
 
-            const std::vector<const Token *> args = getArguments(ftok);
+            const auto args = getArguments(ftok);
             if (args.size() < 2)
                 continue;
 
@@ -772,7 +772,7 @@ void CheckStl::mismatchingContainerIterator()
             if (!Token::Match(tok, "%var% . %name% ( !!)"))
                 continue;
             const Token * const ftok = tok->tokAt(2);
-            const std::vector<const Token *> args = getArguments(ftok);
+            const auto args = getArguments(ftok);
 
             const Library::Container * c = tok->valueType()->container;
             Library::Container::Action action = c->getAction(tok->strAt(2));
@@ -894,7 +894,7 @@ struct InvalidContainerAnalyzer {
                         return false;
                     return true;
                 });
-                std::vector<const Token*> args = getArguments(tok);
+                auto args = getArguments(tok);
                 for (Info::Reference& r : result) {
                     r.errorPath.push_front(epi);
                     const Variable* var = r.tok->variable();
@@ -2682,7 +2682,7 @@ void CheckStl::knownEmptyContainer()
                     continue;
                 knownEmptyContainerError(contTok, "");
             } else {
-                const std::vector<const Token *> args = getArguments(tok);
+                const auto args = getArguments(tok);
                 if (args.empty())
                     continue;
 

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -362,8 +362,8 @@ void CheckString::overlappingStrcmp()
                         continue;
                     if (!Token::Match(ne0->previous(), "strcmp|wcscmp ("))
                         continue;
-                    const std::vector<const Token *> args1 = getArguments(eq0->previous());
-                    const std::vector<const Token *> args2 = getArguments(ne0->previous());
+                    const auto args1 = getArguments(eq0->previous());
+                    const auto args2 = getArguments(ne0->previous());
                     if (args1.size() != 2 || args2.size() != 2)
                         continue;
                     if (args1[1]->isLiteral() &&
@@ -402,7 +402,7 @@ void CheckString::sprintfOverlappingData()
             if (!Token::Match(tok, "sprintf|snprintf|swprintf ("))
                 continue;
 
-            const std::vector<const Token *> args = getArguments(tok);
+            const auto args = getArguments(tok);
 
             const int formatString = Token::simpleMatch(tok, "sprintf") ? 1 : 2;
             for (unsigned int argnr = formatString + 1; argnr < args.size(); ++argnr) {

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -314,7 +314,7 @@ CTU::FileInfo *CTU::getFileInfo(const Tokenizer *tokenizer)
                 continue;
             if (!tok->astOperand1()->function())
                 continue;
-            const std::vector<const Token *> args(getArguments(tok->previous()));
+            const auto args(getArguments(tok->previous()));
             for (int argnr = 0; argnr < args.size(); ++argnr) {
                 const Token *argtok = args[argnr];
                 if (!argtok)

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -2046,7 +2046,7 @@ static ExprEngine::ValuePtr executeFunctionCall(const Token *tok, Data &data)
         }
     }
 
-    const std::vector<const Token *> &argTokens = getArguments(tok);
+    const auto &argTokens = getArguments(tok);
     std::vector<ExprEngine::ValuePtr> argValues;
     for (const Token *argtok : argTokens) {
         auto val = hasBody ? executeExpression1(argtok, data) : executeExpression(argtok, data);

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4961,7 +4961,7 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
 {
     const bool isCall = Token::Match(tok->next(), "(|{");
 
-    const std::vector<const Token *> arguments = getArguments(tok);
+    const auto arguments = getArguments(tok);
 
     std::vector<const Function *> matches;
 


### PR DESCRIPTION
This appears to be quite beneficial (cppcheck gets twice as fast on
some files).

This is a first proposal, it is not supposed to be merged as it is now (it is probably missing some dependencies in the CI, among other things).
I used boost::container::small_vector, but maybe there are other solutions here, especially if we don't want to add a dependency to boost: copying llvm/ADT/SmallVector.h ?, something else ?
