### PR TITLE
Fix #9740 accessMoved related to designated initialization

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4402,8 +4402,13 @@ static void valueFlowAfterMove(TokenList* tokenlist, SymbolDatabase* symboldatab
                 (parent->str() == "return" || // MOVED in return statement
                  parent->str() == "(")) // MOVED in self assignment, isOpenParenthesisMemberFunctionCallOfVarId == true
                 continue;
-            if (parent && parent->astOperand1() && parent->astOperand1()->varId() == varId)
-                continue;
+            if (parent && parent->astOperand1()) {
+                if (parent->astOperand1()->varId() == varId)
+                    continue;
+                if (parent->str() == "=" && parent->astOperand1()->str() == "." && // assignment to designated member
+                    parent->astOperand1()->astOperand1() && parent->astOperand1()->astOperand1()->tokType() == Token::eType)
+                    continue;
+            }
             const Variable *var = varTok->variable();
             if (!var)
                 continue;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -8947,11 +8947,11 @@ private:
         ASSERT_EQUALS("[test.cpp:5]: (warning) Access of moved variable 'a'.\n", errout.str());
     }
 
-    void moveAndAssign2() { // #9740
+    void moveAndAssign3() { // #9740
         check("struct S{ std::string a, b; };\n"
               "S f(std::string && s) {\n"
-              "    return S({ .a = std::move(s), .b = "" });
-              "}");
+              "    return S({ .a = std::move(s), .b = \"\" });\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -223,6 +223,7 @@ private:
         TEST_CASE(doubleMoveMemberInitialization2);
         TEST_CASE(moveAndAssign1);
         TEST_CASE(moveAndAssign2);
+        TEST_CASE(moveAndAssign3); // #9740
         TEST_CASE(moveAssignMoveAssign);
         TEST_CASE(moveAndReset1);
         TEST_CASE(moveAndReset2);
@@ -8944,6 +8945,14 @@ private:
               "    C c = g(std::move(a));\n"
               "}");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Access of moved variable 'a'.\n", errout.str());
+    }
+
+    void moveAndAssign2() { // #9740
+        check("struct S{ std::string a, b; };\n"
+              "S f(std::string && s) {\n"
+              "    return S({ .a = std::move(s), .b = "" });
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void moveAssignMoveAssign() {


### PR DESCRIPTION
The problem is that `s` in `std::move(s)` gets a MOVED value. There is no warning if the parentheses are removed.