### PR TITLE
use `emptyString` more consistently

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -996,7 +996,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
     }
 
     if (!settings.checkConfiguration) {
-        cppcheck.tooManyConfigsError("",0U);
+        cppcheck.tooManyConfigsError(emptyString,0U);
 
         if (settings.checks.isEnabled(Checks::missingInclude) && (Preprocessor::missingIncludeFlag || Preprocessor::missingSystemIncludeFlag)) {
             const std::list<ErrorMessage::FileLocation> callStack;

--- a/lib/analyzer.h
+++ b/lib/analyzer.h
@@ -179,7 +179,7 @@ struct Analyzer {
     /// The condition that will be assumed during analysis
     virtual void assume(const Token* tok, bool state, unsigned int flags = 0) = 0;
     /// Return analyzer for expression at token
-    virtual ValuePtr<Analyzer> reanalyze(Token* tok, const std::string& msg = "") const = 0;
+    virtual ValuePtr<Analyzer> reanalyze(Token* tok, const std::string& msg = emptyString) const = 0;
     virtual ~Analyzer() {}
 };
 

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -95,7 +95,7 @@ public:
     void nullPointerError(const Token *tok) {
         ValueFlow::Value v(0);
         v.setKnown();
-        nullPointerError(tok, "", &v, false);
+        nullPointerError(tok, emptyString, &v, false);
     }
     void nullPointerError(const Token *tok, const std::string &varname, const ValueFlow::Value* value, bool inconclusive);
 

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3786,6 +3786,6 @@ void CheckOther::overlappingWriteUnion(const Token *tok)
 
 void CheckOther::overlappingWriteFunction(const Token *tok)
 {
-    const std::string funcname = tok ? tok->str() : "";
+    const std::string &funcname = tok ? tok->str() : emptyString;
     reportError(tok, Severity::error, "overlappingWriteFunction", "Overlapping read/write in " + funcname + "() is undefined behavior");
 }

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -191,7 +191,7 @@ void CheckStl::outOfBounds()
     }
 }
 
-static std::string indexValueString(const ValueFlow::Value& indexValue, const std::string& containerName = "")
+static std::string indexValueString(const ValueFlow::Value& indexValue, const std::string& containerName = emptyString)
 {
     if (indexValue.isIteratorStartValue())
         return "at position " + MathLib::toString(indexValue.intvalue) + " from the beginning";
@@ -2345,7 +2345,7 @@ void CheckStl::checkDereferenceInvalidIterator2()
                     outOfBoundsError(emptyAdvance,
                                      lValue.tokvalue->expressionString(),
                                      cValue,
-                                     advanceIndex ? advanceIndex->expressionString() : "",
+                                     advanceIndex ? advanceIndex->expressionString() : emptyString,
                                      nullptr);
                 else
                     outOfBoundsError(tok, lValue.tokvalue->expressionString(), cValue, tok->expressionString(), &value);
@@ -2800,7 +2800,7 @@ void CheckStl::knownEmptyContainer()
                 const Token* contTok = splitTok->astOperand2();
                 if (!isKnownEmptyContainer(contTok))
                     continue;
-                knownEmptyContainerError(contTok, "");
+                knownEmptyContainerError(contTok, emptyString);
             } else {
                 const std::vector<const Token *> args = getArguments(tok);
                 if (args.empty())

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -268,8 +268,8 @@ private:
         c.uselessCallsRemoveError(nullptr, "remove");
         c.dereferenceInvalidIteratorError(nullptr, "i");
         c.readingEmptyStlContainerError(nullptr);
-        c.useStlAlgorithmError(nullptr, "");
-        c.knownEmptyContainerError(nullptr, "");
+        c.useStlAlgorithmError(nullptr, emptyString);
+        c.knownEmptyContainerError(nullptr, emptyString);
         c.globalLockGuardError(nullptr);
         c.localMutexError(nullptr);
     }

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -636,7 +636,7 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                     // Assert that the tokens are '} while ('
                     if (!Token::simpleMatch(tok, "} while (")) {
                         if (printDebug)
-                            reportError(tok,Severity::debug,"","assertion failed '} while ('");
+                            reportError(tok,Severity::debug,emptyString,"assertion failed '} while ('");
                         break;
                     }
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -232,7 +232,7 @@ static std::string getDumpFileName(const Settings& settings, const std::string& 
     if (!settings.dumpFile.empty())
         return settings.dumpFile;
     if (!settings.dump && !settings.buildDir.empty())
-        return AnalyzerInformation::getAnalyzerInfoFile(settings.buildDir, filename, "") + ".dump";
+        return AnalyzerInformation::getAnalyzerInfoFile(settings.buildDir, filename, emptyString) + ".dump";
     return filename + ".dump";
 }
 
