### PR TITLE
Fix #10469 FP returnTempReference with overloaded operator+=

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7090,7 +7090,7 @@ ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Va
 ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Variable *callVar, const Variable *funcVar)
 {
     ValueType vt;
-    auto pvt = funcVar->valueType();
+    const ValueType* pvt = funcVar->valueType();
     if (pvt && funcVar->isArray()) {
         vt = *pvt;
         ++vt.pointer;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7089,7 +7089,14 @@ ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Va
 
 ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Variable *callVar, const Variable *funcVar)
 {
-    ValueType::MatchResult res = ValueType::matchParameter(call, funcVar->valueType());
+    ValueType vt;
+    auto pvt = funcVar->valueType();
+    if (pvt && funcVar->isArray()) {
+        vt = *pvt;
+        ++vt.pointer;
+        pvt = &vt;
+    }
+    ValueType::MatchResult res = ValueType::matchParameter(call, pvt);
     if (callVar && ((res == ValueType::MatchResult::SAME && call->container) || res == ValueType::MatchResult::UNKNOWN)) {
         const std::string type1 = getTypeString(callVar->typeStartToken());
         const std::string type2 = getTypeString(funcVar->typeStartToken());

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -3299,7 +3299,7 @@ private:
         check("struct String {\n" // #10469
               "    void Append(uint8_t Val);\n"
               "    String& operator+=(const char s[]);\n"
-              "    String & operator+=(const std::string& Str) {\n"
+              "    String& operator+=(const std::string& Str) {\n"
               "        return operator+=(Str.c_str());\n"
               "    }\n"
               "    void operator+=(uint8_t Val) {\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -3295,6 +3295,18 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:9] -> [test.cpp:9] -> [test.cpp:10]: (error) Using iterator that is a temporary.\n",
                       errout.str());
+
+        check("struct String {\n" // #10469
+              "    void Append(uint8_t Val);\n"
+              "    String& operator+=(const char s[]);\n"
+              "    String & operator+=(const std::string& Str) {\n"
+              "        return operator+=(Str.c_str());\n"
+              "    }\n"
+              "    void operator+=(uint8_t Val) {\n"
+              "        Append(Val);\n"
+              "    }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeBorrowedMembers()


### PR DESCRIPTION
Function parameters `const char* s` vs. `const char s[]` were not handled consistently in `Variable` and `ValueType`. I'm not sure that this is the right fix.