### PR TITLE
added MinGW to CI and fixed local MinGW build

### DIFF
--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [windows-2019]
         arch: [x64, x86]
-      fail-fast: true
+      fail-fast: false
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -1,0 +1,41 @@
+# Some convenient links:
+# - https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
+#
+
+name: CI-mingw
+
+on: [push,pull_request]
+
+defaults:
+  run:
+    shell: cmd
+
+jobs:
+  build_mingw:
+    strategy:
+      matrix:
+        os: [windows-2019]
+        arch: [x64] # TODO: fix x86 build?
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up MinGW
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: ${{ matrix.arch }}
+
+      - name: Build cppcheck
+        run: |
+          mingw32-make -j2
+
+      - name: Build test
+        run: |
+          mingw32-make -j2 testrunner
+
+      - name: Run test
+        run: |
+          mingw32-make -j2 check

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ ifeq ($(SRCDIR),build)
 endif
 ifeq ($(MATCHCOMPILER),yes)
     # Find available Python interpreter
-    PYTHON_INTERPRETER := $(shell which python3)
+    ifndef PYTHON_INTERPRETER
+        PYTHON_INTERPRETER := $(shell which python3)
+    endif
     ifndef PYTHON_INTERPRETER
         PYTHON_INTERPRETER := $(shell which python)
     endif

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,15 @@ RDYNAMIC=-rdynamic
 ifndef COMSPEC
     ifdef ComSpec
         #### ComSpec is defined on some WIN32's.
-        COMSPEC=$(ComSpec)
+        WINNT=1
+
+        ifneq (,$(findstring /cygdrive/,$(PATH)))
+            CYGWIN=1
+        endif # CYGWIN
     endif # ComSpec
 endif # COMSPEC
 
-ifdef COMSPEC
+ifdef WINNT
     #### Maybe Windows
     ifndef CPPCHK_GLIBCXX_DEBUG
         CPPCHK_GLIBCXX_DEBUG=
@@ -64,7 +68,7 @@ ifdef COMSPEC
     else
         RDYNAMIC=-lshlwapi
     endif
-else # !COMSPEC
+else # !WINNT
     uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
     ifeq ($(uname_S),Linux)
@@ -79,17 +83,16 @@ else # !COMSPEC
         endif # !CPPCHK_GLIBCXX_DEBUG
     endif # GNU/kFreeBSD
 
-endif # COMSPEC
+endif # WINNT
 
-# Set the UNDEF_STRICT_ANSI flag to address compile time warnings
-# with tinyxml2 and Cygwin.
-ifdef COMSPEC
-    uname_S := $(shell uname -s)
-
-    ifneq (,$(findstring CYGWIN,$(uname_S)))
-        UNDEF_STRICT_ANSI=-U__STRICT_ANSI__
-    endif # CYGWIN
-endif # COMSPEC
+ifdef CYGWIN
+    # Set the UNDEF_STRICT_ANSI flag to address compile time warnings
+    # with tinyxml2 and Cygwin.
+    UNDEF_STRICT_ANSI=-U__STRICT_ANSI__
+    
+    # Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.
+    CXXFLAGS+=-Wl,--stack,8388608
+endif # CYGWIN
 
 ifndef CXX
     CXX=g++
@@ -101,15 +104,6 @@ endif
 ifndef CXXFLAGS
     CXXFLAGS=-pedantic -Wall -Wextra -Wcast-qual -Wno-deprecated-declarations -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-shadow -Wno-missing-field-initializers -Wno-missing-braces -Wno-sign-compare -Wno-multichar $(CPPCHK_GLIBCXX_DEBUG) -g
 endif
-
-# Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.
-ifdef COMSPEC
-    uname_S := $(shell uname -s)
-
-    ifneq (,$(findstring CYGWIN,$(uname_S)))
-        CXXFLAGS+=-Wl,--stack,8388608
-    endif # CYGWIN
-endif # COMSPEC
 
 ifeq (g++, $(findstring g++,$(CXX)))
     override CXXFLAGS += -std=c++0x

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ g++ -o cppcheck -std=c++11 -lpcre -DHAVE_RULES -Ilib -Iexternals -Iexternals/sim
 ### MinGW
 
 ```shell
-mingw32-make LDFLAGS=-lshlwapi
+mingw32-make
 ```
 
 ### Other Compiler/IDE

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,16 @@ g++ -o cppcheck -std=c++11 -lpcre -DHAVE_RULES -Ilib -Iexternals -Iexternals/sim
 mingw32-make
 ```
 
+If you encounter the following error with `MATCHCOMPILER=yes` you need to specify your Python interpreter via `PYTHON_INTERPRETER`.
+
+```
+process_begin: CreateProcess(NULL, which python3, ...) failed.
+makefile:24: pipe: No error
+process_begin: CreateProcess(NULL, which python, ...) failed.
+makefile:27: pipe: No error
+makefile:30: *** Did not find a Python interpreter.  Stop.
+```
+
 ### Other Compiler/IDE
 
 1. Create an empty project file / makefile.

--- a/readmeja.md
+++ b/readmeja.md
@@ -117,7 +117,7 @@ g++ -o cppcheck -std=c++11 -lpcre -DHAVE_RULES -Iexternals -Iexternals/simplecpp
 ### MinGW
 
 ```shell
