### PR TITLE
autovarInvalidDeallocation: Fix fp with impossible value

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -275,7 +275,7 @@ void CheckAutoVariables::autoVariables()
                     for (const ValueFlow::Value &v : tok->values()) {
                         if (!(v.isTokValue()))
                             continue;
-                        if (isArrayVar(v.tokvalue) || v.tokvalue->tokType() == Token::eString) {
+                        if (isArrayVar(v.tokvalue) || ((v.tokvalue->tokType() == Token::eString) && !v.isImpossible())) {
                             errorInvalidDeallocation(tok, &v);
                             break;
                         }

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -782,6 +782,16 @@ private:
                       "[test.cpp:6]: (error) Deallocation of an pointer pointing to a string literal (\"a\") results in undefined behaviour.\n"
                       "[test.cpp:9]: (error) Deallocation of an pointer pointing to a string literal (\"abc\") results in undefined behaviour.\n",
                       errout.str());
+
+        check("void f() {\n"
+              "   char *ptr = malloc(10);\n"
+              "   char *empty_str = \"\";\n"
+              "   if (ptr == NULL)\n"
+              "      ptr = empty_str;\n"
+              "   if (ptr != empty_str)\n"
+              "      free(ptr);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void testinvaliddealloc_C() {


### PR DESCRIPTION
daca reports new false positives after db4f94fdfea6 on the form:

	void f() {
	    char *ptr = malloc(10);
	    char *empty_str = "";
	    if (ptr == NULL)
	        ptr = empty_str;
	    if (ptr != empty_str)
	        free(ptr);
	}

Add a check that the value is not impossible to avoid this.