### PR TITLE
Fix handling of namespace scope with several bodystarts

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4194,19 +4194,19 @@ void Scope::getVariableList(const Settings* settings)
 {
     if (!bodyStartList.empty()) {
         for (const Token *bs: bodyStartList)
-            getVariableList(settings, bs->next());
+            getVariableList(settings, bs->next(), bs->link());
     }
 
     // global scope
     else if (type == Scope::eGlobal)
-        getVariableList(settings, check->mTokenizer->tokens());
+        getVariableList(settings, check->mTokenizer->tokens(), nullptr);
 
     // forward declaration
     else
         return;
 }
 
-void Scope::getVariableList(const Settings* settings, const Token* start)
+void Scope::getVariableList(const Settings* settings, const Token* start, const Token* end)
 {
     // Variable declared in condition: if (auto x = bar())
     if (Token::Match(classDef, "if|while ( %type%") && Token::simpleMatch(classDef->next()->astOperand2(), "=")) {
@@ -4214,7 +4214,7 @@ void Scope::getVariableList(const Settings* settings, const Token* start)
     }
 
     AccessControl varaccess = defaultAccess();
-    for (const Token *tok = start; tok && tok != bodyEnd; tok = tok->next()) {
+    for (const Token *tok = start; tok && tok != end; tok = tok->next()) {
         // syntax error?
         if (tok->next() == nullptr)
             break;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1204,7 +1204,7 @@ private:
     void findFunctionInBase(const std::string & name, nonneg int args, std::vector<const Function *> & matches) const;
 
     /** @brief initialize varlist */
-    void getVariableList(const Settings* settings, const Token *start);
+    void getVariableList(const Settings* settings, const Token *start, const Token *end);
 };
 
 enum class Reference {


### PR DESCRIPTION
Follow up to 0093452bed30f27a8a6366.
Give the proper end to getVariableList, since it might not be bodyEnd.

Before that, getVariableList would add the same variables in several
unrelated scopes, and all kind of false positive would follow.

For instance, with the case I added in the unit-tests, I had:
```
../code.cpp:15:18: warning: The struct 'is_A' defines member variable with name 'foo' also defined in its parent struct 'is_A_impl'. [duplInheritedMember]
static const int foo = 8;
                 ^
../code.cpp:15:18: note: Parent variable 'is_A_impl::foo'
static const int foo = 8;
                 ^
../code.cpp:15:18: note: Derived variable 'is_A::foo'
static const int foo = 8;
                 ^
../code.cpp:15:18: style: struct member 'has_A::foo' is never used. [unusedStructMember]
static const int foo = 8;
                 ^
../code.cpp:15:18: style: struct member 'is_A::foo' is never used. [unusedStructMember]
static const int foo = 8;
                 ^

```