### PR TITLE
windows.cfg: Fix configuration for _atoi_l and _wtoi_l

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -6751,7 +6751,7 @@ HFONT CreateFont(
   </function>
   <!-- int _atoi_l(const char *str, _locale_t locale); -->
   <!-- int _wtoi_l(const wchar_t *str, _locale_t locale); -->
-  <function name="_atol_l,_wtol_l">
+  <function name="_atoi_l,_wtoi_l">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
     <use-retval/>


### PR DESCRIPTION
It's probably copy-pasta, _atol_l and _wtol_l are configured below.