### PR TITLE
smallvector.h: reverted bogus noExplicitConstructor fix and suppress …

### DIFF
--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -35,7 +35,8 @@ template<class T, std::size_t N>
 struct TaggedAllocator : std::allocator<T>
 {
     template<class ... Ts>
-    explicit TaggedAllocator(Ts&&... ts)
+    // cppcheck-suppress noExplicitConstructor
+    TaggedAllocator(Ts&&... ts)
         : std::allocator<T>(std::forward<Ts>(ts)...)
     {}
 };


### PR DESCRIPTION
…the warning

The `noExplicitConstructor` warning fixed in #3937 was actually a false positive and broke `SmallVector`. I filed https://trac.cppcheck.net/ticket/10977 for the issues.