### PR TITLE
astutils.cpp: optimized isSameExpression() a bit - reduces average Ir from 294 to 213 when analyzing test folder

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -983,7 +983,7 @@ bool isEqualKnownValue(const Token * const tok1, const Token * const tok2)
     });
 }
 
-bool isDifferentKnownValues(const Token * const tok1, const Token * const tok2)
+static inline bool isDifferentKnownValues(const Token * const tok1, const Token * const tok2)
 {
     return compareKnownValue(tok1, tok2, [&](const ValueFlow::Value& v1, const ValueFlow::Value& v2, bool sameLifetime) {
         bool r = v1.equalValue(v2);

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -162,8 +162,6 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
 
 bool isEqualKnownValue(const Token * const tok1, const Token * const tok2);
 
-bool isDifferentKnownValues(const Token * const tok1, const Token * const tok2);
-
 /**
  * Is token used a boolean, that is to say cast to a bool, or used as a condition in a if/while/for
  */


### PR DESCRIPTION
Total Ir - before and after (note: I had all checks and valueflow disabled to speed up the testruns)
```
28,535,826,203
26,205,179,202
26,142,812,619
```