### PR TITLE
simplify asm labels

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11391,7 +11391,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!balance) {
+            if (!balance && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11377,7 +11377,7 @@ void Tokenizer::simplifyAsm()
 
         else if (Token::Match(tok, "asm|__asm|__asm__ volatile|__volatile|__volatile__| (")) {
             long balance = 0;
-            for (Token *uptok = tok; uptok; uptok = uptok->previous()) {
+            for (Token *uptok = tok; uptok && balance < 1; uptok = uptok->previous()) {
                if (uptok->str() == "{")
                    balance++;
                else if (uptok->str() == "}")

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11382,7 +11382,7 @@ void Tokenizer::simplifyAsm()
                 partok = partok->next();
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
-            if (!Token::Match(tok->previous(), ";|{")) {
+            if (tok->previous() && !Token::Match(tok->previous(), ";|{")) {
                 // Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11376,13 +11376,13 @@ void Tokenizer::simplifyAsm()
         }
 
         else if (Token::Match(tok, "asm|__asm|__asm__ volatile|__volatile|__volatile__| (")) {
-            // Check if asm is inside fuction (at least one closing curly brace after)
-            Token* downbrace = tok;
-            while (downbrace && downbrace->str != "}")
-                downbrace->next();
-
-            //while (upbrace && upbrace->str() != "{")
-            //    upbrace = upbrace -> previous();
+            long balance = 0;
+            for (Token *uptok = tok; uptok; uptok = uptok->previous()) {
+               if (uptok->str() == "{")
+                   balance++;
+               else if (uptok->str() == "}")
+                   balance--;
+            }
 
             // Goto "("
             Token *partok = tok->next();
@@ -11391,7 +11391,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!downbrace) {
+            if (!balance) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11391,7 +11391,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!balance && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName)) {
+            if (!balance && tok->previous() && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName)) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11382,6 +11382,11 @@ void Tokenizer::simplifyAsm()
                 partok = partok->next();
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
+            if (!Token::Match(tok->previous(), ";|{")) {
+                // Asm label found
+                tok->deleteThis();
+                continue;
+            }
         }
 
         else if (Token::Match(tok, "_asm|__asm")) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11376,14 +11376,23 @@ void Tokenizer::simplifyAsm()
         }
 
         else if (Token::Match(tok, "asm|__asm|__asm__ volatile|__volatile|__volatile__| (")) {
+            // Check if asm is inside fuction (at least one closing curly brace after)
+            Token* downbrace = tok;
+            while (downbrace && downbrace->str != "}")
+                downbrace->next();
+
+            //while (upbrace && upbrace->str() != "{")
+            //    upbrace = upbrace -> previous();
+
             // Goto "("
             Token *partok = tok->next();
             if (partok->str() != "(")
                 partok = partok->next();
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
-            if (tok->previous() && !Token::Match(tok->previous(), ";|{")) {
-                // Asm label found
+
+            if (!downbrace) {
+                // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;
             }

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11391,7 +11391,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!balance && tok->previous() && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName)) {
+            if (!balance && tok->previous() && (tok->previous()->str() == ")" || tok->previous()->tokType() == Token::eName)) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11378,7 +11378,7 @@ void Tokenizer::simplifyAsm()
         else if (Token::Match(tok, "asm|__asm|__asm__ volatile|__volatile|__volatile__| (")) {
             // Searching for unmatched '{' before asm (label or inline?)
             const Token* uptok = tok->previous();
-            while(uptok && uptok->str() != "{") {
+            while (uptok && uptok->str() != "{") {
                if (uptok->str() == "}")
                    uptok = uptok->link();
 
@@ -11392,7 +11392,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!uptok && Token::Match(tok->previous(),"%name%|)")) {
+            if (!uptok && Token::Match(tok->previous(), "%name%|)")) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11379,10 +11379,10 @@ void Tokenizer::simplifyAsm()
             // Searching for unmatched '{' before asm (label or inline?)
             const Token* uptok = tok->previous();
             while (uptok && uptok->str() != "{") {
-               if (uptok->str() == "}")
-                   uptok = uptok->link();
+                if (uptok->str() == "}")
+                    uptok = uptok->link();
 
-               uptok = uptok->previous();
+                uptok = uptok->previous();
             }
 
             // Goto "("

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11391,7 +11391,7 @@ void Tokenizer::simplifyAsm()
             instruction = partok->next()->stringifyList(partok->link());
             Token::eraseTokens(tok, partok->link()->next());
 
-            if (!balance && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName) {
+            if (!balance && (tok->previous()->str() == ")" || tok->previous()->tokType() == eName)) {
                 // Asm outside function => Asm label found
                 tok->deleteThis();
                 continue;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11378,7 +11378,7 @@ void Tokenizer::simplifyAsm()
         else if (Token::Match(tok, "asm|__asm|__asm__ volatile|__volatile|__volatile__| (")) {
             // Searching for unmatched '{' before asm (label or inline?)
             const Token* uptok = tok->previous();
-            while(uptok && uptok->str() != "{")
+            while(uptok && uptok->str() != "{") {
                if (uptok->str() == "}")
                    uptok = uptok->link();
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -998,10 +998,10 @@ private:
     void simplifyAsm() {
         // asm label (variable)
         ASSERT_EQUALS("int * pfoo ; pfoo = NULL ;",
-                      tokenizeAndStringify("int* pfoo asm ("pmyfoo") = NULL;"));
+                      tokenizeAndStringify("int* pfoo asm (\"pmyfoo\") = NULL;"));
         // asm label (function)
         ASSERT_EQUALS("void * func ( ) ;",
-                      tokenizeAndStringify("void* func() asm ("myfunc");"));
+                      tokenizeAndStringify("void* func() asm (\"myfunc\");"));
     }
 
     // #4725 - ^{}

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -110,6 +110,7 @@ private:
         TEST_CASE(simplifyAt);
 
         TEST_CASE(inlineasm);
+        TEST_CASE(simplifyAsm);
         TEST_CASE(simplifyAsm2);  // #4725 (writing asm() around "^{}")
 
         TEST_CASE(ifAddBraces1);
@@ -992,6 +993,15 @@ private:
 
         // 'asm ( ) ;' should be in the same line
         ASSERT_EQUALS(";\n\nasm ( \"\"mov ax,bx\"\" ) ;", tokenizeAndStringify(";\n\n__asm__ volatile ( \"mov ax,bx\" );"));
+    }
+
+    void simplifyAsm() {
+        // asm label (variable)
+        ASSERT_EQUALS("int * pfoo ; pfoo = NULL ;",
+                      tokenizeAndStringify("int* pfoo asm ("pmyfoo") = NULL;"));
+        // asm label (function)
+        ASSERT_EQUALS("void * func ( ) ;",
+                      tokenizeAndStringify("void* func() asm ("myfunc");"));
     }
 
     // #4725 - ^{}


### PR DESCRIPTION
Fixes cppcheck 2.7 regression and adds support for proper (i hope) asm labels processing (https://gcc.gnu.org/onlinedocs/gcc/Asm-Labels.html).

How it looks in cppcheck 2.7:

```
$ cppcheck asmlabel.c
Checking asmlabel.c ...
asmlabel.c:2:7: error: There is an unknown macro here somewhere. Configuration is required. If func is a macro then please configure it. [unknownMacro]
void* func() asm ("myfunc") ;
      ^
$ cat asmlabel.c
int* pfoo asm ("pmyfoo") = NULL;
void* func() asm ("myfunc") ;

$ cppcheck --debug asmlabel.c
Checking asmlabel.c ...


##file asmlabel.c
1: int * pfoo asm ( ""pmyfoo"" ) ; = NULL ;
2: void * func ( ) asm ( ""myfunc"" ) ;



##Value flow
asmlabel.c:2:7: error: There is an unknown macro here somewhere. Configuration is required. If func is a macro then please configure it. [unknownMacro]
void* func() asm ("myfunc") ;
```