### PR TITLE
astutils.cpp: optimized visitAstNodesGeneric() a bit

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -42,7 +42,7 @@
 template<class T, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
 void visitAstNodesGeneric(T *ast, std::function<ChildrenToVisit(T *)> visitor)
 {
-    std::stack<T *> tokens;
+    std::stack<T *, std::vector<T *>> tokens;
     tokens.push(ast);
     while (!tokens.empty()) {
         T *tok = tokens.top();
@@ -54,10 +54,16 @@ void visitAstNodesGeneric(T *ast, std::function<ChildrenToVisit(T *)> visitor)
 
         if (c == ChildrenToVisit::done)
             break;
-        if (c == ChildrenToVisit::op2 || c == ChildrenToVisit::op1_and_op2)
-            tokens.push(tok->astOperand2());
-        if (c == ChildrenToVisit::op1 || c == ChildrenToVisit::op1_and_op2)
-            tokens.push(tok->astOperand1());
+        if (c == ChildrenToVisit::op2 || c == ChildrenToVisit::op1_and_op2) {
+            T *t2 = tok->astOperand2();
+            if (t2)
+                tokens.push(t2);
+        }
+        if (c == ChildrenToVisit::op1 || c == ChildrenToVisit::op1_and_op2) {
+            T *t1 = tok->astOperand1();
+            if (t1)
+                tokens.push(t1);
+        }
     }
 }
 


### PR DESCRIPTION
I tested this with `cli/filelister.cpp`. I wanted to test it with more files but with all the recent performance regressions it's agonizing slow while running in `valgrind`.

The initial Ir count was `353,306,619`.

Reducing the `std::stack` operations by not adding `nullptr` entries reduced it to `334,276,673` even though the checks added some overhead.

Switching the backend of the `std::stack` from `std::deque` to `std::vector` reduced it to `293,371,232`. The main problem is that the construction of a `std::deque` is much more expensive. The destruction cost stays the same.

So in total this saves us about 12% of the Ir count.

The main issue here still remains the creation and destruction of `std::stack` which still amounts to more than 22% of the total Ir count. So it's the same issue we are seeing with short-living small `std::vector` as related to in #3432. It is also still the single most expensive function we call.