### PR TITLE
Python fixes for reduce.py

### DIFF
--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 import subprocess
 import sys
-import time
 
-# TODO: add --hang option to detect code which impacts the analysis time
 def show_syntax():
     print('Syntax:')
     print('  reduce.py --cmd=<full command> --expected=<expected text output> --file=<source file> [--segfault]')
@@ -19,9 +17,7 @@ CMD = None
 EXPECTED = None
 SEGFAULT = False
 FILE = None
-ORGFILE = None
 BACKUPFILE = None
-TIMEOUTFILE = None
 for arg in sys.argv[1:]:
     if arg.startswith('--cmd='):
         CMD = arg[arg.find('=') + 1:]
@@ -29,9 +25,7 @@ for arg in sys.argv[1:]:
         EXPECTED = arg[arg.find('=') + 1:]
     elif arg.startswith('--file='):
         FILE = arg[arg.find('=') + 1:]
-        ORGFILE = FILE + '.org'
         BACKUPFILE = FILE + '.bak'
-        TIMEOUTFILE = FILE + '.timeout'
     elif arg == '--segfault':
         SEGFAULT = True
 
@@ -42,11 +36,6 @@ if CMD is None:
 if not SEGFAULT and EXPECTED is None:
     print('Abort: No --expected')
     show_syntax()
-
-# need to add '--error-exitcode=0' so detected issues will not be interpreted as a crash
-if SEGFAULT and not '--error-exitcode=0' in CMD:
-    print("Adding '--error-exitcode=0' to --cmd")
-    CMD = CMD + ' --error-exitcode=0'
 
 if FILE is None:
     print('Abort: No --file')
@@ -60,22 +49,9 @@ else:
 print('FILE=' + FILE)
 
 
-def runtool(filedata=None):
-    timeout = None
-    if elapsed_time:
-        timeout = elapsed_time * 2
+def runtool():
     p = subprocess.Popen(CMD.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    try:
-        comm = p.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        print('timeout')
-        p.kill()
-        p.communicate()
-        if filedata:
-            writefile(TIMEOUTFILE, filedata)
-        return False
-    #print(p.returncode)
-    #print(comm)
+    comm = p.communicate()
     if SEGFAULT:
         if p.returncode != 0:
             return True
@@ -102,7 +78,7 @@ def replaceandrun(what, filedata, i, line):
     bak = filedata[i]
     filedata[i] = line
     writefile(FILE, filedata)
-    if runtool(filedata):
+    if runtool():
         print('pass')
         writefile(BACKUPFILE, filedata)
         return True
@@ -118,7 +94,7 @@ def replaceandrun2(what, filedata, i, line1, line2):
     filedata[i] = line1
     filedata[i + 1] = line2
     writefile(FILE, filedata)
-    if runtool(filedata):
+    if runtool():
         print('pass')
         writefile(BACKUPFILE, filedata)
     else:
@@ -135,7 +111,7 @@ def clearandrun(what, filedata, i1, i2):
         filedata2[i] = ''
         i = i + 1
     writefile(FILE, filedata2)
-    if runtool(filedata2):
+    if runtool():
         print('pass')
         writefile(BACKUPFILE, filedata2)
         return filedata2
@@ -277,19 +253,15 @@ def removeline(filedata):
 
 # reduce..
 print('Make sure error can be reproduced...')
-elapsed_time = None
-t = time.perf_counter()
 if not runtool():
     print("Cannot reproduce")
     sys.exit(1)
-elapsed_time = time.perf_counter() - t
-print('elapsed_time: {}'.format(elapsed_time))
 
 f = open(FILE, 'rt')
 filedata = f.readlines()
 f.close()
 
-writefile(ORGFILE, filedata)
+writefile(BACKUPFILE, filedata)
 
 while True:
     filedata1 = list(filedata)

--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -3,6 +3,18 @@ import subprocess
 import sys
 import time
 
+if sys.version_info[0] < 3:
+    class TimeoutExpired(Exception):
+        pass
+else:
+    TimeoutExpired = subprocess.TimeoutExpired
+
+def communicate(p, timeout=None, **kwargs):
+    if sys.version_info[0] < 3:
+        return p.communicate(**kwargs)
+    else:
+        return p.communicate(timeout=timeout)
+
 # TODO: add --hang option to detect code which impacts the analysis time
 def show_syntax():
     print('Syntax:')
@@ -59,15 +71,14 @@ else:
     print('EXPECTED=' + EXPECTED)
 print('FILE=' + FILE)
 
-
 def runtool(filedata=None):
     timeout = None
     if elapsed_time:
         timeout = elapsed_time * 2
-    p = subprocess.Popen(CMD.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(CMD.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     try:
-        comm = p.communicate(timeout=timeout, universal_newlines=True)
-    except subprocess.TimeoutExpired:
+        comm = communicate(p, timeout=timeout)
+    except TimeoutExpired:
         print('timeout')
         p.kill()
         p.communicate()


### PR DESCRIPTION
This reverts commit 4f508c93c4c41e40464b09cff8de7ebd35e8afa3, which broke the reduce.py script. It used `time.perf_counter` which is not available in python 2, and this script doesn't work on python 3(due to mixing bytes and str together). 