### PR TITLE
removed OVERRIDE and FINAL defines and use the keywords directly

### DIFF
--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -20,7 +20,6 @@
 #define CPPCHECKEXECUTOR_H
 
 #include "color.h"
-#include "config.h"
 #include "errorlogger.h"
 
 #include <cstdio>

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -54,7 +54,7 @@ public:
     /**
      * Destructor
      */
-    ~CppCheckExecutor() OVERRIDE;
+    ~CppCheckExecutor() override;
 
     /**
      * Starts the checking.
@@ -75,19 +75,19 @@ public:
      *
      * @param outmsg Progress message e.g. "Checking main.cpp..."
      */
-    void reportOut(const std::string &outmsg, Color c = Color::Reset) OVERRIDE;
+    void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
 
     /** xml output of errors */
-    void reportErr(const ErrorMessage &msg) OVERRIDE;
+    void reportErr(const ErrorMessage &msg) override;
 
-    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) OVERRIDE;
+    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;
 
     /**
      * Output information messages.
      */
-    void reportInfo(const ErrorMessage &msg) OVERRIDE;
+    void reportInfo(const ErrorMessage &msg) override;
 
-    void bughuntingReport(const std::string &str) OVERRIDE;
+    void bughuntingReport(const std::string &str) override;
 
     /**
      * Information about how many files have been checked

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -51,14 +51,14 @@ class ThreadExecutor : public ErrorLogger {
 public:
     ThreadExecutor(const std::map<std::string, std::size_t> &files, Settings &settings, ErrorLogger &errorLogger);
     ThreadExecutor(const ThreadExecutor &) = delete;
-    ~ThreadExecutor() OVERRIDE;
+    ~ThreadExecutor() override;
     void operator=(const ThreadExecutor &) = delete;
     unsigned int check();
 
-    void reportOut(const std::string &outmsg, Color c) OVERRIDE;
-    void reportErr(const ErrorMessage &msg) OVERRIDE;
-    void reportInfo(const ErrorMessage &msg) OVERRIDE;
-    void bughuntingReport(const std::string &str) OVERRIDE;
+    void reportOut(const std::string &outmsg, Color c) override;
+    void reportErr(const ErrorMessage &msg) override;
+    void reportInfo(const ErrorMessage &msg) override;
+    void bughuntingReport(const std::string &str) override;
 
     /**
      * @brief Add content to a file, to be used in unit testing.

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -20,7 +20,6 @@
 #define THREADEXECUTOR_H
 
 #include "color.h"
-#include "config.h"
 #include "errorlogger.h"
 
 #include <cstddef>

--- a/lib/check64bit.h
+++ b/lib/check64bit.h
@@ -50,7 +50,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         Check64BitPortability check64BitPortability(tokenizer, settings, errorLogger);
         check64BitPortability.pointerassignment();
     }
@@ -65,7 +65,7 @@ private:
     void returnIntegerError(const Token *tok);
     void returnPointerError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         Check64BitPortability c(nullptr, settings, errorLogger);
         c.assignmentAddressToIntegerError(nullptr);
         c.assignmentIntegerToAddressError(nullptr);
@@ -77,7 +77,7 @@ private:
         return "64-bit portability";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check if there is 64-bit portability issues:\n"
                "- assign address to/from int/long\n"
                "- casting address from/to integer when returning from function\n";

--- a/lib/checkassert.h
+++ b/lib/checkassert.h
@@ -48,7 +48,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** run checks, the token list is not simplified */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckAssert checkAssert(tokenizer, settings, errorLogger);
         checkAssert.assertWithSideEffects();
     }
@@ -63,7 +63,7 @@ private:
     void sideEffectInAssertError(const Token *tok, const std::string& functionName);
     void assignmentInAssertError(const Token *tok, const std::string &varname);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckAssert c(nullptr, settings, errorLogger);
         c.sideEffectInAssertError(nullptr, "function");
         c.assignmentInAssertError(nullptr, "var");
@@ -73,7 +73,7 @@ private:
         return "Assert";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Warn if there are side effects in assert statements (since this cause different behaviour in debug/release builds).\n";
     }
 };

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -53,7 +53,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckAutoVariables checkAutoVariables(tokenizer, settings, errorLogger);
         checkAutoVariables.assignFunctionArg();
         checkAutoVariables.checkVarLifetime();
@@ -93,7 +93,7 @@ private:
     void errorUselessAssignmentArg(const Token *tok);
     void errorUselessAssignmentPtrArg(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         ErrorPath errorPath;
         CheckAutoVariables c(nullptr,settings,errorLogger);
         c.errorAutoVariableAssignment(nullptr, false);
@@ -117,7 +117,7 @@ private:
         return "Auto Variables";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "A pointer to a variable is only valid as long as the variable is in scope.\n"
                "Check:\n"
                "- returning a pointer to auto or temporary variable\n"

--- a/lib/checkbool.h
+++ b/lib/checkbool.h
@@ -48,7 +48,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckBool checkBool(tokenizer, settings, errorLogger);
 
         // Checks
@@ -109,7 +109,7 @@ private:
     void pointerArithBoolError(const Token *tok);
     void returnValueBoolError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckBool c(nullptr, settings, errorLogger);
 
         c.assignBoolToPointerError(nullptr);
@@ -129,7 +129,7 @@ private:
         return "Boolean";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Boolean type checks\n"
                "- using increment on boolean\n"
                "- comparison of a boolean expression with an integer other than 0 or 1\n"

--- a/lib/checkboost.h
+++ b/lib/checkboost.h
@@ -47,7 +47,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (!tokenizer->isCPP())
             return;
 
@@ -61,7 +61,7 @@ public:
 private:
     void boostForeachError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckBoost c(nullptr, settings, errorLogger);
         c.boostForeachError(nullptr);
     }
@@ -70,7 +70,7 @@ private:
         return "Boost usage";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check for invalid usage of Boost:\n"
                "- container modification during BOOST_FOREACH\n";
     }

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -67,7 +67,7 @@ public:
     CheckBufferOverrun(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckBufferOverrun checkBufferOverrun(tokenizer, settings, errorLogger);
         checkBufferOverrun.arrayIndex();
         checkBufferOverrun.pointerArithmetic();
@@ -78,7 +78,7 @@ public:
         checkBufferOverrun.argumentSize();
     }
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckBufferOverrun c(nullptr, settings, errorLogger);
         c.arrayIndexError(nullptr, std::vector<Dimension>(), std::vector<ValueFlow::Value>());
         c.pointerArithmeticError(nullptr, nullptr, nullptr);
@@ -90,10 +90,10 @@ public:
     }
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const OVERRIDE;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
 private:
 
@@ -137,14 +137,14 @@ private:
         std::list<CTU::FileInfo::UnsafeUsage> unsafePointerArith;
 
         /** Convert MyFileInfo data into xml string */
-        std::string toString() const OVERRIDE;
+        std::string toString() const override;
     };
 
     static bool isCtuUnsafeBufferUsage(const Check *check, const Token *argtok, MathLib::bigint *offset, int type);
     static bool isCtuUnsafeArrayIndex(const Check *check, const Token *argtok, MathLib::bigint *offset);
     static bool isCtuUnsafePointerArith(const Check *check, const Token *argtok, MathLib::bigint *offset);
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
     static bool analyseWholeProgram1(const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> &callsMap, const CTU::FileInfo::UnsafeUsage &unsafeUsage, int type, ErrorLogger &errorLogger);
 
 
@@ -152,7 +152,7 @@ private:
         return "Bounds checking";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Out of bounds checking:\n"
                "- Array index out of bounds\n"
                "- Pointer arithmetic overflow\n"

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -60,7 +60,7 @@ public:
     CheckClass(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger);
 
     /** @brief Run checks on the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (tokenizer->isC())
             return;
 
@@ -177,16 +177,16 @@ public:
         std::vector<NameLoc> classDefinitions;
 
         /** Convert MyFileInfo data into xml string */
-        std::string toString() const OVERRIDE;
+        std::string toString() const override;
     };
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const OVERRIDE;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
 private:
     const SymbolDatabase *mSymbolDatabase;
@@ -228,7 +228,7 @@ private:
     void unsafeClassRefMemberError(const Token *tok, const std::string &varname);
     void checkDuplInheritedMembersRecursive(const Type* typeCurrent, const Type* typeBase);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckClass c(nullptr, settings, errorLogger);
         c.noConstructorError(nullptr, "classname", false);
         c.noExplicitConstructorError(nullptr, "classname", false);
