### PR TITLE
Warn when modifying container from another function in a loop

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -810,7 +810,7 @@ void CheckStl::mismatchingContainerIterator()
     }
 }
 
-static const Token* getInvalidMethod(const Token * tok)
+static const Token* getInvalidMethod(const Token* tok)
 {
     if (!astIsLHS(tok))
         return nullptr;
@@ -966,7 +966,7 @@ static const Token* getLoopContainer(const Token* tok)
 {
     if (!Token::simpleMatch(tok, "for ("))
         return nullptr;
-    const Token * sepTok = tok->next()->astOperand2();
+    const Token* sepTok = tok->next()->astOperand2();
     if (!Token::simpleMatch(sepTok, ":"))
         return nullptr;
     return sepTok->astOperand2();
@@ -981,8 +981,8 @@ void CheckStl::invalidContainer()
     for (const Scope * scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (const Token* contTok = getLoopContainer(tok)) {
-                const Token * blockStart = tok->next()->link()->next();
-                const Token * blockEnd = blockStart->link();
+                const Token* blockStart = tok->next()->link()->next();
+                const Token* blockEnd = blockStart->link();
                 if (contTok->exprId() == 0)
                     continue;
                 if (!astIsContainer(contTok))
@@ -1052,7 +1052,7 @@ void CheckStl::invalidContainer()
                                 // An argument always reaches
                                 if (var->isArgument() ||
                                     (!var->isReference() && !var->isRValueReference() && !isVariableDecl(tok) &&
-                                    reaches(var->nameToken(), tok, library, &ep))) {
+                                     reaches(var->nameToken(), tok, library, &ep))) {
                                     errorPath = ep;
                                     return true;
                                 }
@@ -1094,7 +1094,7 @@ void CheckStl::invalidContainer()
     }
 }
 
-void CheckStl::invalidContainerLoopError(const Token *tok, const Token * loopTok, ErrorPath errorPath)
+void CheckStl::invalidContainerLoopError(const Token* tok, const Token* loopTok, ErrorPath errorPath)
 {
     const std::string method = tok ? tok->str() : "erase";
     errorPath.emplace_back(loopTok, "Iterating container here.");

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -216,7 +216,7 @@ private:
     void checkFindInsertError(const Token *tok);
     void sizeError(const Token* tok);
     void redundantIfRemoveError(const Token* tok);
-    void invalidContainerLoopError(const Token *tok, const Token * loopTok, ErrorPath errorPath);
+    void invalidContainerLoopError(const Token* tok, const Token* loopTok, ErrorPath errorPath);
     void invalidContainerError(const Token *tok, const Token * contTok, const ValueFlow::Value *val, ErrorPath errorPath);
     void invalidContainerReferenceError(const Token* tok, const Token* contTok, ErrorPath errorPath);
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -4902,18 +4902,19 @@ private:
         ASSERT_EQUALS("[test.cpp:4]: (style) Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
 
         check("struct A {\n"
-            "  std::vector<int> v;\n"
-            "  void add(int i) {\n"
-            "    v.push_back(i);\n"
-            "  } \n"
-            "  void f() {\n"
-            "    for(auto i:v)\n"
-            "      add(i);\n"
-            "  }\n"
-            "};\n",
+              "  std::vector<int> v;\n"
+              "  void add(int i) {\n"
+              "    v.push_back(i);\n"
+              "  } \n"
+              "  void f() {\n"
+              "    for(auto i:v)\n"
+              "      add(i);\n"
+              "  }\n"
+              "};\n",
               true);
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:7] -> [test.cpp:8]: (error) Calling 'add' while iterating the container is invalid.\n", errout.str());
-
+        ASSERT_EQUALS(
+            "[test.cpp:4] -> [test.cpp:7] -> [test.cpp:8]: (error) Calling 'add' while iterating the container is invalid.\n",
+            errout.str());
     }
 
     void findInsert() {


### PR DESCRIPTION
This will now warn in cases like these:

```cpp
struct A {
  std::vector<int> v;
  void add(int i) {
    v.push_back(i);
  } 
  void f() {
    for(auto i:v)
      add(i);
  }
};
```

With:

```
test.cpp:8:7: error: Calling 'add' while iterating the container is invalid. [invalidContainerLoop]
      add(i);
      ^
test.cpp:4:7: note: After calling 'push_back', iterators or references to the container's data may be invalid .
    v.push_back(i);
      ^
test.cpp:7:5: note: Iterating container here.
    for(auto i:v)
    ^
test.cpp:8:7: note: Calling 'add' while iterating the container is invalid.
      add(i);
      ^
```
