### PR TITLE
Fix check for misra addon in executeAddons.

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1366,7 +1366,7 @@ void CppCheck::executeAddons(const std::vector<std::string>& files)
             mExitCode = 1;
             continue;
         }
-        if (addon != "misra" && !addonInfo.ctu && endsWith(files.back(), ".ctu-info"))
+        if (addonInfo.name != "misra" && !addonInfo.ctu && endsWith(files.back(), ".ctu-info"))
             continue;
 
         const std::string results =


### PR DESCRIPTION
In the CppCheck::executeAddons function, a check that specifically tests for the misra add-on, was not taking into account the cases when the addon is identified with the '.py' extension or indirectly via json. This resulted in the add-on not being executed a second time which is needed to detected some of the misra violations. By using the AddonInfo class name field, the addon name is uniformized for all these cases and the add-on executed a second time.

I've raised the issue descrining how to reproduce the issue in a [sourceforge discussion post](https://sourceforge.net/p/cppcheck/discussion/general/thread/4422407807/). 