### PR TITLE
Fix #10591 FP unusedStructMember with value-initialized struct and typedef

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3952,7 +3952,8 @@ void Tokenizer::setVarIdPass1()
                     } else
                         decl = false;
                 } else if (isCPP() && Token::Match(prev2, "%type% {") && Token::simpleMatch(tok2->link(), "} ;")) { // C++11 initialization style
-                    if (Token::Match(prev2, "do|try|else") || Token::Match(prev2->tokAt(-2), "struct|class|:"))
+                    if (tok2->link() != tok2->next() && // add value-initialized variable T x{};
+                        (Token::Match(prev2, "do|try|else") || Token::Match(prev2->tokAt(-2), "struct|class|:")))
                         continue;
                 } else
                     decl = false;

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -61,6 +61,7 @@ private:
         TEST_CASE(structmember15); // #3088 - #pragma pack(1)
         TEST_CASE(structmember_sizeof);
         TEST_CASE(structmember16); // #10485
+        TEST_CASE(structmember17); // #10591
 
         TEST_CASE(localvar1);
         TEST_CASE(localvar2);
@@ -1572,6 +1573,24 @@ private:
                                "  char E[N];\n" // <- not used
                                "};\n");
         ASSERT_EQUALS("[test.cpp:3]: (style) struct member 'S::E' is never used.\n", errout.str());
+    }
+
+    void structmember17() { // #10591
+        checkStructMemberUsage("struct tagT { int i; };\n"
+                               "void f() {\n"
+                               "    struct tagT t{};\n"
+                               "    t.i = 0;\n" // <- used
+                               "    g(t);\n"
+                               "};\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkStructMemberUsage("typedef struct tagT { int i; } typeT;\n"
+                               "void f() {\n"
+                               "    struct typeT t{};\n"
+                               "    t.i = 0;\n" // <- used
+                               "    g(t);\n"
+                               "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void functionVariableUsage_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {


### PR DESCRIPTION
There is still a FP for
~~~~
struct T { int i; };
void f() {
    struct T t{};
    t.i = 0;
    g(t);
}
~~~~
since the `T` in `struct T t{};` gets removed by `removeMacroInClassDef()` because it looks like a macro. That heuristic should probably be improved.