### PR TITLE
# Fix bug  misra.py misra_7_4 muti args crash

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1833,7 +1833,10 @@ class MisraChecker:
                         continue
 
                     parametersUsed = getArguments(token)
-                    for i in range(len(parametersUsed)):
+
+                    checkArgCount = len(functionDeclaration.argument) - 1 if len(parametersUsed) > len(functionDeclaration.argument) else len(parametersUsed)
+                    checkArgCount = 0 if checkArgCount < 0 else checkArgCount
+                    for i in range(checkArgCount):
                         usedParameter = parametersUsed[i]
                         parameterDefinition = functionDeclaration.argument.get(i+1)
 

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1835,7 +1835,7 @@ class MisraChecker:
                     parametersUsed = getArguments(token)
 
                     checkArgCount = len(functionDeclaration.argument) - 1 if len(parametersUsed) > len(functionDeclaration.argument) else len(parametersUsed)
-                    checkArgCount = 0 if checkArgCount < 0 else checkArgCount
+                    checkArgCount = max(checkArgCount, 0)
                     for i in range(checkArgCount):
                         usedParameter = parametersUsed[i]
                         parameterDefinition = functionDeclaration.argument.get(i+1)

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1833,10 +1833,9 @@ class MisraChecker:
                         continue
 
                     parametersUsed = getArguments(token)
-
-                    checkArgCount = len(functionDeclaration.argument) - 1 if len(parametersUsed) > len(functionDeclaration.argument) else len(parametersUsed)
-                    checkArgCount = max(checkArgCount, 0)
-                    for i in range(checkArgCount):
+                    for i in range(len(parametersUsed)):
+                        if i + 1 >= len(functionDeclaration.argument):
+                            continue
                         usedParameter = parametersUsed[i]
                         parameterDefinition = functionDeclaration.argument.get(i+1)
 


### PR DESCRIPTION
                    # declaration int redisFormatCommand(char **target, const char *format, ...);
                    # len = redisFormatCommand(&cmd,"SET %s %s","foo","bar");
                    # "foo" and "bar" is ...


  File "Release/misra/addons/misra.py", line 4157, in executeCheck
    check_function(*args)
  File "Release/misra/addons/misra.py", line 1823, in misra_7_4
    if usedParameter.isString and parameterDefinition.nameToken:
AttributeError: 'NoneType' object has no attribute 'nameToken'
