### PR TITLE
remove nullScope from TestSymbolDatabase

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4442,6 +4442,9 @@ static const Token* skipPointersAndQualifiers(const Token* tok)
 
 bool Scope::isVariableDeclaration(const Token* const tok, const Token*& vartok, const Token*& typetok) const
 {
+    if (!tok)
+        return false;
+
     const bool isCPP = check && check->mTokenizer->isCPP();
 
     if (isCPP && Token::Match(tok, "throw|new"))


### PR DESCRIPTION
I'm attempting to rewrap my head around #3014 and my first step is to extract some of the more incidental changes which aren't core to the main change.

This change captures the change described in https://github.com/danmar/cppcheck/pull/3014#discussion_r559088969. Hopefully the justification given in that comment is sufficient explanation.