### PR TITLE
added remaining make targets to CMake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,8 +59,9 @@ if (BUILD_TESTS)
                 DEPENDS cppcheck validateCFG)
     endif()
 
-    add_custom_target(test $<TARGET_FILE:testrunner>
-            DEPENDS cppcheck testrunner)
+    # TODO: the target name "test" is reservered by CTest
+    #add_custom_target(test $<TARGET_FILE:testrunner>
+    #        DEPENDS cppcheck testrunner)
 
     add_custom_target(check $<TARGET_FILE:testrunner> -q
             DEPENDS cppcheck testrunner)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -71,7 +71,7 @@ if (BUILD_TESTS)
         ProcessorCount(N)
         set(CTEST_PARALLEL_LEVEL ${N} CACHE STRING "CTest parallel level")
         set(CTEST_TIMEOUT 90 CACHE STRING "CTest timeout")
-        add_custom_target(check ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C ${CMAKE_CFG_INTDIR} --timeout ${CTEST_TIMEOUT}
+        add_custom_target(check-ctest ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C ${CMAKE_CFG_INTDIR} --timeout ${CTEST_TIMEOUT}
                 DEPENDS testrunner cppcheck)
 
         set(SKIP_TESTS "" CACHE STRING "A list of tests to skip")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,12 @@ if (BUILD_TESTS)
                 DEPENDS cppcheck validateCFG)
     endif()
 
+    add_custom_target(test $<TARGET_FILE:testrunner>
+            DEPENDS cppcheck testrunner)
+
+    add_custom_target(check $<TARGET_FILE:testrunner> -q
+            DEPENDS cppcheck testrunner)
+
     if (REGISTER_TESTS)
         # CMP0064 requires 3.4
         # CMAKE_MATCH_<n> usage for if (MATCHES) requires 3.9
@@ -80,7 +86,7 @@ if (BUILD_TESTS)
             if (${NAME} IN_LIST SKIP_TESTS)
             elseif(TEST ${NAME})
             else()
-                add_test(NAME ${NAME} COMMAND testrunner ${NAME} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                add_test(NAME ${NAME} COMMAND $<TARGET_FILE:testrunner> ${NAME} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
             endif()
         endfunction()
 


### PR DESCRIPTION
With these we now have target parity between make and CMake.

There's still some compiler/platform-specific code which needs to be added to CMake for full parity.