### PR TITLE
cppcheck.vcxproj: fixed invalid standard setting in `Debug-PCRE` conf…

### DIFF
--- a/lib/cppcheck.vcxproj
+++ b/lib/cppcheck.vcxproj
@@ -335,7 +335,7 @@ xcopy "$(SolutionDir)platforms" "$(OutDir)platforms" /E /I /D /Y</Command>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>precompiled.h</ForcedIncludeFiles>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp14</LanguageStandard>
       <AdditionalOptions>/Zc:throwingNew /Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>


### PR DESCRIPTION
…iguration for `cppcheck` causing build failures with SmallVector

Extracted from #4020 so it hopefully gets merged faster and work on #3919 and #3925 can resume/finish.