### PR TITLE
reduce.py: improved --segfault / added detection of "hang" caused by reduced code / cleanups

### DIFF
--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -17,6 +17,7 @@ CMD = None
 EXPECTED = None
 SEGFAULT = False
 FILE = None
+ORGFILE = None
 BACKUPFILE = None
 for arg in sys.argv[1:]:
     if arg.startswith('--cmd='):
@@ -25,6 +26,7 @@ for arg in sys.argv[1:]:
         EXPECTED = arg[arg.find('=') + 1:]
     elif arg.startswith('--file='):
         FILE = arg[arg.find('=') + 1:]
+        ORGFILE = FILE + '.org'
         BACKUPFILE = FILE + '.bak'
     elif arg == '--segfault':
         SEGFAULT = True
@@ -257,7 +259,7 @@ f = open(FILE, 'rt')
 filedata = f.readlines()
 f.close()
 
-writefile(BACKUPFILE, filedata)
+writefile(ORGFILE, filedata)
 
 while True:
     filedata1 = list(filedata)

--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import time
 
+# TODO: add --hang option to detect code which impacts the analysis time
 def show_syntax():
     print('Syntax:')
     print('  reduce.py --cmd=<full command> --expected=<expected text output> --file=<source file> [--segfault]')
@@ -73,6 +74,8 @@ def runtool(filedata=None):
         if filedata:
             writefile(TIMEOUTFILE, filedata)
         return False
+    #print(p.returncode)
+    #print(comm)
     if SEGFAULT:
         if p.returncode != 0:
             return True

--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -39,6 +39,11 @@ if not SEGFAULT and EXPECTED is None:
     print('Abort: No --expected')
     show_syntax()
 
+# need to add '--error-exitcode=0' so detected issues will not be interpreted as a crash
+if SEGFAULT and not '--error-exitcode=0' in CMD:
+    print("Adding '--error-exitcode=0' to --cmd")
+    CMD = CMD + ' --error-exitcode=0'
+
 if FILE is None:
     print('Abort: No --file')
     show_syntax()


### PR DESCRIPTION
With these changes I was not able to reduce the code I files https://trac.cppcheck.net/ticket/10708 from. After the first reduction it would hang and even handling the timeout did not help since a reduction which removed the assertion caused findings to appear and thus resulting is a non-0 exitcode.

These improvements will also enable us to integrate it with daca@home.