### PR TITLE
Refactor ProgramMemory to store the expression tokens instead of exprIds

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -410,8 +410,6 @@ static void addVars(ProgramMemory& pm, const ProgramMemory::Map& vars)
     for (const auto& p:vars) {
         const ValueFlow::Value &value = p.second;
         pm.setValue(p.first.tok, value);
-        // if (value.varId)
-            // pm.setIntValue(value.varId, value.varvalue);
     }
 }
 
@@ -494,8 +492,6 @@ ProgramMemory getProgramMemory(const Token *tok, const ProgramMemory::Map& vars)
     for (const auto& p:vars) {
         const ValueFlow::Value &value = p.second;
         programMemory.setValue(p.first.tok, value);
-        // if (value.varId)
-            // programMemory.setIntValue(value.varId, value.varvalue);
     }
     state = programMemory;
     fillProgramMemoryFromAssignments(programMemory, tok, state, vars);
@@ -509,8 +505,6 @@ ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueF
     programMemory.replace(getInitialProgramState(tok, value.condition));
     fillProgramMemoryFromConditions(programMemory, tok, settings);
     programMemory.setValue(expr, value);
-    // if (value.varId)
-        // programMemory.setIntValue(value.varId, value.varvalue);
     const ProgramMemory state = programMemory;
     fillProgramMemoryFromAssignments(programMemory, tok, state, {{expr, value}});
     return programMemory;

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -444,16 +444,6 @@ void ProgramMemoryState::removeModifiedVars(const Token* tok)
         }
         return false;
     });
-    // for (auto i = state.values.begin(), last = state.values.end(); i != last;) {
-    //     const Token* start = origins[i->first.getExpressionId()];
-    //     const Token* expr = i->first.tok;
-    //     if (!expr || isExpressionChanged(expr, start, tok, settings, true)) {
-    //         origins.erase(i->first.getExpressionId());
-    //         i = state.values.erase(i);
-    //     } else {
-    //         ++i;
-    //     }
-    // }
 }
 
 ProgramMemory ProgramMemoryState::get(const Token* tok, const Token* ctx, const ProgramMemory::Map& vars) const

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -38,8 +38,7 @@
 #include <utility>
 #include <vector>
 
-nonneg int ExprIdToken::getExpressionId() const
-{
+nonneg int ExprIdToken::getExpressionId() const {
     return tok ? tok->exprId() : exprid;
 }
 
@@ -48,8 +47,7 @@ std::size_t ExprIdToken::Hash::operator()(ExprIdToken etok) const
     return std::hash<nonneg int>()(etok.getExpressionId());
 }
 
-void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value)
-{
+void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value) {
     values[expr] = value;
 }
 const ValueFlow::Value* ProgramMemory::getValue(nonneg int exprid, bool impossible) const
@@ -126,8 +124,7 @@ void ProgramMemory::setContainerSizeValue(const Token* expr, MathLib::bigint val
     values[expr] = v;
 }
 
-void ProgramMemory::setUnknown(const Token* expr)
-{
+void ProgramMemory::setUnknown(const Token* expr) {
     values[expr].valueType = ValueFlow::Value::ValueType::UNINIT;
 }
 
@@ -136,12 +133,10 @@ bool ProgramMemory::hasValue(nonneg int exprid)
     return values.find(exprid) != values.end();
 }
 
