### PR TITLE
I don't think cppcheck should warn if it can't find the standard header files

### DIFF
--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import unicode_literals
 

--- a/htmlreport/setup.py
+++ b/htmlreport/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup
 

--- a/htmlreport/test_htmlreport.py
+++ b/htmlreport/test_htmlreport.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test cppcheck-htmlreport."""
 
 import os

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -844,8 +844,12 @@ void Preprocessor::missingInclude(const std::string &filename, unsigned int line
     if (mSettings.nomsg.isSuppressed(errorMessage))
         return;
     errorMessage.errorId = "missingIncludeSystem";
-    if (headerType == SystemHeader && mSettings.nomsg.isSuppressed(errorMessage))
-        return;
+    if (headerType == SystemHeader) {
+       if(mSettings.nomsg.isSuppressed(errorMessage)) return;
+       if(header.compare("stdio.h") == 0) return;
+       if(header.compare("stdlib.h") == 0) return;
+       if(header.compare("string.h") == 0) return;
+    }
 
     if (headerType == SystemHeader)
         missingSystemIncludeFlag = true;

--- a/test/synthetic/report.py
+++ b/test/synthetic/report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # continuous integration
 # build daily reports (doxygen,coverage,etc)

--- a/tools/extracttests.py
+++ b/tools/extracttests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Cppcheck - A tool for static C/C++ code analysis
 # Copyright (C) 2007-2021 Cppcheck team.

--- a/tools/listErrorsWithoutCWE.py
+++ b/tools/listErrorsWithoutCWE.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import argparse
 import xml.etree.ElementTree as ET

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Cppcheck - A tool for static C/C++ code analysis
 # Copyright (C) 2007-2021 Cppcheck team.

--- a/tools/parse-glibc.py
+++ b/tools/parse-glibc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os

--- a/tools/reduce.py
+++ b/tools/reduce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import sys
 import time

--- a/tools/test_matchcompiler.py
+++ b/tools/test_matchcompiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Cppcheck - A tool for static C/C++ code analysis
 # Copyright (C) 2007-2021 Cppcheck team.


### PR DESCRIPTION
I've just adjusted `lib/preprocessor.cpp` so that it will not warn anyone it can't find the header files. 

My idea here is that if this

>Please note: Cppcheck does not need standard library headers to get proper results.

is true, then the user shouldn't have to worry about whether the headers not found are ones Cppcheck also doesn't need.

Is this kind of thing good? In that case, it's trivial to add more filenames to ignore for this specific case.