### PR TITLE
release-windows.yml: disabled some unnecessary PCRE build options

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -51,12 +51,8 @@ jobs:
         run: |
           7z x pcre-%PCRE_VERSION%.zip
           cd pcre-%PCRE_VERSION%
-          cmake . -G "Visual Studio 16 2019" -A x64
+          cmake . -G "Visual Studio 16 2019" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF
           msbuild -m PCRE.sln /p:Configuration=Release /p:Platform=x64
-          dir
-          dir Release
-          dir x64
-          dir x64\Release
           copy pcre.h ..\externals
           copy Release\pcre.lib ..\externals\pcre64.lib
 


### PR DESCRIPTION
I pulled this out of #3770 since the actual caching of the build is a bit tricky and needs more work.