### PR TITLE
fix false positive of virtual function call

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2423,7 +2423,7 @@ void CheckClass::checkVirtualFunctionCallInConstructor()
                 continue;
             if (callstack.back()->function()->isPure())
                 pureVirtualFunctionCallInConstructorError(scope->function, callstack, callstack.back()->str());
-            else
+            else if (!callstack.back()->function()->hasFinalSpecifier())
                 virtualFunctionCallInConstructorError(scope->function, callstack, callstack.back()->str());
         }
     }

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6968,6 +6968,17 @@ private:
                                  "    A() { f(); }\n"
                                  "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        checkVirtualFunctionCall("class B {\n"
+                                 "public:"
+                                 "    virtual void f() {}\n"
+                                 "};\n"
+                                 "class A : B {\n"
+                                 "public:"
+                                 "    void f() override final {}\n"
+                                 "    A() { f(); }\n"
+                                 "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void pureVirtualFunctionCall() {


### PR DESCRIPTION
Cppcheck issues a warning if a virtual call is called from a constructor or destructor. If the method is just overridden and marked final, this is a false positive.