### PR TITLE
Use a unique variable name when checking if a flag is valid

### DIFF
--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -1,15 +1,17 @@
 include(CheckCXXCompilerFlag)
 
 function(add_compile_options_safe FLAG)
-    check_cxx_compiler_flag(${FLAG} _has_flag)
-    if (_has_flag)
+    string(MAKE_C_IDENTIFIER "HAS_CXX_FLAG${FLAG}" mangled_flag)
+    check_cxx_compiler_flag(${FLAG} ${mangled_flag})
+    if (${mangled_flag})
         add_compile_options(${FLAG})
     endif()
 endfunction()
-
+    
 function(target_compile_options_safe TARGET FLAG)
-    check_cxx_compiler_flag(${FLAG} _has_flag)
-    if (_has_flag)
+    string(MAKE_C_IDENTIFIER "HAS_CXX_FLAG${FLAG}" mangled_flag)
+    check_cxx_compiler_flag(${FLAG} ${mangled_flag})
+    if (${mangled_flag})
         target_compile_options(${TARGET} PRIVATE ${FLAG})
     endif()
 endfunction()


### PR DESCRIPTION
The variable passed to `check_cxx_compiler_flag` is a cached variable which means it wont run a `try_compile` if it is already set. Instead, this makes a variable name from the flag so its unique to the flag being checked.