### PR TITLE
Update help text in cmdlineparser.cpp

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1028,7 +1028,7 @@ void CmdLineParser::printHelp()
         "                                  Enable warning messages\n"
         "                          * style\n"
         "                                  Enable all coding style checks. All messages\n"
-        "                                  with the severities 'style', 'performance' and\n"
+        "                                  with the severities 'warning', 'performance' and\n"
         "                                  'portability' are enabled.\n"
         "                          * performance\n"
         "                                  Enable performance messages\n"


### PR DESCRIPTION
The option --enable=style, does not enable 'style' but a group of ids.
It enables 'warning', 'performance' and 'portability'