### PR TITLE
donate-cpu-server.py: another function compression improvement for stack trace overview in crash report

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -25,7 +25,7 @@ import html as html_lib
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.20"
+SERVER_VERSION = "1.3.21"
 
 OLD_VERSION = '2.6'
 
@@ -207,7 +207,7 @@ def crashReport(results_path: str) -> str:
                             stack_trace.append(m.group('number') + ' ' + m.group('function') + '(...) from ' + m.group('binary'))
                             continue
                         # #11 0x00000000006f2414 in valueFlowNumber (tokenlist=tokenlist@entry=0x7fffffffc610) at build/valueflow.cpp:2503
-                        m = re.search(r'(?P<number>#\d+) .* in (?P<function>.+) \(.*\) at (?P<location>.*)$', l)
+                        m = re.search(r'(?P<number>#\d+) .* in (?P<function>.+?) \(.*\) at (?P<location>.*)$', l)
                         if m:
                             #print('1 - {} - {} - {}'.format(m.group('number'), m.group('function'), m.group('location')))
                             stack_trace.append(m.group('number') + ' ' + m.group('function') + '(...) at ' + m.group('location'))


### PR DESCRIPTION
Before
```
#3 __GI___assert_fail (assertion=0x7c66f8 "!maxValue->isKnown()", file=0x7c670d "build/infer.cpp", line=136, function=0x7c671d "static Interval Interval::fromValues(const std::list<ValueFlow::Value> &, Predicate) [Predicate =(...) at assert.c:101
```

After
```
#3 __GI___assert_fail(...) at assert.c:101
```

Unfortunately this does not improve the grouping of the existing crashes since they actually differ.