### PR TITLE
de-coupled `--check-library` from `information` severity and other dependencies

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -246,8 +246,6 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             // Check library definitions
             else if (std::strcmp(argv[i], "--check-library") == 0) {
                 mSettings->checkLibrary = true;
-                // need to add "information" or no messages will be shown at all
-                mSettings->addEnabled("information");
             }
 
             else if (std::strncmp(argv[i], "--checks-max-time=", 18) == 0) {

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -593,7 +593,7 @@ void CheckFunctions::memsetValueOutOfRangeError(const Token *tok, const std::str
 
 void CheckFunctions::checkLibraryMatchFunctions()
 {
-    if (!mSettings->checkLibrary || !mSettings->severity.isEnabled(Severity::information))
+    if (!mSettings->checkLibrary)
         return;
 
     bool insideNew = false;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -169,7 +169,7 @@ void CheckLeakAutoVar::deallocReturnError(const Token *tok, const Token *dealloc
 
 void CheckLeakAutoVar::configurationInfo(const Token* tok, const std::string &functionName)
 {
-    if (mSettings->checkLibrary && mSettings->severity.isEnabled(Severity::information)) {
+    if (mSettings->checkLibrary) {
         reportError(tok,
                     Severity::information,
                     "checkLibraryUseIgnore",

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1147,14 +1147,14 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
 
 void CheckUnusedVar::checkFunctionVariableUsage()
 {
-    if (!mSettings->severity.isEnabled(Severity::style))
+    if (!mSettings->severity.isEnabled(Severity::style) && !mSettings->checkLibrary)
         return;
 
     // Parse all executing scopes..
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
 
     auto reportLibraryCfgError = [this](const Token* tok, const std::string& typeName) {
-        if (mSettings->checkLibrary && mSettings->severity.isEnabled(Severity::information)) {
+        if (mSettings->checkLibrary) {
             reportError(tok,
                         Severity::information,
                         "checkLibraryCheckType",
@@ -1380,16 +1380,25 @@ void CheckUnusedVar::checkFunctionVariableUsage()
 
 void CheckUnusedVar::unusedVariableError(const Token *tok, const std::string &varname)
 {
+    if (!mSettings->severity.isEnabled(Severity::style))
+        return;
+
     reportError(tok, Severity::style, "unusedVariable", "$symbol:" + varname + "\nUnused variable: $symbol", CWE563, Certainty::normal);
 }
 
 void CheckUnusedVar::allocatedButUnusedVariableError(const Token *tok, const std::string &varname)
 {
+    if (!mSettings->severity.isEnabled(Severity::style))
+        return;
+
     reportError(tok, Severity::style, "unusedAllocatedMemory", "$symbol:" + varname + "\nVariable '$symbol' is allocated memory that is never used.", CWE563, Certainty::normal);
 }
 
 void CheckUnusedVar::unreadVariableError(const Token *tok, const std::string &varname, bool modified)
 {
+    if (!mSettings->severity.isEnabled(Severity::style))
+        return;
+
     if (modified)
         reportError(tok, Severity::style, "unreadVariable", "$symbol:" + varname + "\nVariable '$symbol' is modified but its new value is never used.", CWE563, Certainty::normal);
     else
@@ -1398,6 +1407,9 @@ void CheckUnusedVar::unreadVariableError(const Token *tok, const std::string &va
 
 void CheckUnusedVar::unassignedVariableError(const Token *tok, const std::string &varname)
 {
+    if (!mSettings->severity.isEnabled(Severity::style))
+        return;
+
     reportError(tok, Severity::style, "unassignedVariable", "$symbol:" + varname + "\nVariable '$symbol' is not assigned a value.", CWE665, Certainty::normal);
 }
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -7172,7 +7172,7 @@ bool Tokenizer::isScopeNoReturn(const Token *endScopeToken, bool *unknown) const
     }
     if (unknown)
         *unknown = !unknownFunc.empty();
-    if (!unknownFunc.empty() && mSettings->checkLibrary && mSettings->severity.isEnabled(Severity::information)) {
+    if (!unknownFunc.empty() && mSettings->checkLibrary) {
         bool warn = true;
         if (Token::simpleMatch(endScopeToken->tokAt(-2), ") ; }")) {
             const Token * const ftok = endScopeToken->linkAt(-2)->previous();

--- a/man/manual-ja.docbook
+++ b/man/manual-ja.docbook
@@ -1360,9 +1360,9 @@ Checking minsize.c...
         <programlisting># cppcheck noreturn.c
 Checking noreturn.c...</programlisting>
 
-        <para>しかし、<literal>--check-library</literal> と<literal>--enable=information</literal>をつかうとエラーが出力されます。:</para>
+        <para>しかし、<literal>--check-library</literal> をつかうとエラーが出力されます。:</para>
 
-        <programlisting># cppcheck --check-library --enable=information noreturn.c
+        <programlisting># cppcheck --check-library noreturn.c
 Checking noreturn.c...
 [noreturn.c:7]: (information) --check-library: Function ZeroMemory() should have &lt;noreturn&gt; configuration
 </programlisting>

--- a/man/manual.md
+++ b/man/manual.md
@@ -925,7 +925,7 @@ Cppcheck already contains configurations for several libraries. They can be load
 
 ## Using your own custom .cfg file
 
-You can create and use your own .cfg files for your projects. Use `--check-library` and `--enable=information` to get hints about what you should configure.
+You can create and use your own .cfg files for your projects. Use `--check-library` to get hints about what you should configure.
 
 You can use the `Library Editor` in the `Cppcheck GUI` to edit configuration files. It is available in the `View` menu.
 

--- a/man/reference-cfg-format.md
+++ b/man/reference-cfg-format.md
@@ -89,7 +89,7 @@ If instead `dostuff` takes care of the memory then this can be configured with:
       </memory>
     </def>
 
-The `<use>` configuration has no logical purpose. You will get the same warnings without it. Use it to silence --check-library information messages.
+The `<use>` configuration has no logical purpose. You will get the same warnings without it. Use it to silence `--check-library` information messages.
 
 # Function behavior
 
@@ -397,9 +397,9 @@ In theory, if ZeroMemory terminates the program then there is no bug. Cppcheck t
     $ cppcheck noreturn.c
     Checking noreturn.c...
 
-However if you use `--check-library` and `--enable=information` you'll get this:
+However if you use `--check-library` you'll get this:
 
-    $ cppcheck --check-library --enable=information noreturn.c
+    $ cppcheck --check-library noreturn.c
     Checking noreturn.c...
     [noreturn.c:7]: (information) --check-library: Function ZeroMemory() should have <noreturn> configuration
 

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for boost.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/boost.cpp
+// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/boost.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for boost.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/boost.cpp
+// $ cppcheck --check-library --library=boost --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/boost.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/bsd.c
+++ b/test/cfg/bsd.c
@@ -1,7 +1,7 @@
 // Test library configuration for bsd.cfg
 //
 // Usage:
-// $ cppcheck --library=bsd --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/bsd.c
+// $ cppcheck --library=bsd --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/bsd.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/bsd.c
+++ b/test/cfg/bsd.c
@@ -1,7 +1,7 @@
 // Test library configuration for bsd.cfg
 //
 // Usage:
-// $ cppcheck --library=bsd --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/bsd.c
+// $ cppcheck --check-library --library=bsd --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/bsd.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cairo.c
+++ b/test/cfg/cairo.c
@@ -2,7 +2,7 @@
 // Test library configuration for cairo.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cairo --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/cairo.c
+// $ cppcheck --check-library --library=cairo --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/cairo.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cairo.c
+++ b/test/cfg/cairo.c
@@ -2,7 +2,7 @@
 // Test library configuration for cairo.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cairo --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/cairo.c
+// $ cppcheck --check-library --library=cairo --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cairo.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -1,7 +1,7 @@
 // Test library configuration for cppunit.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cppunit.cpp
+// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cppunit.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -1,7 +1,7 @@
 // Test library configuration for cppunit.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cppunit.cpp
+// $ cppcheck --check-library --library=cppunit --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/cppunit.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -2,7 +2,7 @@
 // Test library configuration for gnu.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=gnu --enable=information --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/gnu.c
+// $ cppcheck --check-library --library=gnu --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/gnu.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for googletest.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=googletest --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/googletest.cpp
+// $ cppcheck --check-library --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/googletest.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for googletest.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/googletest.cpp
+// $ cppcheck --check-library --library=googletest --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/googletest.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -2,7 +2,7 @@
 // Test library configuration for gtk.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=gtk test/cfg/gtk.cpp
+// $ cppcheck --check-library --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=gtk test/cfg/gtk.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -2,7 +2,7 @@
 // Test library configuration for gtk.cfg
 //
 // Usage:
-// $ cppcheck --check-library --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=gtk test/cfg/gtk.cpp
+// $ cppcheck --check-library --library=gtk --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=gtk test/cfg/gtk.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/kde.cpp
+++ b/test/cfg/kde.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for kde.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/kde.cpp
+// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/kde.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/kde.cpp
+++ b/test/cfg/kde.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for kde.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/kde.cpp
+// $ cppcheck --check-library --library=kde --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/kde.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libcurl.c
+++ b/test/cfg/libcurl.c
@@ -2,7 +2,7 @@
 // Test library configuration for libcurl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=libcurl --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/libcurl.c
+// $ cppcheck --check-library --library=libcurl --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/libcurl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libcurl.c
+++ b/test/cfg/libcurl.c
@@ -2,7 +2,7 @@
 // Test library configuration for libcurl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=libcurl --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/libcurl.c
+// $ cppcheck --check-library --library=libcurl --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/libcurl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libsigc++.cpp
+++ b/test/cfg/libsigc++.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for libsigc++.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/libsigc++.cpp
+// $ cppcheck --check-library --library=libsigc++ --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/libsigc++.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libsigc++.cpp
+++ b/test/cfg/libsigc++.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for libsigc++.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/libsigc++.cpp
+// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/libsigc++.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/lua.c
+++ b/test/cfg/lua.c
@@ -2,7 +2,7 @@
 // Test library configuration for lua.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=lua --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/lua.c
+// $ cppcheck --check-library --library=lua --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/lua.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/lua.c
+++ b/test/cfg/lua.c
@@ -2,7 +2,7 @@
 // Test library configuration for lua.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=lua --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/lua.c
+// $ cppcheck --check-library --library=lua --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/lua.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/opencv2.cpp
+++ b/test/cfg/opencv2.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for opencv2.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cairo --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/opencv2.cpp
+// $ cppcheck --check-library --library=cairo --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/opencv2.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/opencv2.cpp
+++ b/test/cfg/opencv2.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for opencv2.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cairo --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/opencv2.cpp
+// $ cppcheck --check-library --library=opencv2 --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/opencv2.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openmp.c
+++ b/test/cfg/openmp.c
@@ -2,7 +2,7 @@
 // Test library configuration for openmp.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openmp --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openmp.c
+// $ cppcheck --check-library --library=openmp --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/openmp.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openmp.c
+++ b/test/cfg/openmp.c
@@ -2,7 +2,7 @@
 // Test library configuration for openmp.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openmp --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openmp.c
+// $ cppcheck --check-library --library=openmp --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openmp.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openssl.c
+++ b/test/cfg/openssl.c
@@ -2,7 +2,7 @@
 // Test library configuration for openssl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openssl --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openssl.c
+// $ cppcheck --check-library --library=openssl --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/openssl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openssl.c
+++ b/test/cfg/openssl.c
@@ -2,7 +2,7 @@
 // Test library configuration for openssl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openssl --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openssl.c
+// $ cppcheck --check-library --library=openssl --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/openssl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -2,7 +2,7 @@
 // Test library configuration for posix.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=posix --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/posix.c
+// $ cppcheck --check-library --library=posix --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/posix.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -2,7 +2,7 @@
 // Test library configuration for posix.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=posix --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/posix.c
+// $ cppcheck --check-library --library=posix --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/posix.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/python.c
+++ b/test/cfg/python.c
@@ -2,7 +2,7 @@
 // Test library configuration for python.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=python --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/python.c
+// $ cppcheck --check-library --library=python --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/python.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/python.c
+++ b/test/cfg/python.c
@@ -2,7 +2,7 @@
 // Test library configuration for python.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=python --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/python.c
+// $ cppcheck --check-library --library=python --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/python.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for qt.cfg
 //
 // Usage:
-// $ cppcheck --check-library --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=qt test/cfg/qt.cpp
+// $ cppcheck --check-library --library=qt --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/qt.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for qt.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=qt test/cfg/qt.cpp
+// $ cppcheck --check-library --inconclusive --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr --library=qt test/cfg/qt.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -23,7 +23,7 @@ CPPCHECK="$DIR"../../cppcheck
 CFG="$DIR"../../cfg/
 
 # Cppcheck options
-CPPCHECK_OPT='--check-library --platform=unix64 --enable=information --enable=style --error-exitcode=-1 --suppress=missingIncludeSystem --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}"'
+CPPCHECK_OPT='--check-library --platform=unix64 --enable=style --error-exitcode=-1 --suppress=missingIncludeSystem --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}"'
 
 # Compiler settings
 CXX=g++

--- a/test/cfg/sqlite3.c
+++ b/test/cfg/sqlite3.c
@@ -2,7 +2,7 @@
 // Test library configuration for sqlite3.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=sqlite3 --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/sqlite3.c
+// $ cppcheck --check-library --enable=style --library=sqlite3 --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/sqlite3.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/sqlite3.c
+++ b/test/cfg/sqlite3.c
@@ -2,7 +2,7 @@
 // Test library configuration for sqlite3.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=sqlite3 --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/sqlite3.c
+// $ cppcheck --check-library --library=sqlite3 --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/sqlite3.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.c
+// $ cppcheck --check-library --library=std --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.c
+// $ cppcheck --check-library --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library  --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.cpp
+// $ cppcheck --check-library --library=std --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=information --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.cpp
+// $ cppcheck --check-library  --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/std.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for windows.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=windows --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/windows.cpp
+// $ cppcheck --check-library --library=windows --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/windows.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for windows.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=windows --enable=information --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/windows.cpp
+// $ cppcheck --check-library --library=windows --error-exitcode=1 --inline-suppr --suppress=missingIncludeSystem test/cfg/windows.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for wxwidgets.cfg
 //
 // Usage:
-// $ ./cppcheck --check-library --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr '--template="{file}:{line}:{severity}:{id}:{message}"' --inconclusive --library=wxwidgets -f test/cfg/wxwidgets.cpp
+// $ ./cppcheck --check-library --library=wxwidgets --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr test/cfg/wxwidgets.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for wxwidgets.cfg
 //
 // Usage:
-// $ ./cppcheck --check-library --enable=information --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr '--template="{file}:{line}:{severity}:{id}:{message}"' --inconclusive --library=wxwidgets -f test/cfg/wxwidgets.cpp
+// $ ./cppcheck --check-library --enable=style --error-exitcode=1 --suppress=missingIncludeSystem --inline-suppr '--template="{file}:{line}:{severity}:{id}:{message}"' --inconclusive --library=wxwidgets -f test/cfg/wxwidgets.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1827,9 +1827,8 @@ private:
     }
 
     void checkLibraryMatchFunctions() {
+        const auto settings_old = settings;
         settings.checkLibrary = true;
-        auto severity_old = settings.severity;
-        settings.severity.enable(Severity::information);
 
         check("void f() {\n"
               "    lib_func();"
@@ -1951,8 +1950,7 @@ private:
                            "[test.cpp:5]: (information) --check-library: There is no matching configuration for function auto::push_back()\n",
                            errout.str());
 
-        settings.severity = severity_old;
-        settings.checkLibrary = false;
+        settings = settings_old;
     }
 
     void checkUseStandardLibrary1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -239,7 +239,6 @@ private:
         // Check for leaks..
         CheckLeakAutoVar c;
         settings.checkLibrary = true;
-        settings.severity.enable(Severity::information);
         c.runChecks(&tokenizer, &settings, this);
     }
 
@@ -255,7 +254,6 @@ private:
         // Check for leaks..
         CheckLeakAutoVar c;
         settings_.checkLibrary = true;
-        settings_.severity.enable(Severity::information);
         c.runChecks(&tokenizer, &settings_, this);
     }
 
@@ -2645,7 +2643,6 @@ private:
         // Check for leaks..
         CheckLeakAutoVar c;
         settings.checkLibrary = true;
-        settings.addEnabled("information");
         c.runChecks(&tokenizer, &settings, this);
     }
 
@@ -2696,7 +2693,6 @@ private:
         // Check for leaks..
         CheckLeakAutoVar checkLeak;
         settings.checkLibrary = true;
-        settings.severity.enable(Severity::information);
         checkLeak.runChecks(&tokenizer, &settings, this);
     }
 

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -4601,7 +4601,6 @@ private:
 
     void uninitvar_configuration() {
         const auto oldSettings = settings;
-        settings.severity.enable(Severity::information);
         settings.checkLibrary = true;
 
         checkUninitVar("int f() {\n"

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -36,7 +36,6 @@ private:
 
     void run() override {
         settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::information);
         settings.checkLibrary = true;
         LOAD_LIB_2(settings.library, "std.cfg");
 


### PR DESCRIPTION
This is basically a proper fix for `--check-library` displaying things unlike the quick fix I did in 7c5015d54e422b02d58452d958f1c359056236c1 which introduced additional `information` and `missingInclude` ('information' includes that) checks and messages when using that flag. That does not make sense at all so I de-coupled those (as checks already were).

It was mentioned in some versions of the "documentation" that you should specify `--enable=information` as well but it was everything but clear.

On a side note I wonder if the cfg tests should also include `--inconclusive` in their flags.