### PR TITLE
Add leak-ignore for fopen_s(), test cases

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -1867,6 +1867,7 @@
   <function name="fopen_s">
     <returnValue type="errno_t"/>
     <noreturn>false</noreturn>
+    <leak-ignore/>
     <arg nr="1">
       <not-null/>
     </arg>

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1743,7 +1743,7 @@ private:
 
         check("FILE* f() {\n"
               "    char* temp = strdup(\"temp.txt\");\n"
-              "    FILE * fp = NULL;\n"
+              "    FILE* fp = NULL;\n"
               "    fopen_s(&fp, temp, \"rt\");\n"
               "    return fp;\n"
               "}\n", s);
@@ -1751,7 +1751,7 @@ private:
 
         check("void f() {\n"
               "    char* temp = strdup(\"temp.txt\");\n"
-              "    FILE * fp = fopen(\"a.txt\", \"rb\");\n"
+              "    FILE* fp = fopen(\"a.txt\", \"rb\");\n"
               "    if (fp)\n"
               "        freopen(temp, \"rt\", fp);\n"
               "}\n", s);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1743,6 +1743,24 @@ private:
 
         check("FILE* f() {\n"
               "    char* temp = strdup(\"temp.txt\");\n"
+              "    FILE * fp = NULL;\n"
+              "    fopen_s(&fp, temp, \"rt\");\n"
+              "    return fp;\n"
+              "}\n", s);
+        ASSERT_EQUALS("[test.cpp:5]: (error) Memory leak: temp\n", errout.str());
+
+        check("void f() {\n"
+              "    char* temp = strdup(\"temp.txt\");\n"
+              "    FILE * fp = fopen(\"a.txt\", \"rb\");\n"
+              "    if (fp)\n"
+              "        freopen(temp, \"rt\", fp);\n"
+              "}\n", s);
+        ASSERT_EQUALS("[test.cpp:6]: (error) Memory leak: temp\n"
+                      "[test.cpp:6]: (error) Resource leak: fp\n",
+                      errout.str());
+
+        check("FILE* f() {\n"
+              "    char* temp = strdup(\"temp.txt\");\n"
               "    return fopen(temp, \"rt\");\n"
               "}\n", s);
         TODO_ASSERT_EQUALS("[test.cpp:3]: (error) Memory leak: temp\n", "", errout.str());


### PR DESCRIPTION
`freopen()` doesn't have leak-ignore, but the `temp` leak is still reported.