### PR TITLE
de-coupled ErrorLogger interface from ThreadExecutor

### DIFF
--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -433,9 +433,10 @@ public:
         report(msg, MessageType::REPORT_INFO);
     }
 
-    void bughuntingReport(const std::string  & /*str*/) override
+    void bughuntingReport(const std::string &str) override
     {
-        // TODO
+        std::lock_guard<std::mutex> lg(mReportSync);
+        mThreadExecutor.mErrorLogger.bughuntingReport(str);
     }
 
     ThreadExecutor &mThreadExecutor;


### PR DESCRIPTION
I came across this while trying to align the handling of suppressions in single-threaded and multi-threaded/process analysis.

This is the first step of making the `ErrorLogger` usage a bit clearer. There's several layers of `ErrorLogger` implementations which are hard to follow and possibly even unnecessary,

It also gets rid of implementation-specific stuff in the header.

I think we could also provide a thread-based implementation for non-Windows with a simple change which would enable use to use TSAN or `valgrind` for checking for multi-threading issues.