### PR TITLE
Misra add c11 keywords

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -198,7 +198,7 @@ class Token:
         isName             Is this token a symbol name
         isNumber           Is this token a number, for example 123, 12.34
         isInt              Is this token a int value such as 1234
-        isFloat            Is this token a int value such as 12.34
+        isFloat            Is this token a float value such as 12.34
         isString           Is this token a string literal such as "hello"
         strlen             string length for string literal
         isChar             Is this token a char literal such as 'x'

--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -159,7 +159,7 @@ class ValueType:
 
     def __repr__(self):
         attrs = ["type", "sign", "bits", "typeScopeId", "originalTypeName",
-                 "constness", "constness", "pointer"]
+                 "constness", "pointer"]
         return "{}({})".format(
             "ValueType",
             ", ".join(("{}={}".format(a, repr(getattr(self, a))) for a in attrs))

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -362,7 +362,7 @@ C11_ADDED_KEYWORDS = {
 
 def isKeyword(keyword, standard='c99'):
     kw_set = {}
-    if standard == 'c90':
+    if standard == 'c89':
         kw_set = C90_KEYWORDS
     elif standard == 'c99':
         kw_set = C90_KEYWORDS

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -340,30 +340,37 @@ def isStdLibId(id_, standard='c99'):
 
 # Reserved keywords defined in ISO/IEC9899:1990 -- ch 6.1.1
 C90_KEYWORDS = {
-    'auto', 'break', 'double', 'else', 'enum', 'extern', 'float', 'for',
-    'goto', 'if', 'case', 'char', 'const', 'continue', 'default', 'do', 'int',
-    'long', 'struct', 'switch', 'register', 'typedef', 'union', 'unsigned',
-    'void', 'volatile', 'while', 'return', 'short', 'signed', 'sizeof',
-    'static'
+    'auto', 'break', 'case', 'char', 'const', 'continue', 'default', 'do',
+    'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if', 
+    'int', 'long', 'register', 'return', 'short', 'signed',
+    'sizeof', 'static', 'struct', 'switch', 'typedef', 'union', 'unsigned',
+    'void', 'volatile', 'while'
 }
 
 
 # Reserved keywords defined in ISO/IEC 9899 WF14/N1256 -- ch. 6.4.1
-C99_KEYWORDS = {
-    'auto', 'break', 'case', 'char', 'const', 'continue', 'default', 'do',
-    'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if', 'inline',
-    'int', 'long', 'register', 'restrict', 'return', 'short', 'signed',
-    'sizeof', 'static', 'struct', 'switch', 'typedef', 'union', 'unsigned',
-    'void', 'volatile', 'while', '_Bool', '_Complex', '_Imaginary'
+C99_ADDED_KEYWORDS = {
+    'inline', 'restrict', '_Bool', '_Complex', '_Imaginary',
+    'bool', 'complex', 'imaginary',
 }
 
+C11_ADDED_KEYWORDS = {
+    '_Alignas', '_Alignof', '_Atomic', '_Generic', '_Noreturn',
+    '_Statis_assert', '_Thread_local' ,
+    'alignas', 'alignof', 'noreturn', 'static_assert'
+}
 
 def isKeyword(keyword, standard='c99'):
     kw_set = {}
-    if standard == 'c89':
+    if standard == 'c90':
         kw_set = C90_KEYWORDS
     elif standard == 'c99':
-        kw_set = C99_KEYWORDS
+        kw_set = C90_KEYWORDS
+        kw_set.update(C99_ADDED_KEYWORDS)
+    else
+        kw_set = C90_KEYWORDS
+        kw_set.update(C99_ADDED_KEYWORDS)
+        kw_set.update(C11_ADDED_KEYWORDS)
     return keyword in kw_set
 
 

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -24,6 +24,7 @@ import os
 import argparse
 import codecs
 import string
+import copy
 
 try:
     from itertools import izip as zip
@@ -365,10 +366,10 @@ def isKeyword(keyword, standard='c99'):
     if standard == 'c89':
         kw_set = C90_KEYWORDS
     elif standard == 'c99':
-        kw_set = C90_KEYWORDS
+        kw_set = copy.copy(C90_KEYWORDS)
         kw_set.update(C99_ADDED_KEYWORDS)
-    else
-        kw_set = C90_KEYWORDS
+    else:
+        kw_set = copy.copy(C90_KEYWORDS)
         kw_set.update(C99_ADDED_KEYWORDS)
         kw_set.update(C11_ADDED_KEYWORDS)
     return keyword in kw_set

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -342,7 +342,7 @@ def isStdLibId(id_, standard='c99'):
 # Reserved keywords defined in ISO/IEC9899:1990 -- ch 6.1.1
 C90_KEYWORDS = {
     'auto', 'break', 'case', 'char', 'const', 'continue', 'default', 'do',
-    'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if', 
+    'double', 'else', 'enum', 'extern', 'float', 'for', 'goto', 'if',
     'int', 'long', 'register', 'return', 'short', 'signed',
     'sizeof', 'static', 'struct', 'switch', 'typedef', 'union', 'unsigned',
     'void', 'volatile', 'while'
@@ -352,7 +352,7 @@ C90_KEYWORDS = {
 # Reserved keywords defined in ISO/IEC 9899 WF14/N1256 -- ch. 6.4.1
 C99_ADDED_KEYWORDS = {
     'inline', 'restrict', '_Bool', '_Complex', '_Imaginary',
-    'bool', 'complex', 'imaginary',
+    'bool', 'complex', 'imaginary'
 }
 
 C11_ADDED_KEYWORDS = {


### PR DESCRIPTION
Updated the isKeyword function
- add c11 keywords.
- use biggest list of keywords in case an invalid standard is used. (instead of an empty list)
Fixed some cosmetic things in cppcheckdata.py