### PR TITLE
Fix false negative with multi-dimensional array

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1494,10 +1494,29 @@ void CheckOther::checkConstPointer()
         pointers.insert(tok->variable());
         const Token *parent = tok->astParent();
         bool deref = false;
-        if (parent && parent->isUnaryOp("*"))
-            deref = true;
-        else if (Token::simpleMatch(parent, "[") && parent->astOperand1() == tok)
-            deref = true;
+        int dimension = tok->valueType()->pointer;
+        if (parent && parent->isUnaryOp("*")) {
+            int nbDeref = 0;
+            const Token *parentDeref = tok->astParent();
+            while (parentDeref && parentDeref->isUnaryOp("*")) {
+                ++nbDeref;
+                parent = parentDeref;
+                parentDeref = parentDeref->astParent();
+            }
+
+            deref = dimension == nbDeref;
+        }
+        else if (Token::simpleMatch(parent, "[") && parent->astOperand1() == tok) {
+            int nbDeref = 0;
+            const Token *parentDeref = tok->astParent();
+            while (Token::simpleMatch(parentDeref, "[")) {
+                ++nbDeref;
+                parent = parentDeref;
+                parentDeref = parentDeref->astParent();
+            }
+
+            deref = dimension == nbDeref;
+        }
         if (deref) {
             if (Token::Match(parent->astParent(), "%cop%") && !parent->astParent()->isUnaryOp("&") && !parent->astParent()->isUnaryOp("*"))
                 continue;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -2764,6 +2764,29 @@ private:
               "    memcpy(data.buf, &a, sizeof(a));\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "  char  foo[2][2];\n"
+              "  char *bar[2];\n"
+              "  bar[0] = foo[0];\n"
+              "  bar[1] = foo[1];\n"
+              "  bar[0][0] = 'a';\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f() {\n"
+              "  char  foo[2][2];\n"
+              "  const char *bar[2];\n"
+              "  bar[0] = foo[0];\n"
+              "  bar[1] = foo[1];\n"
+              "}");
+        TODO_ASSERT_EQUALS("test.cpp:2]: (style) Variable 'foo' can be declared with const\n", "", errout.str());
+
+        check("bool f() {\n"
+              "  char foo[2][2]={{0,1}, {2,3}};\n"
+              "  return foo[0][1] == 42;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'foo' can be declared with const\n", errout.str());
     }
 
     void switchRedundantAssignmentTest() {


### PR DESCRIPTION
```
void f() {
  char  foo[2][2];
  char *bar[2];
  bar[0] = foo[0];
  bar[1] = foo[1];
  bar[0][0] = 'a';
}
```

would give a FP:
```
[test.cpp:2]: (style) Variable 'foo' can be declared with const\n"
```