### PR TITLE
Fix #7754 FP Same expression on both sides of '||'

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1278,16 +1278,22 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         }
         return false;
     }
-    if (macro && (tok1->isExpandedMacro() || tok2->isExpandedMacro() || tok1->isTemplateArg() || tok2->isTemplateArg()))
+    auto flagsDiffer = [](const Token* tok1, const Token* tok2, bool macro) {
+        if (macro && (tok1->isExpandedMacro() || tok2->isExpandedMacro() || tok1->isTemplateArg() || tok2->isTemplateArg()))
+            return true;
+        if (tok1->isComplex() != tok2->isComplex())
+            return true;
+        if (tok1->isLong() != tok2->isLong())
+            return true;
+        if (tok1->isUnsigned() != tok2->isUnsigned())
+            return true;
+        if (tok1->isSigned() != tok2->isSigned())
+            return true;
         return false;
-    if (tok1->isComplex() != tok2->isComplex())
+    };
+    if (flagsDiffer(tok1, tok2, macro))
         return false;
-    if (tok1->isLong() != tok2->isLong())
-        return false;
-    if (tok1->isUnsigned() != tok2->isUnsigned())
-        return false;
-    if (tok1->isSigned() != tok2->isSigned())
-        return false;
+
     if (pure && tok1->isName() && tok1->next()->str() == "(" && tok1->str() != "sizeof" && !(tok1->variable() && tok1 == tok1->variable()->nameToken())) {
         if (!tok1->function()) {
             if (Token::simpleMatch(tok1->previous(), ".")) {
@@ -1329,7 +1335,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token *end1 = t1->link();
         const Token *end2 = t2->link();
         while (t1 && t2 && t1 != end1 && t2 != end2) {
-            if (t1->str() != t2->str() || t1->flags() != t2->flags())
+            if (t1->str() != t2->str() || flagsDiffer(t1, t2, true))
                 return false;
             t1 = t1->next();
             t2 = t2->next();
@@ -1350,9 +1356,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token *t2 = tok2->next();
         while (t1 && t2 &&
                t1->str() == t2->str() &&
-               t1->isLong() == t2->isLong() &&
-               t1->isUnsigned() == t2->isUnsigned() &&
-               t1->isSigned() == t2->isSigned() &&
+               !flagsDiffer(t1, t2, true) &&
                (t1->isName() || t1->str() == "*")) {
             t1 = t1->next();
             t2 = t2->next();

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1329,7 +1329,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token *end1 = t1->link();
         const Token *end2 = t2->link();
         while (t1 && t2 && t1 != end1 && t2 != end2) {
-            if (t1->str() != t2->str())
+            if (t1->str() != t2->str() || t1->flags() != t2->flags())
                 return false;
             t1 = t1->next();
             t2 = t2->next();

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1335,7 +1335,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token *end1 = t1->link();
         const Token *end2 = t2->link();
         while (t1 && t2 && t1 != end1 && t2 != end2) {
-            if (t1->str() != t2->str() || flagsDiffer(t1, t2, true))
+            if (t1->str() != t2->str() || flagsDiffer(t1, t2, macro))
                 return false;
             t1 = t1->next();
             t2 = t2->next();
@@ -1356,7 +1356,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
         const Token *t2 = tok2->next();
         while (t1 && t2 &&
                t1->str() == t2->str() &&
-               !flagsDiffer(t1, t2, true) &&
+               !flagsDiffer(t1, t2, macro) &&
                (t1->isName() || t1->str() == "*")) {
             t1 = t1->next();
             t2 = t2->next();

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5603,12 +5603,27 @@ private:
         ASSERT_EQUALS("", errout.str());
     }
 
-    void duplicateExpressionTemplate() { // #6930
-        check("template <int I> void f() {\n"
+    void duplicateExpressionTemplate() {
+        check("template <int I> void f() {\n" // #6930
               "    if (I >= 0 && I < 3) {}\n"
               "}\n"
               "\n"
               "static auto a = f<0>();");
+        ASSERT_EQUALS("", errout.str());
+
+        check("template<typename T>\n" // #7754
+              "void f() {\n"
+              "    if (std::is_same_v<T, char> || std::is_same_v<T, unsigned char>) {}\n"
+              "}\n");
+        
+        ASSERT_EQUALS("", errout.str());
+
+        check("typedef long long int64_t;"
+              "template<typename T>\n"
+              "void f() {\n"
+              "    if (std::is_same_v<T, long> || std::is_same_v<T, int64_t>) {}\n"
+              "}\n");
+        
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5615,7 +5615,6 @@ private:
               "void f() {\n"
               "    if (std::is_same_v<T, char> || std::is_same_v<T, unsigned char>) {}\n"
               "}\n");
-
         ASSERT_EQUALS("", errout.str());
 
         check("typedef long long int64_t;"
@@ -5623,7 +5622,13 @@ private:
               "void f() {\n"
               "    if (std::is_same_v<T, long> || std::is_same_v<T, int64_t>) {}\n"
               "}\n");
+        ASSERT_EQUALS("", errout.str());
 
+        checkP("#define int32_t int"
+              "template<typename T>\n"
+              "void f() {\n"
+              "    if (std::is_same_v<T, int> || std::is_same_v<T, int32_t>) {}\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5615,7 +5615,7 @@ private:
               "void f() {\n"
               "    if (std::is_same_v<T, char> || std::is_same_v<T, unsigned char>) {}\n"
               "}\n");
-        
+
         ASSERT_EQUALS("", errout.str());
 
         check("typedef long long int64_t;"
@@ -5623,7 +5623,7 @@ private:
               "void f() {\n"
               "    if (std::is_same_v<T, long> || std::is_same_v<T, int64_t>) {}\n"
               "}\n");
-        
+
         ASSERT_EQUALS("", errout.str());
     }
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5625,10 +5625,10 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         checkP("#define int32_t int"
-              "template<typename T>\n"
-              "void f() {\n"
-              "    if (std::is_same_v<T, int> || std::is_same_v<T, int32_t>) {}\n"
-              "}\n");
+               "template<typename T>\n"
+               "void f() {\n"
+               "    if (std::is_same_v<T, int> || std::is_same_v<T, int32_t>) {}\n"
+               "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Which flags should actually be compared? Are the comparisons [here](https://github.com/danmar/cppcheck/blob/main/lib/astutils.cpp#L1282) complete?