@@ -448,7 +448,7 @@ unsigned int CppCheck::check(const std::string &path)
             mErrorLogger.reportOut(std::string("Checking ") + path + "...", Color::FgGreen);
 
         const std::string lang = Path::isCPP(path) ? "-x c++" : "-x c";
-        const std::string analyzerInfo = mSettings.buildDir.empty() ? std::string() : AnalyzerInformation::getAnalyzerInfoFile(mSettings.buildDir, path, "");
+        const std::string analyzerInfo = mSettings.buildDir.empty() ? std::string() : AnalyzerInformation::getAnalyzerInfoFile(mSettings.buildDir, path, emptyString);
         const std::string clangcmd = analyzerInfo + ".clang-cmd";
         const std::string clangStderr = analyzerInfo + ".clang-stderr";
         const std::string clangAst = analyzerInfo + ".clang-ast";
@@ -1584,10 +1584,10 @@ void CppCheck::getErrorMessages()
     s.severity.enable(Severity::performance);
     s.severity.enable(Severity::information);
 
-    purgedConfigurationMessage("","");
+    purgedConfigurationMessage(emptyString,emptyString);
 
     mTooManyConfigs = true;
-    tooManyConfigsError("",0U);
+    tooManyConfigsError(emptyString,0U);
 
     // call all "getErrorMessages" in all registered Check classes
     for (std::list<Check *>::const_iterator it = Check::instances().begin(); it != Check::instances().end(); ++it)
@@ -1613,7 +1613,7 @@ void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings)
 
     const std::string args = "-quiet -checks=*,-clang-analyzer-*,-llvm* \"" + fileSettings.filename + "\" -- " + allIncludes + allDefines;
     std::string output;
-    if (!mExecuteCommand(exe, split(args), "", &output)) {
+    if (!mExecuteCommand(exe, split(args), emptyString, &output)) {
         std::cerr << "Failed to execute '" << exe << "'" << std::endl;
         return;
     }
@@ -1623,7 +1623,7 @@ void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings)
     std::string line;
 
     if (!mSettings.buildDir.empty()) {
-        const std::string analyzerInfoFile = AnalyzerInformation::getAnalyzerInfoFile(mSettings.buildDir, fileSettings.filename, "");
+        const std::string analyzerInfoFile = AnalyzerInformation::getAnalyzerInfoFile(mSettings.buildDir, fileSettings.filename, emptyString);
         std::ofstream fcmd(analyzerInfoFile + ".clang-tidy-cmd");
         fcmd << istr.str();
     }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1183,7 +1183,7 @@ bool ImportProject::importCppcheckGuiProject(std::istream &istr, Settings *setti
                 suppressions.push_back(s);
             }
         } else if (strcmp(node->Name(), CppcheckXml::VSConfigurationElementName) == 0)
-            guiProject.checkVsConfigs = readXmlStringList(node, "", CppcheckXml::VSConfigurationName, nullptr);
+            guiProject.checkVsConfigs = readXmlStringList(node, emptyString, CppcheckXml::VSConfigurationName, nullptr);
         else if (strcmp(node->Name(), CppcheckXml::PlatformElementName) == 0)
             guiProject.platform = node->GetText();
         else if (strcmp(node->Name(), CppcheckXml::AnalyzeAllVsConfigsElementName) == 0)
