### PR TITLE
Restore symbol names from cache

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -220,6 +220,8 @@ ErrorMessage::ErrorMessage(const tinyxml2::XMLElement * const errmsg)
             const int line = strline ? std::atoi(strline) : 0;
             const int column = strcolumn ? std::atoi(strcolumn) : 0;
             callStack.emplace_front(file, info, line, column);
+        } else if (std::strcmp(e->Name(),"symbol")==0) {
+             mSymbolNames += e->GetText();
         }
     }
 }


### PR DESCRIPTION
When reading earlier reported errors from the cache file the
symbol names are not handled. This causes suppressions to no
longer match when rerunning cppcheck.

Signed-off-by: Bart vdr. Meulen <bartvdrmeulen@gmail.com>