### PR TITLE
Import of compile_database.json where file is missing.

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -433,6 +433,10 @@ bool ImportProject::importCompileCommands(std::istream &istr)
             return false;
         }
 
+        //LINKER entries contains a "files" array instead of a single file entry. Skip those without a file.
+        if(!(obj["file"].is<std::string>()))
+             continue;
+        
         const std::string command = comm.str();
         const std::string file = Path::fromNativeSeparators(obj["file"].get<std::string>());
 


### PR DESCRIPTION
IAR Export of compile_database.json contains information about the linking step.

The format of this entry is.

`{
    "arguments": ["FOO"]
    "directory": "BAR"
    "files": ["BAZ"]
    "type": "LINKER"
}`

CppCheck fails with "ICOJSON_ASSERT("type mismatch! call is<type>() before get<type>()" && is<ctype>());" on parsing.

Ignore entries where "file" is not provided. The parsing should probably be improved to only include entries where type="COMPILER".