### PR TITLE
Clang-tidy cmdline checks

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -233,6 +233,18 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 mSettings->addEnabled("information");
             }
 
+            else if (std::strncmp(argv[i], "--clang-tidy-checks=", 20) == 0) {
+                mSettings->clangTidy = true;
+                if (std::strncmp(argv[i] + 20, ".clang-tidy", 11) == 0)
+                    mSettings->clangTidyChecks.clear();
+                else
+                    mSettings->clangTidyChecks = argv[i] + 20;
+            }
+
+            else if (std::strncmp(argv[i], "--clang-tidy", 12) == 0) {
+                mSettings->clangTidy = true;
+            }
+
             else if (std::strncmp(argv[i], "--clang", 7) == 0) {
                 mSettings->clang = true;
                 if (std::strncmp(argv[i], "--clang=", 8) == 0) {
@@ -1003,6 +1015,11 @@ void CmdLineParser::printHelp()
         "                         Cppcheck data. After that the normal Cppcheck analysis is\n"
         "                         used. You must have the executable in PATH if no path is\n"
         "                         given.\n"
+        "    --clang-tidy         Run clang tidy. You must have the executable in PATH.\n"
+        "    --clang-tidy-checks=<checks>\n"
+        "                         Parameter to pass to clang-tidy as -checks= in clang-tidy syntax.\n"
+        "                         Set empty string or \".clang-tidy\" to let clang-tidy search\n"
+        "                         for config files according to default behavior.\n"
         "    --config-exclude=<dir>\n"
         "                         Path (prefix) to be excluded from configuration\n"
         "                         checking. Preprocessor configurations defined in\n"

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -952,7 +952,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck, int /*argc*/, const cha
                 if (!settings.quiet)
                     reportStatus(c, settings.project.fileSettings.size(), c, settings.project.fileSettings.size());
                 if (settings.clangTidy)
-                    cppcheck.analyseClangTidy(fs);
+                    cppcheck.analyseClangTidy(fs, settings.clangTidyChecks);
             }
         }
 

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -460,7 +460,7 @@ unsigned int __stdcall ThreadExecutor::threadProc(ThreadExecutor* threadExecutor
             threadExecutor->mFileSync.unlock();
             result += fileChecker.check(fs);
             if (threadExecutor->mSettings.clangTidy)
-                fileChecker.analyseClangTidy(fs);
+                fileChecker.analyseClangTidy(fs, threadExecutor->mSettings.clangTidyChecks);
         }
 
         threadExecutor->mFileSync.lock();

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1588,7 +1588,7 @@ void CppCheck::getErrorMessages()
     Preprocessor::getErrorMessages(this, &s);
 }
 
-void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings)
+void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings, const std::string& clangTidyChecks)
 {
     std::string allIncludes;
     for (const std::string &inc : fileSettings.includePaths) {
@@ -1603,7 +1603,8 @@ void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings)
     const char exe[] = "clang-tidy";
 #endif
 
-    const std::string args = "-quiet -checks=*,-clang-analyzer-*,-llvm* \"" + fileSettings.filename + "\" -- " + allIncludes + allDefines;
+    const std::string checks = clangTidyChecks.empty() ? "" : "-checks=" + clangTidyChecks;
+    const std::string args = "-quiet " + checks + " \"" + fileSettings.filename + "\" -- " + allIncludes + allDefines;
     std::string output;
     if (!mExecuteCommand(exe, split(args), "", &output)) {
         std::cerr << "Failed to execute '" << exe << "'" << std::endl;

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -133,7 +133,7 @@ public:
     bool analyseWholeProgram();
 
     /** Analyze all files using clang-tidy */
-    void analyseClangTidy(const ImportProject::FileSettings &fileSettings);
+    void analyseClangTidy(const ImportProject::FileSettings &fileSettings, const std::string& clangTidyChecks);
 
     /** analyse whole program use .analyzeinfo files */
     void analyseWholeProgram(const std::string &buildDir, const std::map<std::string, std::size_t> &files);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1199,6 +1199,7 @@ bool ImportProject::importCppcheckGuiProject(std::istream &istr, Settings *setti
     settings->addons = temp.addons;
     settings->clang = temp.clang;
     settings->clangTidy = temp.clangTidy;
+    settings->clangTidyChecks = temp.clangTidyChecks;
 
     for (const std::string &p : paths)
         guiProject.pathNames.push_back(p);

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -45,6 +45,7 @@ Settings::Settings()
     clang(false),
     clangExecutable("clang"),
     clangTidy(false),
+    clangTidyChecks("*,-clang-analyzer-*,-llvm*"),
     daca(false),
     debugBugHunting(false),
     debugnormal(false),

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -151,6 +151,9 @@ public:
     /** Use clang-tidy */
     bool clangTidy;
 
+    /** Checks to pass to clang-tidy, if empty, let clang-tidy search for .clang-tidy files */
+    std::string clangTidyChecks;
+
     /** @brief include paths excluded from checking the configuration */
     std::set<std::string> configExcludePaths;
 


### PR DESCRIPTION
Add two command line options:
--clang-tidy: run clang-tidy, needs to be in PATH and only in combination with --project pointing at VS sln or compile-commands.json  (not needed when using GUI project files that already set clang-tidy)

--clang-tidy-checks: the important one. If not set, defaults to the same values as hard-coded so far. Otherwise, use clang-tidy syntax to forward to -checks=  (for example '-*,hicpp-*' to disable all but hicpp checks. If setting to ".clang-tidy" or empty string ('--clang-tidy-checks=') it will not set -checks at all, letting clang-tidy use the default behavior of searching for .clang-tidy files "upward" from the analyzed source file.