@@ -273,7 +273,7 @@ private:
         return "Class";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check the code for each class.\n"
                "- Missing constructors and copy constructors\n"
                //"- Missing allocation of memory in copy constructor\n"

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -57,7 +57,7 @@ public:
     CheckCondition(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckCondition checkCondition(tokenizer, settings, errorLogger);
         checkCondition.multiCondition();
         checkCondition.clarifyCondition();   // not simplified because ifAssign
@@ -173,7 +173,7 @@ private:
     void checkCompareValueOutOfTypeRange();
     void compareValueOutOfTypeRangeError(const Token *comparison, const std::string &type, long long value, bool result);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckCondition c(nullptr, settings, errorLogger);
 
         ErrorPath errorPath;
@@ -203,7 +203,7 @@ private:
         return "Condition";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Match conditions with assignments and other conditions:\n"
                "- Mismatching assignment and comparison => comparison is always true/false\n"
                "- Mismatching lhs and rhs in comparison => comparison is always true/false\n"

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -59,7 +59,7 @@ public:
     CheckExceptionSafety(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (tokenizer->isC())
             return;
 
@@ -107,7 +107,7 @@ private:
     void rethrowNoCurrentExceptionError(const Token *tok);
 
     /** Generate all possible errors (for --errorlist) */
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckExceptionSafety c(nullptr, settings, errorLogger);
         c.destructorsError(nullptr, "Class");
         c.deallocThrowError(nullptr, "p");
@@ -124,7 +124,7 @@ private:
     }
 
     /** wiki formatted description of the class (for --doc) */
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Checking exception safety\n"
                "- Throwing exceptions in destructors\n"
                "- Throwing exception during invalid state\n"

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -59,7 +59,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckFunctions checkFunctions(tokenizer, settings, errorLogger);
 
         checkFunctions.checkIgnoredReturnValue();
@@ -124,7 +124,7 @@ private:
     void missingReturnError(const Token *tok);
     void copyElisionError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckFunctions c(nullptr, settings, errorLogger);
 
         for (std::map<std::string, Library::WarnInfo>::const_iterator i = settings->library.functionwarn.cbegin(); i != settings->library.functionwarn.cend(); ++i) {
@@ -148,7 +148,7 @@ private:
         return "Check function usage";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check function usage:\n"
                "- missing 'return' in non-void function\n"
                "- return value of certain functions not used\n"

--- a/lib/checkinternal.h
+++ b/lib/checkinternal.h
@@ -42,7 +42,7 @@ public:
     CheckInternal(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (!settings->checks.isEnabled(Checks::internalCheck))
             return;
 
@@ -92,7 +92,7 @@ private:
     void extraWhitespaceError(const Token *tok, const std::string &pattern, const std::string &funcname);
     void checkRedundantTokCheckError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckInternal c(nullptr, settings, errorLogger);
         c.multiComparePatternError(nullptr, ";|%type%", "Match");
         c.simplePatternError(nullptr, "class {", "Match");
@@ -109,7 +109,7 @@ private:
         return "cppcheck internal API usage";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         // Don't include these checks on the WIKI where people can read what
         // checks there are. These checks are not intended for users.
         return "";

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -50,7 +50,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks on the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckIO checkIO(tokenizer, settings, errorLogger);
 
         checkIO.checkWrongPrintfScanfArguments();
@@ -134,7 +134,7 @@ private:
     static void argumentType(std::ostream & os, const ArgumentInfo * argInfo);
     static Severity::SeverityType getSeverity(const ArgumentInfo *argInfo);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckIO c(nullptr, settings, errorLogger);
 
         c.coutCerrMisusageError(nullptr,  "cout");
@@ -166,7 +166,7 @@ private:
         return "IO using format string";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check format string input/output operations.\n"
                "- Bad usage of the function 'sprintf' (overlapping data)\n"
                "- Missing or wrong width specifiers in 'scanf' format string\n"

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -115,7 +115,7 @@ public:
     CheckLeakAutoVar(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckLeakAutoVar checkLeakAutoVar(tokenizer, settings, errorLogger);
         checkLeakAutoVar.check();
     }
@@ -162,7 +162,7 @@ private:
     /** message: user configuration is needed to complete analysis */
     void configurationInfo(const Token* tok, const std::string &functionName);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckLeakAutoVar c(nullptr, settings, errorLogger);
         c.deallocReturnError(nullptr, nullptr, "p");
         c.configurationInfo(nullptr, "f");  // user configuration is needed to complete analysis
@@ -173,7 +173,7 @@ private:
         return "Leaks (auto variables)";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Detect when a auto variable is allocated but not deallocated or deallocated twice.\n";
     }
 };

--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -175,7 +175,7 @@ public:
     CheckMemoryLeakInFunction(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckMemoryLeakInFunction checkMemoryLeak(tokenizer, settings, errorLogger);
         checkMemoryLeak.checkReallocUsage();
     }
@@ -190,7 +190,7 @@ public:
 
 private:
     /** Report all possible errors (for the --errorlist) */
-    void getErrorMessages(ErrorLogger *e, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *e, const Settings *settings) const override {
         CheckMemoryLeakInFunction c(nullptr, settings, e);
 
         c.memleakError(nullptr, "varname");
@@ -216,7 +216,7 @@ private:
      * Get class information (--doc)
      * @return Wiki formatted information about this class
      */
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Is there any allocated memory when a function goes out of scope\n";
     }
 };
@@ -234,7 +234,7 @@ public:
     CheckMemoryLeakInClass(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizr, const Settings *settings, ErrorLogger *errLog) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizr, const Settings *settings, ErrorLogger *errLog) override {
         if (!tokenizr->isCPP())
             return;
 
@@ -253,7 +253,7 @@ private:
 
     void unsafeClassError(const Token *tok, const std::string &classname, const std::string &varname);
 
-    void getErrorMessages(ErrorLogger *e, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *e, const Settings *settings) const override {
         CheckMemoryLeakInClass c(nullptr, settings, e);
         c.publicAllocationError(nullptr, "varname");
         c.unsafeClassError(nullptr, "class", "class::varname");
@@ -263,7 +263,7 @@ private:
         return "Memory leaks (class variables)";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "If the constructor allocate memory then the destructor must deallocate it.\n";
     }
 };
@@ -279,7 +279,7 @@ public:
     CheckMemoryLeakStructMember(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckMemoryLeakStructMember checkMemoryLeak(tokenizer, settings, errorLogger);
         checkMemoryLeak.check();
     }
@@ -293,13 +293,13 @@ private:
 
     void checkStructVariable(const Variable * const variable);
 
-    void getErrorMessages(ErrorLogger * /*errorLogger*/, const Settings * /*settings*/) const OVERRIDE {}
+    void getErrorMessages(ErrorLogger * /*errorLogger*/, const Settings * /*settings*/) const override {}
 
     static std::string myName() {
         return "Memory leaks (struct members)";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Don't forget to deallocate struct members\n";
     }
 };
@@ -315,7 +315,7 @@ public:
     CheckMemoryLeakNoVar(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckMemoryLeakNoVar checkMemoryLeak(tokenizer, settings, errorLogger);
         checkMemoryLeak.check();
     }
@@ -346,7 +346,7 @@ private:
     void returnValueNotUsedError(const Token* tok, const std::string &alloc);
     void unsafeArgAllocError(const Token *tok, const std::string &funcName, const std::string &ptrType, const std::string &objType);
 
-    void getErrorMessages(ErrorLogger *e, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *e, const Settings *settings) const override {
         CheckMemoryLeakNoVar c(nullptr, settings, e);
 
         c.functionCallLeak(nullptr, "funcName", "funcName");
@@ -358,7 +358,7 @@ private:
         return "Memory leaks (address not taken)";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Not taking the address to allocated memory\n";
     }
 };

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -56,7 +56,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckNullPointer checkNullPointer(tokenizer, settings, errorLogger);
         checkNullPointer.nullPointer();
         checkNullPointer.arithmetic();
@@ -106,20 +106,20 @@ public:
         std::list<CTU::FileInfo::UnsafeUsage> unsafeUsage;
 
         /** Convert MyFileInfo data into xml string */
-        std::string toString() const OVERRIDE;
+        std::string toString() const override;
     };
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const OVERRIDE;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
 private:
     /** Get error messages. Used by --errorlist */
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckNullPointer c(nullptr, settings, errorLogger);
         c.nullPointerError(nullptr, "pointer", nullptr, false);
         c.pointerArithmeticError(nullptr, nullptr, false);
@@ -132,7 +132,7 @@ private:
     }
 
     /** class info in WIKI format. Used by --doc */
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Null pointers\n"
                "- null pointer dereferencing\n"
                "- undefined null pointer arithmetic\n";

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -57,7 +57,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckOther checkOther(tokenizer, settings, errorLogger);
 
         // Checks
@@ -289,7 +289,7 @@ private:
     void comparePointersError(const Token *tok, const ValueFlow::Value *v1, const ValueFlow::Value *v2);
     void checkModuloOfOneError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckOther c(nullptr, settings, errorLogger);
 
         ErrorPath errorPath;
@@ -370,7 +370,7 @@ private:
         return "Other";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Other checks\n"
 
                // error

--- a/lib/checkpostfixoperator.h
+++ b/lib/checkpostfixoperator.h
@@ -48,7 +48,7 @@ public:
     CheckPostfixOperator(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (tokenizer->isC())
             return;
 
@@ -63,7 +63,7 @@ private:
     /** Report Error */
     void postfixOperatorError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckPostfixOperator c(nullptr, settings, errorLogger);
         c.postfixOperatorError(nullptr);
     }
@@ -72,7 +72,7 @@ private:
         return "Using postfix operators";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Warn if using postfix operators ++ or -- rather than prefix operator\n";
     }
 };

