### PR TITLE
added CMake option CPPCHK_GLIBCXX_DEBUG to make usage of _GLIBCXX_DEBUG in Debug build configurable

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           mkdir cmake.output
           cd cmake.output
-          cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On ..
+          cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On -DCPPCHK_GLIBCXX_DEBUG=Off ..
           cd ..
 
       - name: Prepare CMake dependencies

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -41,10 +41,14 @@ jobs:
           cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On ..
           cd ..
 
-      - name: Clang-Tidy
+      - name: Prepare CMake dependencies
         run: |
           # make sure the precompiled headers exist
           make -C cmake.output lib/CMakeFiles/lib_objs.dir/cmake_pch.hxx.cxx
           make -C cmake.output test/CMakeFiles/testrunner.dir/cmake_pch.hxx.cxx
+          # make sure the auto-generated GUI sources exist
           make -C cmake.output autogen
+
+      - name: Clang-Tidy
+        run: |
           cmake --build cmake.output --target run-clang-tidy 2> /dev/null

--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -7,7 +7,8 @@ if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-if (UNIX)
+# TODO: this should probably apply to the compiler and not the platform
+if (CPPCHK_GLIBCXX_DEBUG AND UNIX)
     # TODO: check if this can be enabled again for Clang - also done in Makefile
     if (CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
         add_definitions(-D_GLIBCXX_DEBUG)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -42,6 +42,7 @@ option(WITH_QCHART          "When building GUI(need BUILD_GUI=ON), use Qt5 Chart
 option(HAVE_RULES           "Usage of rules (needs PCRE library and headers)"               OFF)
 option(USE_Z3               "Usage of z3 library"                                           OFF)
 option(USE_BUNDLED_TINYXML2 "Usage of bundled tinyxml2 library"                             ON)
+option(CPPCHK_GLIBCXX_DEBUG "Usage of _GLIBCXX_DEBUG in Debug build"                        ON)
 
 if (CMAKE_VERSION VERSION_EQUAL "3.16" OR CMAKE_VERSION VERSION_GREATER "3.16")
     set(CMAKE_DISABLE_PRECOMPILE_HEADERS Off CACHE BOOL "Disable precompiled headers")


### PR DESCRIPTION
This matches what can be done with `Makefile`.