@@ -1191,11 +1191,11 @@ bool ImportProject::importCppcheckGuiProject(std::istream &istr, Settings *setti
         else if (strcmp(node->Name(), CppcheckXml::Parser) == 0)
             temp.clang = true;
         else if (strcmp(node->Name(), CppcheckXml::AddonsElementName) == 0)
-            temp.addons = readXmlStringList(node, "", CppcheckXml::AddonElementName, nullptr);
+            temp.addons = readXmlStringList(node, emptyString, CppcheckXml::AddonElementName, nullptr);
         else if (strcmp(node->Name(), CppcheckXml::TagsElementName) == 0)
             node->Attribute(CppcheckXml::TagElementName); // FIXME: Write some warning
         else if (strcmp(node->Name(), CppcheckXml::ToolsElementName) == 0) {
-            const std::list<std::string> toolList = readXmlStringList(node, "", CppcheckXml::ToolElementName, nullptr);
+            const std::list<std::string> toolList = readXmlStringList(node, emptyString, CppcheckXml::ToolElementName, nullptr);
             for (const std::string &toolName : toolList) {
                 if (toolName == std::string(CppcheckXml::ClangTidy))
                     temp.clangTidy = true;

--- a/lib/library.h
+++ b/lib/library.h
@@ -549,7 +549,7 @@ public:
      */
     std::string getFunctionName(const Token *ftok) const;
 
-    static bool isContainerYield(const Token * const cond, Library::Container::Yield y, const std::string& fallback="");
+    static bool isContainerYield(const Token * const cond, Library::Container::Yield y, const std::string& fallback=emptyString);
 
     /** Suppress/check a type */
     enum class TypeCheck { def, check, suppress };

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -129,7 +129,7 @@ std::string Path::getCurrentPath()
 #endif
         return std::string(currentPath);
 
-    return emptyString;
+    return "";
 }
 
 bool Path::isAbsolute(const std::string& path)

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -488,7 +488,7 @@ static void getConfigs(const simplecpp::TokenList &tokens, std::set<std::string>
         } else if (cmdtok->str() == "error") {
             if (!configs_ifndef.empty() && !configs_ifndef.back().empty()) {
                 if (configs_ifndef.size() == 1U)
-                    ret.erase("");
+                    ret.erase(emptyString);
                 std::vector<std::string> configs(configs_if);
                 configs.push_back(configs_ifndef.back());
                 ret.erase(cfg(configs, userDefines));

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5523,7 +5523,7 @@ const Type* Scope::findType(const std::string & name) const
         return (*it).second;
 
     // is type defined in anonymous namespace..
-    it = definedTypesMap.find("");
+    it = definedTypesMap.find(emptyString);
     if (it != definedTypesMap.end()) {
         for (const Scope *scope : nestedList) {
             if (scope->className.empty() && (scope->type == eNamespace || scope->isClassOrStructOrUnion())) {

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -961,11 +961,11 @@ void TemplateSimplifier::getTemplateInstantiations()
                                 std::string::size_type offset = 0;
                                 std::string::size_type pos = 0;
                                 while ((pos = nameSpace.substr(offset).find(' ')) != std::string::npos) {
-                                    qualificationTok->insertToken(nameSpace.substr(offset, pos), "", true);
+                                    qualificationTok->insertToken(nameSpace.substr(offset, pos), emptyString, true);
                                     offset = offset + pos + 1;
                                 }
-                                qualificationTok->insertToken(nameSpace.substr(offset), "", true);
-                                qualificationTok->insertToken("::", "", true);
+                                qualificationTok->insertToken(nameSpace.substr(offset), emptyString, true);
+                                qualificationTok->insertToken("::", emptyString, true);
                                 addInstantiation(tok, it1->scope());
                                 found = true;
                                 break;
@@ -1530,7 +1530,7 @@ void TemplateSimplifier::addNamespace(const TokenAndName &templateDeclaration, c
             }
         } else {
             if (insert)
-                mTokenList.back()->tokAt(offset)->insertToken(token, "");
+                mTokenList.back()->tokAt(offset)->insertToken(token, emptyString);
             else
                 mTokenList.addtoken(token, tok->linenr(), tok->column(), tok->fileIndex());
         }
@@ -1541,10 +1541,10 @@ void TemplateSimplifier::addNamespace(const TokenAndName &templateDeclaration, c
     if (token != tokStart->str() || tok->strAt(-1) != "::") {
         if (insert) {
             if (!inTemplate)
-                mTokenList.back()->tokAt(offset)->insertToken(templateDeclaration.scope().substr(start), "");
+                mTokenList.back()->tokAt(offset)->insertToken(templateDeclaration.scope().substr(start), emptyString);
             else
                 mTokenList.back()->tokAt(offset)->str(mTokenList.back()->strAt(offset) + templateDeclaration.scope().substr(start));
-            mTokenList.back()->tokAt(offset)->insertToken("::", "");
+            mTokenList.back()->tokAt(offset)->insertToken("::", emptyString);
         } else {
             if (!inTemplate)
                 mTokenList.addtoken(templateDeclaration.scope().substr(start), tok->linenr(), tok->column(), tok->fileIndex());
@@ -1596,9 +1596,9 @@ void TemplateSimplifier::expandTemplate(
 
     // add forward declarations
     if (copy && isClass) {
-        templateDeclaration.token()->insertToken(templateDeclarationToken->strAt(1), "", true);
-        templateDeclaration.token()->insertToken(newName, "", true);
-        templateDeclaration.token()->insertToken(";", "", true);
+        templateDeclaration.token()->insertToken(templateDeclarationToken->strAt(1), emptyString, true);
+        templateDeclaration.token()->insertToken(newName, emptyString, true);
+        templateDeclaration.token()->insertToken(";", emptyString, true);
     } else if ((isFunction && (copy || isSpecialization)) ||
                (isVariable && !isSpecialization) ||
                (isClass && isSpecialization && mTemplateSpecializationMap.find(templateDeclaration.token()) != mTemplateSpecializationMap.end())) {
@@ -1662,7 +1662,7 @@ void TemplateSimplifier::expandTemplate(
         }
 
         if (isStatic) {
-            dst->insertToken("static", "", true);
+            dst->insertToken("static", emptyString, true);
             if (start) {
                 dst->previous()->linenr(start->linenr());
                 dst->previous()->column(start->column());
@@ -1745,13 +1745,13 @@ void TemplateSimplifier::expandTemplate(
                            !(templateDeclaration.isFunction() && templateDeclaration.scope().empty() &&
                              (start->strAt(-1) == "." || Token::simpleMatch(start->tokAt(-2), ". template")))) {
                     if (start->strAt(1) != "<" || Token::Match(start, newName.c_str()) || !inAssignment) {
-                        dst->insertToken(newName, "", true);
+                        dst->insertToken(newName, emptyString, true);
                         dst->previous()->linenr(start->linenr());
                         dst->previous()->column(start->column());
                         if (start->strAt(1) == "<")
                             start = start->next()->findClosingBracket();
                     } else {
-                        dst->insertToken(start->str(), "", true);
+                        dst->insertToken(start->str(), emptyString, true);
                         dst->previous()->linenr(start->linenr());
                         dst->previous()->column(start->column());
                         newInstantiations.emplace_back(dst->previous(), templateDeclaration.scope());
@@ -1774,7 +1774,7 @@ void TemplateSimplifier::expandTemplate(
                             for (const auto & inst : mTemplateInstantiations) {
                                 if (Token::simpleMatch(inst.token(), name.c_str(), name.size())) {
                                     // use the instantiated name
-                                    dst->insertToken(name, "", true);
+                                    dst->insertToken(name, emptyString, true);
                                     dst->previous()->linenr(start->linenr());
                                     dst->previous()->column(start->column());
                                     start = closing;
@@ -1820,7 +1820,7 @@ void TemplateSimplifier::expandTemplate(
 
             start = start->next();
         }
-        dst->insertToken(";", "", true);
+        dst->insertToken(";", emptyString, true);
         dst->previous()->linenr(dst->tokAt(-2)->linenr());
         dst->previous()->column(dst->tokAt(-2)->column() + 1);
 

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -485,7 +485,7 @@ private:
     void printOut(
         const TokenAndName &tokenAndName,
         const std::string &indent = "    ") const;
-    void printOut(const std::string &text = "") const;
+    void printOut(const std::string &text = emptyString) const;
 
     Tokenizer *mTokenizer;
     TokenList &mTokenList;

--- a/lib/token.h
+++ b/lib/token.h
@@ -726,12 +726,12 @@ public:
     }
 
     bool isCChar() const {
-        return (((mTokType == eString) && isPrefixStringCharLiteral(mStr, '"', "")) ||
-                ((mTokType ==  eChar) && isPrefixStringCharLiteral(mStr, '\'', "") && mStr.length() == 3));
+        return (((mTokType == eString) && isPrefixStringCharLiteral(mStr, '"', emptyString)) ||
+                ((mTokType ==  eChar) && isPrefixStringCharLiteral(mStr, '\'', emptyString) && mStr.length() == 3));
     }
 
     bool isCMultiChar() const {
-        return (((mTokType ==  eChar) && isPrefixStringCharLiteral(mStr, '\'', "")) &&
+        return (((mTokType ==  eChar) && isPrefixStringCharLiteral(mStr, '\'', emptyString)) &&
                 (mStr.length() > 3));
     }
     /**

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2003,7 +2003,7 @@ namespace {
                 }
 
                 if (!added)
-                    *scopeInfo = (*scopeInfo)->addChild(ScopeInfo3::Other, "", tok, tok->link());
+                    *scopeInfo = (*scopeInfo)->addChild(ScopeInfo3::Other, emptyString, tok, tok->link());
             }
             return;
         }
@@ -2353,7 +2353,7 @@ bool Tokenizer::simplifyUsing()
             structEnd = structEnd->link();
 
             // add ';' after end of struct
-            structEnd->insertToken(";", "");
+            structEnd->insertToken(";", emptyString);
 
             // add name for anonymous struct
             if (!hasName) {
@@ -2363,8 +2363,8 @@ bool Tokenizer::simplifyUsing()
                 else
                     newName = "Unnamed" + MathLib::toString(mUnnamedCount++);
                 TokenList::copyTokens(structEnd->next(), tok, start);
-                structEnd->tokAt(5)->insertToken(newName, "");
-                start->insertToken(newName, "");
+                structEnd->tokAt(5)->insertToken(newName, emptyString);
+                start->insertToken(newName, emptyString);
             } else
                 TokenList::copyTokens(structEnd->next(), tok, start->next());
 
@@ -3318,7 +3318,7 @@ void Tokenizer::calculateScopes()
         tok->scopeInfo(nullptr);
 
     std::string nextScopeNameAddition;
-    std::shared_ptr<ScopeInfo2> primaryScope = std::make_shared<ScopeInfo2>("", nullptr);
+    std::shared_ptr<ScopeInfo2> primaryScope = std::make_shared<ScopeInfo2>(emptyString, nullptr);
     list.front()->scopeInfo(primaryScope);
 
     for (Token* tok = list.front(); tok; tok = tok->next()) {

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -638,7 +638,7 @@ private:
 public:
 
     /** Syntax error */
-    NORETURN void syntaxError(const Token *tok, const std::string &code = "") const;
+    NORETURN void syntaxError(const Token *tok, const std::string &code = emptyString) const;
 
     /** Syntax error. Unmatched character. */
     NORETURN void unmatchedToken(const Token *tok) const;

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -510,7 +510,7 @@ int main(int argc, char **argv)
     compilefiles(fout, libfiles, "${INCLUDE_FOR_LIB}");
     compilefiles(fout, clifiles, "${INCLUDE_FOR_CLI}");
     compilefiles(fout, testfiles, "${INCLUDE_FOR_TEST}");
-    compilefiles(fout, extfiles, "");
+    compilefiles(fout, extfiles, emptyString);
     compilefiles(fout, toolsfiles, "${INCLUDE_FOR_LIB}");
 
     return 0;


### PR DESCRIPTION
Using an existing empty string object makes sense if it is used as a `const std::string&` - also as default parameter. See https://godbolt.org/z/bEfTr1r43.

Returning it from a function is actually more expensive than using the implicit construction from a literal. See https://godbolt.org/z/o9aT4Trz9.
This is not a problem with a local non-`const` object since those will be implicitly moved (FYI that's what the `performance-move-constructor-init` warning is about).

An `const std::string` cannot be used as `const QString&` so I did not change the GUI code.

I will file tickets about such suboptimal cases we might be able to detect.