### PR TITLE
CI-unixish.yml: disabled GUI build on macos since Qt installation is flakey

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -47,18 +47,30 @@ jobs:
         run: |
           python -m pip install pip --upgrade
           python -m pip install pytest
-          
+
+      # TODO: Qt installation often fails with timeout errors on macos
       - name: Install Qt
+        if: !contains(matrix.os, 'macos')
         uses: jurplel/install-qt-action@v2
         with:
           version: '5.15.2'
           modules: 'qtcharts'
 
       - name: Test CMake build (with GUI)
+        if: !contains(matrix.os, 'macos')
         run: |
           mkdir cmake.output
           cd cmake.output
           cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On ..
+          cmake --build . -- -j$(nproc)
+          cd ..
+
+      - name: Test CMake build (without GUI)
+        if: contains(matrix.os, 'macos')
+        run: |
+          mkdir cmake.output
+          cd cmake.output
+          cmake -G "Unix Makefiles" -DUSE_Z3=On -DHAVE_RULES=On -DBUILD_TESTS=On ..
           cmake --build . -- -j$(nproc)
           cd ..
 


### PR DESCRIPTION
I will look into using `brew` instead when moving to the platform-provided Qt for the CI builds.