### PR TITLE
moved uncrustify into a separate GitHub action

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -22,20 +22,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Cache uncrustify
-        uses: actions/cache@v2
-        id: cache-uncrustify
-        with:
-          path: |
-            ~/uncrustify
-          key: ${{ runner.os }}-uncrustify
-
-      - name: build uncrustify
-        if: steps.cache-uncrustify.outputs.cache-hit != 'true'
-        run: |
-          wget https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
-          tar xzvf uncrustify-0.72.0.tar.gz && cd uncrustify-uncrustify-0.72.0 && mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j$(nproc) -s && mkdir ~/uncrustify && cp uncrustify ~/uncrustify/
-
       - name: Install missing software on ubuntu 18.04
         if: matrix.os == 'ubuntu-18.04'
         run: |
@@ -67,10 +53,6 @@ jobs:
         uses: jurplel/install-qt-action@v2
         with:
           modules: 'qtcharts'
-
-      - name: Uncrustify check
-        run: |
-          ~/uncrustify/uncrustify -c .uncrustify.cfg -l CPP --check */*.cpp */*.h
 
       - name: Test CMake build
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,37 @@
+# Syntax reference https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# Environment reference https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+name: format
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache uncrustify
+        uses: actions/cache@v2
+        id: cache-uncrustify
+        with:
+          path: |
+            ~/uncrustify
+          key: ${{ runner.os }}-uncrustify
+
+      - name: build uncrustify
+        if: steps.cache-uncrustify.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
+          tar xzvf uncrustify-0.72.0.tar.gz && cd uncrustify-uncrustify-0.72.0 
+          mkdir build 
+          cd build 
+          cmake -DCMAKE_BUILD_TYPE=Release .. 
+          make -j$(nproc) -s 
+          mkdir ~/uncrustify 
+          cp uncrustify ~/uncrustify/
+
+      - name: Uncrustify check
+        run: |
+          ~/uncrustify/uncrustify -c .uncrustify.cfg -l CPP --check */*.cpp */*.h


### PR DESCRIPTION
Having it run on multiple platforms doesn't make sense and also it breaking the regular build and test execution might hide other issues so we will have to potentially do multiple pushes to fix the build.

The best way would be if it were possible to run the format check before all other jobs so it will fail extremely fast, but unfortunately GitHub actions do not offer this.

Also uncrustify doesn't appear to be able to format all the code - see `threadexecutor.cpp` at line 255 (`FD_SET`).