### PR TITLE
Misra false positive fixes for rules 8.7 and 5.9

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1395,7 +1395,9 @@ class MisraChecker:
                 local_identifiers.append(identifier(var.nameToken))
             elif var.isStatic:
                 names.append(var.nameToken.str)
-                internal_identifiers.append(identifier(var.nameToken))
+                i = identifier(var.nameToken)
+                i['inlinefunc'] = False
+                internal_identifiers.append(i)
             else:
                 names.append(var.nameToken.str)
                 i = identifier(var.nameToken)
@@ -1406,7 +1408,9 @@ class MisraChecker:
             if func.tokenDef is None:
                 continue
             if func.isStatic:
-                internal_identifiers.append(identifier(func.tokenDef))
+                i = identifier(func.tokenDef)
+                i['inlinefunc'] = func.isInlineKeyword
+                internal_identifiers.append(i)
             else:
                 if func.token is None:
                     i = identifier(func.tokenDef)
@@ -4478,8 +4482,9 @@ class MisraChecker:
                 if summary_type == 'MisraInternalIdentifiers':
                     for s in summary_data:
                         if s['name'] in all_internal_identifiers:
-                            self.reportError(Location(s), 5, 9)
-                            self.reportError(Location(all_internal_identifiers[s['name']]), 5, 9)
+                            if not s['inlinefunc'] or s['file'] != all_internal_identifiers[s['name']]['file']:
+                                self.reportError(Location(s), 5, 9)
+                                self.reportError(Location(all_internal_identifiers[s['name']]), 5, 9)
                         all_internal_identifiers[s['name']] = s
 
                 if summary_type == 'MisraLocalIdentifiers':

--- a/addons/test/misra/misra-ctu-1-test.c
+++ b/addons/test/misra/misra-ctu-1-test.c
@@ -39,3 +39,4 @@ extern int misra_8_5;
 // cppcheck-suppress misra-c2012-8.6
 int32_t misra_8_6 = 1;
 
+void misra_8_7_external(void) {}

--- a/addons/test/misra/misra-ctu-2-test.c
+++ b/addons/test/misra/misra-ctu-2-test.c
@@ -41,5 +41,8 @@ int32_t misra_8_6 = 2;
 // cppcheck-suppress misra-c2012-8.4
 // cppcheck-suppress misra-c2012-8.7
 void misra_8_7(void) {}
-static void misra_8_7_caller(void) { misra_8_7(); }
+static void misra_8_7_caller(void) { 
+    misra_8_7(); 
+    misra_8_7_external();
+}
 

--- a/addons/test/misra/misra-ctu-test.h
+++ b/addons/test/misra/misra-ctu-test.h
@@ -9,6 +9,10 @@ struct misra_2_4_violation_t {
     int x;
 };
 
+static inline void misra_5_9_exception(void) {}
+
+void misra_8_7_external(void);
+
 #define MISRA_2_5_OK_1 1
 #define MISRA_2_5_OK_2 2
 // cppcheck-suppress misra-c2012-2.5

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -11236,8 +11236,13 @@ void Tokenizer::simplifyKeyword()
         if (keywords.find(tok->str()) != keywords.end()) {
             // Don't remove struct members
             if (!Token::simpleMatch(tok->previous(), ".")) {
-                if (tok->str().find("inline") != std::string::npos && Token::Match(tok->next(), "%name%"))
-                    tok->next()->isInline(true);
+                if (tok->str().find("inline") != std::string::npos) {
+                    Token *temp = tok->next();
+                    while (temp != nullptr && Token::Match(temp, "%name%")) {
+                        temp->isInline(true);
+                        temp = temp->next();
+                    }
+                }
                 tok->deleteThis(); // Simplify..
             }
         }


### PR DESCRIPTION
The fixed false positive violations are reported in trac tickets [#10751](https://trac.cppcheck.net/ticket/10751), [#10814](https://trac.cppcheck.net/ticket/10814) and [#10820](https://trac.cppcheck.net/ticket/10820).

The PR also includes a fix for when sometimes the inline keyword was being ignored as detailed in this [sourceforge thread](https://sourceforge.net/p/cppcheck/discussion/general/thread/368fc732dc/#bf40).