### PR TITLE
Improve definitions for googletest ASSERT_* macros

### DIFF
--- a/cfg/googletest.cfg
+++ b/cfg/googletest.cfg
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <def format="2">
-  <!-- see https://github.com/google/googletest/blob/master/googletest/docs/primer.md -->
-  <define name="ASSERT_TRUE(cond)" value="assert(cond)"/>
+  <!-- see https://github.com/google/googletest/blob/main/docs/primer.md -->
+  <define name="ASSERT_TRUE(cond)" value="{if (!(cond)) throw false;}"/>
   <define name="EXPECT_TRUE(cond)" value="(void)(cond)"/>
-  <define name="ASSERT_FALSE(cond)" value="assert(!(cond))"/>
+  <define name="ASSERT_FALSE(cond)" value="{if (cond) throw false;}"/>
   <define name="EXPECT_FALSE(cond)" value="(void)(cond)"/>
-  <define name="ASSERT_EQ(val1,val2)" value="assert((val1)==(val2))"/>
+  <define name="ASSERT_EQ(val1,val2)" value="{if (!((val1) == (val2))) throw false;}"/>
   <define name="EXPECT_EQ(val1,val2)" value="(void)((val1)==(val2))"/>
-  <define name="ASSERT_NE(val1,val2)" value="assert((val1)!=(val2))"/>
+  <define name="ASSERT_NE(val1,val2)" value="{if (!((val1) != (val2))) throw false;}"/>
   <define name="EXPECT_NE(val1,val2)" value="(void)((val1)!=(val2))"/>
-  <define name="ASSERT_LT(val1,val2)" value="assert((val1)&lt;(val2))"/>
+  <define name="ASSERT_LT(val1,val2)" value="{if (!((val1) &lt; (val2))) throw false;}"/>
   <define name="EXPECT_LT(val1,val2)" value="(void)((val1)&lt;(val2))"/>
-  <define name="ASSERT_LE(val1,val2)" value="assert((val1)&lt;=(val2))"/>
+  <define name="ASSERT_LE(val1,val2)" value="{if (!((val1) &lt;= (val2))) throw false;}"/>
   <define name="EXPECT_LE(val1,val2)" value="(void)((val1)&lt;=(val2))"/>
-  <define name="ASSERT_GT(val1,val2)" value="assert((val1)&gt;(val2))"/>
+  <define name="ASSERT_GT(val1,val2)" value="{if (!((val1) &gt; (val2))) throw false;}"/>
   <define name="EXPECT_GT(val1,val2)" value="(void)((val1)&gt;(val2))"/>
-  <define name="ASSERT_GE(val1,val2)" value="assert((val1)&gt;=(val2))"/>
+  <define name="ASSERT_GE(val1,val2)" value="{if (!((val1) &gt;= (val2))) throw false;}"/>
   <define name="EXPECT_GE(val1,val2)" value="(void)((val1)&gt;=(val2))"/>
-  <define name="ASSERT_STREQ(str1,str2)" value="assert(strcmp(str1, str2) == 0)"/>
+  <define name="ASSERT_STREQ(str1,str2)" value="{if (!(strcmp(str1, str2) == 0)) throw false;}"/>
   <define name="EXPECT_STREQ(str1,str2)" value="(void)(*(str1)==*(str2))"/>
-  <define name="ASSERT_STRNE(str1,str2)" value="assert(strcmp(str1, str2) != 0)"/>
+  <define name="ASSERT_STRNE(str1,str2)" value="{if (!(strcmp(str1, str2) != 0)) throw false;}"/>
   <define name="EXPECT_STRNE(str1,str2)" value="(void)(*(str1)!=*(str2))"/>
-  <define name="ASSERT_STRCASEEQ(str1,str2)" value="assert(stricmp(str1, str2) == 0)"/>
+  <define name="ASSERT_STRCASEEQ(str1,str2)" value="{if (!(stricmp(str1, str2) == 0)) throw false;}"/>
   <define name="EXPECT_STRCASEEQ(str1,str2)" value="(void)(*(str1)==*(str2))"/>
-  <define name="ASSERT_STRCASENE(str1,str2)" value="assert(stricmp(str1, str2) != 0)"/>
+  <define name="ASSERT_STRCASENE(str1,str2)" value="{if (!(stricmp(str1, str2) != 0)) throw false;}"/>
   <define name="EXPECT_STRCASENE(str1,str2)" value="(void)(*(str1)!=*(str2))"/>
   <define name="ASSERT_THROW(code, e)" value="try{code;}catch(e){}"/>
   <define name="EXPECT_THROW(code, e)" value="try{code;}catch(e){}"/>

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -47,6 +47,32 @@ TEST(test_cppcheck, cppcheck)
 // #9964 - avoid compareBoolExpressionWithInt false positive
 TEST(Test, assert_false_fp)
 {
-    // cppcheck-suppress checkLibraryNoReturn
     ASSERT_FALSE(errno < 0);
+}
+
+// Check that conditions in the ASSERT_* macros are processed correctly.
+TEST(Test, warning_in_assert_macros)
+{
+    int i = 5;
+    int j = 6;
+
+    // cppcheck-suppress knownConditionTrueFalse
+    ASSERT_TRUE(i == 5);
+    // cppcheck-suppress knownConditionTrueFalse
+    ASSERT_FALSE(i != 5);
+    // cppcheck-suppress duplicateExpression
+    ASSERT_EQ(i, i);
+    ASSERT_NE(i, j); // expected knownConditionTrueFalse...
+    ASSERT_LT(i, j); // expected knownConditionTrueFalse...
+    // cppcheck-suppress duplicateExpression
+    ASSERT_LE(i, i);
+    ASSERT_GT(j, i); // expected knownConditionTrueFalse
+    // cppcheck-suppress duplicateExpression
+    ASSERT_GE(i, i);
+
+    unsigned int u = errno;
+    // cppcheck-suppress unsignedPositive
+    ASSERT_GE(u, 0);
+    // cppcheck-suppress unsignedLessThanZero
+    ASSERT_LT(u, 0);
 }


### PR DESCRIPTION
This avoids assertWithSideEffect and follows more closely what the real macros
are doing, similar to the ones in boost.cfg and cppunit.cfg.

In theory the macros should also cause unreachableCode if the condition is always true, but that doesn't seem to work.