### PR TITLE
Improve definitions for boost test macros

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -25,21 +25,41 @@
   <define name="BOOST_THROW_EXCEPTION(X)" value="boost::throw_exception(X)"/>
   <define name="BOOST_LIKELY(X)" value="(X)"/>
   <define name="BOOST_UNLIKELY(X)" value="(X)"/>
-  <define name="BOOST_FIXTURE_TEST_SUITE(...)" value=""/>
-  <define name="BOOST_FIXTURE_TEST_SUITE_END()" value=""/>
+  <define name="BOOST_FIXTURE_TEST_SUITE(name, fixture, ...)" value="struct name : fixture {" />
+  <define name="BOOST_FIXTURE_TEST_SUITE_END()" value="};"/>
   <define name="BOOST_TEST_GLOBAL_FIXTURE(name)" value=""/>
   <define name="BOOST_PYTHON_FUNCTION_OVERLOADS(foo_overloads, foo, x, y)" value=""/>
-  <define name="BOOST_AUTO_TEST_SUITE(...)" value=""/>
-  <define name="BOOST_AUTO_TEST_SUITE_END()" value=""/>
+  <define name="BOOST_AUTO_TEST_SUITE(name, ...)" value="namespace name {" />
+  <define name="BOOST_AUTO_TEST_SUITE_END()" value="}" />
   <define name="BOOST_ASSERT(condition)" value="assert(condition)"/>
-  <define name="BOOST_TEST(condition)" value="assert(condition)"/>
-  <define name="BOOST_WARN(condition)" value="assert(condition)"/>
-  <define name="BOOST_CHECK(condition)" value="assert(condition)"/>
-  <define name="BOOST_REQUIRE(condition)" value="assert(condition)"/>
-  <define name="BOOST_CHECK_EQUAL(a,b)" value="assert((a) == (b))"/>
-  <define name="BOOST_WARN_EQUAL(a,b)" value="assert((a) == (b))"/>
-  <define name="BOOST_REQUIRE_EQUAL(a,b)" value="assert((a) == (b))"/>
+  <define name="BOOST_TEST(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_TEST_REQUIRE(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_WARN(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_WARN_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_WARN_EQUAL(a, b)" value="static_cast&lt;void&gt;((a) == (b))" />
+  <define name="BOOST_WARN_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
+  <define name="BOOST_WARN_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
+  <define name="BOOST_WARN_GE(a, b)" value="static_cast&lt;void&gt;((a) &gt;= (b))" />
+  <define name="BOOST_WARN_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
+  <define name="BOOST_WARN_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
+  <define name="BOOST_CHECK(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_CHECK_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_CHECK_EQUAL(a, b)" value="static_cast&lt;void&gt;((a) == (b))" />
+  <define name="BOOST_CHECK_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
+  <define name="BOOST_CHECK_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
+  <define name="BOOST_CHECK_GE(a, b)" value="static_cast&lt;void&gt;((a) &gt;= (b))" />
+  <define name="BOOST_CHECK_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
+  <define name="BOOST_CHECK_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
+  <define name="BOOST_REQUIRE(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_REQUIRE_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_REQUIRE_EQUAL(a, b)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;((a) == (b)))" />
+  <define name="BOOST_REQUIRE_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
+  <define name="BOOST_REQUIRE_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
+  <define name="BOOST_REQUIRE_GE(a, b)" value="static_cast&lt;void&gt;((a) &gt;= (b))" />
+  <define name="BOOST_REQUIRE_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
+  <define name="BOOST_REQUIRE_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
   <define name="BOOST_LOG_ATTRIBUTE_KEYWORD(keyword, name_, value_type_)" value="value_type_ keyword;"/>
+  <define name="BOOST_TEST_DONT_PRINT_LOG_VALUE(the_type)" value="" />
   <!--Boost.Math Macros -->
   <define name="BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS" value=""/>
   <define name="BOOST_MATH_USE_FLOAT128" value=""/>
@@ -64,8 +84,8 @@
   <define name="BOOST_MATH_INT_VALUE_SUFFIX" value=""/>
   <!-- Tell cppcheck to interpret BOOST_AUTO_TEST_CASE as a function definition -->
   <define name="BOOST_AUTO_TEST_CASE(...)" value="void BOOST_AUTO_TEST_CASE_run(__VA_ARGS__)"/>
-  <define name="BOOST_FIXTURE_TEST_CASE(...)" value="void BOOST_FIXTURE_TEST_CASE_run(__VA_ARGS__)"/>
-  <define name="BOOST_AUTO_TEST_CASE_TEMPLATE( test_name, type_name, TL )" value="void BOOST_AUTO_TEST_CASE_TEMPLATE_run( test_name, type_name, TL )"/>
+  <define name="BOOST_FIXTURE_TEST_CASE(name, fixture, ...)" value="struct name : fixture { void test_method(); }; void name::test_method()" />
+  <define name="BOOST_FIXTURE_TEST_CASE_TEMPLATE(test_name, type_name, TL, F)" value="template&lt;typename type_name&gt; struct test_name : public F { void test_method(); }; template&lt;typename type_name&gt; void test_name&lt;type_name&gt;::test_method()" />
   <define name="BOOST_DATA_TEST_CASE(...)" value="void BOOST_DATA_TEST_CASE_run(__VA_ARGS__)"/>
   <define name="BOOST_DATA_TEST_CASE_F(...)" value="void BOOST_DATA_TEST_CASE_F_run(__VA_ARGS__)"/>
   <define name="BOOST_PYTHON_MODULE(str)" value="void BOOST_PYTHON_MODULE_definition(str)"/>


### PR DESCRIPTION
Using assert in macros causes assertWithSideEffect in some cases, which is not
a valid issue for these macros.
Macros for test case/suite were causing unusedStructMember warnings because
the test function could not be parsed correctly. The new defines don't match
completely what the macros really do, but it seems to be a good enough
approximation.