### PR TITLE
use lowercase header filenames with MinGW toolchain

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -72,9 +72,15 @@
 #if defined(_MSC_VER)
 #define USE_WINDOWS_SEH
 #endif
-#include <Windows.h>
-#include <DbgHelp.h>
-#include <TCHAR.H>
+#if defined (__MINGW32__)
+#   include <windows.h>
+#   include <dbghelp.h>
+#   include <tchar.h>
+#else
+#   include <Windows.h>
+#   include <DbgHelp.h>
+#   include <TCHAR.H>
+#endif
 #include <excpt.h>
 #endif
 


### PR DESCRIPTION
Fix MinGW build regression. Uppercase headers were previously masked by #if defined(_MSC_VER).