--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -48,7 +48,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer* tokenizer, const Settings* settings, ErrorLogger* errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer* tokenizer, const Settings* settings, ErrorLogger* errorLogger) override {
         CheckSizeof checkSizeof(tokenizer, settings, errorLogger);
 
         // Checks
@@ -101,7 +101,7 @@ private:
     void sizeofDereferencedVoidPointerError(const Token *tok, const std::string &varname);
     void arithOperationsOnVoidPointerError(const Token* tok, const std::string &varname, const std::string &vartype);
 
-    void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         CheckSizeof c(nullptr, settings, errorLogger);
 
         c.sizeofForArrayParameterError(nullptr);
@@ -122,7 +122,7 @@ private:
         return "Sizeof";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "sizeof() usage checks\n"
                "- sizeof for array given as function argument\n"
                "- sizeof for numeric given as function argument\n"

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -53,7 +53,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** run checks, the token list is not simplified */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         if (!tokenizer->isCPP()) {
             return;
         }
@@ -234,7 +234,7 @@ private:
     void globalLockGuardError(const Token *tok);
     void localMutexError(const Token *tok);
 
-    void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         ErrorPath errorPath;
         CheckStl c(nullptr, settings, errorLogger);
         c.outOfBoundsError(nullptr, "container", nullptr, "x", nullptr);
@@ -279,7 +279,7 @@ private:
         return "STL usage";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check for invalid usage of STL:\n"
                "- out of bounds errors\n"
                "- misuse of iterators when iterating through a container\n"

--- a/lib/checkstring.h
+++ b/lib/checkstring.h
@@ -48,7 +48,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckString checkString(tokenizer, settings, errorLogger);
 
         // Checks
@@ -94,7 +94,7 @@ private:
     void suspiciousStringCompareError_char(const Token* tok, const std::string& var);
     void overlappingStrcmpError(const Token* eq0, const Token *ne0);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckString c(nullptr, settings, errorLogger);
 
         c.stringLiteralWriteError(nullptr, nullptr);
@@ -114,7 +114,7 @@ private:
         return "String";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Detect misusage of C-style strings:\n"
                "- overlapping buffers passed to sprintf as source and destination\n"
                "- incorrect length arguments for 'substr' and 'strncmp'\n"

--- a/lib/checktype.h
+++ b/lib/checktype.h
@@ -51,7 +51,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         // These are not "simplified" because casts can't be ignored
         CheckType checkType(tokenizer, settings, errorLogger);
         checkType.checkTooBigBitwiseShift();
@@ -88,7 +88,7 @@ private:
     void longCastReturnError(const Token *tok);
     void floatToIntegerOverflowError(const Token *tok, const ValueFlow::Value &value);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckType c(nullptr, settings, errorLogger);
         c.tooBigBitwiseShiftError(nullptr, 32, ValueFlow::Value(64));
         c.tooBigSignedBitwiseShiftError(nullptr, 31, ValueFlow::Value(31));
@@ -106,7 +106,7 @@ private:
         return "Type";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Type checks\n"
                "- bitwise shift by too many bits (only enabled when --platform is used)\n"
                "- signed integer overflow (only enabled when --platform is used)\n"

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -70,7 +70,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckUninitVar checkUninitVar(tokenizer, settings, errorLogger);
         checkUninitVar.check();
         checkUninitVar.valueFlowUninit();
@@ -104,16 +104,16 @@ public:
         std::list<CTU::FileInfo::UnsafeUsage> unsafeUsage;
 
         /** Convert MyFileInfo data into xml string */
-        std::string toString() const OVERRIDE;
+        std::string toString() const override;
     };
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const OVERRIDE;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
-    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const OVERRIDE;
+    Check::FileInfo * loadFileInfoFromXml(const tinyxml2::XMLElement *xmlElement) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
     void uninitvarError(const Token* tok, const ValueFlow::Value& v);
     void uninitstringError(const Token *tok, const std::string &varname, bool strncpy_);
@@ -135,7 +135,7 @@ private:
     Check::FileInfo *getFileInfo() const;
     bool isUnsafeFunction(const Scope *scope, int argnr, const Token **tok) const;
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckUninitVar c(nullptr, settings, errorLogger);
 
         ValueFlow::Value v{};
@@ -151,7 +151,7 @@ private:
         return "Uninitialized variables";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Uninitialized variables\n"
                "- using uninitialized local variables\n"
                "- using allocated data before it has been initialized\n";

--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -66,10 +66,10 @@ public:
     bool check(ErrorLogger * const errorLogger, const Settings& settings);
 
     /** @brief Parse current TU and extract file info */
-    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const OVERRIDE;
+    Check::FileInfo *getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const override;
 
     /** @brief Analyse all file infos for all TU */
-    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) OVERRIDE;
+    bool analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<Check::FileInfo*> &fileInfo, const Settings& settings, ErrorLogger &errorLogger) override;
 
     static CheckUnusedFunctions instance;
 
@@ -80,11 +80,11 @@ public:
 
 private:
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings * /*settings*/) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings * /*settings*/) const override {
         CheckUnusedFunctions::unusedFunctionError(errorLogger, emptyString, 0, "funcName");
     }
 
-    void runChecks(const Tokenizer * /*tokenizer*/, const Settings * /*settings*/, ErrorLogger * /*errorLogger*/) OVERRIDE {}
+    void runChecks(const Tokenizer * /*tokenizer*/, const Settings * /*settings*/, ErrorLogger * /*errorLogger*/) override {}
 
     /**
      * Dummy implementation, just to provide error for --errorlist
@@ -97,7 +97,7 @@ private:
         return "Unused functions";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check for functions that are never called\n";
     }
 

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -54,7 +54,7 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckUnusedVar checkUnusedVar(tokenizer, settings, errorLogger);
 
         // Coding style checks
@@ -83,7 +83,7 @@ private:
     void unreadVariableError(const Token *tok, const std::string &varname, bool modified);
     void unassignedVariableError(const Token *tok, const std::string &varname);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckUnusedVar c(nullptr, settings, errorLogger);
 
         // style/warning
@@ -98,7 +98,7 @@ private:
         return "UnusedVar";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "UnusedVar checks\n"
 
                // style

--- a/lib/checkvaarg.h
+++ b/lib/checkvaarg.h
@@ -46,7 +46,7 @@ public:
     CheckVaarg(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) OVERRIDE {
+    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
         CheckVaarg check(tokenizer, settings, errorLogger);
         check.va_start_argument();
         check.va_list_usage();
@@ -62,7 +62,7 @@ private:
     void va_list_usedBeforeStartedError(const Token *tok, const std::string& varname);
     void va_start_subsequentCallsError(const Token *tok, const std::string& varname);
 
-    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const OVERRIDE {
+    void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckVaarg c(nullptr, settings, errorLogger);
         c.wrongParameterTo_va_start_error(nullptr, "arg1", "arg2");
         c.referenceAs_va_start_error(nullptr, "arg1");
@@ -75,7 +75,7 @@ private:
         return "Vaarg";
     }
 
-    std::string classInfo() const OVERRIDE {
+    std::string classInfo() const override {
         return "Check for misusage of variable argument lists:\n"
                "- Wrong parameter passed to va_start()\n"
                "- Reference passed to va_start()\n"

--- a/lib/config.h
+++ b/lib/config.h
@@ -37,17 +37,6 @@
 #  include <crtdbg.h>
 #endif
 
-// C++11 override
-#if defined(_MSC_VER) || (defined(__GNUC__) && (__GNUC__ >= 5)) \
-    || (defined(__clang__) && (defined (__cplusplus)) && (__cplusplus >= 201103L)) \
-    || defined(__CPPCHECK__)
-#  define OVERRIDE override
-#  define FINAL final
-#else
-#  define OVERRIDE
-#  define FINAL
-#endif
-
 // C++11 noexcept
 #if (defined(__GNUC__) && (__GNUC__ >= 5)) \
     || (defined(__clang__) && (defined (__cplusplus)) && (__cplusplus >= 201103L)) \

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -60,7 +60,7 @@ public:
     /**
      * @brief Destructor.
      */
-    ~CppCheck() OVERRIDE;
+    ~CppCheck() override;
 
     /**
      * @brief This starts the actual checking. Note that you must call
@@ -197,26 +197,26 @@ private:
      * "[filepath:line number] Message", e.g.
      * "[main.cpp:4] Uninitialized member variable"
      */
-    void reportErr(const ErrorMessage &msg) OVERRIDE;
+    void reportErr(const ErrorMessage &msg) override;
 
     /**
      * @brief Information about progress is directed here.
      *
      * @param outmsg Message to show, e.g. "Checking main.cpp..."
      */
-    void reportOut(const std::string &outmsg, Color c = Color::Reset) OVERRIDE;
+    void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
 
-    void bughuntingReport(const std::string &str) OVERRIDE;
+    void bughuntingReport(const std::string &str) override;
 
     std::list<std::string> mErrorList;
     Settings mSettings;
 
-    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) OVERRIDE;
+    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;
 
     /**
      * Output information messages.
      */
