### PR TITLE
Fix the ability to recognize return types when simplifying attributes.

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10968,7 +10968,7 @@ void Tokenizer::simplifyAttribute()
             Token *functok = nullptr;
             if (Token::Match(after, "%name%|*")) {
                 Token *ftok = after;
-                while (Token::Match(ftok, "%name%|::|* !!("))
+                while (Token::Match(ftok, "%name%|::|<|>|* !!("))
                     ftok = ftok->next();
                 if (Token::Match(ftok, "%name% ("))
                     functok = ftok;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10970,11 +10970,9 @@ void Tokenizer::simplifyAttribute()
                 Token *ftok = after;
                 while (Token::Match(ftok, "%name%|::|<|* !!(")) {
                     if (ftok->str() == "<") {
-                        Token *tmp = ftok->link();
-                        if (tmp == nullptr)
-                            ftok = ftok->findClosingBracket();
-                        else
-                            ftok = tmp;
+                        ftok = ftok->findClosingBracket();
+                        if (!ftok)
+                            break;
                     }
                     ftok = ftok->next();
                 }

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10968,8 +10968,16 @@ void Tokenizer::simplifyAttribute()
             Token *functok = nullptr;
             if (Token::Match(after, "%name%|*")) {
                 Token *ftok = after;
-                while (Token::Match(ftok, "%name%|::|<|>|* !!("))
+                while (Token::Match(ftok, "%name%|::|<|* !!(")) {
+                    if (ftok->str() == "<") {
+                        Token *tmp = ftok->link();
+                        if (tmp == nullptr)
+                            ftok = ftok->findClosingBracket();
+                        else
+                            ftok = tmp;
+                    }
                     ftok = ftok->next();
+                }
                 if (Token::Match(ftok, "%name% ("))
                     functok = ftok;
             } else if (Token::Match(after, "[;{=:]")) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10968,7 +10968,7 @@ void Tokenizer::simplifyAttribute()
             Token *functok = nullptr;
             if (Token::Match(after, "%name%|*")) {
                 Token *ftok = after;
-                while (Token::Match(ftok, "%name%|* !!("))
+                while (Token::Match(ftok, "%name%|::|* !!("))
                     ftok = ftok->next();
                 if (Token::Match(ftok, "%name% ("))
                     functok = ftok;

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -4952,6 +4952,7 @@ private:
         ASSERT_EQUALS("int f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) __attribute__ ((warn_unused_result)) int f();", true));
         ASSERT_EQUALS("blah :: blah f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) blah::blah f();", true));
         ASSERT_EQUALS("template < T > Result < T > f ( ) ;", tok("template<T> __attribute__ ((warn_unused_result)) Result<T> f();", true));
+        ASSERT_EQUALS("template < T , U > Result < T , U > f ( ) ;", tok("template<T, U> __attribute__ ((warn_unused_result)) Result<T, U> f();", true));
     }
 
     void simplifyFunctorCall() {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -4951,6 +4951,7 @@ private:
         ASSERT_EQUALS("int f ( ) ;", tok("__attribute ((visibility(\"default\"))) int f();", true));
         ASSERT_EQUALS("int f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) __attribute__ ((warn_unused_result)) int f();", true));
         ASSERT_EQUALS("blah :: blah f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) blah::blah f();", true));
+        ASSERT_EQUALS("template < T > Result < T > f ( ) ;", tok("template<T> __attribute__ ((warn_unused_result)) Result<T> f();", true));
     }
 
     void simplifyFunctorCall() {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -241,6 +241,9 @@ private:
         // remove calling convention __cdecl, __stdcall, ...
         TEST_CASE(simplifyCallingConvention);
 
+        // remove __attribute, __attribute__
+        TEST_CASE(simplifyAttribute);
+
         TEST_CASE(simplifyFunctorCall);
 
         TEST_CASE(simplifyFunctionPointer); // ticket #5339 (simplify function pointer after comma)
@@ -4940,6 +4943,14 @@ private:
 
         // don't simplify Microsoft defines in unix code (#7554)
         ASSERT_EQUALS("enum E { CALLBACK } ;", tok("enum E { CALLBACK } ;", true, Settings::Unix32));
+    }
+
+    void simplifyAttribute() {
+        ASSERT_EQUALS("int f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) int f();", true));
+        ASSERT_EQUALS("int f ( ) ;", tok("__attribute__((visibility(\"default\"))) int f();", true));
+        ASSERT_EQUALS("int f ( ) ;", tok("__attribute ((visibility(\"default\"))) int f();", true));
+        ASSERT_EQUALS("int f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) __attribute__ ((warn_unused_result)) int f();", true));
+        ASSERT_EQUALS("blah :: blah f ( ) ;", tok("__attribute__ ((visibility(\"default\"))) blah::blah f();", true));
     }
 
     void simplifyFunctorCall() {


### PR DESCRIPTION
When parsing attributes to remove them, we have to allow for
the case where the return type of the function that follows
the attribute has a namespaced C++ type, like foo::bar .
That means that :: has to be recognized as a valid token.
Fix this in simplifyAttribute, and add tests for this as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>