### PR TITLE
use the latest clang and -O2 for sanitizer jobs

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,36 +9,45 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    container:
+      image: "ubuntu:21.10"
+
     env:
       ASAN_OPTIONS: detect_stack_use_after_return=1
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
       - name: Install missing software on ubuntu
         run: |
-          sudo apt-get update
-          sudo apt-get install libz3-4 libz3-dev
+          apt-get update
+          apt-get install -y make libz3-dev libpcre3-dev
+          apt-get install -y clang-13
 
       - name: Build
         run: make -j$(nproc) cppcheck testrunner USE_Z3=yes HAVE_RULES=yes MATCHCOMPILER=yes VERIFY=1
         env:
-          CC: clang
-          CXX: clang++
-          CXXFLAGS: "-fsanitize=address -O1 -g3 -DCPPCHK_GLIBCXX_DEBUG"
+          CC: clang-13
+          CXX: clang++-13
+          CXXFLAGS: "-fsanitize=address -O2 -g3 -DCPPCHK_GLIBCXX_DEBUG"
           CPPFLAGS: "-DCHECK_INTERNAL"
 
       - name: Run tests
         run: ./testrunner
 
-# Does not work
+# TODO: re-enable - was being killed because of incresaed memory usage
 #      - name: Self check
 #        run: |
 #          ./cppcheck -q -j$(nproc) --std=c++11 --template=selfcheck -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli --inconclusive --enable=style,performance,portability,warning,internal --exception-handling --debug-warnings cli lib
 #          ./cppcheck -q -j$(nproc) --std=c++11 --template=selfcheck -D__CPPCHECK__ -DQT_VERSION=0x050000 --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=qt -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ --enable=style,performance,portability,warning,internal --exception-handling --debug-warnings gui/*.cpp
 #          ./cppcheck -q -j$(nproc) --std=c++11 --template=selfcheck -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli -Igui --inconclusive --enable=style,performance,portability,warning,internal --exception-handling --debug-warnings test/*.cpp tools
 
-# This takes too long time right now
+# TODO: This does takes too long to run
 #      - name: Bughunting lib
 #        run: ./cppcheck -D__CPPCHECK__ --bug-hunting -j$(nproc) lib
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -9,23 +9,32 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    container:
+      image: "ubuntu:21.10"
+
     env:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
       - name: Install missing software on ubuntu
         run: |
-          sudo apt-get update
-          sudo apt-get install libz3-4 libz3-dev
+          apt-get update
+          apt-get install -y make libz3-dev libpcre3-dev
+          apt-get install -y clang-13
 
       - name: Build
         run: make -j$(nproc) cppcheck testrunner USE_Z3=yes HAVE_RULES=yes MATCHCOMPILER=yes VERIFY=1
         env:
-          CC: clang
-          CXX: clang++
-          CXXFLAGS: "-fsanitize=undefined -fsanitize=nullability -fno-sanitize=signed-integer-overflow -O1 -g3 -DCPPCHK_GLIBCXX_DEBUG"
+          CC: clang-13
+          CXX: clang++-13
+          CXXFLAGS: "-fsanitize=undefined -fsanitize=nullability -fno-sanitize=signed-integer-overflow -O2 -g3 -DCPPCHK_GLIBCXX_DEBUG"
           CPPFLAGS: "-DCHECK_INTERNAL"
 
       - name: Run tests
@@ -37,7 +46,7 @@ jobs:
           ./cppcheck -q -j$(nproc) --std=c++11 --template=selfcheck -D__CPPCHECK__ -DQT_VERSION=0x050000 --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=qt -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ --enable=style,performance,portability,warning,internal --exception-handling --debug-warnings gui/*.cpp
           ./cppcheck -q -j$(nproc) --std=c++11 --template=selfcheck -D__CPPCHECK__ --error-exitcode=1 --inline-suppr --suppressions-list=.travis_suppressions --library=cppcheck-lib -Ilib -Iexternals/simplecpp/ -Iexternals/tinyxml2/ -Icli -Igui --inconclusive --enable=style,performance,portability,warning,internal --exception-handling --debug-warnings test/*.cpp tools
 
-# This takes too long time right now
+# TODO: This does takes too long to run
 #      - name: Bughunting lib
 #        run: ./cppcheck -D__CPPCHECK__ --bug-hunting -j$(nproc) lib
 


### PR DESCRIPTION
This might cause an increase in compilation time but makes the test and selfcheck faster. The newer clang version should also improve the runtime since it produces better code for us. With these changes UBSAN is no longer the slowest job.