### PR TITLE
cleaned up GUI includes based on include-what-you-use

### DIFF
--- a/gui/applicationlist.cpp
+++ b/gui/applicationlist.cpp
@@ -21,8 +21,6 @@
 #include "application.h"
 #include "common.h"
 
-#include <cstdlib>
-
 #include <QFileInfo>
 #include <QSettings>
 #include <QStringList>

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -32,7 +32,6 @@
 
 #include <QApplication>
 #include <QCoreApplication>
-#include <QMetaType>
 #include <QStringList>
 #include <QSettings>
 

--- a/gui/showtypes.cpp
+++ b/gui/showtypes.cpp
@@ -20,9 +20,7 @@
 
 #include "common.h"
 
-#include <QMap>
 #include <QSettings>
-#include <QString>
 
 ShowTypes::ShowTypes()
 {

--- a/gui/statsdialog.cpp
+++ b/gui/statsdialog.cpp
@@ -31,6 +31,17 @@
 #include <QTextDocument>
 #include <QWidget>
 
+#ifdef HAVE_QCHART
+#include <QAbstractSeries>
+#include <QChartView>
+#include <QDateTimeAxis>
+#include <QLineSeries>
+#include <QTextStream>
+#include <QValueAxis>
+
+using namespace QtCharts;
+#endif
+
 static const QString CPPCHECK("cppcheck");
 
 StatsDialog::StatsDialog(QWidget *parent)

--- a/gui/statsdialog.h
+++ b/gui/statsdialog.h
@@ -22,12 +22,16 @@
 #include "ui_stats.h"
 
 #include <QDialog>
-#ifdef HAVE_QCHART
-#include <QtCharts>
-#endif
 
 class ProjectFile;
 class CheckStatistics;
+
+#ifdef HAVE_QCHART
+namespace QtCharts {
+    class QChartView;
+    class QLineSeries;
+}
+#endif
 
 /// @addtogroup GUI
 /// @{
@@ -70,8 +74,8 @@ private slots:
     void copyToClipboard();
     void pdfExport();
 #ifdef HAVE_QCHART
-    QChartView *createChart(const QString &statsFile, const QString &tool);
-    QLineSeries *numberOfReports(const QString &fileName, const QString &severity) const;
+    QtCharts::QChartView *createChart(const QString &statsFile, const QString &tool);
+    QtCharts::QLineSeries *numberOfReports(const QString &fileName, const QString &severity) const;
 #endif
 private:
     Ui::StatsDialog mUI;

--- a/gui/test/benchmark/simple/benchmarksimple.cpp
+++ b/gui/test/benchmark/simple/benchmarksimple.cpp
@@ -19,15 +19,14 @@
 #include "benchmarksimple.h"
 
 #include "settings.h"
-#include "token.h"
 #include "tokenize.h"
 
 #include <sstream>
 
 #include <QByteArray>
 #include <QFile>
-#include <QObject>
 #include <QString>
+#include <QtTest>
 
 void BenchmarkSimple::tokenize()
 {

--- a/gui/test/benchmark/simple/benchmarksimple.h
+++ b/gui/test/benchmark/simple/benchmarksimple.h
@@ -19,7 +19,6 @@
 #include "errorlogger.h"
 
 #include <QObject>
-#include <QtTest/QtTest>
 
 class BenchmarkSimple : public QObject, public ErrorLogger {
     Q_OBJECT

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -18,6 +18,9 @@
 
 #include "testcppchecklibrarydata.h"
 
+#include <QDebug>
+#include <QTest>
+
 const QString TestCppcheckLibraryData::TempCfgFile = "./tmp.cfg";
 
 void TestCppcheckLibraryData::init()

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -18,7 +18,7 @@
 
 #include "cppchecklibrarydata.h"
 
-#include <QtTest/QtTest>
+#include <QObject>
 
 class TestCppcheckLibraryData : public QObject {
     Q_OBJECT

--- a/gui/test/filelist/testfilelist.cpp
+++ b/gui/test/filelist/testfilelist.cpp
@@ -21,8 +21,8 @@
 #include "filelist.h"
 
 #include <QDir>
-#include <QObject>
 #include <QString>
+#include <QTest>
 
 void TestFileList::addFile()
 {

--- a/gui/test/filelist/testfilelist.h
+++ b/gui/test/filelist/testfilelist.h
@@ -17,7 +17,6 @@
  */
 
 #include <QObject>
-#include <QtTest/QtTest>
 
 class TestFileList : public QObject {
     Q_OBJECT

--- a/gui/test/projectfile/testprojectfile.cpp
+++ b/gui/test/projectfile/testprojectfile.cpp
@@ -21,7 +21,7 @@
 #include "projectfile.h"
 #include "settings.h"
 
-#include <QObject>
+#include <QtTest>
 
 // Mock...
 const char Settings::SafeChecks::XmlRootName[] = "safe-checks";

--- a/gui/test/projectfile/testprojectfile.h
+++ b/gui/test/projectfile/testprojectfile.h
@@ -17,7 +17,6 @@
  */
 
 #include <QObject>
-#include <QtTest/QtTest>
 
 class TestProjectFile : public QObject {
     Q_OBJECT

--- a/gui/test/translationhandler/testtranslationhandler.cpp
+++ b/gui/test/translationhandler/testtranslationhandler.cpp
@@ -20,7 +20,7 @@
 
 #include "translationhandler.h"
 
-#include <QObject>
+#include <QtTest>
 
 static const QStringList getTranslationNames(const TranslationHandler& handler)
 {

--- a/gui/test/translationhandler/testtranslationhandler.h
+++ b/gui/test/translationhandler/testtranslationhandler.h
@@ -17,7 +17,6 @@
  */
 
 #include <QObject>
-#include <QtTest/QtTest>
 
 class TestTranslationHandler : public QObject {
     Q_OBJECT

--- a/gui/test/xmlreportv2/testxmlreportv2.cpp
+++ b/gui/test/xmlreportv2/testxmlreportv2.cpp
@@ -21,7 +21,7 @@
 #include "erroritem.h"
 #include "xmlreportv2.h"
 
-#include <QObject>
+#include <QtTest>
 
 void TestXmlReportV2::readXml()
 {

--- a/gui/test/xmlreportv2/testxmlreportv2.h
+++ b/gui/test/xmlreportv2/testxmlreportv2.h
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtTest/QtTest>
 #include <QObject>
 
 class TestXmlReportV2 : public QObject {

--- a/gui/translationhandler.h
+++ b/gui/translationhandler.h
@@ -21,7 +21,6 @@
 
 #include <QList>
 #include <QObject>
-#include <QStringList>
 
 class QTranslator;
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -19,7 +19,7 @@
 // Generate Makefile for cppcheck
 
 #include <algorithm>
-#include <fstream>
+#include <fstream> // IWYU pragma: keep
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I was able to adjust the Qt mapping to work around the slowdown so I could at least partially clean up the includes. Full cleanup requires a fixed include-what-you-use.