### PR TITLE
release-windows.yml: use windows-2022

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -20,7 +20,7 @@ jobs:
 
   build:
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     env:
       # see https://www.pcre.org/original/changelog.txt
@@ -49,7 +49,7 @@ jobs:
         run: |
           7z x pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
           cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
-          cmake . -G "Visual Studio 16 2019" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF || exit /b !errorlevel!
+          cmake . -G "Visual Studio 17 2022" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF || exit /b !errorlevel!
           msbuild -m PCRE.sln -p:Configuration=Release -p:Platform=x64 || exit /b !errorlevel!
           copy pcre.h ..\externals || exit /b !errorlevel!
           copy Release\pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!

--- a/win_installer/config.wxi
+++ b/win_installer/config.wxi
@@ -10,10 +10,10 @@
   <?define QtDllDir = "files" ?>
 
   <?if $(var.Platform) = x64 ?>
-    <?define CrtMergeModule = "$(env.VCToolsRedistDir)\MergeModules\Microsoft_VC142_CRT_x64.msm" ?>
+    <?define CrtMergeModule = "$(env.VCINSTALLDIR)Redist\MSVC\v143\MergeModules\Microsoft_VC143_CRT_x64.msm" ?>
     <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
   <?else?>
-    <?define CrtMergeModule = "$(env.VCToolsRedistDir)\MergeModules\Microsoft_VC142_CRT_x86.msm" ?>
+    <?define CrtMergeModule = "$(env.VCINSTALLDIR)Redist\MSVC\v143\MergeModules\Microsoft_VC143_CRT_x86.msm" ?>
     <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
   <?endif?>
 </Include>

--- a/win_installer/readme.txt
+++ b/win_installer/readme.txt
@@ -32,7 +32,7 @@ Before building the installer make sure all the components are build:
 And that runtime files are available:
   - Qt runtimes:
       Qt5Core.dll, Qt5PrintSupport.dll, Qt5Widgets.dll, Qt5Gui.dll and platforms/qwindows.dll
-  - MS CRT merge module (Microsoft_VC140_CRT_x86.msm or Microsoft_VC140_CRT_x64.msm)
+  - MS CRT merge module (Microsoft_VC143_CRT_x86.msm or Microsoft_VC143_CRT_x64.msm)
 
 Build installer by giving this command line in VS command prompt (or run
 vcvars32.bat in DOS prompt first to setup environment):


### PR DESCRIPTION
We have been using `windows-2022` in the CI for a while without any issues. I have been using it locally as the Windows compiler of choice as well.

Since we might switch to Qt6 is the next release it would be good to do the compiler switch first so we don't have too many major version bumps in a single release.

The updated MSM location is documented at https://github.com/MicrosoftDocs/cpp-docs/blob/main/docs/windows/redistributing-visual-cpp-files.md#locate-the-redistributable-files.