### PR TITLE
Feedback from gcc 8.3 showed recommendation for the c++11 term final …

### DIFF
--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -42,7 +42,7 @@ class Settings;
  * just rewrite this class for your needs and possibly use other methods
  * from CppCheck class instead the ones used here.
  */
-class CppCheckExecutor : public ErrorLogger {
+class CppCheckExecutor FINAL : public ErrorLogger {
 public:
     /**
      * Constructor

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -128,7 +128,7 @@ private:
     // CTU
 
     /** data for multifile checking */
-    class MyFileInfo : public Check::FileInfo {
+    class MyFileInfo FINAL : public Check::FileInfo {
     public:
         /** unsafe array index usage */
         std::list<CTU::FileInfo::UnsafeUsage> unsafeArrayIndex;

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -155,7 +155,7 @@ public:
 
 
     /* multifile checking; one definition rule violations */
-    class MyFileInfo : public Check::FileInfo {
+    class MyFileInfo FINAL : public Check::FileInfo {
     public:
         struct NameLoc {
             std::string className;

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -48,7 +48,7 @@ class Tokenizer;
  * errors or places that could be improved.
  * Usage: See check() for more info.
  */
-class CPPCHECKLIB CppCheck : ErrorLogger {
+class CPPCHECKLIB CppCheck FINAL : ErrorLogger {
 public:
     /**
      * @brief Constructor.

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -50,7 +50,7 @@ namespace tinyxml2 {
 
 /** @brief Whole program analysis (ctu=Cross Translation Unit) */
 namespace CTU {
-    class CPPCHECKLIB FileInfo : public Check::FileInfo {
+    class CPPCHECKLIB FileInfo FINAL : public Check::FileInfo {
     public:
         enum class InvalidValueType { null, uninit, bufferOverflow };
 
@@ -93,7 +93,7 @@ namespace CTU {
             bool loadBaseFromXml(const tinyxml2::XMLElement *xmlElement);
         };
 
-        class FunctionCall : public CallBase {
+        class FunctionCall FINAL : public CallBase {
         public:
             std::string callArgumentExpression;
             MathLib::bigint callArgValue;
@@ -105,7 +105,7 @@ namespace CTU {
             bool loadFromXml(const tinyxml2::XMLElement *xmlElement);
         };
 
-        class NestedCall : public CallBase {
+        class NestedCall FINAL : public CallBase {
         public:
             NestedCall() = default;
 

--- a/lib/exprengine.h
+++ b/lib/exprengine.h
@@ -128,7 +128,7 @@ namespace ExprEngine {
         ValueType type;
     };
 
-    class UninitValue : public Value {
+    class UninitValue FINAL : public Value {
     public:
         UninitValue() : Value("?", ValueType::UninitValue) {}
         bool isEqual(const DataBase *dataBase, int value) const OVERRIDE {
@@ -139,7 +139,7 @@ namespace ExprEngine {
         bool isUninit(const DataBase *dataBase) const OVERRIDE;
     };
 
-    class IntRange : public Value {
+    class IntRange FINAL : public Value {
     public:
         IntRange(const std::string &name, int128_t minValue, int128_t maxValue)
             : Value(name, ValueType::IntRange)
@@ -160,7 +160,7 @@ namespace ExprEngine {
         const Scope *loopScope;
     };
 
-    class FloatRange : public Value {
+    class FloatRange FINAL : public Value {
     public:
         FloatRange(const std::string &name, long double minValue, long double maxValue)
             : Value(name, ValueType::FloatRange)
@@ -179,7 +179,7 @@ namespace ExprEngine {
         long double maxValue;
     };
 
-    class ConditionalValue : public Value {
+    class ConditionalValue FINAL : public Value {
     public:
         typedef std::vector<std::pair<ValuePtr,ValuePtr>> Vector;
 
@@ -191,7 +191,7 @@ namespace ExprEngine {
     };
 
     // Array or pointer
-    class ArrayValue : public Value {
+    class ArrayValue FINAL : public Value {
     public:
         enum { MAXSIZE = 0x7fffffff };
 
@@ -218,7 +218,7 @@ namespace ExprEngine {
         std::vector<ValuePtr> size;
     };
 
-    class StringLiteralValue : public Value {
+    class StringLiteralValue FINAL : public Value {
     public:
         StringLiteralValue(const std::string &name, const std::string &s) : Value(name, ValueType::StringLiteralValue), string(s) {}
 
@@ -232,7 +232,7 @@ namespace ExprEngine {
         const std::string string;
     };
 
-    class StructValue : public Value {
+    class StructValue FINAL : public Value {
     public:
         explicit StructValue(const std::string &name) : Value(name, ValueType::StructValue) {}
 
@@ -258,7 +258,7 @@ namespace ExprEngine {
         std::map<std::string, ValuePtr> member;
     };
 
-    class AddressOfValue : public Value {
+    class AddressOfValue FINAL : public Value {
     public:
         AddressOfValue(const std::string &name, int varId)
             : Value(name, ValueType::AddressOfValue)
@@ -272,7 +272,7 @@ namespace ExprEngine {
         int varId;
     };
 
-    class BinOpResult : public Value {
+    class BinOpResult FINAL : public Value {
     public:
         BinOpResult(const std::string &binop, ValuePtr op1, ValuePtr op2)
             : Value(getName(binop, op1, op2), ValueType::BinOpResult)
@@ -298,7 +298,7 @@ namespace ExprEngine {
         }
     };
 
-    class IntegerTruncation : public Value {
+    class IntegerTruncation FINAL : public Value {
     public:
         IntegerTruncation(const std::string &name, ValuePtr inputValue, int bits, char sign)
             : Value(name, ValueType::IntegerTruncation)
@@ -313,7 +313,7 @@ namespace ExprEngine {
         char sign;
     };
 
-    class FunctionCallArgumentValues : public Value {
+    class FunctionCallArgumentValues FINAL : public Value {
     public:
         explicit FunctionCallArgumentValues(const std::vector<ExprEngine::ValuePtr> &argValues)
             : Value("argValues", ValueType::FunctionCallArgumentValues)
@@ -323,7 +323,7 @@ namespace ExprEngine {
         const std::vector<ExprEngine::ValuePtr> argValues;
     };
 
-    class BailoutValue : public Value {
+    class BailoutValue FINAL : public Value {
     public:
         BailoutValue() : Value("bailout", ValueType::BailoutValue) {}
         bool isEqual(const DataBase * /*dataBase*/, int /*value*/) const OVERRIDE {

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -48,7 +48,7 @@ class Settings;
 /**
  * @brief Importing project settings.
  */
-class CPPCHECKLIB ImportProject {
+class CPPCHECKLIB ImportProject FINAL {
 public:
     enum class Type {
         UNKNOWN,

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1971,7 +1971,7 @@ struct ValueFlowAnalyzer : Analyzer {
 
     virtual ProgramState getProgramState() const = 0;
 
-    virtual int getIndirect(const Token* tok) const {
+    virtual int getIndirect(const Token* tok) const FINAL {
         const ValueFlow::Value* value = getValue(tok);
         if (value)
             return value->indirect;
@@ -2120,7 +2120,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return read;
     }
 
-    virtual Action isAliasModified(const Token* tok) const {
+    virtual Action isAliasModified(const Token* tok) const FINAL {
         // Lambda function call
         if (Token::Match(tok, "%var% ("))
             // TODO: Check if modified in the lambda function
@@ -2133,7 +2133,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return Action::None;
     }
 
-    virtual Action isThisModified(const Token* tok) const {
+    virtual Action isThisModified(const Token* tok) const FINAL {
         if (isThisChanged(tok, 0, getSettings(), isCPP()))
             return Action::Invalid;
         return Action::None;
@@ -2351,7 +2351,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return Action::None;
     }
 
-    virtual Action analyze(const Token* tok, Direction d) const OVERRIDE {
+    virtual Action analyze(const Token* tok, Direction d) const OVERRIDE FINAL {
         if (invalid())
             return Action::Invalid;
         // Follow references
@@ -2379,7 +2379,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return Action::None;
     }
 
-    virtual std::vector<MathLib::bigint> evaluate(Evaluate e, const Token* tok, const Token* ctx = nullptr) const OVERRIDE
+    virtual std::vector<MathLib::bigint> evaluate(Evaluate e, const Token* tok, const Token* ctx = nullptr) const OVERRIDE FINAL
     {
         if (e == Evaluate::Integral) {
             if (tok->hasKnownIntValue())
@@ -2572,7 +2572,7 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
         return true;
     }
 
-    virtual bool isConditional() const OVERRIDE {
+    virtual bool isConditional() const OVERRIDE FINAL {
         if (value.conditional)
             return true;
         if (value.condition)
@@ -6091,7 +6091,7 @@ static void valueFlowForLoop(TokenList *tokenlist, SymbolDatabase* symboldatabas
     }
 }
 
-struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
+struct MultiValueFlowAnalyzer FINAL : ValueFlowAnalyzer {
     std::unordered_map<nonneg int, ValueFlow::Value> values;
     std::unordered_map<nonneg int, const Variable*> vars;
     SymbolDatabase* symboldatabase;
@@ -6106,7 +6106,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         }
     }
 
-    virtual const std::unordered_map<nonneg int, const Variable*>& getVars() const {
+    virtual const std::unordered_map<nonneg int, const Variable*>& getVars() const FINAL {
         return vars;
     }
 
@@ -6174,7 +6174,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
         return true;
     }
 
-    virtual bool isConditional() const OVERRIDE {
+    virtual bool isConditional() const OVERRIDE FINAL {
         for (auto&& p:values) {
             if (p.second.conditional)
                 return true;
@@ -6892,7 +6892,7 @@ static bool isContainerSizeChangedByFunction(const Token* tok, const Settings* s
     return (isChanged || inconclusive);
 }
 
-struct ContainerExpressionAnalyzer : ExpressionAnalyzer {
+struct ContainerExpressionAnalyzer FINAL : ExpressionAnalyzer {
     ContainerExpressionAnalyzer() : ExpressionAnalyzer() {}
 
     ContainerExpressionAnalyzer(const Token* expr, const ValueFlow::Value& val, const TokenList* t)


### PR DESCRIPTION
…to be added to several types and methods.  Which allowed the compiler to more easily devirtualize several pointers.  After doing so showed a small performance gain of less than 0.2%, but it seemed consistent enough that I should submit a PR for it.