### PR TITLE
Fix in MISRA rule 6.1 check

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1695,7 +1695,7 @@ class MisraChecker:
             isExplicitlySignedOrUnsigned = False
             typeToken = token.variable.typeStartToken
             while typeToken:
-                if typeToken.isUnsigned or typeToken.isSigned:
+                if typeToken.isUnsigned or typeToken.isSigned or isUnsignedType(typeToken.str):
                     isExplicitlySignedOrUnsigned = True
                     break
 

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1686,7 +1686,7 @@ class MisraChecker:
                 continue
 
             if data.standards.c == 'c89':
-                if token.valueType.type != 'int':
+                if token.valueType.type != 'int' and  not isUnsignedType(token.variable.typeStartToken.str):
                     self.reportError(token, 6, 1)
             elif data.standards.c == 'c99':
                 if token.valueType.type == 'bool':

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -252,6 +252,7 @@ struct struct_with_bitfields
   signed long  f:2; // 6.1 - signed long not compliant
   unsigned int g:1; // Compliant
   signed int   h:1; // 6.2 - signed int with size 1 is not compliant
+  uint16_t     i:1; // Compliant
 };
 
 static void misra6_1_fn(void) {


### PR DESCRIPTION
Hi @danmar congrats for cppcheck!!! such a great tool. We are using it and we found some with MISRA rule 6.1.
This is an example of our code:

![imagen](https://user-images.githubusercontent.com/32535596/133751022-88864c2b-d0ef-4ac1-abc8-130e8ce747a9.png)

and this is the report:

![imagen](https://user-images.githubusercontent.com/32535596/133751055-0b693c24-9625-4eef-bc23-42be57832058.png)

as you can see, "unsigned int" is being accepted, but "uint16_t" not.

This is the official MIRSA 2012 rule:
![imagen](https://user-images.githubusercontent.com/32535596/133751213-7fe7b289-ee87-473b-bb9d-33ce6ab87c2f.png)

(see in yellow that typedefs shall be accepted)

so I've been debuging your misra.py file......and I did a fix. Now It detects the sign for both conventions ("unsiged int" and "uint")


Thanks!!

Dani

