### PR TITLE
Fix #9570 duplicateValueTernary related to references to static variables

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1037,6 +1037,9 @@ static bool compareKnownValue(const Token * const tok1, const Token * const tok2
 {
     static const auto isKnownFn = std::mem_fn(&ValueFlow::Value::isKnown);
 
+    if ((tok1->variable() && tok1->variable()->isStatic()) || (tok2->variable() && tok2->variable()->isStatic()))
+        return false;
+
     const auto v1 = std::find_if(tok1->values().begin(), tok1->values().end(), isKnownFn);
     if (v1 == tok1->values().end()) {
         return false;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5593,6 +5593,14 @@ private:
               "  std::vector<int> v = b ? bar : baz;\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void f(bool q) {\n" // #9570
+              "    static int a = 0;\n"
+              "    static int b = 0;\n"
+              "    int& x = q ? a : b;\n"
+              "    ++x;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void duplicateExpressionTemplate() { // #6930


### PR DESCRIPTION
Not sure if this is the right fix. Maybe those values should not be set in the first place?