### PR TITLE
Refactor: Use a template instead of std::function in forward analyzer to help improve debugging

### DIFF
--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -93,8 +93,8 @@ struct ForwardTraversal {
         return evalCond(tok, ctx).second;
     }
 
-    template<class T, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-    Progress traverseTok(T* tok, std::function<Progress(T*)> f, bool traverseUnknown, T** out = nullptr) {
+    template<class T, class F, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
+    Progress traverseTok(T* tok, F f, bool traverseUnknown, T** out = nullptr) {
         if (Token::Match(tok, "asm|goto|setjmp|longjmp"))
             return Break(Analyzer::Terminate::Bail);
         else if (Token::simpleMatch(tok, "continue")) {
@@ -134,8 +134,8 @@ struct ForwardTraversal {
         return Progress::Continue;
     }
 
-    template<class T, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-    Progress traverseRecursive(T* tok, std::function<Progress(T*)> f, bool traverseUnknown, unsigned int recursion=0) {
+    template<class T, class F, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
+    Progress traverseRecursive(T* tok, F f, bool traverseUnknown, unsigned int recursion=0) {
         if (!tok)
             return Progress::Continue;
         if (recursion > 10000)
@@ -206,7 +206,7 @@ struct ForwardTraversal {
     }
 
     Progress updateTok(Token* tok, Token** out = nullptr) {
-        std::function<Progress(Token*)> f = [this](Token* tok2) {
+        auto f = [this](Token* tok2) {
             return update(tok2);
         };
         return traverseTok(tok, f, false, out);
@@ -214,14 +214,14 @@ struct ForwardTraversal {
 
     Progress updateRecursive(Token* tok) {
         forked = false;
-        std::function<Progress(Token*)> f = [this](Token* tok2) {
+        auto f = [this](Token* tok2) {
             return update(tok2);
         };
         return traverseRecursive(tok, f, false);
     }
 
-    template<class T>
-    T* findRange(T* start, const Token* end, std::function<bool(Analyzer::Action)> pred) {
+    template<class T, class F>
+    T* findRange(T* start, const Token* end, F pred) {
         for (T* tok = start; tok && tok != end; tok = tok->next()) {
             Analyzer::Action action = analyzer->analyze(tok, Analyzer::Direction::Forward);
             if (pred(action))
@@ -232,7 +232,7 @@ struct ForwardTraversal {
 
     Analyzer::Action analyzeRecursive(const Token* start) {
         Analyzer::Action result = Analyzer::Action::None;
-        std::function<Progress(const Token*)> f = [&](const Token* tok) {
+        auto f = [&](const Token* tok) {
             result = analyzer->analyze(tok, Analyzer::Direction::Forward);
             if (result.isModified() || result.isInconclusive())
                 return Break();


### PR DESCRIPTION
Using std::function requires stepping through a bunch std calls to get to the lambda function. Using a template, the debugger will step directly to the lambda when stepping in, which makes debugging the forward analyzer much easier.