### PR TITLE
Fix #10698 FP uninitvar with new and braced initializer

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -913,7 +913,7 @@ static bool isPrefixUnary(const Token* tok, bool cpp)
 
 static void compilePrecedence2(Token *&tok, AST_state& state)
 {
-    const bool isStartOfCpp11Init = state.cpp && tok->str() == "{" && iscpp11init(tok);
+    const bool isStartOfCpp11Init = state.cpp && tok && tok->str() == "{" && iscpp11init(tok);
     if (!(isStartOfCpp11Init && Token::Match(tok->tokAt(-2), "new %type% {")))
         compileScope(tok, state);
     while (tok) {

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -913,7 +913,9 @@ static bool isPrefixUnary(const Token* tok, bool cpp)
 
 static void compilePrecedence2(Token *&tok, AST_state& state)
 {
-    compileScope(tok, state);
+    const bool isStartOfCpp11Init = state.cpp && tok->str() == "{" && iscpp11init(tok);
+    if (!(isStartOfCpp11Init && Token::Match(tok->tokAt(-2), "new %type% {")))
+        compileScope(tok, state);
     while (tok) {
         if (tok->tokType() == Token::eIncDecOp && !isPrefixUnary(tok, state.cpp)) {
             compileUnaryOp(tok, state, compileScope);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7889,7 +7889,7 @@ static void valueFlowDynamicBufferSize(TokenList* tokenlist, SymbolDatabase* sym
             else {
                 typeTok = newTok->astOperand1();
                 if (typeTok && typeTok->str() == "{")
-                    typeTok = typeTok->astOperand2();
+                    typeTok = typeTok->astOperand1();
             }
             if (bracTok && bracTok->astOperand2() && bracTok->astOperand2()->hasKnownIntValue())
                 numElem = bracTok->astOperand2()->getKnownIntValue();

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6030,6 +6030,8 @@ private:
         ASSERT_EQUALS("aA1(new(bB2(new(,", testAst("a(new A(1)), b(new B(2))"));
         ASSERT_EQUALS("Fred10[new", testAst(";new Fred[10];"));
         ASSERT_EQUALS("adelete", testAst("void f() { delete a; }"));
+        ASSERT_EQUALS("Aa*A{new=", testAst("A* a = new A{};"));
+        ASSERT_EQUALS("Aa*A12,{new=", testAst("A* a = new A{ 1, 2 };"));
 
         // placement new
         ASSERT_EQUALS("X12,3,(new ab,c,", testAst("new (a,b,c) X(1,2,3);"));

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -2024,6 +2024,12 @@ private:
                        "    a = *pBuf;\n"
                        "}", "test.c");
         ASSERT_EQUALS("", errout.str());
+
+        checkUninitVar("class A {};\n" // #10698
+                       "void f() {\n"
+                       "    A* a = new A{};\n"
+                       "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     // class / struct..


### PR DESCRIPTION
The AST for `A* a = new A{};` still looks odd, is this correct?.
~~~
##AST
[bar.cpp:3]
*
|-A
`-a '*'

[bar.cpp:3]
= '*'
|-a '*'
`-new
  `-{
    `-A
~~~
Edit: probably just the split variable declaration.