### PR TITLE
New check: merge containers with pointers without proper compare functor

### DIFF
--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -69,6 +69,7 @@ public:
         checkStl.string_c_str();
         checkStl.uselessCalls();
         checkStl.useStlAlgorithm();
+        checkStl.checkMergeArguments();
 
         checkStl.stlOutOfBounds();
         checkStl.negativeIndex();
@@ -184,6 +185,8 @@ public:
 
     void checkMutexes();
 
+    void checkMergeArguments();
+
 private:
     bool isContainerSize(const Token *containerToken, const Token *expr) const;
     bool isContainerSizeGE(const Token * containerToken, const Token *expr) const;
@@ -233,6 +236,8 @@ private:
     void globalLockGuardError(const Token *tok);
     void localMutexError(const Token *tok);
 
+    void checkMergeArgumentsError(const Token *tok);
+
     void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         ErrorPath errorPath;
         CheckStl c(nullptr, settings, errorLogger);
@@ -272,6 +277,7 @@ private:
         c.knownEmptyContainerError(nullptr, "");
         c.globalLockGuardError(nullptr);
         c.localMutexError(nullptr);
+        c.checkMergeArgumentsError(nullptr);
     }
 
     static std::string myName() {
@@ -296,7 +302,8 @@ private:
                "- reading from empty STL container\n"
                "- iterating over an empty STL container\n"
                "- consider using an STL algorithm instead of raw loop\n"
-               "- incorrect locking with mutex\n";
+               "- incorrect locking with mutex\n"
+               "- comparing pointers instead of objects in merge\n";
     }
 };
 /// @}

--- a/lib/token.h
+++ b/lib/token.h
@@ -977,6 +977,7 @@ public:
      * "{" <-> "}"
      * "(" <-> ")"
      * "[" <-> "]"
+     * "<" <-> ">"
      *
      * @return The token where this token links to.
      */

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -174,6 +174,13 @@ private:
 
         TEST_CASE(checkKnownEmptyContainer);
         TEST_CASE(checkMutexes);
+
+        TEST_CASE(checkMergeArguments0);
+        TEST_CASE(checkMergeArguments1);
+        TEST_CASE(checkMergeArguments2);
+        TEST_CASE(checkMergeArguments3);
+        TEST_CASE(checkMergeArguments4);
+        TEST_CASE(checkMergeArguments5);
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -5698,6 +5705,58 @@ private:
               "        std::scoped_lock shared_multi_lock(shared_foo_lock, shared_bar_lock);\n"
               "    }\n"
               "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkMergeArguments0() {
+        checkNormal("void f() {\n"
+                    "    std::list<unsigned long long int> list1, list2;\n"
+                    "    list1.merge(list2);\n"
+                    "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkMergeArguments1() {
+        checkNormal("void f() {\n"
+                    "    std::list<int long unsigned long *> list1, list2;\n"
+                    "    list1.merge(list2);\n"
+                    "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Merge operation expects both containers in a sorted order. But now code compares pointers "
+                      "instead of objects inside. You can use lambda expression to compare objects itself\n", errout.str());
+    }
+
+    void checkMergeArguments2() {
+        checkNormal("void f() {\n"
+                    "    std::list<unsigned long long int *> list1, list2;\n"
+                    "    list1.merge(list2,\n"
+                    "                [](const unsigned long long int* a, const unsigned long long int* b){ return *a < *b; });\n"
+                    "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkMergeArguments3() {
+        checkNormal("void f() {\n"
+                    "    std::forward_list<char *, std::allocator<char *>> list1, list2;\n"
+                    "    list1.merge(list2);\n"
+                    "}\n");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Merge operation expects both containers in a sorted order. But now code compares pointers "
+                      "instead of objects inside. You can use lambda expression to compare objects itself\n", errout.str());
+    }
+
+    void checkMergeArguments4() {
+        checkNormal("void f() {\n"
+                    "    std::forward_list<int *> list1, list2;\n"
+                    "    list1.merge(list2,\n"
+                    "                [](const int* a, const int* b){ return *a < *b; });\n"
+                    "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void checkMergeArguments5() {
+        checkNormal("void f() {\n"
+                    "    std::list<unsigned int, std::allocator<unsigned int>> list1, list2;\n"
+                    "    list1.merge(list2);\n"
+                    "}\n");
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
`std::(forward_)list` has a [merge](https://en.cppreference.com/w/cpp/container/forward_list/merge) member function. This function has a [prerequisite](https://eel.is/c++draft/list.ops#26): `*this` and `arg` are both sorted with respect to the comparator `operator<`. In compile time we can detect applying `merge` operation to container where element type is pointer type. In general, comparing pointers with `operator<` doesn't have much sense (except may be custom allocator class or something hw-related).
Also MSVC runtime in debug mode can detect unsorted values in runtime (that's how I got idea for this check)

This check can detect such cases, when user trying to merge containers of pointers without proper compare functor. Still not sure about message text and errorId, comments will be appreciated.

About TODO: in <algorithm> header, we can find non-member [function ](https://eel.is/c++draft/alg.merge)`merge`. And I'm not sure how to write quality check for this case. The main question is how to deduce the correct type from arguments. E.g. argument can be expression like: `cont1.cbegin()`, or iterator itself, or user function call.

And in `lib/token.h`, is it correct that `Token::link` can be used for pair "<"  ">"?
And one more thing, I saw strange behaviour in tests if I left `#include <list>` as a first line. That's very suspicious.