### PR TITLE
scriptcheck.yml: avoid duplicated cppcheck builds

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -8,6 +8,25 @@ jobs:
   build:
 
     runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Cppcheck
+        uses: actions/cache@v2
+        with:
+          path: cppcheck
+          key: ${{ runner.os }}-scriptcheck-cppcheck-${{ github.sha }}
+
+      - name: build cppcheck
+        run: |
+          make -j$(nproc) -s
+          strip -s ./cppcheck
+
+  scriptcheck:
+
+    needs: build
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
@@ -15,6 +34,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Restore Cppcheck
+        uses: actions/cache@v2
+        with:
+          path: cppcheck
+          key: ${{ runner.os }}-scriptcheck-cppcheck-${{ github.sha }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -83,10 +108,6 @@ jobs:
         run: |
           python tools/test_matchcompiler.py
 
-      - name: build cppcheck
-        run: |
-          make -j$(nproc) -s
-
       - name: test addons
         run: |
           python -m pytest addons/test/test-*.py
@@ -104,4 +125,3 @@ jobs:
         run: |
           make -j$(nproc) run-dmake
           git diff --exit-code
-


### PR DESCRIPTION
The cache builds are removed after 7 days of not being accessed and the maximum storage is 10 GB. I stripped the binary since we don't need the debug symbols and we store less.