### PR TITLE
Fix false positive in memory leak

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -1006,7 +1006,7 @@ void CheckLeakAutoVar::ret(const Token *tok, VarInfo &varInfo, const bool isEndO
                     tok2 = tok3->tokAt(4);
                 else
                     continue;
-                if (Token::Match(tok2, "[});,]")) {
+                if (Token::Match(tok2, "[});,+]")) {
                     used = true;
                     break;
                 }

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -184,6 +184,7 @@ private:
         TEST_CASE(return6); // #8282 return {p, p}
         TEST_CASE(return7); // #9343 return (uint8_t*)x
         TEST_CASE(return8);
+        TEST_CASE(return9);        
 
         // General tests: variable type, allocation type, etc
         TEST_CASE(test1);
@@ -2103,6 +2104,14 @@ private:
               "}", true);
         ASSERT_EQUALS("", errout.str());
     }
+    
+    void return9() {
+        check("void* f() {\n"
+              "    void *x = malloc (sizeof (struct alloc));\n"
+              "    return x + sizeof (struct alloc);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+    }    
 
     void test1() { // 3809
         check("void f(double*&p) {\n"


### PR DESCRIPTION
Fix false positive in memory leak

simplified case:

```
void *alloc_memory (size_t size)
{
    uint8_t *ptr;
    ptr = malloc (sizeof (struct alloc) + size);
    if (!ptr)
        return NULL;
    return ptr + sizeof (struct alloc);
}
```