### PR TITLE
Propagate partially uninit variables in ValueFlow

### DIFF
--- a/lib/analyzer.h
+++ b/lib/analyzer.h
@@ -50,6 +50,7 @@ struct Analyzer {
             Idempotent = (1 << 5),
             Incremental = (1 << 6),
             SymbolicMatch = (1 << 7),
+            Internal = (1 << 8),
         };
 
         void set(unsigned int f, bool state = true) {
@@ -94,6 +95,10 @@ struct Analyzer {
 
         bool isSymbolicMatch() const {
             return get(SymbolicMatch);
+        }
+
+        bool isInternal() const {
+            return get(Internal);
         }
 
         bool matches() const {

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1484,7 +1484,7 @@ void CheckUninitVar::uninitvarError(const Token *tok, const std::string &varname
     reportError(errorPath, Severity::error, "uninitvar", "$symbol:" + varname + "\nUninitialized variable: $symbol", CWE_USE_OF_UNINITIALIZED_VARIABLE, Certainty::normal);
 }
 
-void CheckUninitVar::uninitvarError(const Token *tok, const ValueFlow::Value& v)
+void CheckUninitVar::uninitvarError(const Token* tok, const ValueFlow::Value& v)
 {
     const Token* ltok = tok;
     if (tok && Token::simpleMatch(tok->astParent(), ".") && astIsRHS(tok))
@@ -1493,16 +1493,26 @@ void CheckUninitVar::uninitvarError(const Token *tok, const ValueFlow::Value& v)
     ErrorPath errorPath = v.errorPath;
     errorPath.emplace_back(tok, "");
     if (v.subexpressions.empty()) {
-        reportError(errorPath, Severity::error, "uninitvar", "$symbol:" + varname + "\nUninitialized variable: $symbol", CWE_USE_OF_UNINITIALIZED_VARIABLE, Certainty::normal);
+        reportError(errorPath,
+                    Severity::error,
+                    "uninitvar",
+                    "$symbol:" + varname + "\nUninitialized variable: $symbol",
+                    CWE_USE_OF_UNINITIALIZED_VARIABLE,
+                    Certainty::normal);
         return;
     }
     std::string vars = v.subexpressions.size() == 1 ? "variable: " : "variables: ";
     std::string prefix;
-    for(const std::string& var:v.subexpressions) {
+    for (const std::string& var : v.subexpressions) {
         vars += prefix + varname + "." + var;
         prefix = ", ";
     }
-    reportError(errorPath, Severity::error, "uninitvar", "$symbol:" + varname + "\nUninitialized " + vars, CWE_USE_OF_UNINITIALIZED_VARIABLE, Certainty::normal);
+    reportError(errorPath,
+                Severity::error,
+                "uninitvar",
+                "$symbol:" + varname + "\nUninitialized " + vars,
+                CWE_USE_OF_UNINITIALIZED_VARIABLE,
+                Certainty::normal);
 }
 
 void CheckUninitVar::uninitStructMemberError(const Token *tok, const std::string &membername)
@@ -1529,11 +1539,7 @@ static bool isUsedByFunction(const Token* tok, int indirect, const Settings* set
     return isuninitbad && (!addressOf || isnullbad);
 }
 
-enum class FunctionUsage {
-    None,
-    PassedByReference,
-    Used
-};
+enum class FunctionUsage { None, PassedByReference, Used };
 
 static FunctionUsage getFunctionUsage(const Token* tok, int indirect, const Settings* settings)
 {
@@ -1545,7 +1551,7 @@ static FunctionUsage getFunctionUsage(const Token* tok, int indirect, const Sett
         return FunctionUsage::None;
     if (ftok->function()) {
         std::vector<const Variable*> args = getArgumentVars(ftok, argnr);
-        for (const Variable *arg:args) {
+        for (const Variable* arg : args) {
             if (!arg)
                 continue;
             if (arg->isReference())

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1523,22 +1523,6 @@ void CheckUninitVar::uninitStructMemberError(const Token *tok, const std::string
                 "$symbol:" + membername + "\nUninitialized struct member: $symbol", CWE_USE_OF_UNINITIALIZED_VARIABLE, Certainty::normal);
 }
 
-static bool isUsedByFunction(const Token* tok, int indirect, const Settings* settings)
-{
-    const bool addressOf = tok->astParent() && tok->astParent()->isUnaryOp("&");
-
-    int argnr;
-    const Token* ftok = getTokenArgumentFunction(tok, argnr);
-    if (!ftok)
-        return false;
-    const bool isnullbad = settings->library.isnullargbad(ftok, argnr + 1);
-    if (indirect == 0 && astIsPointer(tok) && !addressOf && isnullbad)
-        return true;
-    bool hasIndirect = false;
-    const bool isuninitbad = settings->library.isuninitargbad(ftok, argnr + 1, indirect, &hasIndirect);
-    return isuninitbad && (!addressOf || isnullbad);
-}
-
 enum class FunctionUsage { None, PassedByReference, Used };
 
 static FunctionUsage getFunctionUsage(const Token* tok, int indirect, const Settings* settings)

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -110,7 +110,7 @@ public:
     /** @brief Analyse all file infos for all TU */
     bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
 
-    void uninitvarError(const Token *tok, const ValueFlow::Value& v);
+    void uninitvarError(const Token* tok, const ValueFlow::Value& v);
     void uninitstringError(const Token *tok, const std::string &varname, bool strncpy_);
     void uninitdataError(const Token *tok, const std::string &varname);
     void uninitvarError(const Token *tok, const std::string &varname, ErrorPath errorPath);

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -110,6 +110,7 @@ public:
     /** @brief Analyse all file infos for all TU */
     bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
 
+    void uninitvarError(const Token *tok, const ValueFlow::Value& v);
     void uninitstringError(const Token *tok, const std::string &varname, bool strncpy_);
     void uninitdataError(const Token *tok, const std::string &varname);
     void uninitvarError(const Token *tok, const std::string &varname, ErrorPath errorPath);
@@ -132,10 +133,12 @@ private:
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
         CheckUninitVar c(nullptr, settings, errorLogger);
 
+        ValueFlow::Value v{};
+
         // error
+        c.uninitvarError(nullptr, v);
         c.uninitstringError(nullptr, "varname", true);
         c.uninitdataError(nullptr, "varname");
-        c.uninitvarError(nullptr, "varname");
         c.uninitStructMemberError(nullptr, "a.b");
     }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2718,7 +2718,7 @@ struct OppositeExpressionAnalyzer : ExpressionAnalyzer {
 };
 
 struct SubExpressionAnalyzer : ExpressionAnalyzer {
-    typedef std::vector<std::pair<Token*, ValueFlow::Value>> PartialReadContainer;
+    using PartialReadContainer = std::vector<std::pair<Token *, ValueFlow::Value>>;
     // A shared_ptr is used so partial reads can be captured even after forking
     std::shared_ptr<PartialReadContainer> partialReads;
     SubExpressionAnalyzer() : ExpressionAnalyzer(), partialReads(nullptr) {}

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6486,7 +6486,7 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
                             continue;
                         addToErrorPath(v2, v);
                     }
-                    v2.errorPath.push_back(std::make_pair(memVar.nameToken(), "Member variable not initialized"));
+                    v2.subexpressions.push_back(memVar.nameToken()->str());
                 }
             }
         }
@@ -7430,6 +7430,7 @@ ValueFlow::Value::Value(const Token* c, long long val, Bound b)
     indirect(0),
     path(0),
     wideintvalue(0),
+    subexpressions(),
     lifetimeKind(LifetimeKind::Object),
     lifetimeScope(LifetimeScope::Local),
     valueKind(ValueKind::Possible)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -564,6 +564,12 @@ static void setTokenValue(Token* tok, ValueFlow::Value value, const Settings* se
         if (Token::Match(tok, ". %var%"))
             setTokenValue(tok->next(), value, settings);
         ValueFlow::Value pvalue = value;
+        if (!value.subexpressions.empty()) {
+            if (Token::Match(parent, ". %var%") && contains(value.subexpressions, parent->next()->str()))
+                pvalue.subexpressions.clear();
+        }
+        if (!pvalue.subexpressions.empty())
+            return;
         if (parent->isUnaryOp("&")) {
             pvalue.indirect++;
             setTokenValue(parent, pvalue, settings);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2440,7 +2440,8 @@ struct ValueFlowAnalyzer : Analyzer {
             makeConditional();
     }
 
-    virtual void internalUpdate(Token*, const ValueFlow::Value&, Direction d) {
+    virtual void internalUpdate(Token*, const ValueFlow::Value&, Direction d)
+    {
         assert(false && "Internal update unimplemented.");
     }
 
@@ -6422,9 +6423,9 @@ static void addToErrorPath(ValueFlow::Value& value, const ValueFlow::Value& from
     if (from.condition && !value.condition)
         value.condition = from.condition;
     std::copy_if(from.errorPath.begin(),
-                    from.errorPath.end(),
-                    std::back_inserter(value.errorPath),
-                    [&](const ErrorPathItem& e) {
+                 from.errorPath.end(),
+                 std::back_inserter(value.errorPath),
+                 [&](const ErrorPathItem& e) {
         return locations.insert(e.first).second;
     });
 }
@@ -6479,7 +6480,7 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
                 MemberExpressionAnalyzer analyzer(memVar.nameToken()->str(), vardecl, uninitValue, tokenlist);
                 valueFlowGenericForward(vardecl->next(), vardecl->scope()->bodyEnd, analyzer, settings);
 
-                for(auto&& p:*analyzer.partialReads) {
+                for (auto&& p : *analyzer.partialReads) {
                     Token* tok2 = p.first;
                     const ValueFlow::Value& v = p.second;
                     // Try to insert into map
@@ -6497,7 +6498,7 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
             }
         }
 
-        for(auto&& p:partialReads) {
+        for (auto&& p : partialReads) {
             Token* tok2 = p.first;
             const ValueFlow::Value& v = p.second;
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1963,7 +1963,7 @@ struct ValueFlowAnalyzer : Analyzer {
 
     virtual bool match(const Token* tok) const = 0;
 
-    virtual bool internalMatch(const Token* tok) const {
+    virtual bool internalMatch(const Token*) const {
         return false;
     }
 
@@ -2440,7 +2440,7 @@ struct ValueFlowAnalyzer : Analyzer {
             makeConditional();
     }
 
-    virtual void internalUpdate(Token*, const ValueFlow::Value&, Direction d)
+    virtual void internalUpdate(Token*, const ValueFlow::Value&, Direction)
     {
         assert(false && "Internal update unimplemented.");
     }

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -98,6 +98,7 @@ namespace ValueFlow {
             indirect(0),
             path(0),
             wideintvalue(val),
+            subexpressions(),
             lifetimeKind(LifetimeKind::Object),
             lifetimeScope(LifetimeScope::Local),
             valueKind(ValueKind::Possible)
@@ -351,6 +352,8 @@ namespace ValueFlow {
 
         /** int value before implicit truncation */
         long long wideintvalue;
+
+        std::vector<std::string> subexpressions;
 
         enum class LifetimeKind {
             // Pointer points to a member of lifetime

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -81,6 +81,9 @@ private:
     Suppressions::ErrorMessage errorMessage(const std::string &errorId) const {
         Suppressions::ErrorMessage ret;
         ret.errorId = errorId;
+        ret.hash = 0;
+        ret.lineNumber = 0;
+        ret.certainty = Certainty::CertaintyLevel::normal;
         return ret;
     }
 

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -5252,6 +5252,95 @@ private:
                         "test.c");
         ASSERT_EQUALS("[test.c:4]: (error) Uninitialized variable: ab.a\n", errout.str());
 
+        valueFlowUninit("struct AB { int a; int b; };\n"
+                       "void f(void) {\n"
+                       "    struct AB ab;\n"
+                       "    ab.a = 1;\n"
+                       "    x = ab;\n"
+                       "}\n", "test.c");
+        ASSERT_EQUALS("[test.c:5]: (error) Uninitialized variable: ab.b\n", errout.str());
+
+        valueFlowUninit("struct AB { int a; int b; };\n"
+                       "void f(void) {\n"
+                       "    struct AB ab;\n"
+                       "    ab.a = 1;\n"
+                       "    x = *(&ab);\n"
+                       "}\n", "test.c");
+        ASSERT_EQUALS("[test.c:5] -> [test.c:5]: (error) Uninitialized variable: *(&ab).b\n", errout.str());
+
+        valueFlowUninit("void f(void) {\n"
+                       "    struct AB ab;\n"
+                       "    int x;\n"
+                       "    ab.a = (addr)&x;\n"
+                       "    dostuff(&ab,0);\n"
+                       "}\n", "test.c");
+        ASSERT_EQUALS("", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    static void f() { }\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; element->f();\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    static void f() { }\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; (*element).f();\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    static int v;\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; element->v;\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    static int v;\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; (*element).v;\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    void f() { }\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; element->f();\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    void f() { }\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; (*element).f();\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    int v;\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; element->v;\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+        valueFlowUninit("struct Element {\n"
+                       "    int v;\n"
+                       "};\n"
+                       "void test() {\n"
+                       "    Element *element; (*element).v;\n"
+                       "}");
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
+
+
         valueFlowUninit("struct AB { int a; int b; };\n" // pass struct member by address
                         "void f(void) {\n"
                         "    struct AB ab;\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -5230,6 +5230,15 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         valueFlowUninit("struct AB { int a; int b; };\n"
+                        "void do_something(const struct AB &ab) { a = ab.b; }\n"
+                        "void f(void) {\n"
+                        "    struct AB ab;\n"
+                        "    ab.a = 0;\n"
+                        "    do_something(ab);\n"
+                        "}");
+        ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:2]: (error) Uninitialized variable: ab.b\n", errout.str());
+
+        valueFlowUninit("struct AB { int a; int b; };\n"
                         "void f(void) {\n"
                         "    struct AB ab;\n"
                         "    int a = ab.a;\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -5262,93 +5262,95 @@ private:
         ASSERT_EQUALS("[test.c:4]: (error) Uninitialized variable: ab.a\n", errout.str());
 
         valueFlowUninit("struct AB { int a; int b; };\n"
-                       "void f(void) {\n"
-                       "    struct AB ab;\n"
-                       "    ab.a = 1;\n"
-                       "    x = ab;\n"
-                       "}\n", "test.c");
+                        "void f(void) {\n"
+                        "    struct AB ab;\n"
+                        "    ab.a = 1;\n"
+                        "    x = ab;\n"
+                        "}\n",
+                        "test.c");
         ASSERT_EQUALS("[test.c:5]: (error) Uninitialized variable: ab.b\n", errout.str());
 
         valueFlowUninit("struct AB { int a; int b; };\n"
-                       "void f(void) {\n"
-                       "    struct AB ab;\n"
-                       "    ab.a = 1;\n"
-                       "    x = *(&ab);\n"
-                       "}\n", "test.c");
+                        "void f(void) {\n"
+                        "    struct AB ab;\n"
+                        "    ab.a = 1;\n"
+                        "    x = *(&ab);\n"
+                        "}\n",
+                        "test.c");
         ASSERT_EQUALS("[test.c:5] -> [test.c:5]: (error) Uninitialized variable: *(&ab).b\n", errout.str());
 
         valueFlowUninit("void f(void) {\n"
-                       "    struct AB ab;\n"
-                       "    int x;\n"
-                       "    ab.a = (void*)&x;\n"
-                       "    dostuff(&ab,0);\n"
-                       "}\n", "test.c");
+                        "    struct AB ab;\n"
+                        "    int x;\n"
+                        "    ab.a = (void*)&x;\n"
+                        "    dostuff(&ab,0);\n"
+                        "}\n",
+                        "test.c");
         ASSERT_EQUALS("", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    static void f() { }\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; element->f();\n"
-                       "}");
+                        "    static void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; element->f();\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    static void f() { }\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; (*element).f();\n"
-                       "}");
+                        "    static void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).f();\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    static int v;\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; element->v;\n"
-                       "}");
+                        "    static int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; element->v;\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    static int v;\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; (*element).v;\n"
-                       "}");
+                        "    static int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).v;\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    void f() { }\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; element->f();\n"
-                       "}");
+                        "    void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; element->f();\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    void f() { }\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; (*element).f();\n"
-                       "}");
+                        "    void f() { }\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).f();\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    int v;\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; element->v;\n"
-                       "}");
+                        "    int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; element->v;\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
 
         valueFlowUninit("struct Element {\n"
-                       "    int v;\n"
-                       "};\n"
-                       "void test() {\n"
-                       "    Element *element; (*element).v;\n"
-                       "}");
+                        "    int v;\n"
+                        "};\n"
+                        "void test() {\n"
+                        "    Element *element; (*element).v;\n"
+                        "}");
         ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: element\n", errout.str());
-
 
         valueFlowUninit("struct AB { int a; int b; };\n" // pass struct member by address
                         "void f(void) {\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -4543,7 +4543,7 @@ private:
                         "        p = new S(io);\n"
                         "    p->Write();\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:8] -> [test.cpp:10]: (error) Uninitialized variable: p\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:8] -> [test.cpp:10]: (error) Uninitialized variable: p.rIo\n", errout.str());
 
         // Unknown types
         {
@@ -5271,7 +5271,7 @@ private:
         valueFlowUninit("void f(void) {\n"
                        "    struct AB ab;\n"
                        "    int x;\n"
-                       "    ab.a = (addr)&x;\n"
+                       "    ab.a = (void*)&x;\n"
                        "    dostuff(&ab,0);\n"
                        "}\n", "test.c");
         ASSERT_EQUALS("", errout.str());
@@ -5561,7 +5561,7 @@ private:
                         "    s.a = 0;\n"
                         "    return s;\n"
                         "}\n");
-        TODO_ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: s.b\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: s.b\n", errout.str());
 
         valueFlowUninit("struct S { int a; int b; };\n" // #9810
                         "void f(void) {\n"


### PR DESCRIPTION
This also fixes issues [10573](https://trac.cppcheck.net/ticket/10573) and [10554](https://trac.cppcheck.net/ticket/10554).