### PR TITLE
Fix regression: functionStatic related to overload resolution

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7090,7 +7090,7 @@ ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Va
 ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Variable *callVar, const Variable *funcVar)
 {
     ValueType vt;
-    auto pvt = funcVar->valueType();
+    const ValueType* pvt = funcVar->valueType();
     if (pvt && funcVar->isArray()) {
         vt = *pvt;
         ++vt.pointer;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7089,7 +7089,14 @@ ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Va
 
 ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Variable *callVar, const Variable *funcVar)
 {
-    ValueType::MatchResult res = ValueType::matchParameter(call, funcVar->valueType());
+    ValueType vt;
+    auto pvt = funcVar->valueType();
+    if (pvt && funcVar->isArray()) {
+        vt = *pvt;
+        ++vt.pointer;
+        pvt = &vt;
+    }
+    ValueType::MatchResult res = ValueType::matchParameter(call, pvt);
     if (callVar && ((res == ValueType::MatchResult::SAME && call->container) || res == ValueType::MatchResult::UNKNOWN)) {
         const std::string type1 = getTypeString(callVar->typeStartToken());
         const std::string type2 = getTypeString(funcVar->typeStartToken());

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7094,9 +7094,10 @@ ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const Va
 {
     ValueType vt;
     const ValueType* pvt = funcVar->valueType();
-    if (pvt && funcVar->isArray()) {
+    if (pvt && funcVar->isArray() && !(funcVar->isStlType() && Token::simpleMatch(funcVar->typeStartToken(), "std :: array"))) { // std::array doesn't decay to a pointer
         vt = *pvt;
-        ++vt.pointer;
+        if (vt.pointer == 0) // don't bump array of pointers
+            ++vt.pointer;
         pvt = &vt;
     }
     ValueType::MatchResult res = ValueType::matchParameter(call, pvt);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -3299,7 +3299,7 @@ private:
         check("struct String {\n" // #10469
               "    void Append(uint8_t Val);\n"
               "    String& operator+=(const char s[]);\n"
-              "    String & operator+=(const std::string& Str) {\n"
+              "    String& operator+=(const std::string& Str) {\n"
               "        return operator+=(Str.c_str());\n"
               "    }\n"
               "    void operator+=(uint8_t Val) {\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -3295,6 +3295,18 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:9] -> [test.cpp:9] -> [test.cpp:10]: (error) Using iterator that is a temporary.\n",
                       errout.str());
+
+        check("struct String {\n" // #10469
+              "    void Append(uint8_t Val);\n"
+              "    String& operator+=(const char s[]);\n"
+              "    String & operator+=(const std::string& Str) {\n"
+              "        return operator+=(Str.c_str());\n"
+              "    }\n"
+              "    void operator+=(uint8_t Val) {\n"
+              "        Append(Val);\n"
+              "    }\n"
+              "};\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void danglingLifetimeBorrowedMembers()

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -201,6 +201,7 @@ private:
         TEST_CASE(const_shared_ptr);
         TEST_CASE(constPtrToConstPtr);
         TEST_CASE(constTrailingReturnType);
+        TEST_CASE(staticArrayPtrOverload);
 
         TEST_CASE(initializerListOrder);
         TEST_CASE(initializerListUsage);
@@ -6566,6 +6567,23 @@ private:
                    "    int x = 1;\n"
                    "    auto get() -> int & { return x; }\n"
                    "};");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void staticArrayPtrOverload() {
+        checkConst("struct S {\n"
+                   "    template<size_t N>\n"
+                   "    void f(const std::array<std::string_view, N>& sv);\n"
+                   "    template<long N>\n"
+                   "    void f(const char* const (&StrArr)[N]);\n"
+                   "};\n"
+                   "template<size_t N>\n"
+                   "void S::f(const std::array<std::string_view, N>&sv) {\n"
+                   "    const char* ptrs[N]{};\n"
+                   "    return f(ptrs);\n"
+                   "}\n"
+                   "template void S::f(const std::array<std::string_view, 3>&sv);\n"
+                   "\n");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
The fix for the test case is `if (vt.pointer == 0)`. But since `std::array` cannot decay to a pointer, I fixed that as well.