-mingw32-make LDFLAGS=-lshlwapi
+mingw32-make
 ```
 
 ### その他のコンパイラ/IDE

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -287,11 +287,15 @@ int main(int argc, char **argv)
          << "ifndef COMSPEC\n"
          << "    ifdef ComSpec\n"
          << "        #### ComSpec is defined on some WIN32's.\n"
-         << "        COMSPEC=$(ComSpec)\n"
+         << "        WINNT=1\n"
+         << "\n"
+         << "        ifneq (,$(findstring /cygdrive/,$(PATH)))\n"
+         << "            CYGWIN=1\n"
+         << "        endif # CYGWIN\n"
          << "    endif # ComSpec\n"
          << "endif # COMSPEC\n"
          << "\n"
-         << "ifdef COMSPEC\n"
+         << "ifdef WINNT\n"
          << "    #### Maybe Windows\n"
          << "    ifndef CPPCHK_GLIBCXX_DEBUG\n"
          << "        CPPCHK_GLIBCXX_DEBUG=\n"
@@ -302,7 +306,7 @@ int main(int argc, char **argv)
          << "    else\n"
          << "        RDYNAMIC=-lshlwapi\n"
          << "    endif\n"
-         << "else # !COMSPEC\n"
+         << "else # !WINNT\n"
          << "    uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')\n"
          << "\n"
          << "    ifeq ($(uname_S),Linux)\n"
@@ -317,19 +321,18 @@ int main(int argc, char **argv)
          << "        endif # !CPPCHK_GLIBCXX_DEBUG\n"
          << "    endif # GNU/kFreeBSD\n"
          << "\n"
-         << "endif # COMSPEC\n"
+         << "endif # WINNT\n"
          << "\n";
 
     // tinymxl2 requires __STRICT_ANSI__ to be undefined to compile under CYGWIN.
-    fout << "# Set the UNDEF_STRICT_ANSI flag to address compile time warnings\n"
-         << "# with tinyxml2 and Cygwin.\n"
-         << "ifdef COMSPEC\n"
-         << "    uname_S := $(shell uname -s)\n"
-         << "\n"
-         << "    ifneq (,$(findstring CYGWIN,$(uname_S)))\n"
-         << "        UNDEF_STRICT_ANSI=-U__STRICT_ANSI__\n"
-         << "    endif # CYGWIN\n"
-         << "endif # COMSPEC\n"
+    fout << "ifdef CYGWIN\n"
+         << "    # Set the UNDEF_STRICT_ANSI flag to address compile time warnings\n"
+         << "    # with tinyxml2 and Cygwin.\n"
+         << "    UNDEF_STRICT_ANSI=-U__STRICT_ANSI__\n"
+         << "    \n"
+         << "    # Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.\n"
+         << "    CXXFLAGS+=-Wl,--stack,8388608\n"
+         << "endif # CYGWIN\n"
          << "\n";
 
     // skip "-D_GLIBCXX_DEBUG" if clang, since it breaks the build
@@ -373,16 +376,6 @@ int main(int argc, char **argv)
                                 "$(CPPCHK_GLIBCXX_DEBUG) "
                                 "-g");
     }
-
-    fout << "# Increase stack size for Cygwin builds to avoid segmentation fault in limited recursive tests.\n"
-         << "ifdef COMSPEC\n"
-         << "    uname_S := $(shell uname -s)\n"
-         << "\n"
-         << "    ifneq (,$(findstring CYGWIN,$(uname_S)))\n"
-         << "        CXXFLAGS+=-Wl,--stack,8388608\n"
-         << "    endif # CYGWIN\n"
-         << "endif # COMSPEC\n"
-         << "\n";
 
     fout << "ifeq (g++, $(findstring g++,$(CXX)))\n"
          << "    override CXXFLAGS += -std=c++0x\n"

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -254,7 +254,9 @@ int main(int argc, char **argv)
          << "endif\n";
     fout << "ifeq ($(MATCHCOMPILER),yes)\n"
          << "    # Find available Python interpreter\n"
-         << "    PYTHON_INTERPRETER := $(shell which python3)\n"
+         << "    ifndef PYTHON_INTERPRETER\n"
+         << "        PYTHON_INTERPRETER := $(shell which python3)\n"
+         << "    endif\n"
          << "    ifndef PYTHON_INTERPRETER\n"
          << "        PYTHON_INTERPRETER := $(shell which python)\n"
          << "    endif\n"


### PR DESCRIPTION
I removed `LDFLAGS` from the documentation since the `Makefile` sets it implicitly.

Somehow the MinGW setup in the CI contains `which` and `uname` which are not available if I install MinGW locally. So even though the build works in the CI we need to adjust the detection and configuration in the `Makefile`. These are more reasons which would justify dropping the `Makefile` in favor of CMake (but I am not prepared to do that for several reasons...yet).

This is in preparation of natively running daca@home on Windows via MinGW.