### PR TITLE
release-windows.yml: set up Visual Studio environment and added missing exitcode checks

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -101,7 +101,8 @@ jobs:
           copy addons\*.* win_installer\files\addons || exit /b !errorlevel!
           mkdir win_installer\files\cfg || exit /b !errorlevel!
           copy cfg\*.cfg win_installer\files\cfg || exit /b !errorlevel!
-          mkdir win_installer\files\platforms || exit /b !errorlevel!
+          :: "platforms" is a folder used by Qt as well so it already exists
+          :: mkdir win_installer\files\platforms || exit /b !errorlevel!
           copy platforms\*.xml win_installer\files\platforms || exit /b !errorlevel!
           copy bin\cppcheck.exe win_installer\files || exit /b !errorlevel!
           copy bin\cppcheck-core.dll win_installer\files || exit /b !errorlevel!

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup msbuild.exe
-        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Set up Visual Studio environment
+        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Cache PCRE
         id: cache-pcre
@@ -79,7 +79,6 @@ jobs:
 
       - name: Build x64 release GUI
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd gui
           qmake HAVE_QCHART=yes
           nmake release

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -50,7 +50,7 @@ jobs:
           7z x pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
           cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
           cmake . -G "Visual Studio 16 2019" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF || exit /b !errorlevel!
-          msbuild -m PCRE.sln /p:Configuration=Release /p:Platform=x64 || exit /b !errorlevel!
+          msbuild -m PCRE.sln -p:Configuration=Release -p:Platform=x64 || exit /b !errorlevel!
           copy pcre.h ..\externals || exit /b !errorlevel!
           copy Release\pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!
 
@@ -92,7 +92,7 @@ jobs:
           del Build\gui\cppcheck-gui.pdb || exit /b !errorlevel!
 
       - name: Build CLI x64 release configuration using MSBuild
-        run: msbuild -m cppcheck.sln /t:cli /p:Configuration=Release-PCRE /p:Platform=x64 || exit /b !errorlevel!
+        run: msbuild -m cppcheck.sln -t:cli -p:Configuration=Release-PCRE -p:Platform=x64 || exit /b !errorlevel!
 
       - name: Collect files
         run: |
@@ -119,7 +119,7 @@ jobs:
           REM Remove double quotes
           set PRODUCTVER=%PRODUCTVER:"=% || exit /b !errorlevel!
           echo ProductVersion=%PRODUCTVER% || exit /b !errorlevel!
-          msbuild -m cppcheck.wixproj /p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }} || exit /b !errorlevel!
+          msbuild -m cppcheck.wixproj -p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }} || exit /b !errorlevel!
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -115,10 +115,10 @@ jobs:
         run: |
           cd win_installer || exit /b !errorlevel!
           REM Read ProductVersion
-          for /f "tokens=4 delims= " %%a in ('find "ProductVersion" productInfo.wxi') do set PRODUCTVER=%%a || exit /b !errorlevel!
+          for /f "tokens=4 delims= " %%a in ('find "ProductVersion" productInfo.wxi') do set PRODUCTVER=%%a
           REM Remove double quotes
-          set PRODUCTVER=%PRODUCTVER:"=% || exit /b !errorlevel!
-          echo ProductVersion=%PRODUCTVER% || exit /b !errorlevel!
+          set PRODUCTVER=%PRODUCTVER:"=%
+          echo ProductVersion="%PRODUCTVER%" || exit /b !errorlevel!
           msbuild -m cppcheck.wixproj -p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }} || exit /b !errorlevel!
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -43,16 +43,16 @@ jobs:
       - name: Download PCRE
         if: steps.cache-pcre.outputs.cache-hit != 'true'
         run: |
-          curl -fsSL https://github.com/pfultz2/pcre/archive/refs/tags/%PCRE_VERSION%.zip -o pcre-%PCRE_VERSION%.zip
+          curl -fsSL https://github.com/pfultz2/pcre/archive/refs/tags/%PCRE_VERSION%.zip -o pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
 
       - name: Install PCRE
         run: |
-          7z x pcre-%PCRE_VERSION%.zip
-          cd pcre-%PCRE_VERSION%
-          cmake . -G "Visual Studio 16 2019" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF
-          msbuild -m PCRE.sln /p:Configuration=Release /p:Platform=x64
-          copy pcre.h ..\externals
-          copy Release\pcre.lib ..\externals\pcre64.lib
+          7z x pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
+          cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
+          cmake . -G "Visual Studio 16 2019" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF || exit /b !errorlevel!
+          msbuild -m PCRE.sln /p:Configuration=Release /p:Platform=x64 || exit /b !errorlevel!
+          copy pcre.h ..\externals || exit /b !errorlevel!
+          copy Release\pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!
 
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt
@@ -70,57 +70,55 @@ jobs:
 
       - name: Create .qm
         run: |
