### PR TITLE
donate_cpu_lib.py: fixed detection of ThreadExecutor error

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.15"
+CLIENT_VERSION = "1.3.16"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60
@@ -385,19 +385,20 @@ def scan_package(work_path, cppcheck_path, jobs, libraries):
         return returncode, stacktrace, '', returncode, options, ''
 
     if returncode != 0:
+        # returncode is always 1 when this message is written
+        thr_pos = stderr.find('#### ThreadExecutor')
+        if thr_pos != -1:
+            print('Thread!')
+            return -222, stderr[thr_pos:], '', -222, options, ''
+
         print('Error!')
         if returncode > 0:
             returncode = -100-returncode
         return returncode, stdout, '', returncode, options, ''
 
     if sig_num != -1:
-        print('Error!')
+        print('Signal!')
         return -sig_num, ''.join(internal_error_messages_list), '', -sig_num, options, ''
-
-    thr_pos = stderr.find('#### ThreadExecutor')
-    if thr_pos != -1:
-        print('Thread!')
-        return -222, stderr[thr_pos:], '', -222, options, ''
 
     return count, ''.join(issue_messages_list), ''.join(information_messages_list), elapsed_time, options, timing_str
 


### PR DESCRIPTION
This did not work since the processing was already finished because `returncode` is always `1` in case of a `#### ThreadExecutor`. It is possible the stored output needs to be adjusted - but there needs to be some cases to look at to decide that first.

It is a very unlikely error to begin with and it appears we currently do not have one in the currently stored daca data.