### PR TITLE
Don't simplify template for class names in declarations

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1167,6 +1167,10 @@ void Tokenizer::simplifyTypedef()
                     }
                 }
 
+                else if (Token::Match(tok2->previous(), "class|struct %name% [:{]")) {
+                    // don't replace names in struct/class definition
+                }
+
                 // check for typedef that can be substituted
                 else if ((tok2->isNameOnly() || (tok2->isName() && tok2->isExpandedMacro())) &&
                          (Token::simpleMatch(tok2, pattern.c_str(), pattern.size()) ||

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -181,6 +181,7 @@ private:
         TEST_CASE(simplifyTypedef135); // ticket #10068
         TEST_CASE(simplifyTypedef136);
         TEST_CASE(simplifyTypedef137);
+        TEST_CASE(simplifyTypedef138);
 
         TEST_CASE(simplifyTypedefFunction1);
         TEST_CASE(simplifyTypedefFunction2); // ticket #1685
@@ -2995,6 +2996,14 @@ private:
             ASSERT_EQUALS(exp, tok(code, true, Settings::Native, true));
             ASSERT_EQUALS("", errout.str());
         }
+    }
+
+    void simplifyTypedef138() {
+        const char code[] = "namespace foo { class Bar; }\n"
+                            "class Baz;\n"
+                            "typedef foo::Bar C;\n"
+                            "class C : Baz {};";
+        ASSERT_EQUALS("namespace foo { class Bar ; } class Baz ; class C : Baz { } ;", tok(code));
     }
 
     void simplifyTypedefFunction1() {

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -3002,8 +3002,10 @@ private:
         const char code[] = "namespace foo { class Bar; }\n"
                             "class Baz;\n"
                             "typedef foo::Bar C;\n"
-                            "class C : Baz {};";
-        ASSERT_EQUALS("namespace foo { class Bar ; } class Baz ; class C : Baz { } ;", tok(code));
+                            "namespace bar {\n"
+                            "class C : Baz {};\n"
+                            "}\n";
+        ASSERT_EQUALS("namespace foo { class Bar ; } class Baz ; namespace bar { class C : Baz { } ; }", tok(code));
     }
 
     void simplifyTypedefFunction1() {


### PR DESCRIPTION
Without the patch, the test would give:

```
Expected:
namespace foo { class Bar ; } class Baz ; class C : Baz { } ;

Actual:
namespace foo { class Bar ; } class Baz ; class foo :: Bar : Baz { } ;

```