### PR TITLE
Fix incorrect warning with `%zi` in format string

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1782,7 +1782,7 @@ void CheckIO::invalidScanfArgTypeError_int(const Token* tok, nonneg int numForma
         else
             errmsg << "intmax_t";
     } else if (specifier[0] == 'z') {
-        if (specifier[1] == 'd')
+        if (specifier[1] == 'd' || specifier[1] == 'i')
             errmsg << "ssize_t";
         else
             errmsg << "size_t";
@@ -1875,7 +1875,7 @@ static void printfFormatType(std::ostream& os, const std::string& specifier, boo
         else
             os << "intmax_t";
     } else if (specifier[0] == 'z') {
-        if (specifier[1] == 'd')
+        if (specifier[1] == 'd' || specifier[1] == 'i')
             os << "ssize_t";
         else
             os << "size_t";

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -1533,6 +1533,8 @@ private:
         TEST_SCANF_NOWARN("%zd", "ssize_t", "ssize_t");
         TEST_SCANF_WARN_AKA("%zd", "ssize_t", "ptrdiff_t", "signed long", "signed long long");
 
+        TEST_SCANF_WARN_AKA("%zi", "ssize_t", "size_t", "unsigned long", "unsigned long long");
+
         TEST_SCANF_WARN("%tu", "unsigned ptrdiff_t", "bool");
         TEST_SCANF_WARN("%tu", "unsigned ptrdiff_t", "char");
         TEST_SCANF_WARN("%tu", "unsigned ptrdiff_t", "signed char");
@@ -3704,6 +3706,9 @@ private:
         TEST_PRINTF_WARN_AKA("%jx", "uintmax_t", "std::ptrdiff_t", "signed long", "signed long long");
         TEST_PRINTF_WARN_AKA("%jx", "uintmax_t", "std::intptr_t", "signed long", "signed long long");
         TEST_PRINTF_WARN_AKA("%jx", "uintmax_t", "std::uintptr_t", "unsigned long", "unsigned long long");
+
+        TEST_PRINTF_WARN_AKA("%zd", "ssize_t", "size_t", "unsigned long", "unsigned long long");
+        TEST_PRINTF_WARN_AKA("%zi", "ssize_t", "size_t", "unsigned long", "unsigned long long");
 
         TEST_PRINTF_WARN("%zu", "size_t", "bool");
         TEST_PRINTF_WARN("%zu", "size_t", "char");


### PR DESCRIPTION
For the following code:
```c++
#include <cstdio>

void foo(size_t s) {
    ::printf("%zi\n", s);
    ::scanf("%zi\n", &s);
}
```
I currently get the following nonsensical output:
```
Checking test.cc ...
test.cc:4:7: portability: %zi in format string (no. 1) requires 'size_t' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_sint]
    ::printf("%zi\n", s);
      ^
test.cc:5:7: portability: %zi in format string (no. 1) requires 'size_t *' but the argument type is 'size_t * {aka unsigned long *}'. [invalidScanfArgType_int]
    ::scanf("%zi\n", &s);
      ^
```
i.e. the required and expected type are seemingly equal. The warning is correct, though, because `%zi` expects a _signed_ integer, i.e. a `ssize_t`; I have adjusted the output accordingly, so that I get the less confusing
```
Checking test.cc ...
test.cc:4:7: portability: %zi in format string (no. 1) requires 'ssize_t' but the argument type is 'size_t {aka unsigned long}'. [invalidPrintfArgType_sint]
    ::printf("%zi\n", s);
      ^
test.cc:5:7: portability: %zi in format string (no. 1) requires 'ssize_t *' but the argument type is 'size_t * {aka unsigned long *}'. [invalidScanfArgType_int]
    ::scanf("%zi\n", &s);
      ^
```
with my changes.