### PR TITLE
Fix strcpy memory overlap false negative

### DIFF
--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -189,6 +189,8 @@ private:
         TEST_CASE(redundantInitialization);
         TEST_CASE(redundantMemWrite);
 
+        TEST_CASE(memOverlap);
+
         TEST_CASE(varFuncNullUB);
 
         TEST_CASE(checkPipeParameterSize); // ticket #3521
@@ -7872,6 +7874,22 @@ private:
               "    strcpy(buf, x);\n"
               "}");
         TODO_ASSERT_EQUALS("error", "", errout.str());
+    }
+
+    void memOverlap() {
+        check("void f()\n"
+              "{\n"
+              "    char str[] = \"test\";\n"
+              "    strcpy(str, str + 1);\n"
+              "}");
+        TODO_ASSERT_EQUALS("[test.cpp:4]: (error) Overlapping read/write in strcpy() is undefined behavior\n","", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "    char str[] = \"test\";\n"
+              "    strncpy(str, str + 1, 2);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Overlapping read/write in strncpy() is undefined behavior\n", errout.str());
     }
 
     void varFuncNullUB() { // #4482


### PR DESCRIPTION
Cppcheck does not report undefined behavior of `strcpy` memory overlap, however it reports the problem for `strncpy`.

I have found the commit where the new feature for `strncpy` is added, with a possibly relevant comment:
https://github.com/danmar/cppcheck/commit/6234b5438ee1be035e9581c3367f037bf66bac42#commitcomment-53225278

So far I have added tests with expected behavior, which should clarify the problem.

The next step will be trying to remove the false negative.