### PR TITLE
inline visitAstNodes() calls

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -45,8 +45,8 @@
 #include <unordered_map>
 #include <utility>
 
-template<class T, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-void visitAstNodesGeneric(T *ast, std::function<ChildrenToVisit(T *)> visitor)
+template<class T, class TFunc, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
+void visitAstNodesGeneric(T *ast, const TFunc &visitor)
 {
     if (!ast)
         return;
@@ -79,12 +79,12 @@ void visitAstNodesGeneric(T *ast, std::function<ChildrenToVisit(T *)> visitor)
 
 void visitAstNodes(const Token *ast, std::function<ChildrenToVisit(const Token *)> visitor)
 {
-    visitAstNodesGeneric(ast, std::move(visitor));
+    visitAstNodesGeneric(ast, visitor);
 }
 
 void visitAstNodes(Token *ast, std::function<ChildrenToVisit(Token *)> visitor)
 {
-    visitAstNodesGeneric(ast, std::move(visitor));
+    visitAstNodesGeneric(ast, visitor);
 }
 
 const Token* findAstNode(const Token* ast, const std::function<bool(const Token*)>& pred)

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -40,52 +40,9 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <stack>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
-
-template<class T, class TFunc, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-void visitAstNodesGeneric(T *ast, const TFunc &visitor)
-{
-    if (!ast)
-        return;
-
-    std::stack<T *, std::vector<T *>> tokens;
-    T *tok = ast;
-    do {
-        ChildrenToVisit c = visitor(tok);
-
-        if (c == ChildrenToVisit::done)
-            break;
-        if (c == ChildrenToVisit::op2 || c == ChildrenToVisit::op1_and_op2) {
-            T *t2 = tok->astOperand2();
-            if (t2)
-                tokens.push(t2);
-        }
-        if (c == ChildrenToVisit::op1 || c == ChildrenToVisit::op1_and_op2) {
-            T *t1 = tok->astOperand1();
-            if (t1)
-                tokens.push(t1);
-        }
-
-        if (tokens.empty())
-            break;
-
-        tok = tokens.top();
-        tokens.pop();
-    } while (true);
-}
-
-void visitAstNodes(const Token *ast, std::function<ChildrenToVisit(const Token *)> visitor)
-{
-    visitAstNodesGeneric(ast, visitor);
-}
-
-void visitAstNodes(Token *ast, std::function<ChildrenToVisit(Token *)> visitor)
-{
-    visitAstNodesGeneric(ast, visitor);
-}
 
 const Token* findAstNode(const Token* ast, const std::function<bool(const Token*)>& pred)
 {


### PR DESCRIPTION
See https://blog.demofox.org/2015/02/25/avoiding-the-performance-hazzards-of-stdfunction/.

Testing with `cli/threadexecutor.cpp`:
GCC 11 `656,137,737` -> `582,567,111`
Clang 13 `605,911,420` -> `556,949,984`