### PR TITLE
 Fix #10360 FP uninitMemberVar from copy constructor [inconclusive]

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -74,8 +74,8 @@ static const char * getFunctionTypeName(Function::Type type)
 static bool isVariableCopyNeeded(const Variable &var)
 {
     return !var.hasDefault() && (var.isPointer() ||
-           (var.type() && var.type()->needInitialization == Type::NeedInitialization::True) ||
-           (var.valueType() && var.valueType()->type >= ValueType::Type::CHAR));
+                                 (var.type() && var.type()->needInitialization == Type::NeedInitialization::True) ||
+                                 (var.valueType() && var.valueType()->type >= ValueType::Type::CHAR));
 }
 
 static bool isVcl(const Settings *settings)

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -73,9 +73,9 @@ static const char * getFunctionTypeName(Function::Type type)
 
 static bool isVariableCopyNeeded(const Variable &var)
 {
-    return var.isPointer() ||
+    return !var.hasDefault() && (var.isPointer() ||
            (var.type() && var.type()->needInitialization == Type::NeedInitialization::True) ||
-           (var.valueType() && var.valueType()->type >= ValueType::Type::CHAR);
+           (var.valueType() && var.valueType()->type >= ValueType::Type::CHAR));
 }
 
 static bool isVcl(const Settings *settings)

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -256,11 +256,9 @@ void CheckClass::constructors()
 
                 // Don't warn about unknown types in copy constructors since we
                 // don't know if they can be copied or not..
-                if (!isVariableCopyNeeded(var, func.type))
-                    inconclusive = true;
-
-                if (!printInconclusive && inconclusive)
-                    continue;
+                if (!isVariableCopyNeeded(var, func.type)) {
+                    if (!printInconclusive)
+                        continue;
 
                     missingCopy = true;
                 }

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -191,7 +191,7 @@ void CheckClass::constructors()
                 const Variable& var = *usage.var;
 
                 // check for C++11 initializer
-                if (var.hasDefault()) {
+                if (var.hasDefault() && func.type != Function::eOperatorEqual && func.type != Function::eCopyConstructor) { // variable still needs to be copied
                     usage.init = true;
                     continue;
                 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5221,7 +5221,9 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
         return fallback2Func;
 
     // remove pure virtual function
-    matches.erase(std::remove_if(matches.begin(), matches.end(), [](const Function* m) { return m->isPure(); }), matches.end());
+    matches.erase(std::remove_if(matches.begin(), matches.end(), [](const Function* m) {
+        return m->isPure();
+    }), matches.end());
 
     // Only one candidate left
     if (matches.size() == 1)

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5220,6 +5220,9 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
     if (fallback2Func)
         return fallback2Func;
 
+    // remove pure virtual function
+    matches.erase(std::remove_if(matches.begin(), matches.end(), [](const Function* m) { return m->isPure(); }), matches.end());
+
     // Only one candidate left
     if (matches.size() == 1)
         return matches[0];

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -7126,6 +7126,27 @@ private:
                                  "    A() { f(); }\n"
                                  "};\n");
         ASSERT_EQUALS("", errout.str());
+
+        checkVirtualFunctionCall("class Base {\n"
+                                 "public:\n"
+                                 "    virtual void Copy(const Base& Src) = 0;\n"
+                                 "};\n"
+                                 "class Derived : public Base {\n"
+                                 "public:\n"
+                                 "    Derived() : i(0) {}\n"
+                                 "    Derived(const Derived& Src);\n"
+                                 "    void Copy(const Base& Src) override;\n"
+                                 "    int i;\n"
+                                 "};\n"
+                                 "Derived::Derived(const Derived & Src) {\n"
+                                 "    Copy(Src);\n"
+                                 "}\n"
+                                 "void Derived::Copy(const Base & Src) {\n"
+                                 "    auto d = dynamic_cast<const Derived&>(Src);\n"
+                                 "    i = d.i;\n"
+                                 "}\n");
+          ASSERT_EQUALS("[test.cpp:13] -> [test.cpp:9]: (style) Virtual function 'Copy' is called from copy constructor 'Derived(const Derived&Src)' at line 13. Dynamic binding is not used.\n",
+                        errout.str());
     }
 
     void pureVirtualFunctionCall() {

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -7145,8 +7145,8 @@ private:
                                  "    auto d = dynamic_cast<const Derived&>(Src);\n"
                                  "    i = d.i;\n"
                                  "}\n");
-          ASSERT_EQUALS("[test.cpp:13] -> [test.cpp:9]: (style) Virtual function 'Copy' is called from copy constructor 'Derived(const Derived&Src)' at line 13. Dynamic binding is not used.\n",
-                        errout.str());
+        ASSERT_EQUALS("[test.cpp:13] -> [test.cpp:9]: (style) Virtual function 'Copy' is called from copy constructor 'Derived(const Derived&Src)' at line 13. Dynamic binding is not used.\n",
+                      errout.str());
     }
 
     void pureVirtualFunctionCall() {

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -7189,10 +7189,10 @@ private:
                                  "    void Copy(const Base& Src) override;\n"
                                  "    int i;\n"
                                  "};\n"
-                                 "Derived::Derived(const Derived & Src) {\n"
+                                 "Derived::Derived(const Derived& Src) {\n"
                                  "    Copy(Src);\n"
                                  "}\n"
-                                 "void Derived::Copy(const Base & Src) {\n"
+                                 "void Derived::Copy(const Base& Src) {\n"
                                  "    auto d = dynamic_cast<const Derived&>(Src);\n"
                                  "    i = d.i;\n"
                                  "}\n");

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -499,7 +499,7 @@ private:
               "    S& operator=(const S & s) { return *this; }\n"
               "};\n", /*inconclusive*/ true);
         ASSERT_EQUALS("[test.cpp:4]: (warning, inconclusive) Member variable 'S::i' is not assigned in the copy constructor. Should it be copied?\n"
-                      "[test.cpp:5]: (warning, inconclusive) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
+                      "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
                       errout.str());
 
         check("struct S {\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -81,6 +81,7 @@ private:
         TEST_CASE(simple14); // #6253 template base
         TEST_CASE(simple15); // #8942 multiple arguments, decltype
         TEST_CASE(simple16); // copy members with c++11 init
+        TEST_CASE(simple17); // #10360
 
         TEST_CASE(noConstructor1);
         TEST_CASE(noConstructor2);
@@ -510,6 +511,28 @@ private:
         ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'S::i' is not initialized in the constructor.\n"
                       "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
                       errout.str());
