### PR TITLE
remove redundant code of preprocessor remove removeComments

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -679,7 +679,6 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         if ((mSettings.dump || !mSettings.addons.empty()) && fdump.is_open()) {
             mSettings.nomsg.dump(fdump);
         }
-        tokens1.removeComments();
         preprocessor.removeComments();
 
         if (!mSettings.buildDir.empty()) {


### PR DESCRIPTION
I think the action of deleting comments should be performed by preprocessor, not the token list itself. And in the same place, both token and processor are deleting comments. In fact, they operate on the same token list (I see they address).

![image](https://user-images.githubusercontent.com/56127613/147237206-c06168e8-a59f-47d1-9513-fd5f9f53ed7c.png)

Is there anything special here？？？