### PR TITLE
removed unnecessary varid0 inline suppressions

### DIFF
--- a/lib/calculate.h
+++ b/lib/calculate.h
@@ -48,7 +48,6 @@ bool isZero(T x)
 template<class R, class T>
 R calculate(const std::string& s, const T& x, const T& y, bool* error = nullptr)
 {
-    // cppcheck-suppress varid0
     auto wrap = [](T z) {
         return R{z};
     };

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1163,7 +1163,6 @@ static int estimateSize(const Type* type, const Settings* settings, const Symbol
 
     int cumulatedSize = 0;
     const bool isUnion = type->classScope->type == Scope::ScopeType::eUnion;
-    // cppcheck-suppress varid0
     const auto accumulateSize = [](int& cumulatedSize, int size, bool isUnion) -> void {
         if (isUnion)
             cumulatedSize = std::max(cumulatedSize, size);

--- a/lib/summaries.cpp
+++ b/lib/summaries.cpp
@@ -58,7 +58,6 @@ std::string Summaries::create(const Tokenizer *tokenizer, const std::string &cfg
         }
 
         // Write summary for function
-        // cppcheck-suppress varid0
         auto join = [](const std::set<std::string> &data) -> std::string {
             std::string ret;
             const char *sep = "";

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3995,7 +3995,6 @@ void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *s
             argType = findVariableTypeIncludingUsedNamespaces(symbolDatabase, scope, typeTok);
 
             // save type
-            // cppcheck-suppress varid0
             const_cast<Token *>(typeTok)->type(argType);
         }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4294,7 +4294,6 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
             };
 
             bool update = false;
-            // cppcheck-suppress varid0
             auto captureVariable = [&](const Token* tok2, LifetimeCapture c, std::function<bool(const Token*)> pred) {
                 if (varids.count(tok->varId()) > 0)
                     return;


### PR DESCRIPTION
All the issues are fixed now so we can remove those. 

FYI `unmatchedSuppression` is still disabled in the selfcheck because of the existing issues with it.