### PR TITLE
fix in unknown macro analysis

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -10221,7 +10221,7 @@ void Tokenizer::reportUnknownMacros() const
 
     // String concatenation with unknown macros
     for (const Token *tok = tokens(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "%str% %name% (") && Token::Match(tok->linkAt(2), ") %str%")) {
+        if (Token::Match(tok, "%str% %name% (") && Token::Match(tok->linkAt(2), ") %str%") && !Token::Match(tok->linkAt(2), ") \"\0\"")) {
             if (tok->next()->isKeyword())
                 continue;
             unknownMacroError(tok->next());


### PR DESCRIPTION
Hello everyone,

I was using cppcheck in code similar to this:
```
const char abc[] att =
   {
#define A 1
     test_one("1")
     "\0"
#define B 2
     test_two("2")
     "\0"
#define C 3
     test_three("3")
   };

void* f(){
    void* p = malloc(1);
    return;
}
```

This code has a Memory Leak, but cppcheck wasn't warning because it threw an exception at the line 7 **(     test_two("2"))**. Interestingly, he didn't complain about the line 4 **(test_one("1"))**. I changed the code to take into account **"\0"** token.

Do you think cppcheck should really throw exception and not analyze the rest of the code in this case?

Do you think this change is useful?

Reagrds