-    void reportInfo(const ErrorMessage &msg) OVERRIDE;
+    void reportInfo(const ErrorMessage &msg) override;
 
     ErrorLogger &mErrorLogger;
 

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -54,7 +54,7 @@ namespace CTU {
     public:
         enum class InvalidValueType { null, uninit, bufferOverflow };
 
-        std::string toString() const OVERRIDE;
+        std::string toString() const override;
 
         struct Location {
             Location() = default;

--- a/lib/exprengine.cpp
+++ b/lib/exprengine.cpp
@@ -419,10 +419,10 @@ namespace {
         int recursion;
         std::time_t startTime;
 
-        bool isC() const OVERRIDE {
+        bool isC() const override {
             return tokenizer->isC();
         }
-        bool isCPP() const OVERRIDE {
+        bool isCPP() const override {
             return tokenizer->isCPP();
         }
 
@@ -492,7 +492,7 @@ namespace {
             }
         }
 
-        std::string getNewSymbolName() FINAL {
+        std::string getNewSymbolName() final {
             return "$" + std::to_string(++(*symbolValueIndex));
         }
 
@@ -651,7 +651,7 @@ namespace {
                          CWE cwe,
                          bool inconclusive,
                          bool incomplete,
-                         const std::string &functionName) OVERRIDE {
+                         const std::string &functionName) override {
             if (errorPath.empty())
                 mTrackExecution->addError(tok->linenr());
 

--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -131,12 +131,12 @@ namespace ExprEngine {
     class UninitValue : public Value {
     public:
         UninitValue() : Value("?", ValueType::UninitValue) {}
-        bool isEqual(const DataBase *dataBase, int value) const OVERRIDE {
+        bool isEqual(const DataBase *dataBase, int value) const override {
             (void)dataBase;
             (void)value;
             return true;
         }
-        bool isUninit(const DataBase *dataBase) const OVERRIDE;
+        bool isUninit(const DataBase *dataBase) const override;
     };
 
     class IntRange : public Value {
@@ -146,14 +146,14 @@ namespace ExprEngine {
             , minValue(minValue)
             , maxValue(maxValue)
             , loopScope(nullptr) {}
-        std::string getRange() const OVERRIDE {
+        std::string getRange() const override {
             if (minValue == maxValue)
                 return str(minValue);
             return str(minValue) + ":" + str(maxValue);
         }
-        bool isEqual(const DataBase *dataBase, int value) const OVERRIDE;
-        bool isGreaterThan(const DataBase *dataBase, int value) const OVERRIDE;
-        bool isLessThan(const DataBase *dataBase, int value) const OVERRIDE;
+        bool isEqual(const DataBase *dataBase, int value) const override;
+        bool isGreaterThan(const DataBase *dataBase, int value) const override;
+        bool isLessThan(const DataBase *dataBase, int value) const override;
 
         int128_t minValue;
         int128_t maxValue;
@@ -167,13 +167,13 @@ namespace ExprEngine {
             , minValue(minValue)
             , maxValue(maxValue) {}
 
-        std::string getRange() const OVERRIDE {
+        std::string getRange() const override {
             return std::to_string(minValue) + ":" + std::to_string(maxValue);
         }
 
-        bool isEqual(const DataBase *dataBase, int value) const OVERRIDE;
-        bool isGreaterThan(const DataBase *dataBase, int value) const OVERRIDE;
-        bool isLessThan(const DataBase *dataBase, int value) const OVERRIDE;
+        bool isEqual(const DataBase *dataBase, int value) const override;
+        bool isGreaterThan(const DataBase *dataBase, int value) const override;
+        bool isLessThan(const DataBase *dataBase, int value) const override;
 
         long double minValue;
         long double maxValue;
@@ -185,7 +185,7 @@ namespace ExprEngine {
 
         ConditionalValue(const std::string &name, const Vector &values) : Value(name, ValueType::ConditionalValue), values(values) {}
 
-        std::string getSymbolicExpression() const OVERRIDE;
+        std::string getSymbolicExpression() const override;
 
         Vector values;
     };
@@ -199,8 +199,8 @@ namespace ExprEngine {
         ArrayValue(DataBase *data, const Variable *var);
         ArrayValue(const std::string &name, const ArrayValue &arrayValue);
 
-        std::string getRange() const OVERRIDE;
-        std::string getSymbolicExpression() const OVERRIDE;
+        std::string getRange() const override;
+        std::string getSymbolicExpression() const override;
 
         void assign(ValuePtr index, ValuePtr value);
         void clear();
@@ -222,7 +222,7 @@ namespace ExprEngine {
     public:
         StringLiteralValue(const std::string &name, const std::string &s) : Value(name, ValueType::StringLiteralValue), string(s) {}
 
-        std::string getRange() const OVERRIDE {
+        std::string getRange() const override {
             return "\"" + string + "\"";
         }
 
@@ -236,9 +236,9 @@ namespace ExprEngine {
     public:
         explicit StructValue(const std::string &name) : Value(name, ValueType::StructValue) {}
 
-        std::string getSymbolicExpression() const OVERRIDE;
+        std::string getSymbolicExpression() const override;
 
-        std::string getRange() const OVERRIDE {
+        std::string getRange() const override {
             return getSymbolicExpression();
         }
 
@@ -265,7 +265,7 @@ namespace ExprEngine {
             , varId(varId)
         {}
 
-        std::string getRange() const OVERRIDE {
+        std::string getRange() const override {
             return "&@" + std::to_string(varId);
         }
 
@@ -280,9 +280,9 @@ namespace ExprEngine {
             , op1(op1)
             , op2(op2) {}
 
-        bool isEqual(const DataBase *dataBase, int value) const OVERRIDE;
-        bool isGreaterThan(const DataBase *dataBase, int value) const OVERRIDE;
-        virtual bool isLessThan(const DataBase *dataBase, int value) const OVERRIDE;
+        bool isEqual(const DataBase *dataBase, int value) const override;
+        bool isGreaterThan(const DataBase *dataBase, int value) const override;
+        virtual bool isLessThan(const DataBase *dataBase, int value) const override;
         bool isTrue(const DataBase *dataBase) const;
 
         std::string getExpr(DataBase *dataBase) const;
@@ -306,7 +306,7 @@ namespace ExprEngine {
             , bits(bits)
             , sign(sign) {}
 
-        std::string getSymbolicExpression() const OVERRIDE;
+        std::string getSymbolicExpression() const override;
 
         ExprEngine::ValuePtr inputValue;
         int bits;
@@ -326,10 +326,10 @@ namespace ExprEngine {
     class BailoutValue : public Value {
     public:
         BailoutValue() : Value("bailout", ValueType::BailoutValue) {}
-        bool isEqual(const DataBase * /*dataBase*/, int /*value*/) const OVERRIDE {
+        bool isEqual(const DataBase * /*dataBase*/, int /*value*/) const override {
             return true;
         }
-        bool isUninit(const DataBase *dataBase) const OVERRIDE {
+        bool isUninit(const DataBase *dataBase) const override {
             (void)dataBase;
             return true;
         }

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -59,7 +59,7 @@ public:
     TimerResults() {}
 
     void showResults(SHOWTIME_MODES mode) const;
-    void addResults(const std::string& str, std::clock_t clocks) OVERRIDE;
+    void addResults(const std::string& str, std::clock_t clocks) override;
 
 private:
     std::map<std::string, struct TimerResultsData> mResults;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2351,7 +2351,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return Action::None;
     }
 
-    virtual Action analyze(const Token* tok, Direction d) const OVERRIDE {
+    virtual Action analyze(const Token* tok, Direction d) const override {
         if (invalid())
             return Action::Invalid;
         // Follow references
@@ -2379,7 +2379,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return Action::None;
     }
 
-    virtual std::vector<MathLib::bigint> evaluate(Evaluate e, const Token* tok, const Token* ctx = nullptr) const OVERRIDE
+    virtual std::vector<MathLib::bigint> evaluate(Evaluate e, const Token* tok, const Token* ctx = nullptr) const override
     {
         if (e == Evaluate::Integral) {
             if (tok->hasKnownIntValue())
@@ -2416,7 +2416,7 @@ struct ValueFlowAnalyzer : Analyzer {
         }
     }
 
-    virtual void assume(const Token* tok, bool state, unsigned int flags) OVERRIDE {
+    virtual void assume(const Token* tok, bool state, unsigned int flags) override {
         // Update program state
         pms.removeModifiedVars(tok);
         pms.addState(tok, getProgramState());
@@ -2458,7 +2458,7 @@ struct ValueFlowAnalyzer : Analyzer {
         assert(false && "Internal update unimplemented.");
     }
 
-    virtual void update(Token* tok, Action a, Direction d) OVERRIDE {
+    virtual void update(Token* tok, Action a, Direction d) override {
         ValueFlow::Value* value = getValue(tok);
         if (!value)
             return;
@@ -2484,7 +2484,7 @@ struct ValueFlowAnalyzer : Analyzer {
             setTokenValue(tok, *value, getSettings());
     }
 
-    virtual ValuePtr<Analyzer> reanalyze(Token*, const std::string&) const OVERRIDE {
+    virtual ValuePtr<Analyzer> reanalyze(Token*, const std::string&) const override {
         return {};
     }
 };
@@ -2508,18 +2508,18 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return aliases;
     }
 
-    virtual const ValueFlow::Value* getValue(const Token*) const OVERRIDE {
+    virtual const ValueFlow::Value* getValue(const Token*) const override {
         return &value;
     }
-    virtual ValueFlow::Value* getValue(const Token*) OVERRIDE {
+    virtual ValueFlow::Value* getValue(const Token*) override {
         return &value;
     }
 
-    virtual void makeConditional() OVERRIDE {
+    virtual void makeConditional() override {
         value.conditional = true;
     }
 
-    virtual bool useSymbolicValues() const OVERRIDE
+    virtual bool useSymbolicValues() const override
     {
         if (value.isUninitValue())
             return false;
@@ -2528,11 +2528,11 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return true;
     }
 
-    virtual void addErrorPath(const Token* tok, const std::string& s) OVERRIDE {
+    virtual void addErrorPath(const Token* tok, const std::string& s) override {
         value.errorPath.emplace_back(tok, s);
     }
 
-    virtual bool isAlias(const Token* tok, bool& inconclusive) const OVERRIDE {
+    virtual bool isAlias(const Token* tok, bool& inconclusive) const override {
         if (value.isLifetimeValue())
             return false;
         for (const auto& m: {
@@ -2550,7 +2550,7 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool isGlobal() const OVERRIDE {
+    virtual bool isGlobal() const override {
         for (const auto&p:getVars()) {
             const Variable* var = p.second;
             if (!var->isLocal() && !var->isArgument() && !var->isConst())
@@ -2559,20 +2559,20 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool lowerToPossible() OVERRIDE {
+    virtual bool lowerToPossible() override {
         if (value.isImpossible())
             return false;
         value.changeKnownToPossible();
         return true;
     }
-    virtual bool lowerToInconclusive() OVERRIDE {
+    virtual bool lowerToInconclusive() override {
         if (value.isImpossible())
             return false;
         value.setInconclusive();
         return true;
     }
 
-    virtual bool isConditional() const OVERRIDE {
+    virtual bool isConditional() const override {
         if (value.conditional)
             return true;
         if (value.condition)
@@ -2580,7 +2580,7 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool stopOnCondition(const Token* condTok) const OVERRIDE
+    virtual bool stopOnCondition(const Token* condTok) const override
     {
         if (value.isNonValue())
             return false;
@@ -2594,7 +2594,7 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return cs.isUnknownDependent();
     }
 
-    virtual bool updateScope(const Token* endBlock, bool) const OVERRIDE {
+    virtual bool updateScope(const Token* endBlock, bool) const override {
         const Scope* scope = endBlock->scope();
         if (!scope)
             return false;
@@ -2617,7 +2617,7 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual ValuePtr<Analyzer> reanalyze(Token* tok, const std::string& msg) const OVERRIDE {
+    virtual ValuePtr<Analyzer> reanalyze(Token* tok, const std::string& msg) const override {
         ValueFlow::Value newValue = value;
         newValue.errorPath.emplace_back(tok, msg);
         return makeAnalyzer(tok, newValue, tokenlist);
@@ -2687,29 +2687,29 @@ struct ExpressionAnalyzer : SingleValueFlowAnalyzer {
         });
     }
 
-    virtual bool invalid() const OVERRIDE {
+    virtual bool invalid() const override {
         return unknown;
     }
 
-    virtual ProgramState getProgramState() const OVERRIDE {
+    virtual ProgramState getProgramState() const override {
         ProgramState ps;
         ps[expr] = value;
         return ps;
     }
 
-    virtual bool match(const Token* tok) const OVERRIDE {
+    virtual bool match(const Token* tok) const override {
         return tok->exprId() == expr->exprId();
     }
 
-    virtual bool dependsOnThis() const OVERRIDE {
+    virtual bool dependsOnThis() const override {
         return dependOnThis;
     }
 
-    virtual bool isGlobal() const OVERRIDE {
+    virtual bool isGlobal() const override {
         return !local;
     }
 
-    virtual bool isVariable() const OVERRIDE {
+    virtual bool isVariable() const override {
         return expr->varId() > 0;
     }
 };
@@ -2723,7 +2723,7 @@ struct OppositeExpressionAnalyzer : ExpressionAnalyzer {
         : ExpressionAnalyzer(e, val, t), isNot(pIsNot)
     {}
 
-    virtual bool match(const Token* tok) const OVERRIDE {
+    virtual bool match(const Token* tok) const override {
         return isOppositeCond(isNot, isCPP(), expr, tok, getSettings()->library, true, true);
     }
 };
@@ -2740,28 +2740,28 @@ struct SubExpressionAnalyzer : ExpressionAnalyzer {
 
     virtual bool submatch(const Token* tok, bool exact = true) const = 0;
 
-    virtual bool isAlias(const Token* tok, bool& inconclusive) const OVERRIDE
+    virtual bool isAlias(const Token* tok, bool& inconclusive) const override
     {
         if (tok->exprId() == expr->exprId() && tok->astParent() && submatch(tok->astParent(), false))
             return false;
         return ExpressionAnalyzer::isAlias(tok, inconclusive);
     }
 
-    virtual bool match(const Token* tok) const OVERRIDE
+    virtual bool match(const Token* tok) const override
     {
         return tok->astOperand1() && tok->astOperand1()->exprId() == expr->exprId() && submatch(tok);
     }
-    virtual bool internalMatch(const Token* tok) const OVERRIDE
+    virtual bool internalMatch(const Token* tok) const override
     {
         return tok->exprId() == expr->exprId() && !(astIsLHS(tok) && submatch(tok->astParent(), false));
     }
-    virtual void internalUpdate(Token* tok, const ValueFlow::Value& v, Direction) OVERRIDE
+    virtual void internalUpdate(Token* tok, const ValueFlow::Value& v, Direction) override
     {
         partialReads->push_back(std::make_pair(tok, v));
     }
 
     // No reanalysis for subexression
-    virtual ValuePtr<Analyzer> reanalyze(Token*, const std::string&) const OVERRIDE {
+    virtual ValuePtr<Analyzer> reanalyze(Token*, const std::string&) const override {
         return {};
     }
 };
@@ -2774,7 +2774,7 @@ struct MemberExpressionAnalyzer : SubExpressionAnalyzer {
         : SubExpressionAnalyzer(e, val, t), varname(std::move(varname))
     {}
 
-    virtual bool submatch(const Token* tok, bool exact) const OVERRIDE
+    virtual bool submatch(const Token* tok, bool exact) const override
     {
         if (!Token::Match(tok, ". %var%"))
             return false;
@@ -4789,11 +4789,11 @@ struct SymbolicInferModel : InferModel {
     explicit SymbolicInferModel(const Token* tok) : expr(tok) {
         assert(expr->exprId() != 0);
     }
-    virtual bool match(const ValueFlow::Value& value) const OVERRIDE
+    virtual bool match(const ValueFlow::Value& value) const override
     {
         return value.isSymbolicValue() && value.tokvalue && value.tokvalue->exprId() == expr->exprId();
     }
-    virtual ValueFlow::Value yield(MathLib::bigint value) const OVERRIDE
+    virtual ValueFlow::Value yield(MathLib::bigint value) const override
     {
         ValueFlow::Value result(value);
         result.valueType = ValueFlow::Value::ValueType::SYMBOLIC;
@@ -5711,7 +5711,7 @@ struct SimpleConditionHandler : ConditionHandler {
                                      const Token* exprTok,
                                      const std::list<ValueFlow::Value>& values,
                                      TokenList* tokenlist,
-                                     const Settings* settings) const OVERRIDE {
+                                     const Settings* settings) const override {
         return valueFlowForward(start->next(), stop, exprTok, values, tokenlist, settings);
     }
 
@@ -5719,7 +5719,7 @@ struct SimpleConditionHandler : ConditionHandler {
                                      const Token* exprTok,
                                      const std::list<ValueFlow::Value>& values,
                                      TokenList* tokenlist,
-                                     const Settings* settings) const OVERRIDE {
+                                     const Settings* settings) const override {
         return valueFlowForward(top, exprTok, values, tokenlist, settings);
     }
 
@@ -5728,11 +5728,11 @@ struct SimpleConditionHandler : ConditionHandler {
                          const Token* exprTok,
                          const std::list<ValueFlow::Value>& values,
                          TokenList* tokenlist,
-                         const Settings* settings) const OVERRIDE {
+                         const Settings* settings) const override {
         return valueFlowReverse(start, endToken, exprTok, values, tokenlist, settings);
     }
 
-    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const OVERRIDE {
+    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const override {
         Condition cond;
         ValueFlow::Value true_value;
         ValueFlow::Value false_value;
@@ -5770,10 +5770,10 @@ struct SimpleConditionHandler : ConditionHandler {
 };
 
 struct IntegralInferModel : InferModel {
-    virtual bool match(const ValueFlow::Value& value) const OVERRIDE {
+    virtual bool match(const ValueFlow::Value& value) const override {
         return value.isIntValue();
     }
-    virtual ValueFlow::Value yield(MathLib::bigint value) const OVERRIDE
+    virtual ValueFlow::Value yield(MathLib::bigint value) const override
     {
         ValueFlow::Value result(value);
         result.valueType = ValueFlow::Value::ValueType::INT;
@@ -5812,10 +5812,10 @@ ValueFlow::Value inferCondition(std::string op, MathLib::bigint val, const Token
 
 struct IteratorInferModel : InferModel {
     virtual ValueFlow::Value::ValueType getType() const = 0;
-    virtual bool match(const ValueFlow::Value& value) const OVERRIDE {
+    virtual bool match(const ValueFlow::Value& value) const override {
         return value.valueType == getType();
     }
-    virtual ValueFlow::Value yield(MathLib::bigint value) const OVERRIDE
+    virtual ValueFlow::Value yield(MathLib::bigint value) const override
     {
         ValueFlow::Value result(value);
         result.valueType = getType();
@@ -5825,13 +5825,13 @@ struct IteratorInferModel : InferModel {
 };
 
 struct EndIteratorInferModel : IteratorInferModel {
-    virtual ValueFlow::Value::ValueType getType() const OVERRIDE {
+    virtual ValueFlow::Value::ValueType getType() const override {
         return ValueFlow::Value::ValueType::ITERATOR_END;
     }
 };
 
 struct StartIteratorInferModel : IteratorInferModel {
-    virtual ValueFlow::Value::ValueType getType() const OVERRIDE {
+    virtual ValueFlow::Value::ValueType getType() const override {
         return ValueFlow::Value::ValueType::ITERATOR_END;
     }
 };
@@ -5877,7 +5877,7 @@ static void valueFlowInferCondition(TokenList* tokenlist,
 }
 
 struct SymbolicConditionHandler : SimpleConditionHandler {
-    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const OVERRIDE
+    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const override
     {
         if (!Token::Match(tok, "%comp%"))
             return {};
@@ -6184,7 +6184,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return vars;
     }
 
-    virtual const ValueFlow::Value* getValue(const Token* tok) const OVERRIDE {
+    virtual const ValueFlow::Value* getValue(const Token* tok) const override {
         if (tok->varId() == 0)
             return nullptr;
         auto it = values.find(tok->varId());
@@ -6192,7 +6192,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
             return nullptr;
         return &it->second;
     }
-    virtual ValueFlow::Value* getValue(const Token* tok) OVERRIDE {
+    virtual ValueFlow::Value* getValue(const Token* tok) override {
         if (tok->varId() == 0)
             return nullptr;
         auto it = values.find(tok->varId());
@@ -6201,19 +6201,19 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return &it->second;
     }
 
-    virtual void makeConditional() OVERRIDE {
+    virtual void makeConditional() override {
         for (auto&& p:values) {
             p.second.conditional = true;
         }
     }
 
-    virtual void addErrorPath(const Token* tok, const std::string& s) OVERRIDE {
+    virtual void addErrorPath(const Token* tok, const std::string& s) override {
         for (auto&& p:values) {
             p.second.errorPath.emplace_back(tok, "Assuming condition is " + s);
         }
     }
 
-    virtual bool isAlias(const Token* tok, bool& inconclusive) const OVERRIDE {
+    virtual bool isAlias(const Token* tok, bool& inconclusive) const override {
         const auto range = SelectValueFromVarIdMapRange(&values);
 
         for (const auto& p:getVars()) {
@@ -6227,11 +6227,11 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool isGlobal() const OVERRIDE {
+    virtual bool isGlobal() const override {
         return false;
     }
 
-    virtual bool lowerToPossible() OVERRIDE {
+    virtual bool lowerToPossible() override {
         for (auto&& p:values) {
             if (p.second.isImpossible())
                 return false;
@@ -6239,7 +6239,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         }
         return true;
     }
-    virtual bool lowerToInconclusive() OVERRIDE {
+    virtual bool lowerToInconclusive() override {
         for (auto&& p:values) {
             if (p.second.isImpossible())
                 return false;
@@ -6248,7 +6248,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return true;
     }
 
-    virtual bool isConditional() const OVERRIDE {
+    virtual bool isConditional() const override {
         for (auto&& p:values) {
             if (p.second.conditional)
                 return true;
@@ -6258,11 +6258,11 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool stopOnCondition(const Token*) const OVERRIDE {
+    virtual bool stopOnCondition(const Token*) const override {
         return isConditional();
     }
 
-    virtual bool updateScope(const Token* endBlock, bool) const OVERRIDE {
+    virtual bool updateScope(const Token* endBlock, bool) const override {
         const Scope* scope = endBlock->scope();
         if (!scope)
             return false;
@@ -6296,11 +6296,11 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return false;
     }
 
-    virtual bool match(const Token* tok) const OVERRIDE {
+    virtual bool match(const Token* tok) const override {
         return values.count(tok->varId()) > 0;
     }
 
-    virtual ProgramState getProgramState() const OVERRIDE {
+    virtual ProgramState getProgramState() const override {
         ProgramState ps;
         for (const auto& p : values) {
             const Variable* var = vars.at(p.first);
@@ -6309,7 +6309,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return ps;
     }
 
-    virtual void forkScope(const Token* endBlock) OVERRIDE {
+    virtual void forkScope(const Token* endBlock) override {
         ProgramMemory pm{getProgramState()};
         const Scope* scope = endBlock->scope();
         const Token* condTok = getCondTokFromEnd(endBlock);
@@ -6981,11 +6981,11 @@ struct ContainerExpressionAnalyzer : ExpressionAnalyzer {
         : ExpressionAnalyzer(expr, val, t)
     {}
 
-    virtual bool match(const Token* tok) const OVERRIDE {
+    virtual bool match(const Token* tok) const override {
         return tok->exprId() == expr->exprId() || (astIsIterator(tok) && isAliasOf(tok, expr->exprId()));
     }
 
-    virtual Action isWritable(const Token* tok, Direction d) const OVERRIDE {
+    virtual Action isWritable(const Token* tok, Direction d) const override {
         if (astIsIterator(tok))
             return Action::None;
         if (d == Direction::Reverse)
@@ -7021,7 +7021,7 @@ struct ContainerExpressionAnalyzer : ExpressionAnalyzer {
         return Action::None;
     }
 
-    virtual void writeValue(ValueFlow::Value* val, const Token* tok, Direction d) const OVERRIDE {
+    virtual void writeValue(ValueFlow::Value* val, const Token* tok, Direction d) const override {
         if (d == Direction::Reverse)
             return;
         if (!val)
@@ -7056,7 +7056,7 @@ struct ContainerExpressionAnalyzer : ExpressionAnalyzer {
         }
     }
 
-    virtual Action isModified(const Token* tok) const OVERRIDE {
+    virtual Action isModified(const Token* tok) const override {
         Action read = Action::Read;
         // An iterator won't change the container size
         if (astIsIterator(tok))
@@ -7281,7 +7281,7 @@ static std::list<ValueFlow::Value> getIteratorValues(std::list<ValueFlow::Value>
 }
 
 struct IteratorConditionHandler : SimpleConditionHandler {
-    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const OVERRIDE {
+    virtual std::vector<Condition> parse(const Token* tok, const Settings*) const override {
         Condition cond;
 
         ValueFlow::Value true_value;
@@ -7493,7 +7493,7 @@ struct ContainerConditionHandler : ConditionHandler {
                                      const Token* exprTok,
                                      const std::list<ValueFlow::Value>& values,
                                      TokenList* tokenlist,
-                                     const Settings*) const OVERRIDE {
+                                     const Settings*) const override {
         Analyzer::Result result{};
         for (const ValueFlow::Value& value : values)
             result.update(valueFlowContainerForward(start->next(), stop, exprTok, value, tokenlist));
@@ -7504,7 +7504,7 @@ struct ContainerConditionHandler : ConditionHandler {
                                      const Token* exprTok,
                                      const std::list<ValueFlow::Value>& values,
                                      TokenList* tokenlist,
-                                     const Settings*) const OVERRIDE {
+                                     const Settings*) const override {
         Analyzer::Result result{};
         for (const ValueFlow::Value& value : values)
             result.update(valueFlowContainerForwardRecursive(top, exprTok, value, tokenlist));
@@ -7516,11 +7516,11 @@ struct ContainerConditionHandler : ConditionHandler {
                          const Token* exprTok,
                          const std::list<ValueFlow::Value>& values,
                          TokenList* tokenlist,
-                         const Settings* settings) const OVERRIDE {
+                         const Settings* settings) const override {
         return valueFlowContainerReverse(start, endTok, exprTok, values, tokenlist, settings);
     }
 
-    virtual std::vector<Condition> parse(const Token* tok, const Settings* settings) const OVERRIDE
+    virtual std::vector<Condition> parse(const Token* tok, const Settings* settings) const override
     {
         Condition cond;
         ValueFlow::Value true_value;

--- a/oss-fuzz/main.cpp
+++ b/oss-fuzz/main.cpp
@@ -37,20 +37,20 @@ public:
         cppcheck.check("test.cpp", code);
     }
 
-    void reportOut(const std::string &outmsg, Color) OVERRIDE {
+    void reportOut(const std::string &outmsg, Color) override {
         (void)outmsg;
     }
-    void reportErr(const ErrorMessage &msg) OVERRIDE {
+    void reportErr(const ErrorMessage &msg) override {
         (void)msg;
     }
     void reportProgress(const std::string& filename,
                         const char stage[],
-                        const std::size_t value) OVERRIDE {
+                        const std::size_t value) override {
         (void)filename;
         (void)stage;
         (void)value;
     }
-    void bughuntingReport(const std::string &str) OVERRIDE {
+    void bughuntingReport(const std::string &str) override {
         (void)str;
     }
 };

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -18,7 +18,6 @@
 
 
 #include "check64bit.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -33,7 +33,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::portability);
 
         TEST_CASE(novardecl);

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkassert.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -49,7 +49,7 @@ private:
         checkAssert.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
 
         TEST_CASE(assignmentInAssert);

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -18,7 +18,6 @@
 
 
 #include "astutils.h"
-#include "config.h"
 #include "library.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -35,7 +35,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(findLambdaEndTokenTest);
         TEST_CASE(findLambdaStartTokenTest);
         TEST_CASE(isNullOperandTest);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkautovariables.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -49,7 +49,7 @@ private:
         checkAutoVariables.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::style);
         LOAD_LIB_2(settings.library, "std.cfg");

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkbool.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -33,7 +33,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::warning);
         settings.certainty.enable(Certainty::inconclusive);

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -33,7 +33,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::performance);
 

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkboost.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -116,7 +116,7 @@ private:
         checkBufferOverrun.runChecks(&tokenizer, settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings0.library, "std.cfg");
 
         settings0.severity.enable(Severity::warning);

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -19,7 +19,6 @@
 
 #include "check.h"
 #include "checkbufferoverrun.h"
-#include "config.h"
 #include "ctu.h"
 #include "errortypes.h"
 #include "standards.h"

--- a/test/testbughuntingchecks.cpp
+++ b/test/testbughuntingchecks.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "errortypes.h"
 #include "exprengine.h"
 #include "library.h"

--- a/test/testbughuntingchecks.cpp
+++ b/test/testbughuntingchecks.cpp
@@ -36,7 +36,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
 #ifdef USE_Z3
         settings.certainty.setEnabled(Certainty::inconclusive, true);
         LOAD_LIB_2(settings.library, "std.cfg");

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -34,7 +34,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.platform(Settings::Unspecified);
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::portability);

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkother.h"
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "clangimport.h"
-#include "config.h"
 #include "platform.h"
 #include "settings.h"
 #include "symboldatabase.h"

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -38,7 +38,7 @@ public:
 
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(breakStmt);
         TEST_CASE(callExpr);
         TEST_CASE(caseStmt1);

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -18,7 +18,6 @@
 
 #include "check.h"
 #include "checkclass.h"
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -41,7 +41,7 @@ private:
     Settings settings0;
     Settings settings1;
 
-    void run() OVERRIDE {
+    void run() override {
         settings0.severity.enable(Severity::style);
         settings1.severity.enable(Severity::warning);
 

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -42,7 +42,7 @@ private:
     Settings settings;
     CmdLineParser defParser;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(nooptions);
         TEST_CASE(helpshort);
         TEST_CASE(helplong);

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "cmdlineparser.h"
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "redirect.h"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkcondition.h"
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "platform.h"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -44,7 +44,7 @@ private:
     Settings settings0;
     Settings settings1;
 
-    void run() OVERRIDE {
+    void run() override {
         // known platform..
         settings0.platform(cppcheck::Platform::PlatformType::Native);
         settings1.platform(cppcheck::Platform::PlatformType::Native);

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkclass.h"
-#include "config.h"
 #include "errortypes.h"
 #include "standards.h"
 #include "settings.h"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -68,7 +68,7 @@ private:
         checkClass.constructors();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::warning);
 

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -18,7 +18,6 @@
 
 #include "check.h"
 #include "color.h"
-#include "config.h"
 #include "cppcheck.h"
 #include "errorlogger.h"
 #include "testsuite.h"

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -39,15 +39,15 @@ private:
     public:
         std::list<std::string> id;
 
-        void reportOut(const std::string & /*outmsg*/, Color = Color::Reset) OVERRIDE {}
-        void bughuntingReport(const std::string & /*str*/) OVERRIDE {}
+        void reportOut(const std::string & /*outmsg*/, Color = Color::Reset) override {}
+        void bughuntingReport(const std::string & /*str*/) override {}
 
-        void reportErr(const ErrorMessage &msg) OVERRIDE {
+        void reportErr(const ErrorMessage &msg) override {
             id.push_back(msg.id);
         }
     };
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(instancesSorted);
         TEST_CASE(classInfoFormat);
         TEST_CASE(getErrorMessages);

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -38,7 +38,7 @@ private:
     const ErrorMessage::FileLocation fooCpp5;
     const ErrorMessage::FileLocation barCpp8;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(PatternSearchReplace);
         TEST_CASE(FileLocationDefaults);
         TEST_CASE(FileLocationSetFile);

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -33,7 +33,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.fill();
 
         TEST_CASE(destructors);

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkexceptionsafety.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -37,7 +37,7 @@ public:
     TestExprEngine() : TestFixture("TestExprEngine") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
 #ifdef USE_Z3
         TEST_CASE(annotation1);
         TEST_CASE(annotation2);

--- a/test/testexprengine.cpp
+++ b/test/testexprengine.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "exprengine.h"
 #include "library.h"
 #include "platform.h"

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "filelister.h"
 #include "pathmatch.h"
 #include "testsuite.h"

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -34,7 +34,7 @@ public:
         : TestFixture("TestFileLister") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         // bail out if the tests are not executed from the base folder
         {
             std::ifstream fin("test/testfilelister.cpp");

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -38,7 +38,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::performance);

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkfunctions.h"
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "check.h"
-#include "config.h"
 #include "errortypes.h"
 #include "mathlib.h"
 #include "settings.h"

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -37,7 +37,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.debugwarnings = true;
         settings.severity.fill();
         settings.certainty.fill();

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -33,7 +33,7 @@ public:
     using ImportProject::importCompileCommands;
     using ImportProject::importCppcheckGuiProject;
 
-    bool sourceFileExists(const std::string & /*file*/) OVERRIDE {
+    bool sourceFileExists(const std::string & /*file*/) override {
         return true;
     }
 };
@@ -45,7 +45,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(setDefines);
         TEST_CASE(setIncludePaths1);
         TEST_CASE(setIncludePaths2);

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "importproject.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -64,7 +64,7 @@ private:
         checkOther.checkIncompleteStatement();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
 
         TEST_CASE(test1);

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkother.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testinternal.cpp
+++ b/test/testinternal.cpp
@@ -30,7 +30,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.addEnabled("internal");
 
         TEST_CASE(simplePatternInTokenMatch);

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -35,7 +35,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
         LOAD_LIB_2(settings.library, "windows.cfg");
         LOAD_LIB_2(settings.library, "qt.cfg");

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkleakautovar.h"
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -45,7 +45,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         int id = 0;
         while (!Library::ismemory(++id));
         settings.library.setalloc("malloc", id, -1);
@@ -2312,7 +2312,7 @@ private:
         c.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(recursiveCountLimit); // #5872 #6157 #9097
@@ -2363,7 +2363,7 @@ private:
         checkLeak.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(returnedValue); // #9298
@@ -2411,7 +2411,7 @@ private:
         checkLeak.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "windows.cfg");
 
         TEST_CASE(heapDoubleFree);

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -43,7 +43,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(isCompliantValidationExpression);
         TEST_CASE(empty);
         TEST_CASE(function);

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -17,7 +17,6 @@
  */
 
 
-#include "config.h"
 #include "mathlib.h"
 #include "testsuite.h"
 

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -33,7 +33,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(isint);
         TEST_CASE(isbin);
         TEST_CASE(isdec);

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -42,7 +42,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(testFunctionReturnType);
         TEST_CASE(open);
     }
@@ -149,7 +149,7 @@ private:
     }
 
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings1.library, "std.cfg");
         LOAD_LIB_2(settings1.library, "posix.cfg");
         LOAD_LIB_2(settings2.library, "std.cfg");
@@ -491,7 +491,7 @@ private:
         (checkMemoryLeak.check)();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::style);
 
@@ -1679,7 +1679,7 @@ private:
         (checkMemoryLeakStructMember.check)();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
         LOAD_LIB_2(settings.library, "posix.cfg");
 
@@ -2184,7 +2184,7 @@ private:
         (checkMemoryLeakNoVar.check)();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.certainty.setEnabled(Certainty::inconclusive, true);
         settings.libraries.emplace_back("posix");
         settings.severity.enable(Severity::warning);

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkmemoryleak.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "symboldatabase.h"

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -44,7 +44,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
         settings.severity.enable(Severity::warning);
 

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -18,7 +18,6 @@
 
 #include "check.h"
 #include "checknullpointer.h"
-#include "config.h"
 #include "ctu.h"
 #include "errortypes.h"
 #include "library.h"

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -29,7 +29,7 @@ public:
 
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(which_test);
         TEST_CASE(which_test_method);
         TEST_CASE(no_test_method);

--- a/test/testoptions.cpp
+++ b/test/testoptions.cpp
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "config.h"
 #include "options.h"
 #include "testsuite.h"
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -46,7 +46,7 @@ public:
 private:
     Settings _settings;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(_settings.library, "std.cfg");
 
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkother.h"
-#include "config.h"
 #include "errortypes.h"
 #include "library.h"
 #include "platform.h"

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -29,7 +29,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(removeQuotationMarks);
         TEST_CASE(acceptFile);
         TEST_CASE(getCurrentPath);

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "path.h"
 #include "testsuite.h"
 

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -39,7 +39,7 @@ private:
     const PathMatch fooCppMatcher;
     const PathMatch srcFooCppMatcher;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(emptymaskemptyfile);
         TEST_CASE(emptymaskpath1);
         TEST_CASE(emptymaskpath2);

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "pathmatch.h"
 #include "testsuite.h"
 

--- a/test/testplatform.cpp
+++ b/test/testplatform.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "platform.h"
 #include "testsuite.h"
 

--- a/test/testplatform.cpp
+++ b/test/testplatform.cpp
@@ -28,7 +28,7 @@ public:
     TestPlatform() : TestFixture("TestPlatform") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(empty);
         TEST_CASE(valid_config_native_1);
         TEST_CASE(valid_config_native_2);

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -48,7 +48,7 @@ private:
         checkPostfixOperator.postfixOperator();
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::performance);
 
         TEST_CASE(testsimple);

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkpostfixoperator.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -75,7 +75,7 @@ private:
     Settings settings0;
     Preprocessor preprocessor0;
 
-    void run() OVERRIDE {
+    void run() override {
 
         // The bug that started the whole work with the new preprocessor
         TEST_CASE(Bug2190219);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -20,7 +20,6 @@
 // The preprocessor that Cppcheck uses is a bit special. Instead of generating
 // the code for a known configuration, it generates the code for each configuration.
 
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "preprocessor.h"

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -40,7 +40,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::portability);
 
         // If there are unused templates, keep those

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -17,7 +17,6 @@
  */
 
 
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -40,7 +40,7 @@ private:
     Settings settings_std;
     Settings settings_windows;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings_std.library, "std.cfg");
         LOAD_LIB_2(settings_windows.library, "windows.cfg");
         settings0.severity.enable(Severity::portability);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -17,7 +17,6 @@
  */
 
 
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -45,7 +45,7 @@ private:
     Settings settings1;
     Settings settings2;
 
-    void run() OVERRIDE {
+    void run() override {
         settings0.severity.enable(Severity::style);
         settings2.severity.enable(Severity::style);
 

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -17,7 +17,6 @@
  */
 
 
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -39,7 +39,7 @@ private:
     Settings settings1;
     Settings settings2;
 
-    void run() OVERRIDE {
+    void run() override {
         settings0.severity.enable(Severity::style);
         settings2.severity.enable(Severity::style);
 

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -38,7 +38,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::portability);
         settings.certainty.enable(Certainty::inconclusive);

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checksizeof.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkstl.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "standards.h"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -36,7 +36,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::performance);

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkstring.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -34,7 +34,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
         settings.severity.enable(Severity::style);
 

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -104,15 +104,15 @@ protected:
 
     void processOptions(const options& args);
 public:
-    void bughuntingReport(const std::string & /*str*/) OVERRIDE {}
-    void reportOut(const std::string &outmsg, Color c = Color::Reset) OVERRIDE;
-    void reportErr(const ErrorMessage &msg) OVERRIDE;
+    void bughuntingReport(const std::string & /*str*/) override {}
+    void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
+    void reportErr(const ErrorMessage &msg) override;
     void run(const std::string &str);
     static void printHelp();
     const std::string classname;
 
     explicit TestFixture(const char * const _name);
-    ~TestFixture() OVERRIDE {}
+    ~TestFixture() override {}
 
     static std::size_t runTests(const options& args);
 };

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -32,7 +32,7 @@ public:
     TestSummaries() : TestFixture("TestSummaries") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
 
         TEST_CASE(createSummaries1);
         TEST_CASE(createSummariesGlobal);

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -17,7 +17,6 @@
  */
 
 
-#include "config.h"
 #include "settings.h"
 #include "summaries.h"
 #include "testsuite.h"

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -41,7 +41,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(suppressionsBadId1);
         TEST_CASE(suppressionsDosFormat);     // Ticket #1836
         TEST_CASE(suppressionsFileNameWithColon);    // Ticket #1919 - filename includes colon

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "library.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -117,7 +117,7 @@ private:
         return nullptr;
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings1.library, "std.cfg");
         settings2.platform(Settings::Unspecified);
 

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -61,7 +61,7 @@ private:
         ASSERT_EQUALS(result, executor.check());
     }
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(deadlock_with_many_errors);

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "threadexecutor.h"

--- a/test/testtimer.cpp
+++ b/test/testtimer.cpp
@@ -29,7 +29,7 @@ public:
 
 private:
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(result);
     }
 

--- a/test/testtimer.cpp
+++ b/test/testtimer.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "testsuite.h"
 #include "timer.h"
 

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -45,7 +45,7 @@ private:
     std::vector<std::string> extendedOps;
     std::vector<std::string> assignmentOps;
 
-    void run() OVERRIDE {
+    void run() override {
         arithmeticalOps = { "+", "-", "*", "/", "%", "<<", ">>" };
         logicalOps = { "&&", "||", "!" };
         comparisonOps = { "==", "!=", "<", "<=", ">", ">=" };

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "testutils.h"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -48,7 +48,7 @@ private:
     Settings settings2;
     Settings settings_windows;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings_windows.library, "windows.cfg");
 
         // If there are unused templates, keep those

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -32,7 +32,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(testaddtoken1);
         TEST_CASE(testaddtoken2);
         TEST_CASE(inc);

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -37,7 +37,7 @@ public:
     TestTokenRange() : TestFixture("TestTokenRange") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(enumerationToEnd);
         TEST_CASE(untilHelperToEnd);
         TEST_CASE(untilHelperPartWay);

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "settings.h"
 #include "testsuite.h"
 #include "token.h"

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checktype.h"
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -35,7 +35,7 @@ public:
 private:
 
 
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(checkTooBigShift_Unix32);
         TEST_CASE(checkIntegerOverflow);
         TEST_CASE(signConversion);

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -38,7 +38,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(uninitvar1);

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -18,7 +18,6 @@
 
 #include "check.h"
 #include "checkuninitvar.h"
-#include "config.h"
 #include "ctu.h"
 #include "errortypes.h"
 #include "library.h"

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkunusedfunctions.h"
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -34,7 +34,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
 
         TEST_CASE(incondition);

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkclass.h"
-#include "config.h"
 #include "errortypes.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -39,7 +39,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
 
         TEST_CASE(test1);

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "checkunusedvar.h"
-#include "config.h"
 #include "errortypes.h"
 #include "preprocessor.h"
 #include "settings.h"

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -35,7 +35,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::style);
         settings.severity.enable(Severity::information);
         settings.checkLibrary = true;

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -27,7 +27,7 @@ public:
     TestUtils() : TestFixture("TestUtils") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(isValidGlobPattern);
         TEST_CASE(matchglob);
     }

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -58,10 +58,10 @@ class SimpleSuppressor : public ErrorLogger {
 public:
     SimpleSuppressor(Settings &settings, ErrorLogger *next)
         : settings(settings), next(next) {}
-    void reportOut(const std::string &outmsg, Color = Color::Reset) OVERRIDE {
+    void reportOut(const std::string &outmsg, Color = Color::Reset) override {
         next->reportOut(outmsg);
     }
-    void reportErr(const ErrorMessage &msg) OVERRIDE {
+    void reportErr(const ErrorMessage &msg) override {
         if (!msg.callStack.empty() && !settings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage()))
             next->reportErr(msg);
     }

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -20,7 +20,6 @@
 #define TestUtilsH
 
 #include "color.h"
-#include "config.h"
 #include "errorlogger.h"
 #include "settings.h"
 #include "suppressions.h"

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -48,7 +48,7 @@ private:
         checkVaarg.runChecks(&tokenizer, &settings, this);
     }
 
-    void run() OVERRIDE {
+    void run() override {
         settings.severity.enable(Severity::warning);
 
         TEST_CASE(wrongParameterTo_va_start);

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -18,7 +18,6 @@
 
 
 #include "checkvaarg.h"
-#include "config.h"
 #include "errortypes.h"
 #include "settings.h"
 #include "testsuite.h"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "library.h"
 #include "mathlib.h"
 #include "platform.h"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -50,7 +50,7 @@ public:
 private:
     Settings settings;
 
-    void run() OVERRIDE {
+    void run() override {
         // strcpy, abort cfg
         const char cfg[] = "<?xml version=\"1.0\"?>\n"
                            "<def>\n"

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "config.h"
 #include "mathlib.h"
 #include "platform.h"
 #include "settings.h"

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -36,7 +36,7 @@ public:
     TestVarID() : TestFixture("TestVarID") {}
 
 private:
-    void run() OVERRIDE {
+    void run() override {
         TEST_CASE(varid1);
         TEST_CASE(varid2);
         TEST_CASE(varid3);


### PR DESCRIPTION
We have been using `override` directly in the GUI code ever since. Also with not having to support GCC 4.6 anymore this should probably not be an issue since GCC 4.8 will support all the c++11 stuff just fine.