### PR TITLE
errorlogger.cpp: avoid unnecessary storing of line contents

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -32,6 +32,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
+#include <limits>
 #include <memory>
 #include <sstream> // IWYU pragma: keep
 #include <string>
@@ -457,8 +458,14 @@ static std::string readCode(const std::string &file, int linenr, int column, con
 {
     std::ifstream fin(file);
     std::string line;
-    while (linenr > 0 && std::getline(fin,line)) {
-        linenr--;
+    if (linenr > 0) {
+        while (true) {
+            if (--linenr == 0) {
+                std::getline(fin,line);
+                break;
+            }
+            fin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        }
     }
     const std::string::size_type endPos = line.find_last_not_of("\r\n\t ");
     if (endPos + 1 < line.size())


### PR DESCRIPTION
reduces average Ir from `201,554` to `164,375` when scanning `test` folder with `--debug-warnings`

Total Ir - before and after
```
3,053,160,825
2,606,367,442
```