### PR TITLE
avoid dependency on transitive includes - based on include-what-you-use

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -20,6 +20,7 @@
 
 #include "check.h"
 #include "cppcheckexecutor.h"
+#include "errortypes.h"
 #include "filelister.h"
 #include "importproject.h"
 #include "path.h"
@@ -32,6 +33,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <climits>
 #include <cstdio>
 #include <cstdlib> // EXIT_FAILURE
 #include <cstring>

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -23,6 +23,7 @@
 #include "color.h"
 #include "config.h"
 #include "cppcheck.h"
+#include "errortypes.h"
 #include "filelister.h"
 #include "importproject.h"
 #include "library.h"
@@ -35,13 +36,17 @@
 #include "utils.h"
 #include "checkunusedfunctions.h"
 
+#include <algorithm>
+#include <atomic>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib> // EXIT_SUCCESS and EXIT_FAILURE
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <list>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -20,13 +20,16 @@
 #define CPPCHECKEXECUTOR_H
 
 #include "color.h"
+#include "config.h"
 #include "errorlogger.h"
 
 #include <cstdio>
 #include <ctime>
+#include <iosfwd>
 #include <map>
 #include <set>
 #include <string>
+#include <vector>
 
 class CppCheck;
 class Library;

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -59,7 +59,12 @@
  */
 
 
+#include "errortypes.h"
 #include "cppcheckexecutor.h"
+
+#include <cstdlib>
+#include <exception>
+#include <string>
 
 #ifdef NDEBUG
 #include <iostream>

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "cppcheck.h"
 #include "cppcheckexecutor.h"
+#include "errortypes.h"
 #include "importproject.h"
 #include "settings.h"
 #include "suppressions.h"
@@ -30,6 +31,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <utility>
 

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -33,10 +33,15 @@
 
 #include <algorithm>
 #include <functional>
+#include <initializer_list>
 #include <iterator>
 #include <list>
+#include <map>
+#include <memory>
 #include <set>
 #include <stack>
+#include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 template<class T, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>

--- a/lib/bughuntingchecks.cpp
+++ b/lib/bughuntingchecks.cpp
@@ -17,12 +17,25 @@
  */
 
 #include "bughuntingchecks.h"
+
 #include "astutils.h"
 #include "errorlogger.h"
+#include "errortypes.h"
+#include "library.h"
+#include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
+#include "utils.h"
+#include "valueflow.h"
+
+#include <algorithm>
 #include <cstring>
+#include <list>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
 
 static const CWE CWE_BUFFER_UNDERRUN(786U);  // Access of Memory Location Before Start of Buffer
 static const CWE CWE_BUFFER_OVERRUN(788U);   // Access of Memory Location After End of Buffer

--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -22,7 +22,9 @@
 
 #include "errorlogger.h"
 #include "settings.h"
+#include "token.h"
 #include "tokenize.h"
+#include "valueflow.h"
 
 #include <cctype>
 #include <iostream>

--- a/lib/check64bit.cpp
+++ b/lib/check64bit.cpp
@@ -22,11 +22,13 @@
 
 #include "check64bit.h"
 
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
 
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -22,6 +22,7 @@
 
 #include "checkassert.h"
 
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -28,10 +28,14 @@
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
+#include "utils.h"
 #include "valueflow.h"
 
 #include <algorithm>
 #include <list>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -34,6 +34,10 @@ class Tokenizer;
 class ErrorLogger;
 class Variable;
 
+namespace ValueFlow {
+    class Value;
+}
+
 /// @addtogroup Checks
 /** @brief Various small checks for automatic variables */
 /// @{

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -21,12 +21,15 @@
 #include "checkbool.h"
 
 #include "astutils.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
+#include "valueflow.h"
 
 #include <list>
+#include <vector>
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)

--- a/lib/checkboost.cpp
+++ b/lib/checkboost.cpp
@@ -18,8 +18,11 @@
 
 #include "checkboost.h"
 
+#include "errortypes.h"
 #include "symboldatabase.h"
 #include "token.h"
