### PR TITLE
removed ThreadExecutor::addFileContent()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -740,13 +740,13 @@ test/testsuite.o: test/testsuite.cpp lib/color.h lib/config.h lib/errorlogger.h 
 test/testsummaries.o: test/testsummaries.cpp lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/summaries.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testsummaries.o test/testsummaries.cpp
 
-test/testsuppressions.o: test/testsuppressions.cpp cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/testsuite.h
+test/testsuppressions.o: test/testsuppressions.cpp cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h test/testutils.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testsuppressions.o test/testsuppressions.cpp
 
 test/testsymboldatabase.o: test/testsymboldatabase.cpp externals/tinyxml2/tinyxml2.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h test/testutils.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testsymboldatabase.o test/testsymboldatabase.cpp
 
-test/testthreadexecutor.o: test/testthreadexecutor.cpp cli/threadexecutor.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/testsuite.h
+test/testthreadexecutor.o: test/testthreadexecutor.cpp cli/threadexecutor.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h test/testsuite.h test/testutils.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CPPFILESDIR) $(CXXFLAGS) $(UNDEF_STRICT_ANSI) -c -o test/testthreadexecutor.o test/testthreadexecutor.cpp
 
 test/testtimer.o: test/testtimer.cpp lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h lib/timer.h test/testsuite.h

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -67,12 +67,6 @@ ThreadExecutor::ThreadExecutor(const std::map<std::string, std::size_t> &files, 
 ThreadExecutor::~ThreadExecutor()
 {}
 
-// cppcheck-suppress unusedFunction - only used in unit tests
-void ThreadExecutor::addFileContent(const std::string &path, const std::string &content)
-{
-    mFileContents[path] = content;
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 ////// This code is for platforms that support fork() only ////////////////////
 ///////////////////////////////////////////////////////////////////////////////
@@ -285,9 +279,6 @@ unsigned int ThreadExecutor::check()
 
                 if (iFileSettings != mSettings.project.fileSettings.end()) {
                     resultOfCheck = fileChecker.check(*iFileSettings);
-                } else if (!mFileContents.empty() && mFileContents.find(iFile->first) != mFileContents.end()) {
-                    // File content was given as a string
-                    resultOfCheck = fileChecker.check(iFile->first, mFileContents[iFile->first]);
                 } else {
                     // Read file from a file
                     resultOfCheck = fileChecker.check(iFile->first);
@@ -538,14 +529,8 @@ unsigned int STDCALL ThreadExecutor::threadProc(LogWriter* logWriter)
 
             logWriter->mFileSync.unlock();
 
-            const std::map<std::string, std::string>::const_iterator fileContent = logWriter->mThreadExecutor.mFileContents.find(file);
-            if (fileContent != logWriter->mThreadExecutor.mFileContents.end()) {
-                // File content was given as a string
-                result += fileChecker.check(file, fileContent->second);
-            } else {
-                // Read file from a file
-                result += fileChecker.check(file);
-            }
+            // Read file from a file
+            result += fileChecker.check(file);
         } else { // file settings..
             const ImportProject::FileSettings &fs = *itFileSettings;
             ++itFileSettings;

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -44,23 +44,11 @@ public:
     void operator=(const ThreadExecutor &) = delete;
     unsigned int check();
 
-    /**
-     * @brief Add content to a file, to be used in unit testing.
-     *
-     * @param path File name (used as a key to link with real file).
-     * @param content If the file would be a real file, this should be
-     * the content of the file.
-     */
-    void addFileContent(const std::string &path, const std::string &content);
-
 private:
     const std::map<std::string, std::size_t> &mFiles;
     Settings &mSettings;
     ErrorLogger &mErrorLogger;
     std::list<std::string> mErrorList;
-
-    /** @brief Key is file name, and value is the content of the file */
-    std::map<std::string, std::string> mFileContents;
 
 #if defined(THREADING_MODEL_FORK)
 

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -22,10 +22,12 @@
 #include "settings.h"
 #include "suppressions.h"
 #include "testsuite.h"
+#include "testutils.h"
 #include "threadexecutor.h"
 
 #include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <iosfwd>
 #include <list>
@@ -216,7 +218,7 @@ private:
         output.str("");
 
         std::map<std::string, std::size_t> files;
-        files["test.cpp"] = 1;
+        files["test.cpp"] = strlen(code);
 
         Settings settings;
         settings.jobs = 1;
@@ -226,8 +228,10 @@ private:
             EXPECT_EQ("", settings.nomsg.addSuppressionLine(suppression));
         }
         ThreadExecutor executor(files, settings, *this);
+        std::vector<ScopedFile> scopedfiles;
+        scopedfiles.reserve(files.size());
         for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end(); ++i)
-            executor.addFileContent(i->first, code);
+            scopedfiles.emplace_back(i->first, code);
 
         const unsigned int exitCode = executor.check();
 

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -18,6 +18,7 @@
 
 #include "settings.h"
 #include "testsuite.h"
+#include "testutils.h"
 #include "threadexecutor.h"
 
 #include <cstddef>
@@ -49,13 +50,15 @@ private:
         for (int i = 1; i <= files; ++i) {
             std::ostringstream oss;
             oss << "file_" << i << ".cpp";
-            filemap[oss.str()] = 1;
+            filemap[oss.str()] = data.size();
         }
 
         settings.jobs = jobs;
         ThreadExecutor executor(filemap, settings, *this);
+        std::vector<ScopedFile> scopedfiles;
+        scopedfiles.reserve(filemap.size());
         for (std::map<std::string, std::size_t>::const_iterator i = filemap.begin(); i != filemap.end(); ++i)
-            executor.addFileContent(i->first, data);
+            scopedfiles.emplace_back(i->first, data);
 
         ASSERT_EQUALS(result, executor.check());
     }

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -26,6 +26,7 @@
 #include "tokenize.h"
 #include "tokenlist.h"
 
+#include <cstdio>
 #include <iosfwd>
 #include <list>
 #include <string>
@@ -67,6 +68,20 @@ public:
 private:
     Settings &settings;
     ErrorLogger *next;
+};
+
+class ScopedFile {
+public:
+    ScopedFile(const std::string &name, const std::string &content) : mName(name) {
+        std::ofstream of(mName);
+        of << content;
+    }
+
+    ~ScopedFile() {
+        remove(mName.c_str());
+    }
+private:
+    std::string mName;
 };
 
 #endif // TestUtilsH


### PR DESCRIPTION
This gets rid of the test-only code, simplifies the handling and also now unit tests the actual production code.

I am not too happy about the `ScopedFile` implementation but without `std::filesystem` it is bound to be a bit awkward. :(

This is another steps towards `ErrorLogger`, suppression handling etc. unification since it was using a `CppCheck::check()` overload which can probably be moved/cleaned up.