### PR TITLE
Fix FP due to namespace scope

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3194,7 +3194,7 @@ static const Token* getEndOfVarScope(const Token* tok, const std::vector<const V
 {
     const Token* endOfVarScope = nullptr;
     for (const Variable* var : vars) {
-        if (var && (var->isLocal() || var->isArgument()))
+        if (var && (var->isLocal() || var->isArgument()) && var->typeStartToken()->scope()->type != Scope::eNamespace)
             endOfVarScope = var->typeStartToken()->scope()->bodyEnd;
         else if (!endOfVarScope)
             endOfVarScope = tok->scope()->bodyEnd;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -3117,6 +3117,76 @@ private:
               "    }\n"
               "};");
         ASSERT_EQUALS("", errout.str());
+
+        check("namespace test {\n"
+              "class Foo {};\n"
+              "struct Bar {\n"
+              "  Foo *_foo;\n"
+              "};\n"
+              "\n"
+              "int f(Bar *bar);\n"
+              "\n"
+              "void g(Bar *bar) {\n"
+              "  {\n"
+              "    Foo foo;\n"
+              "    bar->_foo = &foo;\n"
+              "    bar->_foo = nullptr;\n"
+              "  }\n"
+              "  f(bar);\n"
+              "}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("class Foo {};\n"
+              "struct Bar {\n"
+              "  Foo *_foo;\n"
+              "};\n"
+              "\n"
+              "int f(Bar *bar);\n"
+              "\n"
+              "void g(Bar *bar) {\n"
+              "  {\n"
+              "    Foo foo;\n"
+              "    bar->_foo = &foo;\n"
+              "    bar->_foo = nullptr;\n"
+              "  }\n"
+              "  f(bar);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("namespace test {\n"
+              "class Foo {};\n"
+              "struct Bar {\n"
+              "  Foo *_foo;\n"
+              "};\n"
+              "\n"
+              "int f(Bar *bar);\n"
+              "\n"
+              "void g(Bar *bar) {\n"
+              "  {\n"
+              "    Foo foo;\n"
+              "    bar->_foo = &foo;\n"
+              "  }\n"
+              "  f(bar);\n"
+              "}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:12]: (error) Address of local auto-variable assigned to a function parameter.\n", errout.str());
+
+        check("class Foo {};\n"
+              "struct Bar {\n"
+              "  Foo *_foo;\n"
+              "};\n"
+              "\n"
+              "int f(Bar *bar);\n"
+              "\n"
+              "void g(Bar *bar) {\n"
+              "  {\n"
+              "    Foo foo;\n"
+              "    bar->_foo = &foo;\n"
+              "  }\n"
+              "  f(bar);\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:11]: (error) Address of local auto-variable assigned to a function parameter.\n", errout.str());
     }
 
     void deadPointer() {


### PR DESCRIPTION
```
namespace test {
class Foo {};
struct Bar {
  Foo *_foo;
};

int f(Bar *bar);

void g(Bar *bar) {
  {
    Foo foo;
    bar->_foo = &foo;
    bar->_foo = nullptr;
  }
  f(bar);
}
}
```
would give
```
a.cpp:15:5: error: Using pointer to local variable 'foo' that is out of scope. [invalidLifetime]
  f(bar);
    ^
a.cpp:12:17: note: Address of variable taken here.
    bar->_foo = &foo;
                ^
a.cpp:11:9: note: Variable created here.
    Foo foo;
        ^
```