### PR TITLE
fixed most of the Qt deprecation warnings

### DIFF
--- a/gui/checkstatistics.cpp
+++ b/gui/checkstatistics.cpp
@@ -104,5 +104,5 @@ QStringList CheckStatistics::getTools() const
     foreach (QString tool, mPerformance.keys()) ret.insert(tool);
     foreach (QString tool, mPortability.keys()) ret.insert(tool);
     foreach (QString tool, mError.keys()) ret.insert(tool);
-    return QStringList(ret.toList());
+    return QStringList(ret.values());
 }

--- a/gui/codeeditor.cpp
+++ b/gui/codeeditor.cpp
@@ -336,7 +336,11 @@ int CodeEditor::lineNumberAreaWidth()
         ++digits;
     }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+#else
     int space = 3 + fontMetrics().width(QLatin1Char('9')) * digits;
+#endif
     return space;
 }
 

--- a/gui/codeeditstyledialog.cpp
+++ b/gui/codeeditstyledialog.cpp
@@ -119,7 +119,11 @@ StyleEditDialog::StyleEditDialog(const CodeEditorStyle& newStyle,
     mSampleEditor = new CodeEditor(this);
     QFont sampleFont("Monospace");
     QFontMetrics fm(sampleFont);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    mSampleEditor->setMinimumWidth(fm.horizontalAdvance(QString(40, 'W')));
+#else
     mSampleEditor->setMinimumWidth(fm.width(QString(40, 'W')));
+#endif
     // designate highlight, errors, and symbols
     mSampleEditor->setError(mSampleDocument, mErrLineNum, mErrSymbolsList);
     // End Controls

--- a/gui/csvreport.cpp
+++ b/gui/csvreport.cpp
@@ -41,7 +41,11 @@ bool CsvReport::create()
 void CsvReport::writeHeader()
 {
     // Added 5 columns to the header.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    mTxtWriter << "File, Line, Severity, Id, Summary" << Qt::endl;
+#else
     mTxtWriter << "File, Line, Severity, Id, Summary" << endl;
+#endif
 }
 
 void CsvReport::writeFooter()
@@ -59,5 +63,9 @@ void CsvReport::writeError(const ErrorItem &error)
     const QString file = QDir::toNativeSeparators(error.errorPath.back().file);
     QString line = QString("%1,%2,").arg(file).arg(error.errorPath.back().line);
     line += QString("%1,%2,%3").arg(GuiSeverity::toString(error.severity)).arg(error.errorId).arg(error.summary);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    mTxtWriter << line << Qt::endl;
+#else
     mTxtWriter << line << endl;
+#endif
 }

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -410,7 +410,11 @@ void ProjectFileDialog::saveToProjectFile(ProjectFile *projectFile) const
     projectFile->setAddons(list);
     projectFile->setClangAnalyzer(mUI.mToolClangAnalyzer->isChecked());
     projectFile->setClangTidy(mUI.mToolClangTidy->isChecked());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    projectFile->setTags(mUI.mEditTags->text().split(";", Qt::SkipEmptyParts));
+#else
     projectFile->setTags(mUI.mEditTags->text().split(";", QString::SkipEmptyParts));
+#endif
 }
 
 void ProjectFileDialog::ok()
@@ -584,13 +588,21 @@ QStringList ProjectFileDialog::getIncludePaths() const
 
 QStringList ProjectFileDialog::getDefines() const
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return mUI.mEditDefines->text().trimmed().split(QRegExp("\\s*;\\s*"), Qt::SkipEmptyParts);
+#else
     return mUI.mEditDefines->text().trimmed().split(QRegExp("\\s*;\\s*"), QString::SkipEmptyParts);
+#endif
 }
 
 QStringList ProjectFileDialog::getUndefines() const
 {
     const QString undefine = mUI.mEditUndefines->text().trimmed();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QStringList undefines = undefine.split(QRegExp("\\s*;\\s*"), Qt::SkipEmptyParts);
+#else
     QStringList undefines = undefine.split(QRegExp("\\s*;\\s*"), QString::SkipEmptyParts);
+#endif
     undefines.removeDuplicates();
     return undefines;
 }

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -1058,7 +1058,7 @@ void ResultsTree::suppressSelectedIds()
     }
 
 
-    emit suppressIds(selectedIds.toList());
+    emit suppressIds(selectedIds.values());
 }
 
 void ResultsTree::suppressHash()

--- a/gui/statsdialog.cpp
+++ b/gui/statsdialog.cpp
@@ -157,7 +157,7 @@ void StatsDialog::pdfExport()
     }
     QPrinter printer(QPrinter::PrinterResolution);
     printer.setOutputFormat(QPrinter::PdfFormat);
-    printer.setPaperSize(QPrinter::A4);
+    printer.setPageSize(QPageSize(QPageSize::A4));
     printer.setOutputFileName(fileName);
 
     QTextDocument doc;

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -112,7 +112,7 @@ void ThreadHandler::check(const Settings &settings)
 
     mAnalyseWholeProgram = true;
 
-    mTime.start();
+    mTimer.start();
 }
 
 bool ThreadHandler::isChecking() const
@@ -168,7 +168,7 @@ void ThreadHandler::threadDone()
     if (mRunningThreadCount == 0) {
         emit done();
 
-        mScanDuration = mTime.elapsed();
+        mScanDuration = mTimer.elapsed();
 
         // Set date/time used by the recheck
         if (!mCheckStartTime.isNull()) {

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -23,6 +23,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QDateTime>
+#include <QElapsedTimer>
 #include <set>
 #include "threadresult.h"
 #include "suppressions.h"
@@ -222,7 +223,7 @@ protected:
      * @brief Timer used for measuring scan duration
      *
      */
-    QTime mTime;
+    QElapsedTimer mTimer;
 
     /**
      * @brief The previous scan duration in milliseconds.

--- a/gui/txtreport.cpp
+++ b/gui/txtreport.cpp
@@ -76,5 +76,9 @@ void TxtReport::writeError(const ErrorItem &error)
     line += temp.arg(GuiSeverity::toString(error.severity));
     line += error.summary;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    mTxtWriter << line << Qt::endl;
+#else
     mTxtWriter << line << endl;
+#endif
 }


### PR DESCRIPTION
I verified the version which made the replacements with the Qt documentation and only added version checks if necessary.

The remaining warning is
```
/mnt/s/GitHub/cppcheck-fw/gui/resultstree.cpp:829:34: warning: 'startDetached' is deprecated: Use QProcess::startDetached(const QString &program, const QStringList &arguments) instead [-Wdeprecated-declarations]
        bool success = QProcess::startDetached(cmdLine);
                                 ^
```

This requires changes to our GUI code as well so I didn't fix it yet.

This will also help with some of the remaining Qt6 compilation errors.