### PR TITLE
Fix #9549 FP knownConditionTrueFalse (bitshift)

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -373,7 +373,7 @@ static const Token *getCastTypeStartToken(const Token *parent)
 
 static bool isComputableValue(const Token* parent, const ValueFlow::Value& value)
 {
-    const bool noninvertible = parent->isComparisonOp() || Token::Match(parent, "%|/|&|%or%");
+    const bool noninvertible = isNonInvertibleOperation(parent);
     if (noninvertible && value.isImpossible())
         return false;
     if (!value.isIntValue() && !value.isFloatValue() && !value.isTokValue() && !value.isIteratorValue())
@@ -383,6 +383,12 @@ static bool isComputableValue(const Token* parent, const ValueFlow::Value& value
     if (value.isTokValue() && (!parent->isComparisonOp() || value.tokvalue->tokType() != Token::eString))
         return false;
     return true;
+}
+
+// does the operation cause a loss of information?
+static bool isNonInvertibleOperation(const Token* tok)
+{
+    return tok->isComparisonOp() || Token::Match(tok, "%|/|&|%or%|<<|>>");
 }
 
 /** Set token value for cast */
@@ -669,7 +675,7 @@ static void setTokenValue(Token* tok, ValueFlow::Value value, const Settings* se
              parent->astOperand1() &&
              parent->astOperand2()) {
 
-        const bool noninvertible = parent->isComparisonOp() || Token::Match(parent, "%|/|&|%or%|<<|>>");
+        const bool noninvertible = isNonInvertibleOperation(parent);
 
         // Skip operators with impossible values that are not invertible
         if (noninvertible && value.isImpossible())

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -669,7 +669,7 @@ static void setTokenValue(Token* tok, ValueFlow::Value value, const Settings* se
              parent->astOperand1() &&
              parent->astOperand2()) {
 
-        const bool noninvertible = parent->isComparisonOp() || Token::Match(parent, "%|/|&|%or%");
+        const bool noninvertible = parent->isComparisonOp() || Token::Match(parent, "%|/|&|%or%|<<|>>");
 
         // Skip operators with impossible values that are not invertible
         if (noninvertible && value.isImpossible())

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -371,6 +371,12 @@ static const Token *getCastTypeStartToken(const Token *parent)
     return nullptr;
 }
 
+// does the operation cause a loss of information?
+static bool isNonInvertibleOperation(const Token* tok)
+{
+    return tok->isComparisonOp() || Token::Match(tok, "%|/|&|%or%|<<|>>");
+}
+
 static bool isComputableValue(const Token* parent, const ValueFlow::Value& value)
 {
     const bool noninvertible = isNonInvertibleOperation(parent);
@@ -383,12 +389,6 @@ static bool isComputableValue(const Token* parent, const ValueFlow::Value& value
     if (value.isTokValue() && (!parent->isComparisonOp() || value.tokvalue->tokType() != Token::eString))
         return false;
     return true;
-}
-
-// does the operation cause a loss of information?
-static bool isNonInvertibleOperation(const Token* tok)
-{
-    return tok->isComparisonOp() || Token::Match(tok, "%|/|&|%or%|<<|>>");
 }
 
 /** Set token value for cast */

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3927,7 +3927,7 @@ private:
               "  if (pD) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
-        
+
         // #9549
         check("void f(const uint32_t v) {\n"
               "    const uint32_t v16 = v >> 16;\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -3927,6 +3927,16 @@ private:
               "  if (pD) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+        
+        // #9549
+        check("void f(const uint32_t v) {\n"
+              "    const uint32_t v16 = v >> 16;\n"
+              "    if (v16) {\n"
+              "        const uint32_t v8 = v16 >> 8;\n"
+              "        if (v8) {}\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void alwaysTrueInfer() {


### PR DESCRIPTION
I have no idea what "noninvertible" means in this context. Maybe "potentially induces loss of information"? There could be other operators missing from the list.
Anyway, without the bailout, the impossible value `0` for `v16` was incorrectly propagated to `=` and `>>`.