-const ValueFlow::Value& ProgramMemory::at(nonneg int exprid) const
-{
+const ValueFlow::Value& ProgramMemory::at(nonneg int exprid) const {
     return values.at(exprid);
 }
-ValueFlow::Value& ProgramMemory::at(nonneg int exprid)
-{
+ValueFlow::Value& ProgramMemory::at(nonneg int exprid) {
     return values.at(exprid);
 }
 
@@ -179,7 +174,7 @@ void ProgramMemory::replace(const ProgramMemory &pm)
 
 void ProgramMemory::insert(const ProgramMemory &pm)
 {
-    for (auto&& p:pm)
+    for (auto&& p : pm)
         values.insert(p);
 }
 
@@ -392,7 +387,7 @@ ProgramMemoryState::ProgramMemoryState(const Settings* s) : state(), origins(), 
 void ProgramMemoryState::insert(const ProgramMemory &pm, const Token* origin)
 {
     if (origin)
-        for (auto&& p:pm)
+        for (auto&& p : pm)
             origins.insert(std::make_pair(p.first.getExpressionId(), origin));
     state.insert(pm);
 }
@@ -400,7 +395,7 @@ void ProgramMemoryState::insert(const ProgramMemory &pm, const Token* origin)
 void ProgramMemoryState::replace(const ProgramMemory &pm, const Token* origin)
 {
     if (origin)
-        for (auto&& p:pm)
+        for (auto&& p : pm)
             origins[p.first.getExpressionId()] = origin;
     state.replace(pm);
 }
@@ -498,7 +493,7 @@ ProgramMemory getProgramMemory(const Token *tok, const ProgramMemory::Map& vars)
     return programMemory;
 }
 
-ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueFlow::Value& value, const Settings *settings)
+ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueFlow::Value& value, const Settings* settings)
 {
     ProgramMemory programMemory;
     programMemory.replace(getInitialProgramState(tok, value.tokvalue));

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -48,12 +48,12 @@ std::size_t ExprIdToken::Hash::operator()(ExprIdToken etok) const
 }
 
 void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value) {
-    values[expr] = value;
+    mValues[expr] = value;
 }
 const ValueFlow::Value* ProgramMemory::getValue(nonneg int exprid, bool impossible) const
 {
-    const ProgramMemory::Map::const_iterator it = values.find(exprid);
-    const bool found = it != values.end() && (impossible || !it->second.isImpossible());
+    const ProgramMemory::Map::const_iterator it = mValues.find(exprid);
+    const bool found = it != mValues.end() && (impossible || !it->second.isImpossible());
     if (found)
         return &it->second;
     else
@@ -76,7 +76,7 @@ void ProgramMemory::setIntValue(const Token* expr, MathLib::bigint value, bool i
     ValueFlow::Value v(value);
     if (impossible)
         v.setImpossible();
-    values[expr] = v;
+    mValues[expr] = v;
 }
 
 bool ProgramMemory::getTokValue(nonneg int exprid, const Token** result) const
@@ -121,30 +121,30 @@ void ProgramMemory::setContainerSizeValue(const Token* expr, MathLib::bigint val
     v.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
     if (!isEqual)
         v.valueKind = ValueFlow::Value::ValueKind::Impossible;
-    values[expr] = v;
+    mValues[expr] = v;
 }
 
 void ProgramMemory::setUnknown(const Token* expr) {
-    values[expr].valueType = ValueFlow::Value::ValueType::UNINIT;
+    mValues[expr].valueType = ValueFlow::Value::ValueType::UNINIT;
 }
 
 bool ProgramMemory::hasValue(nonneg int exprid)
 {
-    return values.find(exprid) != values.end();
+    return mValues.find(exprid) != mValues.end();
 }
 
 const ValueFlow::Value& ProgramMemory::at(nonneg int exprid) const {
-    return values.at(exprid);
+    return mValues.at(exprid);
 }
 ValueFlow::Value& ProgramMemory::at(nonneg int exprid) {
-    return values.at(exprid);
+    return mValues.at(exprid);
 }
 
 void ProgramMemory::erase_if(const std::function<bool(const ExprIdToken&)>& pred)
 {
-    for (auto it = values.begin(); it != values.end();) {
+    for (auto it = mValues.begin(); it != mValues.end();) {
         if (pred(it->first))
-            it = values.erase(it);
+            it = mValues.erase(it);
         else
             ++it;
     }
@@ -152,30 +152,30 @@ void ProgramMemory::erase_if(const std::function<bool(const ExprIdToken&)>& pred
 
 void ProgramMemory::swap(ProgramMemory &pm)
 {
-    values.swap(pm.values);
+    mValues.swap(pm.mValues);
 }
 
 void ProgramMemory::clear()
 {
-    values.clear();
+    mValues.clear();
 }
 
 bool ProgramMemory::empty() const
 {
-    return values.empty();
+    return mValues.empty();
 }
 
 void ProgramMemory::replace(const ProgramMemory &pm)
 {
-    for (auto&& p : pm.values) {
-        values[p.first] = p.second;
+    for (auto&& p : pm.mValues) {
+        mValues[p.first] = p.second;
     }
 }
 
 void ProgramMemory::insert(const ProgramMemory &pm)
 {
     for (auto&& p : pm)
-        values.insert(p);
+        mValues.insert(p);
 }
 
 bool evaluateCondition(const std::string& op,

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -28,24 +28,56 @@
 class Token;
 class Settings;
 
-struct ProgramMemory {
-    using Map = std::unordered_map<nonneg int, ValueFlow::Value>;
-    Map values;
+struct ExprIdToken {
+    const Token* tok = nullptr;
+    nonneg int exprid = 0;
 
-    void setValue(nonneg int exprid, const ValueFlow::Value& value);
+    ExprIdToken() = default;
+    ExprIdToken(const Token* tok) : tok(tok) {}
+    ExprIdToken(nonneg int exprid) : exprid(exprid) {}
+
+    nonneg int getExpressionId() const;
+
+    bool operator==(const ExprIdToken& rhs) const {
+        return getExpressionId() == rhs.getExpressionId();
+    }
+
+    template<class T, class U>
+    friend bool operator!=(const T& lhs, const U& rhs) {
+        return !(lhs == rhs);
+    }
+
+    struct Hash {
+        std::size_t operator()(ExprIdToken etok) const;
+    };
+};
+
+struct ProgramMemory {
+    using Map = std::unordered_map<ExprIdToken, ValueFlow::Value, ExprIdToken::Hash>;
+
+    ProgramMemory() = default;
+
+    ProgramMemory(const Map& values) : values(values) {}
+
+    void setValue(const Token* expr, const ValueFlow::Value& value);
     const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;
 
     bool getIntValue(nonneg int exprid, MathLib::bigint* result) const;
-    void setIntValue(nonneg int exprid, MathLib::bigint value, bool impossible = false);
+    void setIntValue(const Token* expr, MathLib::bigint value, bool impossible = false);
 
     bool getContainerSizeValue(nonneg int exprid, MathLib::bigint* result) const;
     bool getContainerEmptyValue(nonneg int exprid, MathLib::bigint* result) const;
-    void setContainerSizeValue(nonneg int exprid, MathLib::bigint value, bool isEqual = true);
+    void setContainerSizeValue(const Token* expr, MathLib::bigint value, bool isEqual = true);
 
-    void setUnknown(nonneg int exprid);
+    void setUnknown(const Token* expr);
 
     bool getTokValue(nonneg int exprid, const Token** result) const;
     bool hasValue(nonneg int exprid);
+
+    const ValueFlow::Value& at(nonneg int exprid) const;
+    ValueFlow::Value& at(nonneg int exprid);
+
+    void erase_if(const std::function<bool(const ExprIdToken&)>& pred);
 
     void swap(ProgramMemory &pm);
 
@@ -56,6 +88,25 @@ struct ProgramMemory {
     void replace(const ProgramMemory &pm);
 
     void insert(const ProgramMemory &pm);
+
+    Map::iterator begin() {
+        return values.begin();
+    }
+
+    Map::iterator end() {
+        return values.end();
+    }
+
+    Map::const_iterator begin() const {
+        return values.begin();
+    }
+
+    Map::const_iterator end() const {
+        return values.end();
+    }
+
+    private:
+    Map values;
 };
 
 void programMemoryParseCondition(ProgramMemory& pm, const Token* tok, const Token* endTok, const Settings* settings, bool then);
@@ -102,7 +153,7 @@ bool conditionIsTrue(const Token* condition, ProgramMemory pm, const Settings* s
 /**
  * Get program memory by looking backwards from given token.
  */
-ProgramMemory getProgramMemory(const Token* tok, nonneg int exprid, const ValueFlow::Value& value, const Settings *settings);
+ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueFlow::Value& value, const Settings *settings);
 
 ProgramMemory getProgramMemory(const Token *tok, const ProgramMemory::Map& vars);
 

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -62,7 +62,7 @@ struct ProgramMemory {
 
     ProgramMemory() = default;
 
-    explicit ProgramMemory(const Map& values) : values(values) {}
+    explicit ProgramMemory(const Map& values) : mValues(values) {}
 
     void setValue(const Token* expr, const ValueFlow::Value& value);
     const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;
@@ -95,23 +95,23 @@ struct ProgramMemory {
     void insert(const ProgramMemory &pm);
 
     Map::iterator begin() {
-        return values.begin();
+        return mValues.begin();
     }
 
     Map::iterator end() {
-        return values.end();
+        return mValues.end();
     }
 
     Map::const_iterator begin() const {
-        return values.begin();
+        return mValues.begin();
     }
 
     Map::const_iterator end() const {
-        return values.end();
+        return mValues.end();
     }
 
 private:
-    Map values;
+    Map mValues;
 };
 
 void programMemoryParseCondition(ProgramMemory& pm, const Token* tok, const Token* endTok, const Settings* settings, bool then);

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -46,7 +46,8 @@ struct ExprIdToken {
     }
 
     template<class T, class U>
-    friend bool operator!=(const T& lhs, const U& rhs) {
+    friend bool operator!=(const T& lhs, const U& rhs)
+    {
         return !(lhs == rhs);
     }
 
@@ -108,7 +109,7 @@ struct ProgramMemory {
         return values.end();
     }
 
-    private:
+private:
     Map values;
 };
 
@@ -156,7 +157,7 @@ bool conditionIsTrue(const Token* condition, ProgramMemory pm, const Settings* s
 /**
  * Get program memory by looking backwards from given token.
  */
-ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueFlow::Value& value, const Settings *settings);
+ProgramMemory getProgramMemory(const Token* tok, const Token* expr, const ValueFlow::Value& value, const Settings* settings);
 
 ProgramMemory getProgramMemory(const Token *tok, const ProgramMemory::Map& vars);
 

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -28,12 +28,15 @@
 class Token;
 class Settings;
 
+// Class used to handle hetrogeneous keys in unordered_map(since we can't use C++20 yet)
 struct ExprIdToken {
     const Token* tok = nullptr;
     nonneg int exprid = 0;
 
     ExprIdToken() = default;
+    // cppcheck-suppress noExplicitConstructor
     ExprIdToken(const Token* tok) : tok(tok) {}
+    // cppcheck-suppress noExplicitConstructor
     ExprIdToken(nonneg int exprid) : exprid(exprid) {}
 
     nonneg int getExpressionId() const;

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -28,7 +28,7 @@
 class Token;
 class Settings;
 
-// Class used to handle hetrogeneous keys in unordered_map(since we can't use C++20 yet)
+// Class used to handle hetrogeneous lookup in unordered_map(since we can't use C++20 yet)
 struct ExprIdToken {
     const Token* tok = nullptr;
     nonneg int exprid = 0;

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -61,7 +61,7 @@ struct ProgramMemory {
 
     ProgramMemory() = default;
 
-    ProgramMemory(const Map& values) : values(values) {}
+    explicit ProgramMemory(const Map& values) : values(values) {}
 
     void setValue(const Token* expr, const ValueFlow::Value& value);
     const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -36,6 +36,7 @@ struct ExprIdToken {
     ExprIdToken() = default;
     // cppcheck-suppress noExplicitConstructor
     ExprIdToken(const Token* tok) : tok(tok) {}
+    // TODO: Make this constructor only available from ProgramMemory
     // cppcheck-suppress noExplicitConstructor
     ExprIdToken(nonneg int exprid) : exprid(exprid) {}
 

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -28,7 +28,7 @@
 class Token;
 class Settings;
 
-// Class used to handle hetrogeneous lookup in unordered_map(since we can't use C++20 yet)
+// Class used to handle heterogeneous lookup in unordered_map(since we can't use C++20 yet)
 struct ExprIdToken {
     const Token* tok = nullptr;
     nonneg int exprid = 0;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -866,8 +866,8 @@ static void setTokenValue(Token* tok, ValueFlow::Value value, const Settings* se
                     ValueFlow::Value result(0);
                     result.condition = value1.condition ? value1.condition : value2.condition;
                     result.setInconclusive(value1.isInconclusive() | value2.isInconclusive());
-                    // result.varId = (value1.varId != 0) ? value1.varId : value2.varId;
-                    // result.varvalue = (result.varId == value1.varId) ? value1.intvalue : value2.intvalue;
+                    result.varId = (value1.varId != 0) ? value1.varId : value2.varId;
+                    result.varvalue = (result.varId == value1.varId) ? value1.intvalue : value2.intvalue;
                     if (value1.valueKind == value2.valueKind)
                         result.valueKind = value1.valueKind;
                     if (value1.tokvalue->tokType() == Token::eString) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6303,7 +6303,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
     }
 
     virtual void forkScope(const Token* endBlock) OVERRIDE {
-        ProgramMemory pm = {getProgramState()};
+        ProgramMemory pm{getProgramState()};
         const Scope* scope = endBlock->scope();
         const Token* condTok = getCondTokFromEnd(endBlock);
         if (scope && condTok)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -866,8 +866,8 @@ static void setTokenValue(Token* tok, ValueFlow::Value value, const Settings* se
                     ValueFlow::Value result(0);
                     result.condition = value1.condition ? value1.condition : value2.condition;
                     result.setInconclusive(value1.isInconclusive() | value2.isInconclusive());
-                    result.varId = (value1.varId != 0) ? value1.varId : value2.varId;
-                    result.varvalue = (result.varId == value1.varId) ? value1.intvalue : value2.intvalue;
+                    // result.varId = (value1.varId != 0) ? value1.varId : value2.varId;
+                    // result.varvalue = (result.varId == value1.varId) ? value1.intvalue : value2.intvalue;
                     if (value1.valueKind == value2.valueKind)
                         result.valueKind = value1.valueKind;
                     if (value1.tokvalue->tokType() == Token::eString) {
@@ -1967,7 +1967,7 @@ struct ValueFlowAnalyzer : Analyzer {
 
     virtual bool isAlias(const Token* tok, bool& inconclusive) const = 0;
 
-    using ProgramState = std::unordered_map<nonneg int, ValueFlow::Value>;
+    using ProgramState = ProgramMemory::Map;
 
     virtual ProgramState getProgramState() const = 0;
 
@@ -5910,16 +5910,16 @@ static bool valueFlowForLoop2(const Token *tok,
     return true;
 }
 
-static void valueFlowForLoopSimplify(Token * const bodyStart, const nonneg int varid, bool globalvar, const MathLib::bigint value, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
+static void valueFlowForLoopSimplify(Token * const bodyStart, const Token* expr, bool globalvar, const MathLib::bigint value, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
 {
     const Token * const bodyEnd = bodyStart->link();
 
     // Is variable modified inside for loop
-    if (isVariableChanged(bodyStart, bodyEnd, varid, globalvar, settings, tokenlist->isCPP()))
+    if (isVariableChanged(bodyStart, bodyEnd, expr->varId(), globalvar, settings, tokenlist->isCPP()))
         return;
 
     for (Token *tok2 = bodyStart->next(); tok2 != bodyEnd; tok2 = tok2->next()) {
-        if (tok2->varId() == varid) {
+        if (tok2->varId() == expr->varId()) {
             const Token * parent = tok2->astParent();
             while (parent) {
                 const Token * const p = parent;
@@ -5944,7 +5944,7 @@ static void valueFlowForLoopSimplify(Token * const bodyStart, const nonneg int v
         }
 
         if (Token::Match(tok2, "%oror%|&&")) {
-            const ProgramMemory programMemory(getProgramMemory(tok2->astTop(), varid, ValueFlow::Value(value), settings));
+            const ProgramMemory programMemory(getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings));
             if ((tok2->str() == "&&" && !conditionIsTrue(tok2->astOperand1(), programMemory)) ||
                 (tok2->str() == "||" && !conditionIsFalse(tok2->astOperand1(), programMemory))) {
                 // Skip second expression..
@@ -5961,12 +5961,12 @@ static void valueFlowForLoopSimplify(Token * const bodyStart, const nonneg int v
             }
 
         }
-        if ((tok2->str() == "&&" && conditionIsFalse(tok2->astOperand1(), getProgramMemory(tok2->astTop(), varid, ValueFlow::Value(value), settings))) ||
-            (tok2->str() == "||" && conditionIsTrue(tok2->astOperand1(), getProgramMemory(tok2->astTop(), varid, ValueFlow::Value(value), settings))))
+        if ((tok2->str() == "&&" && conditionIsFalse(tok2->astOperand1(), getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))) ||
+            (tok2->str() == "||" && conditionIsTrue(tok2->astOperand1(), getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))))
             break;
 
-        else if (Token::simpleMatch(tok2, ") {") && Token::findmatch(tok2->link(), "%varid%", tok2, varid)) {
-            if (Token::findmatch(tok2, "continue|break|return", tok2->linkAt(1), varid)) {
+        else if (Token::simpleMatch(tok2, ") {") && Token::findmatch(tok2->link(), "%varid%", tok2, expr->varId())) {
+            if (Token::findmatch(tok2, "continue|break|return", tok2->linkAt(1), expr->varId())) {
                 if (settings->debugwarnings)
                     bailout(tokenlist, errorLogger, tok2, "For loop variable bailout on conditional continue|break|return");
                 break;
@@ -5975,7 +5975,7 @@ static void valueFlowForLoopSimplify(Token * const bodyStart, const nonneg int v
                 bailout(tokenlist, errorLogger, tok2, "For loop variable skipping conditional scope");
             tok2 = tok2->next()->link();
             if (Token::simpleMatch(tok2, "} else {")) {
-                if (Token::findmatch(tok2, "continue|break|return", tok2->linkAt(2), varid)) {
+                if (Token::findmatch(tok2, "continue|break|return", tok2->linkAt(2), expr->varId())) {
                     if (settings->debugwarnings)
                         bailout(tokenlist, errorLogger, tok2, "For loop variable bailout on conditional continue|break|return");
                     break;
@@ -6071,20 +6071,20 @@ static void valueFlowForLoop(TokenList *tokenlist, SymbolDatabase* symboldatabas
             ProgramMemory mem1, mem2, memAfter;
             if (valueFlowForLoop2(tok, &mem1, &mem2, &memAfter)) {
                 ProgramMemory::Map::const_iterator it;
-                for (it = mem1.values.begin(); it != mem1.values.end(); ++it) {
+                for (it = mem1.begin(); it != mem1.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplify(bodyStart, it->first, false, it->second.intvalue, tokenlist, errorLogger, settings);
+                    valueFlowForLoopSimplify(bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
                 }
-                for (it = mem2.values.begin(); it != mem2.values.end(); ++it) {
+                for (it = mem2.begin(); it != mem2.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplify(bodyStart, it->first, false, it->second.intvalue, tokenlist, errorLogger, settings);
+                    valueFlowForLoopSimplify(bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
                 }
-                for (it = memAfter.values.begin(); it != memAfter.values.end(); ++it) {
+                for (it = memAfter.begin(); it != memAfter.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplifyAfter(tok, it->first, it->second.intvalue, tokenlist, settings);
+                    valueFlowForLoopSimplifyAfter(tok, it->first.getExpressionId(), it->second.intvalue, tokenlist, settings);
                 }
             }
         }
@@ -6245,8 +6245,8 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
                 pm.replace(endMemory);
         }
         // ProgramMemory pm = pms.get(endBlock->link()->next(), getProgramState());
-        for (const auto& p:pm.values) {
-            nonneg int varid = p.first;
+        for (const auto& p:pm) {
+            nonneg int varid = p.first.getExpressionId();
             if (symboldatabase && !symboldatabase->isVarId(varid))
                 continue;
             ValueFlow::Value value = p.second;
@@ -6483,11 +6483,13 @@ static void valueFlowLibraryFunction(Token *tok, const std::string &returnValue,
         return;
 
     // set varids
+    std::unordered_map<nonneg int, const Token*> lookupVarId;
     for (Token* tok2 = tokenList.front(); tok2; tok2 = tok2->next()) {
         if (tok2->str().compare(0, 3, "arg") != 0)
             continue;
         nonneg int id = std::atoi(tok2->str().c_str() + 3);
         tok2->varId(id);
+        lookupVarId[id] = tok2;
     }
 
     // Evaluate expression
@@ -6496,7 +6498,11 @@ static void valueFlowLibraryFunction(Token *tok, const std::string &returnValue,
     ValueFlow::valueFlowConstantFoldAST(expr, settings);
 
     productParams(argValues, [&](const std::unordered_map<nonneg int, ValueFlow::Value>& arg) {
-        ProgramMemory pm{arg};
+        ProgramMemory pm{};
+        for(const auto& p:arg) {
+            const Token* tok = lookupVarId[p.first];
+            pm.setValue(tok, p.second);
+        }
         MathLib::bigint result = 0;
         bool error = false;
         execute(expr, &pm, &result, &error);
@@ -6697,7 +6703,7 @@ static void valueFlowFunctionReturn(TokenList *tokenlist, ErrorLogger *errorLogg
                 programMemory.clear();
                 break;
             }
-            programMemory.setIntValue(arg->declarationId(), parvalues[i]);
+            programMemory.setIntValue(arg->nameToken(), parvalues[i]);
         }
         if (programMemory.empty() && !parvalues.empty())
             continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5964,7 +5964,13 @@ static bool valueFlowForLoop2(const Token *tok,
     return true;
 }
 
-static void valueFlowForLoopSimplify(Token * const bodyStart, const Token* expr, bool globalvar, const MathLib::bigint value, TokenList *tokenlist, ErrorLogger *errorLogger, const Settings *settings)
+static void valueFlowForLoopSimplify(Token* const bodyStart,
+                                     const Token* expr,
+                                     bool globalvar,
+                                     const MathLib::bigint value,
+                                     TokenList* tokenlist,
+                                     ErrorLogger* errorLogger,
+                                     const Settings* settings)
 {
     const Token * const bodyEnd = bodyStart->link();
 
@@ -6015,8 +6021,12 @@ static void valueFlowForLoopSimplify(Token * const bodyStart, const Token* expr,
             }
 
         }
-        if ((tok2->str() == "&&" && conditionIsFalse(tok2->astOperand1(), getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))) ||
-            (tok2->str() == "||" && conditionIsTrue(tok2->astOperand1(), getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))))
+        if ((tok2->str() == "&&" &&
+             conditionIsFalse(tok2->astOperand1(),
+                              getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))) ||
+            (tok2->str() == "||" &&
+             conditionIsTrue(tok2->astOperand1(),
+                             getProgramMemory(tok2->astTop(), expr, ValueFlow::Value(value), settings))))
             break;
 
         else if (Token::simpleMatch(tok2, ") {") && Token::findmatch(tok2->link(), "%varid%", tok2, expr->varId())) {
@@ -6128,17 +6138,20 @@ static void valueFlowForLoop(TokenList *tokenlist, SymbolDatabase* symboldatabas
                 for (it = mem1.begin(); it != mem1.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplify(bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
+                    valueFlowForLoopSimplify(
+                        bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
                 }
                 for (it = mem2.begin(); it != mem2.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplify(bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
+                    valueFlowForLoopSimplify(
+                        bodyStart, it->first.tok, false, it->second.intvalue, tokenlist, errorLogger, settings);
                 }
                 for (it = memAfter.begin(); it != memAfter.end(); ++it) {
                     if (!it->second.isIntValue())
                         continue;
-                    valueFlowForLoopSimplifyAfter(tok, it->first.getExpressionId(), it->second.intvalue, tokenlist, settings);
+                    valueFlowForLoopSimplifyAfter(
+                        tok, it->first.getExpressionId(), it->second.intvalue, tokenlist, settings);
                 }
             }
         }
@@ -6282,7 +6295,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
 
     virtual ProgramState getProgramState() const OVERRIDE {
         ProgramState ps;
-        for (const auto& p:values) {
+        for (const auto& p : values) {
             const Variable* var = vars.at(p.first);
             ps[var->nameToken()] = p.second;
         }
@@ -6301,7 +6314,7 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
                 pm.replace(endMemory);
         }
         // ProgramMemory pm = pms.get(endBlock->link()->next(), getProgramState());
-        for (const auto& p:pm) {
+        for (const auto& p : pm) {
             nonneg int varid = p.first.getExpressionId();
             if (symboldatabase && !symboldatabase->isVarId(varid))
                 continue;
@@ -6555,7 +6568,7 @@ static void valueFlowLibraryFunction(Token *tok, const std::string &returnValue,
 
     productParams(argValues, [&](const std::unordered_map<nonneg int, ValueFlow::Value>& arg) {
         ProgramMemory pm{};
-        for(const auto& p:arg) {
+        for (const auto& p : arg) {
             const Token* tok = lookupVarId[p.first];
             pm.setValue(tok, p.second);
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2693,7 +2693,7 @@ struct ExpressionAnalyzer : SingleValueFlowAnalyzer {
 
     virtual ProgramState getProgramState() const OVERRIDE {
         ProgramState ps;
-        ps[expr->exprId()] = value;
+        ps[expr] = value;
         return ps;
     }
 
@@ -6228,8 +6228,10 @@ struct MultiValueFlowAnalyzer : ValueFlowAnalyzer {
 
     virtual ProgramState getProgramState() const OVERRIDE {
         ProgramState ps;
-        for (const auto& p:values)
-            ps[p.first] = p.second;
+        for (const auto& p:values) {
+            const Variable* var = vars.at(p.first);
+            ps[var->nameToken()] = p.second;
+        }
         return ps;
     }
 


### PR DESCRIPTION
This gets rid of the extra unnecessary calls to `findExpression`. I see about ~11% improvement.