+
+#include <vector>
 
 // Register this check class (by creating a static instance of it)
 namespace {

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -35,7 +35,9 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <functional>
 #include <iterator>
+#include <memory>
 #include <numeric> // std::accumulate
 #include <sstream>
 #include <tinyxml2.h>

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -28,6 +28,7 @@
 #include "errortypes.h"
 #include "mathlib.h"
 #include "symboldatabase.h"
+#include "utils.h"
 #include "valueflow.h"
 
 #include <list>

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -26,15 +26,26 @@
 #include "symboldatabase.h"
 #include "errorlogger.h"
 #include "errortypes.h"
+#include "mathlib.h"
 #include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
 #include "utils.h"
 
-#include "tinyxml2.h"
-
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
+#include <cstring>
+#include <memory>
 #include <utility>
+#include <unordered_map>
+
+#include <tinyxml2.h>
+
+namespace CTU {
+    class FileInfo;
+}
+
 //---------------------------------------------------------------------------
 
 // Register CheckClass..

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -23,9 +23,11 @@
 
 #include "check.h"
 #include "config.h"
-#include "tokenize.h"
 #include "symboldatabase.h"
+#include "tokenize.h"
+#include "utils.h"
 
+#include <cstddef>
 #include <list>
 #include <map>
 #include <set>
@@ -35,6 +37,14 @@
 class ErrorLogger;
 class Settings;
 class Token;
+
+namespace CTU {
+    class FileInfo;
+}
+
+namespace tinyxml2 {
+    class XMLElement;
+}
 
 /// @addtogroup Checks
 /// @{

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -23,6 +23,8 @@
 #include "checkcondition.h"
 
 #include "astutils.h"
+#include "library.h"
+#include "platform.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
@@ -34,8 +36,11 @@
 #include <algorithm>
 #include <limits>
 #include <list>
+#include <memory>
+#include <ostream>
 #include <set>
 #include <utility>
+#include <vector>
 
 // CWE ids used
 static const struct CWE uncheckedErrorConditionCWE(391U);

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -37,6 +37,10 @@ class Tokenizer;
 class ErrorLogger;
 class ValueType;
 
+namespace ValueFlow {
+    class Value;
+}
+
 /// @addtogroup Checks
 /// @{
 

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -21,9 +21,12 @@
 
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 
+#include <list>
 #include <set>
 #include <utility>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -31,6 +31,8 @@
 #include "valueflow.h"
 
 #include <iomanip>
+#include <ostream>
+#include <unordered_map>
 #include <vector>
 
 //---------------------------------------------------------------------------

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -24,9 +24,10 @@
 
 #include "check.h"
 #include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
-#include "errortypes.h"
+#include "utils.h"
 
 #include <map>
 #include <string>

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -28,11 +28,15 @@
 #include "utils.h"
 #include "valueflow.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <functional>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -34,7 +34,9 @@
 
 #include <iostream>
 #include <list>
+#include <memory>
 #include <utility>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 
 class ErrorLogger;
 class Settings;

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -29,6 +29,8 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <unordered_set>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -36,6 +36,7 @@
 #include "config.h"
 #include "errortypes.h"
 #include "tokenize.h"
+#include "utils.h"
 
 #include <list>
 #include <string>

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -22,6 +22,7 @@
 
 #include "astutils.h"
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "library.h"
 #include "mathlib.h"
 #include "settings.h"
@@ -31,7 +32,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <map>
+#include <memory>
 #include <set>
+#include <vector>
+
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -36,6 +36,9 @@ class Settings;
 class Token;
 class Tokenizer;
 
+namespace tinyxml2 {
+    class XMLElement;
+}
 
 /// @addtogroup Checks
 /// @{

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -20,8 +20,6 @@
 //---------------------------------------------------------------------------
 #include "checkother.h"
 
-#include "checkuninitvar.h" // CheckUninitVar::isVariableUsage
-
 #include "astutils.h"
 #include "library.h"
 #include "mathlib.h"
@@ -33,11 +31,18 @@
 #include "utils.h"
 #include "valueflow.h"
 
+#include "checkuninitvar.h" // CheckUninitVar::isVariableUsage
+
 #include <algorithm> // find_if()
+#include <cctype>
 #include <list>
 #include <map>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <type_traits>
 #include <utility>
-#include <cctype>
+
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)

--- a/lib/checkpostfixoperator.cpp
+++ b/lib/checkpostfixoperator.cpp
@@ -23,9 +23,12 @@
 
 #include "checkpostfixoperator.h"
 
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
+
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -20,10 +20,14 @@
 //---------------------------------------------------------------------------
 #include "checksizeof.h"
 
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
+
+#include <map>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -20,7 +20,6 @@
 
 #include "astutils.h"
 #include "check.h"
-#include "checknullpointer.h"
 #include "errortypes.h"
 #include "library.h"
 #include "mathlib.h"
@@ -33,14 +32,21 @@
 #include "utils.h"
 #include "valueflow.h"
 
+#include "checknullpointer.h"
+
 #include <algorithm>
+#include <cassert>
 #include <iterator>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
+#include <tuple>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 // Register this check class (by creating a static instance of it)
 namespace {

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -21,6 +21,7 @@
 #include "checkstring.h"
 
 #include "astutils.h"
+#include "errortypes.h"
 #include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -20,15 +20,20 @@
 //---------------------------------------------------------------------------
 #include "checktype.h"
 
+#include "errortypes.h"
 #include "mathlib.h"
 #include "platform.h"
 #include "settings.h"
+#include "standards.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
 
 #include <cmath>
 #include <list>
+#include <ostream>
+#include <vector>
+
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)

--- a/lib/checktype.h
+++ b/lib/checktype.h
@@ -26,10 +26,14 @@
 #include "config.h"
 #include "valueflow.h"
 
+#include <list>
+#include <string>
+
 class ErrorLogger;
 class Settings;
 class Token;
 class Tokenizer;
+class ValueType;
 
 /// @addtogroup Checks
 /// @{

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -21,7 +21,6 @@
 #include "checkuninitvar.h"
 
 #include "astutils.h"
-#include "checknullpointer.h"   // CheckNullPointer::isPointerDeref
 #include "errorlogger.h"
 #include "library.h"
 #include "mathlib.h"
@@ -31,10 +30,17 @@
 #include "tokenize.h"
 #include "valueflow.h"
 
+#include "checknullpointer.h"   // CheckNullPointer::isPointerDeref
+
+#include <algorithm>
 #include <cassert>
