### PR TITLE
more copyright fixes

### DIFF
--- a/gui/cppcheck_de.ts
+++ b/gui/cppcheck_de.ts
@@ -21,7 +21,7 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation>Copyright © 2007-%1 Cppcheck-Team.</translation>
     </message>
     <message>

--- a/gui/cppcheck_es.ts
+++ b/gui/cppcheck_es.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 el equipo de cppcheck.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright © 2007-2021 el equipo de cppcheck.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_fi.ts
+++ b/gui/cppcheck_fi.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright (C) 2007-2019 Daniel Marjamäki ja cppcheck tiimi.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright (C) 2007-2021 Daniel Marjamäki ja cppcheck tiimi.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_fr.ts
+++ b/gui/cppcheck_fr.ts
@@ -33,7 +33,7 @@ General Public License version 3</translation>
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_it.ts
+++ b/gui/cppcheck_it.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 il team Cppcheck.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright © 2007-2021 il team Cppcheck.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_ja.ts
+++ b/gui/cppcheck_ja.ts
@@ -21,7 +21,7 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation>Copyright © 2007-%1 Cppcheck team.</translation>
     </message>
     <message>

--- a/gui/cppcheck_ko.ts
+++ b/gui/cppcheck_ko.ts
@@ -33,7 +33,7 @@ of the GNU General Public License version 3</source>
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_nl.ts
+++ b/gui/cppcheck_nl.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 het cppcheck team.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright © 2007-2021 het cppcheck team.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_ru.ts
+++ b/gui/cppcheck_ru.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 Cppcheck team.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright © 2007-2021 Cppcheck team.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_sr.ts
+++ b/gui/cppcheck_sr.ts
@@ -21,7 +21,7 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/gui/cppcheck_sv.ts
+++ b/gui/cppcheck_sv.ts
@@ -21,8 +21,8 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
-        <translation type="unfinished">Copyright © 2007-2019 Cppcheck team.</translation>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
+        <translation type="unfinished">Copyright © 2007-2021 Cppcheck team.</translation>
     </message>
     <message>
         <location filename="about.ui" line="91"/>

--- a/gui/cppcheck_zh_CN.ts
+++ b/gui/cppcheck_zh_CN.ts
@@ -21,7 +21,7 @@
     <message>
         <location filename="about.ui" line="81"/>
         <source>Copyright © 2007-%1 Cppcheck team.</source>
-        <oldsource>Copyright © 2007-2019 Cppcheck team.</oldsource>
+        <oldsource>Copyright © 2007-2021 Cppcheck team.</oldsource>
         <translation>版权所有 © 2007-%1 Cppcheck 团队。</translation>
     </message>
     <message>

--- a/gui/test/benchmark/simple/benchmarksimple.cpp
+++ b/gui/test/benchmark/simple/benchmarksimple.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/benchmark/simple/benchmarksimple.h
+++ b/gui/test/benchmark/simple/benchmarksimple.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/data/benchmark/simple.cpp
+++ b/gui/test/data/benchmark/simple.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/filelist/testfilelist.cpp
+++ b/gui/test/filelist/testfilelist.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/filelist/testfilelist.h
+++ b/gui/test/filelist/testfilelist.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/projectfile/testprojectfile.cpp
+++ b/gui/test/projectfile/testprojectfile.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/projectfile/testprojectfile.h
+++ b/gui/test/projectfile/testprojectfile.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/translationhandler/testtranslationhandler.cpp
+++ b/gui/test/translationhandler/testtranslationhandler.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/translationhandler/testtranslationhandler.h
+++ b/gui/test/translationhandler/testtranslationhandler.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/xmlreportv2/testxmlreportv2.cpp
+++ b/gui/test/xmlreportv2/testxmlreportv2.cpp
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gui/test/xmlreportv2/testxmlreportv2.h
+++ b/gui/test/xmlreportv2/testxmlreportv2.h
@@ -1,6 +1,6 @@
 /*
  * Cppcheck - A tool for static C/C++ code analysis
- * Copyright (C) 2007-2019 Cppcheck team.
+ * Copyright (C) 2007-2021 Cppcheck team.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/tools/extracttests.py
+++ b/tools/extracttests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Cppcheck - A tool for static C/C++ code analysis
-# Copyright (C) 2007-2019 Cppcheck team.
+# Copyright (C) 2007-2021 Cppcheck team.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Cppcheck - A tool for static C/C++ code analysis
-# Copyright (C) 2007-2019 Cppcheck team.
+# Copyright (C) 2007-2021 Cppcheck team.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tools/test_matchcompiler.py
+++ b/tools/test_matchcompiler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Cppcheck - A tool for static C/C++ code analysis
-# Copyright (C) 2007-2017 Cppcheck team.
+# Copyright (C) 2007-2021 Cppcheck team.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
I guess the translation files can just use `%1` but I have no idea how those work.

We probably also need to add more copyright headers to things like Python scripts and stuff.