### PR TITLE
Fix #10880 FP constStatement with init list in function call

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -632,7 +632,7 @@ static bool iscpp11init_impl(const Token * const tok)
         return false;
     if (nameToken->str() == ")" && Token::simpleMatch(nameToken->link()->previous(), "decltype ("))
         return true;
-    if (nameToken->str() == ",")
+    if (Token::simpleMatch(nameToken, ", {"))
         return true;
     if (nameToken->str() == ">" && nameToken->link())
         nameToken = nameToken->link()->previous();

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -632,6 +632,8 @@ static bool iscpp11init_impl(const Token * const tok)
         return false;
     if (nameToken->str() == ")" && Token::simpleMatch(nameToken->link()->previous(), "decltype ("))
         return true;
+    if (nameToken->str() == ",")
+        return true;
     if (nameToken->str() == ">" && nameToken->link())
         nameToken = nameToken->link()->previous();
 

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -498,9 +498,15 @@ private:
                       "[test.cpp:15]: (warning) Redundant code: Found unused member access.\n",
                       errout.str());
 
-        check("struct S { void* p; };\n"
+        check("struct S { void* p; };\n" // #10875
               "void f(S s) {\n"
               "    delete (int*)s.p;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void f(int i, std::vector<int*> v);\n" // #10880
+              "void g() {\n"
+              "    f(1, { static_cast<int*>(nullptr) });\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6134,8 +6134,8 @@ private:
         ASSERT_EQUALS("xab,c,{=", testAst("x={a,b,(c)};"));
         ASSERT_EQUALS("x0fSa.1=b.2=,c.\"\"=,{(||=", testAst("x = 0 || f(S{.a = 1, .b = 2, .c = \"\" });"));
         ASSERT_EQUALS("x0fSa.1{=b.2{,c.\"\"=,{(||=", testAst("x = 0 || f(S{.a = { 1 }, .b { 2 }, .c = \"\" });"));
-        ASSERT_EQUALS("a0{,( \"\"abc12:?,", testAst("a(0, {{\"\", (abc) ? 1 : 2}});"));
-        ASSERT_EQUALS("a0{,( \'\'abc12:?,", testAst("a(0, {{\'\', (abc) ? 1 : 2}});"));
+        ASSERT_EQUALS("a0\"\"abc12:?,{{,(", testAst("a(0, {{\"\", (abc) ? 1 : 2}});"));
+        ASSERT_EQUALS("a0\'\'abc12:?,{{,(", testAst("a(0, {{\'\', (abc) ? 1 : 2}});"));
         ASSERT_EQUALS("x12,{34,{,{56,{78,{,{,{=", testAst("x = { { {1,2}, {3,4} }, { {5,6}, {7,8} } };"));
         ASSERT_EQUALS("Sa.stdmove::s(=b.1=,{(", testAst("S({.a = std::move(s), .b = 1})"));
 
@@ -6168,7 +6168,7 @@ private:
         ASSERT_EQUALS("a1{ b2{", testAst("auto a{1}; auto b{2};"));
         ASSERT_EQUALS("var1ab::23,{,4ab::56,{,{,{{", testAst("auto var{{1,a::b{2,3}}, {4,a::b{5,6}}};"));
         ASSERT_EQUALS("var{{,{,{{", testAst("auto var{ {{},{}}, {} };"));
-        ASSERT_EQUALS("fX{,{( abcfalse==CD:?", testAst("f({X, {Y, abc == false ? C : D}});"));
+        ASSERT_EQUALS("fXYabcfalse==CD:?,{,{(", testAst("f({X, {Y, abc == false ? C : D}});"));
 
         // Initialization with decltype(expr) instead of a type
         ASSERT_EQUALS("decltypex((", testAst("decltype(x)();"));


### PR DESCRIPTION
I don't know what those tests in `TestTokenizer::astpar()` are doing, because it looks like gibberish to me. However, I would argue that the AST from `--debug -v` is less wrong now, e.g. for `f({X, {Y, abc == false ? C : D}});`:
~~~
(
|-f
`-{
  `-,
    |-X
    `-{
      `-,
        |-Y
        `-?
          |-== 'bool'
          | |-abc
          | `-false 'bool'
          `-:
            |-C
            `-D	
~~~
vs. before
~~~
(
|-f
`-{
  `-,
    |-X
    `-{
~~~