+#include <functional>
+#include <initializer_list>
 #include <list>
 #include <map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 
 namespace tinyxml2 {

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -28,7 +28,10 @@
 #include "mathlib.h"
 #include "errortypes.h"
 #include "utils.h"
+#include "valueflow.h"
 
+#include <list>
+#include <map>
 #include <set>
 #include <string>
 
@@ -39,6 +42,10 @@ class Variable;
 class ErrorLogger;
 class Settings;
 class Library;
+
+namespace tinyxml2 {
+    class XMLElement;
+}
 
 
 struct VariableValue {

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -22,6 +22,7 @@
 
 #include "astutils.h"
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "symboldatabase.h"
@@ -29,11 +30,22 @@
 #include "tokenize.h"
 #include "tokenlist.h"
 
-#include <tinyxml2.h>
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <istream>
+#include <memory>
+
 #include <utility>
+#include <vector>
+
+#include <tinyxml2.h>
+
+namespace CTU {
+    class FileInfo;
+}
+
 //---------------------------------------------------------------------------
 
 

--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -35,6 +35,10 @@ class Function;
 class Settings;
 class Tokenizer;
 
+namespace CTU {
+    class FileInfo;
+}
+
 /// @addtogroup Checks
 /** @brief Check for functions never called */
 /// @{

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -21,14 +21,19 @@
 #include "checkunusedvar.h"
 
 #include "astutils.h"
+#include "errortypes.h"
+#include "library.h"
 #include "preprocessor.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
+#include "utils.h"
 
 #include <algorithm>
 #include <list>
+#include <memory>
 #include <set>
 #include <utility>
 #include <vector>

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -24,6 +24,7 @@
 #include "check.h"
 #include "config.h"
 
+#include <list>
 #include <map>
 #include <string>
 

--- a/lib/checkvaarg.cpp
+++ b/lib/checkvaarg.cpp
@@ -19,6 +19,7 @@
 #include "checkvaarg.h"
 
 #include "astutils.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
@@ -26,6 +27,7 @@
 
 #include <cstddef>
 #include <list>
+#include <vector>
 
 //---------------------------------------------------------------------------
 

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -17,18 +17,30 @@
  */
 
 #include "clangimport.h"
+
+#include "errortypes.h"
+#include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
 #include "utils.h"
+#include "valueflow.h"
 
-#include <cstring>
 #include <algorithm>
-#include <iostream>
-#include <memory>
-#include <stack>
-#include <vector>
 #include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <stack>
+#include <string>
+#include <utility>
+#include <vector>
 
 static const std::string AccessSpecDecl = "AccessSpecDecl";
 static const std::string ArraySubscriptExpr = "ArraySubscriptExpr";

--- a/lib/color.cpp
+++ b/lib/color.cpp
@@ -1,7 +1,9 @@
 #include "color.h"
+
 #ifndef _WIN32
 #include <unistd.h>
 #endif
+#include <cstddef>
 #include <sstream>
 
 #ifdef _WIN32

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -22,33 +22,45 @@
 #include "clangimport.h"
 #include "color.h"
 #include "ctu.h"
+#include "errortypes.h"
+#include "exprengine.h"
 #include "library.h"
 #include "mathlib.h"
 #include "path.h"
 #include "platform.h"
 #include "preprocessor.h" // Preprocessor
+#include "standards.h"
 #include "suppressions.h"
 #include "timer.h"
+#include "token.h"
 #include "tokenize.h" // Tokenizer
 #include "tokenlist.h"
+#include "utils.h"
+#include "valueflow.h"
 #include "version.h"
 
-#include "exprengine.h"
-#include <string>
-
-#define PICOJSON_USE_INT64
-#include <picojson.h>
-#include <simplecpp.h>
-#include <tinyxml2.h>
 #include <algorithm>
+#include <cstdio>
+#include <cstdint>
 #include <cstring>
+#include <cctype>
+#include <cstdlib>
+#include <exception>
+#include <iostream> // <- TEMPORARY
+#include <memory>
 #include <new>
 #include <set>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
-#include <memory>
-#include <iostream> // <- TEMPORARY
-#include <cstdio>
+
+#define PICOJSON_USE_INT64
+#include <picojson.h>
+
+#include <simplecpp.h>
+
+#include <tinyxml2.h>
 
 #ifdef HAVE_RULES
 #ifdef _WIN32
@@ -56,6 +68,8 @@
 #endif
 #include <pcre.h>
 #endif
+
+class SymbolDatabase;
 
 static const char Version[] = CPPCHECK_VERSION_STRING;
 static const char ExtraVersion[] = "";

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -29,11 +29,13 @@
 #include "importproject.h"
 #include "settings.h"
 
+#include <cstddef>
 #include <functional>
 #include <istream>
 #include <list>
 #include <map>
 #include <string>
+#include <vector>
 
 class Tokenizer;
 

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -19,13 +19,22 @@
 
 //---------------------------------------------------------------------------
 #include "ctu.h"
+
 #include "astutils.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
+
+#include <cstdint>
+#include <cstring>
+#include <iterator>  // back_inserter
+#include <ostream>
+#include <utility>
 
 #include <tinyxml2.h>
-#include <iterator>  // back_inserter
 //---------------------------------------------------------------------------
 
 static const char ATTR_CALL_ID[] = "call-id";

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -22,13 +22,27 @@
 #define ctuH
 //---------------------------------------------------------------------------
 
+#include "config.h"
 #include "check.h"
 #include "errorlogger.h"
+#include "mathlib.h"
+#include "utils.h"
 #include "valueflow.h"
 
+#include <algorithm>
+#include <list>
 #include <map>
+#include <string>
+#include <vector>
 
 class Function;
+class Settings;
+class Token;
+class Tokenizer;
+
+namespace tinyxml2 {
+    class XMLElement;
+}
 
 /// @addtogroup Core
 /// @{

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -26,14 +26,17 @@
 #include "tokenlist.h"
 #include "utils.h"
 
-#include <string>
-#include <tinyxml2.h>
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
+#include <memory>
+#include <string>
+
+#include <tinyxml2.h>
 
 InternalError::InternalError(const Token *tok, const std::string &errorMsg, Type type) :
     token(tok), errorMessage(errorMsg), type(type)

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -24,7 +24,6 @@
 #include "path.h"
 #include "token.h"
 #include "tokenlist.h"
-#include "utils.h"
 
 #include <algorithm>
 #include <array>

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -26,6 +26,7 @@
 #include "suppressions.h"
 #include "color.h"
 
+#include <cstddef>
 #include <fstream>
 #include <list>
 #include <string>

--- a/lib/errortypes.h
+++ b/lib/errortypes.h
@@ -25,6 +25,7 @@
 
 #include <list>
 #include <string>
+#include <utility>
 
 /// @addtogroup Core
 /// @{

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -134,15 +134,28 @@
 #include "astutils.h"
 #include "bughuntingchecks.h"
 #include "errorlogger.h"
+#include "library.h"
+#include "mathlib.h"
+#include "platform.h"
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
+#include "utils.h"
 
 #include <cctype>
-#include <limits>
-#include <memory>
+#include <climits>
+#include <cstdint>
+#include <ctime>
+#include <exception>
 #include <iostream>
+#include <limits>
+#include <list>
+#include <memory>
+#include <set>
 #include <tuple>
+
 #ifdef USE_Z3
 #include <z3++.h>
 #include <z3_version.h>

--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -24,11 +24,14 @@
 #include "config.h"
 #include "errortypes.h"
 
+#include <algorithm>
 #include <functional>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 class ErrorLogger;
 class Tokenizer;

--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -1,6 +1,10 @@
 #include "forwardanalyzer.h"
+
 #include "analyzer.h"
 #include "astutils.h"
+#include "config.h"
+#include "errortypes.h"
+#include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
@@ -9,8 +13,13 @@
 #include <algorithm>
 #include <cstdio>
 #include <functional>
+#include <list>
+#include <memory>
+#include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
+#include <vector>
 
 struct OnExit {
     std::function<void()> f;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -20,18 +20,25 @@
 
 #include "path.h"
 #include "settings.h"
+#include "standards.h"
 #include "suppressions.h"
-#include "tinyxml2.h"
 #include "token.h"
 #include "tokenize.h"
 #include "utils.h"
-#define PICOJSON_USE_INT64
-#include <picojson.h>
 
+#include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iostream>
+#include <iterator>
+
 #include <utility>
 
+#include <tinyxml2.h>
+
+#define PICOJSON_USE_INT64
+#include <picojson.h>
 
 ImportProject::ImportProject()
 {

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -25,6 +25,7 @@
 #include "platform.h"
 #include "utils.h"
 
+#include <iosfwd>
 #include <list>
 #include <map>
 #include <set>

--- a/lib/infer.cpp
+++ b/lib/infer.cpp
@@ -1,8 +1,17 @@
 #include "infer.h"
+
 #include "calculate.h"
+#include "errortypes.h"
 #include "valueptr.h"
+
+#include <cassert>
+#include <algorithm>
+#include <functional>
 #include <iterator>
 #include <unordered_set>
+#include <utility>
+
+class Token;
 
 template<class Predicate, class Compare>
 static const ValueFlow::Value* getCompareValue(const std::list<ValueFlow::Value>& values, Predicate pred, Compare compare)

--- a/lib/infer.h
+++ b/lib/infer.h
@@ -19,12 +19,16 @@
 #ifndef inferH
 #define inferH
 
+#include "config.h"
 #include "mathlib.h"
 #include "valueflow.h"
 
+#include <list>
+#include <string>
+#include <vector>
+
 struct Interval;
-template<class T>
-class ValuePtr;
+template<class T> class ValuePtr;
 
 struct InferModel {
     virtual bool match(const ValueFlow::Value& value) const = 0;

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -22,16 +22,21 @@
 #include "mathlib.h"
 #include "path.h"
 #include "symboldatabase.h"
-#include "tinyxml2.h"
 #include "token.h"
 #include "tokenlist.h"
 #include "utils.h"
+#include "valueflow.h"
 
 #include <cctype>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <iosfwd>
 #include <list>
+#include <memory>
 #include <string>
+
+#include <tinyxml2.h>
 
 static std::vector<std::string> getnames(const char *names)
 {

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -21,14 +21,15 @@
 #include "errortypes.h"
 #include "utils.h"
 
-#include <simplecpp.h>
-
 #include <cctype>
 #include <cmath>
 #include <cstdlib>
+#include <exception>
 #include <limits>
 #include <locale>
 #include <stdexcept>
+
+#include <simplecpp.h>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1700  // VS2012 doesn't have std::isinf and std::isnan
 #define ISINF(x)      (!_finite(x))

--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -1,9 +1,14 @@
 #include "pathanalysis.h"
+
 #include "astutils.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "valueflow.h"
+
 #include <algorithm>
+#include <memory>
+#include <string>
+#include <tuple>
 
 const Scope* PathAnalysis::findOuterScope(const Scope * scope)
 {

--- a/lib/pathanalysis.h
+++ b/lib/pathanalysis.h
@@ -4,6 +4,8 @@
 #include "errortypes.h"
 
 #include <functional>
+#include <list>
+#include <utility>
 
 class Library;
 class Scope;

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -17,12 +17,16 @@
  */
 
 #include "platform.h"
+
 #include "path.h"
-#include "tinyxml2.h"
+
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <vector>
+
+#include <tinyxml2.h>
 
 cppcheck::Platform::Platform()
 {

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -20,16 +20,21 @@
 #include "preprocessor.h"
 
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "library.h"
 #include "path.h"
 #include "settings.h"
-#include "simplecpp.h"
+#include "standards.h"
 #include "suppressions.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <iterator> // back_inserter
+#include <memory>
 #include <utility>
+
+#include <simplecpp.h>
 
 static bool sameline(const simplecpp::Token *tok1, const simplecpp::Token *tok2)
 {

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -1,18 +1,26 @@
 
 #include "programmemory.h"
+
 #include "astutils.h"
 #include "calculate.h"
 #include "infer.h"
+#include "library.h"
 #include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "valueflow.h"
 #include "valueptr.h"
+
 #include <algorithm>
 #include <cassert>
 #include <functional>
+#include <list>
 #include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
 void ProgramMemory::setValue(nonneg int exprid, const ValueFlow::Value& value)
 {

--- a/lib/reverseanalyzer.cpp
+++ b/lib/reverseanalyzer.cpp
@@ -1,14 +1,21 @@
 #include "reverseanalyzer.h"
+
 #include "analyzer.h"
 #include "astutils.h"
 #include "errortypes.h"
 #include "forwardanalyzer.h"
+#include "mathlib.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "token.h"
 #include "valueptr.h"
 
 #include <algorithm>
+#include <cstddef>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 struct ReverseTraversal {
     ReverseTraversal(const ValuePtr<Analyzer>& analyzer, const Settings* settings)

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -22,6 +22,7 @@
 //---------------------------------------------------------------------------
 
 #include "config.h"
+#include "errortypes.h"
 #include "importproject.h"
 #include "library.h"
 #include "platform.h"
@@ -31,7 +32,9 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <list>
+#include <map>
 #include <set>
 #include <string>
 #include <vector>

--- a/lib/summaries.cpp
+++ b/lib/summaries.cpp
@@ -4,7 +4,9 @@
 #include "analyzerinfo.h"
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
 
 #include <algorithm>
 #include <fstream>

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -23,11 +23,13 @@
 #include "path.h"
 #include "utils.h"
 
-#include <tinyxml2.h>
-
 #include <algorithm>
 #include <cctype>   // std::isdigit, std::isalnum, etc
+#include <cstdlib>
+#include <cstring>
 #include <functional> // std::bind, std::placeholders
+
+#include <tinyxml2.h>
 
 static bool isAcceptedErrorIdChar(char c)
 {

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "errortypes.h"
 
+#include <cstddef>
 #include <istream>
 #include <list>
 #include <string>

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -21,10 +21,13 @@
 
 #include "astutils.h"
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "library.h"
 #include "mathlib.h"
 #include "platform.h"
 #include "settings.h"
+#include "standards.h"
+#include "templatesimplifier.h"
 #include "token.h"
 #include "tokenize.h"
 #include "tokenlist.h"
@@ -37,8 +40,10 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <stack>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 //---------------------------------------------------------------------------
 
 SymbolDatabase::SymbolDatabase(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -28,10 +28,13 @@
 #include "utils.h"
 
 #include <cctype>
+#include <iosfwd>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -19,8 +19,10 @@
 #include "templatesimplifier.h"
 
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "mathlib.h"
 #include "settings.h"
+#include "standards.h"
 #include "token.h"
 #include "tokenize.h"
 #include "tokenlist.h"
@@ -29,7 +31,9 @@
 #include <cassert>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <stack>
+#include <type_traits>
 #include <utility>
 
 static Token *skipRequires(Token *tok)

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -19,6 +19,7 @@
 #include "token.h"
 
 #include "astutils.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "symboldatabase.h"
@@ -30,12 +31,17 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <climits>
+#include <cstdio>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <set>
 #include <stack>
+#include <unordered_set>
 #include <utility>
 
 const std::list<ValueFlow::Value> TokenImpl::mEmptyValueList;

--- a/lib/token.h
+++ b/lib/token.h
@@ -27,12 +27,15 @@
 #include "templatesimplifier.h"
 #include "utils.h"
 
+#include <cstdint>
 #include <cstddef>
 #include <functional>
 #include <list>
 #include <memory>
 #include <ostream>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 class Enumerator;
@@ -43,8 +46,8 @@ class Type;
 class ValueType;
 class Variable;
 class TokenList;
-
 class ConstTokenRange;
+class Token;
 
 /**
  * @brief This struct stores pointers to the front and back tokens of the list this token is in.

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -38,13 +38,23 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <iterator>
+#include <exception>
+#include <memory>
 #include <set>
 #include <stack>
+#include <stdexcept>
+#include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
+
+#include <simplecpp.h>
+
 //---------------------------------------------------------------------------
 
 namespace {

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -24,11 +24,15 @@
 #include "config.h"
 #include "errortypes.h"
 #include "tokenlist.h"
+#include "utils.h"
 
+#include <iosfwd>
 #include <list>
 #include <map>
 #include <string>
 #include <stack>
+#include <utility>
+#include <vector>
 
 class Settings;
 class SymbolDatabase;

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -21,18 +21,23 @@
 
 #include "astutils.h"
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "library.h"
 #include "path.h"
 #include "settings.h"
 #include "standards.h"
 #include "token.h"
 
-#include <exception>
-#include <simplecpp.h>
+#include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <exception>
+#include <functional>
+#include <utility>
 #include <set>
 #include <stack>
+
+#include <simplecpp.h>
 
 // How many compileExpression recursions are allowed?
 // For practical code this could be endless. But in some special torture test

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -23,7 +23,9 @@
 
 #include "config.h"
 #include "token.h"
+#include "utils.h"
 
+#include <iosfwd>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -18,9 +18,11 @@
 
 #include "utils.h"
 
-#include <utility>
-#include <stack>
 #include <cctype>
+#include <iterator>
+#include <memory>
+#include <stack>
+#include <utility>
 
 
 int caseInsensitiveStringCompare(const std::string &lhs, const std::string &rhs)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -103,12 +103,17 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <functional>
+#include <initializer_list>
+#include <iosfwd>
 #include <iterator>
 #include <limits>
 #include <map>
+#include <memory>
 #include <set>
 #include <stack>
 #include <string>

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -25,7 +25,9 @@
 #include "mathlib.h"
 #include "utils.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <functional>
 #include <list>
 #include <string>

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -18,10 +18,13 @@
 
 
 #include "check64bit.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class Test64BitPortability : public TestFixture {
 public:

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -18,9 +18,13 @@
 
 
 #include "checkassert.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
+
+#include <iosfwd>
 
 
 class TestAssert : public TestFixture {

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -18,6 +18,8 @@
 
 
 #include "astutils.h"
+#include "config.h"
+#include "library.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
@@ -25,6 +27,7 @@
 #include "tokenlist.h"
 
 #include <cstring>
+#include <iosfwd>
 
 class TestAstUtils : public TestFixture {
 public:

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkautovariables.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestAutoVariables : public TestFixture {
 public:

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkbool.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestBool : public TestFixture {
 public:

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkboost.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestBoost : public TestFixture {
 public:

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -21,15 +21,23 @@
 #include "checkbufferoverrun.h"
 #include "config.h"
 #include "ctu.h"
+#include "errortypes.h"
+#include "standards.h"
 #include "library.h"
 #include "preprocessor.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
+#include <map>
 #include <list>
-#include <simplecpp.h>
 #include <string>
+#include <utility>
+#include <vector>
+
+#include <simplecpp.h>
+
 #include <tinyxml2.h>
 
 class TestBufferOverrun : public TestFixture {

--- a/test/testbughuntingchecks.cpp
+++ b/test/testbughuntingchecks.cpp
@@ -17,10 +17,15 @@
  */
 
 #include "config.h"
+#include "errortypes.h"
 #include "exprengine.h"
+#include "library.h"
+#include "platform.h"
 #include "settings.h"
 #include "tokenize.h"
 #include "testsuite.h"
+
+#include <iosfwd>
 
 class TestBughuntingChecks : public TestFixture {
 public:

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -18,11 +18,14 @@
 
 
 #include "checkother.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestCharVar : public TestFixture {
 public:

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -15,10 +15,20 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "clangimport.h"
+#include "config.h"
+#include "platform.h"
 #include "settings.h"
 #include "symboldatabase.h"
+#include "token.h"
 #include "tokenize.h"
 #include "testsuite.h"
+
+#include <cstdint>
+#include <iosfwd>
+#include <list>
+#include <memory>
+#include <string>
+#include <vector>
 
 
 class TestClangImport : public TestFixture {

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -16,13 +16,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <tinyxml2.h>
-
+#include "check.h"
 #include "checkclass.h"
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
+
+#include <iosfwd>
+#include <list>
+#include <string>
+#include <vector>
+
+#include <tinyxml2.h>
 
 
 class TestClass : public TestFixture {

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "cmdlineparser.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "redirect.h"
 #include "settings.h"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -17,16 +17,24 @@
  */
 
 #include "checkcondition.h"
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
+#include "platform.h"
 #include "preprocessor.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
-#include <tinyxml2.h>
+#include <iosfwd>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
+
+#include <tinyxml2.h>
 
 class TestCondition : public TestFixture {
 public:

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -18,9 +18,16 @@
 
 
 #include "checkclass.h"
+#include "config.h"
+#include "errortypes.h"
+#include "standards.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
+
+#include <iosfwd>
+#include <list>
+#include <string>
 
 
 class TestConstructors : public TestFixture {

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -18,11 +18,13 @@
 
 #include "check.h"
 #include "color.h"
+#include "config.h"
 #include "cppcheck.h"
 #include "errorlogger.h"
 #include "testsuite.h"
 
 #include <algorithm>
+#include <functional>
 #include <list>
 #include <string>
 

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -19,13 +19,16 @@
 #include "config.h"
 #include "cppcheck.h"
 #include "errorlogger.h"
+#include "errortypes.h"
 #include "suppressions.h"
 #include "testsuite.h"
 
-#include <tinyxml2.h>
+#include <iosfwd>
 #include <list>
+#include <memory>
 #include <string>
 
+#include <tinyxml2.h>
 
 class TestErrorLogger : public TestFixture {
 public:

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkexceptionsafety.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestExceptionSafety : public TestFixture {
 public:

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -25,7 +25,12 @@
 #include "tokenize.h"
 #include "testsuite.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <istream>
+#include <map>
 #include <string>
+#include <vector>
 
 class TestExprEngine : public TestFixture {
 public:

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -16,14 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "filelister.h"
 #include "pathmatch.h"
 #include "testsuite.h"
 
+#include <cstddef>
 #include <fstream>
 #include <map>
 #include <string>
 #include <vector>
+#include <utility>
 
 class TestFileLister : public TestFixture {
 public:

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -16,15 +16,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <tinyxml2.h>
-
 #include "checkfunctions.h"
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "standards.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
+#include <list>
+#include <string>
+
+#include <tinyxml2.h>
 
 class TestFunctions : public TestFixture {
 public:

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -17,12 +17,17 @@
  */
 
 #include "check.h"
+#include "config.h"
+#include "errortypes.h"
+#include "mathlib.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 #include <list>
+#include <string>
 
 
 class TestGarbage : public TestFixture {

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -16,13 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "importproject.h"
 #include "settings.h"
 #include "testsuite.h"
 
+#include <iosfwd>
 #include <list>
+#include <memory>
 #include <map>
 #include <string>
+#include <vector>
 
 class TestImporter : public ImportProject {
 public:

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -17,13 +17,19 @@
  */
 
 #include "checkother.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
+#include <iosfwd>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
 
 class TestIncompleteStatement : public TestFixture {
 public:

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -18,10 +18,14 @@
 
 
 #include "checkio.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
+
+#include <iosfwd>
 
 
 class TestIO : public TestFixture {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -18,14 +18,25 @@
 
 
 #include "checkleakautovar.h"
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
-#include <tinyxml2.h>
+#include <iosfwd>
+#include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
+
+#include <tinyxml2.h>
+
+class TestLeakAutoVarStrcpy;
+class TestLeakAutoVarWindows;
 
 class TestLeakAutoVar : public TestFixture {
 public:

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "standards.h"
@@ -24,10 +26,13 @@
 #include "tokenize.h"
 #include "tokenlist.h"
 
-#include <tinyxml2.h>
+#include <iosfwd>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
+
+#include <tinyxml2.h>
 
 #define ASSERT_EQ(expected, actual)   ASSERT(expected == actual)
 

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -17,10 +17,12 @@
  */
 
 
+#include "config.h"
 #include "mathlib.h"
 #include "testsuite.h"
 
 #include <limits>
+#include <string>
 
 struct InternalError;
 

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -15,16 +15,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 #include "checkmemoryleak.h"
 #include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 #include <list>
+#include <memory>
 #include <string>
+
+class TestMemleakInClass;
+class TestMemleakNoVar;
+class TestMemleakStructMember;
 
 
 class TestMemleak : private TestFixture {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -20,17 +20,22 @@
 #include "checknullpointer.h"
 #include "config.h"
 #include "ctu.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
+#include <iosfwd>
 #include <list>
 #include <map>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
 
 class TestNullPointer : public TestFixture {
 public:

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -14,8 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include "config.h"
 #include "options.h"
 #include "testsuite.h"
+
+#include <set>
+#include <string>
 
 
 class TestOptions : public TestFixture {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "checkother.h"
+#include "config.h"
+#include "errortypes.h"
 #include "library.h"
 #include "platform.h"
 #include "preprocessor.h"
@@ -25,11 +27,17 @@
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
-#include <tinyxml2.h>
+#include <iosfwd>
+#include <list>
 #include <map>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
+#include <tinyxml2.h>
+
 
 class TestOther : public TestFixture {
 public:

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "path.h"
 #include "testsuite.h"
 

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "pathmatch.h"
 #include "testsuite.h"
 

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkpostfixoperator.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestPostfixOperator : public TestFixture {
 public:

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -20,18 +20,24 @@
 // The preprocessor that Cppcheck uses is a bit special. Instead of generating
 // the code for a known configuration, it generates the code for each configuration.
 
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "preprocessor.h"
 #include "settings.h"
 #include "testsuite.h"
 
-#include <simplecpp.h>
+#include <atomic>
 #include <cstring>
+#include <iosfwd>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
+
+#include <simplecpp.h>
 
 class ErrorLogger;
 

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -16,11 +16,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "errortypes.h"
 #include "options.h"
 #include "preprocessor.h"
 #include "testsuite.h"
 
 #include <cstdlib>
+#include <exception>
+#include <string>
+
 #ifdef NDEBUG
 #include <iostream>
 #endif

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -18,14 +18,19 @@
 
 
 #include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "templatesimplifier.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
+#include "tokenlist.h"
 
 #include <cstring>
+#include <iosfwd>
+#include <string>
+#include <vector>
 
 
 class TestSimplifyTemplate : public TestFixture {

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -24,7 +24,6 @@
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
-#include "tokenlist.h"
 
 #include <istream>
 #include <string>

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -16,13 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
+#include "standards.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
 #include "tokenlist.h"
 
+#include <istream>
 #include <string>
 
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -17,6 +17,8 @@
  */
 
 
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
@@ -24,7 +26,12 @@
 #include "tokenize.h"
 #include "tokenlist.h"
 
+#include <map>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include <simplecpp.h>
 
 

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -18,11 +18,15 @@
 
 
 #include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenize.h"
+
+#include <iosfwd>
+#include <string>
 
 
 class TestSimplifyUsing : public TestFixture {

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -17,13 +17,19 @@
  */
 
 #include "checksizeof.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
+#include <iosfwd>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
 
 class TestSizeof : public TestFixture {
 public:

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -17,12 +17,15 @@
  */
 
 #include "checkstl.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "standards.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
 #include <cstddef>
+#include <iosfwd>
 #include <string>
 
 

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -18,9 +18,13 @@
 
 
 #include "checkstring.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
+
+#include <iosfwd>
 
 
 class TestString : public TestFixture {

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <set>
 #include <sstream>
+#include <string>
 
 class options;
 

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -17,11 +17,14 @@
  */
 
 
+#include "config.h"
+#include "settings.h"
 #include "summaries.h"
 #include "testsuite.h"
-
-#include "settings.h"
 #include "tokenize.h"
+
+#include <iosfwd>       // for istringstream, ostringstream
+#include <string>
 
 
 class TestSummaries : public TestFixture {

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -18,13 +18,19 @@
 
 #include "config.h"
 #include "cppcheck.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "suppressions.h"
 #include "testsuite.h"
 #include "threadexecutor.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <iosfwd>
 #include <list>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -32,14 +32,18 @@
 #include <limits>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <tinyxml2.h>
+#include <unordered_map>
 #include <vector>
 
+#include <tinyxml2.h>
+
 struct InternalError;
+class TestSymbolDatabase;
 
 #define GET_SYMBOL_DB_STD(code) \
     Tokenizer tokenizer(&settings1, this); \

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -16,11 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "threadexecutor.h"
 
+#include <cstddef>
 #include <map>
+#include <ostream>
 #include <string>
 #include <utility>
 

--- a/test/testtimer.cpp
+++ b/test/testtimer.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "testsuite.h"
 #include "timer.h"
 

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -16,13 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "testutils.h"
 #include "token.h"
 #include "tokenize.h"
 #include "tokenlist.h"
+#include "valueflow.h"
 
+#include <algorithm>
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -27,9 +27,14 @@
 #include "tokenlist.h"
 
 #include <list>
+#include <map>
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
+
+#include <simplecpp.h>
 
 struct InternalError;
 

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -16,11 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
 #include "tokenlist.h"
 
+#include <iosfwd>
 #include <string>
 
 class TestTokenList : public TestFixture {

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"
@@ -24,6 +25,10 @@
 #include "tokenrange.h"
 #include "symboldatabase.h"
 
+#include <algorithm>
+#include <iterator>
+#include <list>
+#include <ostream>
 #include <string>
 
 

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -17,11 +17,15 @@
  */
 
 #include "checktype.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
+#include "standards.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 #include <string>
 
 class TestType : public TestFixture {

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -16,12 +16,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "check.h"
 #include "checkuninitvar.h"
+#include "config.h"
+#include "ctu.h"
+#include "errortypes.h"
 #include "library.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <list>
 #include <sstream>
 #include <string>
 

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -17,11 +17,14 @@
  */
 
 #include "checkunusedfunctions.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <sstream>
 #include <string>
 
 class TestUnusedFunctions : public TestFixture {

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -17,14 +17,20 @@
  */
 
 #include "checkclass.h"
+#include "config.h"
+#include "errortypes.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <simplecpp.h>
+#include <iosfwd>
 #include <map>
+#include <string>
+#include <utility>
 #include <vector>
+
+#include <simplecpp.h>
 
 class TestUnusedPrivateFunction : public TestFixture {
 public:

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -17,11 +17,15 @@
  */
 
 #include "checkunusedvar.h"
+#include "config.h"
+#include "errortypes.h"
 #include "preprocessor.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
+#include <list>
 #include <string>
 
 class TestUnusedVar : public TestFixture {

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -20,9 +20,16 @@
 #define TestUtilsH
 
 #include "color.h"
+#include "config.h"
 #include "errorlogger.h"
 #include "settings.h"
+#include "suppressions.h"
 #include "tokenize.h"
+#include "tokenlist.h"
+
+#include <iosfwd>
+#include <list>
+#include <string>
 
 class Token;
 

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -18,10 +18,13 @@
 
 
 #include "checkvaarg.h"
+#include "config.h"
+#include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 
 class TestVaarg : public TestFixture {
 public:

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
 #include "library.h"
+#include "mathlib.h"
 #include "platform.h"
 #include "settings.h"
 #include "testsuite.h"
@@ -25,16 +27,21 @@
 #include "valueflow.h"
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <list>
 #include <map>
-#include <simplecpp.h>
+#include <memory>
+#include <ostream>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <simplecpp.h>
 
 class TestValueFlow : public TestFixture {
 public:

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "config.h"
+#include "mathlib.h"
 #include "platform.h"
 #include "settings.h"
 #include "standards.h"
@@ -23,6 +25,7 @@
 #include "token.h"
 #include "tokenize.h"
 
+#include <iosfwd>
 #include <string>
 
 struct InternalError;


### PR DESCRIPTION
This does not add additional dependencies it just makes the existing ones explicitly.

It will also prevent breakage in case an include will remove another include as it usually happens with new versions of GCC/libstdc++ (including the upcoming GCC 12). This prevented me from bisecting older performance regressions with a current GCC because some files lacked a `limits` include.

I did not clean up the GUI code yet since there's an performance issue with the Qt include mapping in the current version of `include-what-you-use`.