### PR TITLE
Fix #10600: FP invalid dealloc of function array argument

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -60,7 +60,7 @@ static bool isArrayArg(const Token *tok)
 static bool isArrayVar(const Token *tok)
 {
     const Variable *var = tok->variable();
-    return (var && var->isArray());
+    return (var && var->isArray() && !var->isArgument());
 }
 
 static bool isRefPtrArg(const Token *tok)

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -79,6 +79,7 @@ private:
         TEST_CASE(testautovar_extern);
         TEST_CASE(testautovar_reassigned);
         TEST_CASE(testinvaliddealloc);
+        TEST_CASE(testinvaliddealloc_input); // Ticket #10600
         TEST_CASE(testinvaliddealloc_string);
         TEST_CASE(testinvaliddealloc_C);
         TEST_CASE(testassign1);  // Ticket #1819
@@ -761,6 +762,33 @@ private:
               "    std::array<long, 256>* m_Arr{};\n"
               "};\n"
               "Array arr;\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void testinvaliddealloc_input() {
+        // #10600
+        check("void f(int* a[]) {\n"
+              "    free(a);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int a[]) {\n"
+              "    free(a);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int* a[]) {\n"
+              "    int * p = *a;\n"
+              "    free(p);\n"
+              "    int ** q = a;\n"
+              "    free(q);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int a[]) {\n"
+              "    int * p = a;\n"
+              "    free(p);\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Do not warn for array arguments that are free'd, since they decay to
pointers.