### PR TITLE
Improve donate-cpu.py efficiency, do not revert/rebuild cppcheck binary unless there is a new commit

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -42,12 +42,19 @@ def get_cppcheck(cppcheck_path, work_path):
             try:
                 os.chdir(cppcheck_path)
                 try:
+                    subprocess.check_call(['git', 'fetch'])
+                    localrev = subprocess.check_output(['git', 'rev-parse', 'main'])
+                    origrev = subprocess.check_output(['git', 'rev-parse', 'origin/main'])
+                    if localrev == origrev:
+                        print('Already up to date. Continuing with %s.' % localrev.decode().rstrip())
+                        time.sleep(2)
+                        return True
                     subprocess.check_call(['git', 'checkout', '-f', 'main'])
                 except subprocess.CalledProcessError:
                     subprocess.check_call(['git', 'checkout', '-f', 'master'])
-                    subprocess.check_call(['git', 'pull'])
+                    subprocess.check_call(['git', 'merge'])
                     subprocess.check_call(['git', 'checkout', 'origin/main', '-b', 'main'])
-                subprocess.check_call(['git', 'pull'])
+                subprocess.check_call(['git', 'merge'])
             except:
                 print('Failed to update Cppcheck sources! Retrying..')
                 time.sleep(10)


### PR DESCRIPTION
This modify function get_cppcheck to first fetch changes from the remote repository (ie origin), then act depending on the result: 
* No new commit : since the local repository is up to date, return early. This skips checkout, meaning we do not revert, and do not remove the cppcheck binary we just compiled. 
* New commit : since there was a change, do checkout + merge. This situation is equivalent to the existing behavior since pull is equivalent to fetch+merge (cf https://git-scm.com/docs/git-pull)

This should significantly improve DACA performance. 

Currently, for each package, we always do a pull + checkout which is terribly inefficient because checkout causes the following "make" to fully re-compile and re-link cppcheck, even if there is no new commit (and no code change). 
With this change, if there is no new commit; the following make is a NoOp (make would consider cppcheck up to date). But if there is a new commit, the following make would still be a full rebuild cppcheck. 