### PR TITLE
matchcompiler.py: skip comments in _replaceTokenMatch()

### DIFF
--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -384,6 +384,10 @@ class MatchCompiler:
             is_simplematch = func == 'simpleMatch'
             pattern_start = 0
             while True:
+                # skip comments
+                if line.strip().startswith('//'):
+                    break
+
                 pos1 = line.find('Token::' + func + '(', pattern_start)
                 if pos1 == -1:
                     break

--- a/tools/test_matchcompiler.py
+++ b/tools/test_matchcompiler.py
@@ -191,5 +191,10 @@ class MatchCompilerTest(unittest.TestCase):
             'if (match16(parent->tokAt(-3)) && tok->strAt(1) == MatchCompiler::makeConstString(")"))',
             output)
 
+    def test_parseMatchSkipComments(self):
+        input = '// TODO: suggest Token::exactMatch() for Token::simpleMatch() when pattern contains no whitespaces'
+        output = self.mc._replaceTokenMatch(input, 0, "foo.cpp")
+        self.assertEqual(output, '// TODO: suggest Token::exactMatch() for Token::simpleMatch() when pattern contains no whitespaces')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fixes the following error in #3731:

```
Traceback (most recent call last):
  File "tools/matchcompiler.py", line 720, in <module>
    main()
  File "tools/matchcompiler.py", line 717, in main
    mc.convertFile(pi, po, line_directive)
  File "tools/matchcompiler.py", line [6](https://github.com/danmar/cppcheck/runs/4872502058?check_suite_focus=true#step:6:6)20, in convertFile
    line = self._replaceTokenMatch(line, linenr, srcname)
  File "tools/matchcompiler.py", line 3[9](https://github.com/danmar/cppcheck/runs/4872502058?check_suite_focus=true#step:6:9)6, in _replaceTokenMatch
    assert(len(res) == 3 or len(res) == 4)
AssertionError
```