+    }
+
+    void simple17() { // #10360
+        check("class Base {\n"
+              "public:\n"
+              "    virtual void Copy(const Base& Src) = 0;\n"
+              "};\n"
+              "class Derived : public Base {\n"
+              "public:\n"
+              "    Derived() : i(0) {}\n"
+              "    Derived(const Derived& Src);\n"
+              "    void Copy(const Base& Src) override;\n"
+              "    int i;\n"
+              "};\n"
+              "Derived::Derived(const Derived & Src) {\n"
+              "    Copy(Src);\n"
+              "}\n"
+              "void Derived::Copy(const Base & Src) {\n"
+              "    auto d = dynamic_cast<const Derived&>(Src);\n"
+              "    i = d.i;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void simple15() { // #8942

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -80,6 +80,7 @@ private:
         TEST_CASE(simple13); // #5498 - no constructor, c++11 assignments
         TEST_CASE(simple14); // #6253 template base
         TEST_CASE(simple15); // #8942 multiple arguments, decltype
+        TEST_CASE(simple16); // copy members with c++11 init
 
         TEST_CASE(noConstructor1);
         TEST_CASE(noConstructor2);
@@ -487,6 +488,28 @@ private:
               "    int x;\n"
               "};");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void simple16() {
+        check("struct S {\n"
+              "    int i{};\n"
+              "    S() = default;\n"
+              "    S(const S & s) {}\n"
+              "    S& operator=(const S & s) { return *this; }\n"
+              "};\n");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'S::i' is not initialized in the constructor.\n"
+                      "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
+                      errout.str());
+
+        check("struct S {\n"
+              "    int i;\n"
+              "    S() : i(0) {}\n"
+              "    S(const S & s) {}\n"
+              "    S& operator=(const S & s) { return *this; }\n"
+              "};\n");
+        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'S::i' is not initialized in the constructor.\n"
+                      "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
+                      errout.str());
     }
 
     void simple15() { // #8942

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -497,9 +497,9 @@ private:
               "    S() = default;\n"
               "    S(const S & s) {}\n"
               "    S& operator=(const S & s) { return *this; }\n"
-              "};\n");
-        ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'S::i' is not initialized in the constructor.\n"
-                      "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
+              "};\n", /*inconclusive*/ true);
+        ASSERT_EQUALS("[test.cpp:4]: (warning, inconclusive) Member variable 'S::i' is not assigned in the copy constructor. Should it be copied?\n"
+                      "[test.cpp:5]: (warning, inconclusive) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
                       errout.str());
 
         check("struct S {\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -504,8 +504,8 @@ private:
         check("struct S {\n"
               "    int i{};\n"
               "    S() = default;\n"
-              "    S(const S & s) {}\n"
-              "    S& operator=(const S & s) { return *this; }\n"
+              "    S(const S& s) {}\n"
+              "    S& operator=(const S& s) { return *this; }\n"
               "};\n", /*inconclusive*/ true);
         ASSERT_EQUALS("[test.cpp:4]: (warning, inconclusive) Member variable 'S::i' is not assigned in the copy constructor. Should it be copied?\n"
                       "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
@@ -514,8 +514,8 @@ private:
         check("struct S {\n"
               "    int i;\n"
               "    S() : i(0) {}\n"
-              "    S(const S & s) {}\n"
-              "    S& operator=(const S & s) { return *this; }\n"
+              "    S(const S& s) {}\n"
+              "    S& operator=(const S& s) { return *this; }\n"
               "};\n");
         ASSERT_EQUALS("[test.cpp:4]: (warning) Member variable 'S::i' is not initialized in the constructor.\n"
                       "[test.cpp:5]: (warning) Member variable 'S::i' is not assigned a value in 'S::operator='.\n",
@@ -534,10 +534,10 @@ private:
               "    void Copy(const Base& Src) override;\n"
               "    int i;\n"
               "};\n"
-              "Derived::Derived(const Derived & Src) {\n"
+              "Derived::Derived(const Derived& Src) {\n"
               "    Copy(Src);\n"
               "}\n"
-              "void Derived::Copy(const Base & Src) {\n"
+              "void Derived::Copy(const Base& Src) {\n"
               "    auto d = dynamic_cast<const Derived&>(Src);\n"
               "    i = d.i;\n"
               "}\n");


### PR DESCRIPTION
Also:
Fix FN for members with c++11 initializers not assigned in copy constructor/operator=
Fix FN for virtual function call from copy constructor