-          cd gui
-          lupdate gui.pro -no-obsolete
-          lrelease gui.pro -removeidentical
+          cd gui || exit /b !errorlevel!
+          lupdate gui.pro -no-obsolete || exit /b !errorlevel!
+          lrelease gui.pro -removeidentical || exit /b !errorlevel!
 
       - name: Matchcompiler
-        run: python tools\matchcompiler.py --write-dir lib
+        run: python tools\matchcompiler.py --write-dir lib || exit /b !errorlevel!
 
       - name: Build x64 release GUI
         run: |
-          cd gui
-          qmake HAVE_QCHART=yes
-          nmake release
+          cd gui || exit /b !errorlevel!
+          qmake HAVE_QCHART=yes || exit /b !errorlevel!
+          nmake release || exit /b !errorlevel!
         env:
           CL: /MP
 
       - name: Deploy app
         run: |
-          windeployqt Build\gui
-          del Build\gui\cppcheck-gui.ilk
-          del Build\gui\cppcheck-gui.pdb
+          windeployqt Build\gui || exit /b !errorlevel!
+          del Build\gui\cppcheck-gui.ilk || exit /b !errorlevel!
+          del Build\gui\cppcheck-gui.pdb || exit /b !errorlevel!
 
       - name: Build CLI x64 release configuration using MSBuild
-        run: msbuild -m cppcheck.sln /t:cli /p:Configuration=Release-PCRE /p:Platform=x64
+        run: msbuild -m cppcheck.sln /t:cli /p:Configuration=Release-PCRE /p:Platform=x64 || exit /b !errorlevel!
 
       - name: Collect files
         run: |
-          move Build\gui win_installer\files
-          mkdir win_installer\files\addons
-          copy addons\*.* win_installer\files\addons
-          mkdir win_installer\files\cfg
-          copy cfg\*.cfg win_installer\files\cfg
-          mkdir win_installer\files\platforms
-          copy platforms\*.xml win_installer\files\platforms
-          copy bin\cppcheck.exe win_installer\files
-          copy bin\cppcheck-core.dll win_installer\files
-          mkdir win_installer\files\help
-          xcopy /s gui\help win_installer\files\help
-          del win_installer\files\translations\*.qm
-          move gui\*.qm win_installer\files\translations
-
+          move Build\gui win_installer\files || exit /b !errorlevel!
+          mkdir win_installer\files\addons || exit /b !errorlevel!
+          copy addons\*.* win_installer\files\addons || exit /b !errorlevel!
+          mkdir win_installer\files\cfg || exit /b !errorlevel!
+          copy cfg\*.cfg win_installer\files\cfg || exit /b !errorlevel!
+          mkdir win_installer\files\platforms || exit /b !errorlevel!
+          copy platforms\*.xml win_installer\files\platforms || exit /b !errorlevel!
+          copy bin\cppcheck.exe win_installer\files || exit /b !errorlevel!
+          copy bin\cppcheck-core.dll win_installer\files || exit /b !errorlevel!
+          mkdir win_installer\files\help || exit /b !errorlevel!
+          xcopy /s gui\help win_installer\files\help || exit /b !errorlevel!
+          del win_installer\files\translations\*.qm || exit /b !errorlevel!
+          move gui\*.qm win_installer\files\translations || exit /b !errorlevel!
 
       - name: Build Installer
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          cd win_installer
+          cd win_installer || exit /b !errorlevel!
           REM Read ProductVersion
-          for /f "tokens=4 delims= " %%a in ('find "ProductVersion" productInfo.wxi') do set PRODUCTVER=%%a
+          for /f "tokens=4 delims= " %%a in ('find "ProductVersion" productInfo.wxi') do set PRODUCTVER=%%a || exit /b !errorlevel!
           REM Remove double quotes
-          set PRODUCTVER=%PRODUCTVER:"=%
-          echo ProductVersion=%PRODUCTVER%
-          msbuild -m cppcheck.wixproj /p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }}
+          set PRODUCTVER=%PRODUCTVER:"=% || exit /b !errorlevel!
+          echo ProductVersion=%PRODUCTVER% || exit /b !errorlevel!
+          msbuild -m cppcheck.wixproj /p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }} || exit /b !errorlevel!
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
This was split from #3939 since there are issues with missing MSMs for Visual Studio 2022 in the CI runners.