### PR TITLE
Minor improvements to package selection in test-my-pr/donate-cpu

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.18"
+CLIENT_VERSION = "1.3.19"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -223,7 +223,7 @@ def download_package(work_path, package, bandwidth_limit):
     return destfile
 
 
-def unpack_package(work_path, tgz):
+def unpack_package(work_path, tgz, cpp_only=False):
     print('Unpacking..')
     temp_path = work_path + '/temp'
     remove_tree(temp_path)
@@ -233,7 +233,10 @@ def unpack_package(work_path, tgz):
         with tarfile.open(tgz) as tf:
             for member in tf:
                 header_endings = ('.hpp', '.h++', '.hxx', '.hh', '.h')
-                source_endings = ('.cpp', '.c++', '.cxx', '.cc', '.c', '.tpp', '.txx', '.ipp', '.ixx', '.qml')
+                source_endings = ('.cpp', '.c++', '.cxx', '.cc', '.tpp', '.txx', '.ipp', '.ixx', '.qml')
+                c_source_endings = ('.c',)
+                if not cpp_only:
+                    source_endings = source_endings + c_source_endings
                 if member.name.startswith(('/', '..')):
                     # Skip dangerous file names
                     continue

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -232,14 +232,16 @@ def unpack_package(work_path, tgz):
     if tarfile.is_tarfile(tgz):
         with tarfile.open(tgz) as tf:
             for member in tf:
+                header_endings = ('.hpp', '.h++', '.hxx', '.hh', '.h')
+                source_endings = ('.cpp', '.c++', '.cxx', '.cc', '.c', '.tpp', '.txx', '.ipp', '.ixx', '.qml')
                 if member.name.startswith(('/', '..')):
                     # Skip dangerous file names
                     continue
-                elif member.name.lower().endswith(('.c', '.cpp', '.cxx', '.cc', '.c++', '.h', '.hpp',
-                                                   '.h++', '.hxx', '.hh', '.tpp', '.txx', '.ipp', '.ixx', '.qml')):
+                elif member.name.lower().endswith(header_endings + source_endings):
                     try:
                         tf.extract(member.name, temp_path)
-                        found = True
+                        if member.name.lower().endswith(source_endings):
+                            found = True
                     except OSError:
                         pass
                     except AttributeError:

--- a/tools/test-my-pr.py
+++ b/tools/test-my-pr.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
     group.add_argument('-p', default=256, type=int, help='Count of packages to check')
     group.add_argument('--packages', nargs='+', help='Check specific packages and then stop.')
     parser.add_argument('-o', default='my_check_diff.log', help='Filename of result inside a working path dir')
+    parser.add_argument('--cpp-only', dest='cpp_only', help='Only process c++ packages', action='store_true')
     parser.add_argument('--work-path', '--work-path=', default=lib.work_path, type=str, help='Working directory for reference repo')
     args = parser.parse_args()
 
@@ -117,7 +118,7 @@ if __name__ == "__main__":
             print("No package downloaded")
             continue
 
-        if not lib.unpack_package(work_path, tgz):
+        if not lib.unpack_package(work_path, tgz, args.cpp_only):
             print("No files to process")
             continue
 


### PR DESCRIPTION
Two minor improvement to test-my-pr/donate-cpu.

First, since cppcheck needs a source file to process we can skip header-only packages. Second, when testing local changes with test-my-pr, it is sometimes desired to only process c++-packages, and not c-packages (for example when doing changes to checkclass.cpp), so add a flag for this.