### PR TITLE
fail `run-clang-tidy` in case of compiler warnings / fixed Clang warnings / cleanups

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install missing software
         run: |
           apt-get update
-          apt-get install -y cmake g++ make
+          apt-get install -y cmake clang-13 make
           apt-get install -y libpcre3-dev
           apt-get install -y libffi7 # work around missing dependency for Qt install step
           apt-get install -y clang-tidy-13
@@ -47,12 +47,15 @@ jobs:
           cd cmake.output
           cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On -DCPPCHK_GLIBCXX_DEBUG=Off ..
           cd ..
+        env:
+          CC: clang-13
+          CXX: clang++-13
 
       - name: Prepare CMake dependencies
         run: |
           # make sure the precompiled headers exist
-          make -C cmake.output lib/CMakeFiles/lib_objs.dir/cmake_pch.hxx.cxx
-          make -C cmake.output test/CMakeFiles/testrunner.dir/cmake_pch.hxx.cxx
+          make -C cmake.output/lib cmake_pch.hxx.pch
+          make -C cmake.output/test cmake_pch.hxx.pch
           # make sure the auto-generated GUI sources exist
           make -C cmake.output autogen
 

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -11,7 +11,7 @@ find_program(RUN_CLANG_TIDY NAMES run-clang-tidy run-clang-tidy-13 run-clang-tid
 message(STATUS "RUN_CLANG_TIDY=${RUN_CLANG_TIDY}")
 if (RUN_CLANG_TIDY)
     # disable all compiler warnings since we are just interested in the tidy ones
-    add_custom_target(run-clang-tidy ${RUN_CLANG_TIDY} -p=${CMAKE_BINARY_DIR} -j ${NPROC} -extra-arg=-w -quiet)
+    add_custom_target(run-clang-tidy ${RUN_CLANG_TIDY} -p=${CMAKE_BINARY_DIR} -j ${NPROC} -quiet)
     if (BUILD_GUI)
         add_dependencies(run-clang-tidy gui-build-deps)
         if (BUILD_TESTS)

--- a/cmake/clang_tidy.cmake
+++ b/cmake/clang_tidy.cmake
@@ -11,7 +11,7 @@ find_program(RUN_CLANG_TIDY NAMES run-clang-tidy run-clang-tidy-13 run-clang-tid
 message(STATUS "RUN_CLANG_TIDY=${RUN_CLANG_TIDY}")
 if (RUN_CLANG_TIDY)
     # disable all compiler warnings since we are just interested in the tidy ones
-    add_custom_target(run-clang-tidy ${RUN_CLANG_TIDY} -checks=-performance-unnecessary-copy-initialization -p=${CMAKE_BINARY_DIR} -j ${NPROC} -extra-arg=-w -quiet)
+    add_custom_target(run-clang-tidy ${RUN_CLANG_TIDY} -p=${CMAKE_BINARY_DIR} -j ${NPROC} -extra-arg=-w -quiet)
     if (BUILD_GUI)
         add_dependencies(run-clang-tidy gui-build-deps)
         if (BUILD_TESTS)

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -74,11 +74,6 @@ static const char TAGS[] = "tags";
 static const int COLUMN_SINCE_DATE = 6;
 static const int COLUMN_TAGS       = 7;
 
-static QString getFunction(QStandardItem *item)
-{
-    return item->data().toMap().value("function").toString();
-}
-
 ResultsTree::ResultsTree(QWidget * parent) :
     QTreeView(parent),
     mSettings(nullptr),

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -812,7 +812,8 @@ void ResultsTree::startApplication(QStandardItem *target, int application)
 
         const QString cmdLine = QString("%1 %2").arg(program).arg(params);
 
-        bool success = QProcess::startDetached(cmdLine);
+        // this is reported as deprecated in Qt 5.15.2 but no longer in Qt 6
+        bool success = SUPPRESS_DEPRECATED_WARNING(QProcess::startDetached(cmdLine));
         if (!success) {
             QString text = tr("Could not start %1\n\nPlease check the application path and parameters are correct.").arg(program);
 

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -543,11 +543,11 @@ void TestCppcheckLibraryData::markupValid()
     }
 }
 
-void TestCppcheckLibraryData::loadCfgFile(QString filename, CppcheckLibraryData &data, QString &result, bool removeFile)
+void TestCppcheckLibraryData::loadCfgFile(QString filename, CppcheckLibraryData &data, QString &res, bool removeFile)
 {
     QFile file(filename);
     QVERIFY(file.open(QIODevice::ReadOnly | QIODevice::Text));
-    result = data.open(file);
+    res = data.open(file);
     file.close();
     if (removeFile) {
         file.remove();

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -41,7 +41,7 @@ private slots:
     void markupValid();
 
 private:
-    void loadCfgFile(QString filename, CppcheckLibraryData &data, QString &result, bool removeFile = false);
+    void loadCfgFile(QString filename, CppcheckLibraryData &data, QString &res, bool removeFile = false);
     void saveCfgFile(QString filename, CppcheckLibraryData &data);
 
     CppcheckLibraryData libraryData;

--- a/gui/test/translationhandler/CMakeLists.txt
+++ b/gui/test/translationhandler/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(test-translationhandler
         ${CMAKE_SOURCE_DIR}/gui/common.cpp
         ${CMAKE_SOURCE_DIR}/gui/translationhandler.cpp
         )
-target_include_directories(test-translationhandler PRIVATE ${CMAKE_SOURCE_DIR}/gui)
+target_include_directories(test-translationhandler PRIVATE ${CMAKE_SOURCE_DIR}/gui ${CMAKE_SOURCE_DIR}/lib)
 target_link_libraries(test-translationhandler ${QT_CORE_LIB} ${QT_WIDGETS_LIB} ${QT_TEST_LIB})
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/gui/translationhandler.cpp
+++ b/gui/translationhandler.cpp
@@ -18,6 +18,7 @@
 
 #include "translationhandler.h"
 
+#include "config.h"
 #include "common.h"
 
 #include <QApplication>
@@ -29,7 +30,7 @@
 
 
 // Provide own translations for standard buttons. This (garbage) code is needed to enforce them to appear in .ts files even after "lupdate gui.pro"
-static void unused()
+static UNUSED void unused()
 {
     Q_UNUSED(QT_TRANSLATE_NOOP("QPlatformTheme", "OK"))
     Q_UNUSED(QT_TRANSLATE_NOOP("QPlatformTheme", "Cancel"))

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -315,8 +315,8 @@ bool isAliased(const Variable *var);
 const Token* getArgumentStart(const Token* ftok);
 
 /** Determines the number of arguments - if token is a function call or macro
- * @param start token which is supposed to be the function/macro name.
- * \return Number of arguments
+ * @param ftok start token which is supposed to be the function/macro name.
+ * @return Number of arguments
  */
 int numberOfArguments(const Token* ftok);
 

--- a/lib/config.h
+++ b/lib/config.h
@@ -39,7 +39,7 @@
 
 // C++11 noexcept
 #if (defined(__GNUC__) && (__GNUC__ >= 5)) \
-    || (defined(__clang__) && (defined (__cplusplus)) && (__cplusplus >= 201103L)) \
+    || defined(__clang__) \
     || defined(__CPPCHECK__)
 #  define NOEXCEPT noexcept
 #else
@@ -48,7 +48,7 @@
 
 // C++11 noreturn
 #if (defined(__GNUC__) && (__GNUC__ >= 5)) \
-    || (defined(__clang__) && (defined (__cplusplus)) && (__cplusplus >= 201103L)) \
+    || defined(__clang__) \
     || defined(__CPPCHECK__)
 #  define NORETURN [[noreturn]]
 #else

--- a/lib/config.h
+++ b/lib/config.h
@@ -64,6 +64,15 @@
 #  define FALLTHROUGH
 #endif
 
+// unused
+#if defined(__GNUC__) \
+    || defined(__clang__) \
+    || defined(__CPPCHECK__)
+#  define UNUSED __attribute__((unused))
+#else
+#  define UNUSED
+#endif
+
 #define REQUIRES(msg, ...) class=typename std::enable_if<__VA_ARGS__::value>::type
 
 #include <string>

--- a/lib/config.h
+++ b/lib/config.h
@@ -123,6 +123,7 @@ static const std::string emptyString;
 #define SUPPRESS_DEPRECATED_WARNING(...) SUPPRESS_WARNING("-Wdeprecated", __VA_ARGS__)
 #define SUPPRESS_FLOAT_EQUAL_WARNING(...) SUPPRESS_WARNING("-Wfloat-equal", __VA_ARGS__)
 #else
+#define SUPPRESS_WARNING(warning, ...) __VA_ARGS__
 #define SUPPRESS_DEPRECATED_WARNING(...) __VA_ARGS__
 #define SUPPRESS_FLOAT_EQUAL_WARNING(...) __VA_ARGS__
 #endif

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -150,6 +150,7 @@ static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std:
 void ImportProject::FileSettings::setIncludePaths(const std::string &basepath, const std::list<std::string> &in, std::map<std::string, std::string, cppcheck::stricmp> &variables)
 {
     std::set<std::string> found;
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     const std::list<std::string> copyIn(in);
     includePaths.clear();
     for (const std::string &ipath : copyIn) {

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -210,7 +210,6 @@ public:
 
     /**
      * @brief Marks Inline Suppressions as checked if source line is in the token stream
-     * @return No return.
      */
     void markUnmatchedInlineSuppressionsAsChecked(const Tokenizer &tokenizer);
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -131,13 +131,7 @@ static void bailoutInternal(const std::string& type, TokenList *tokenlist, Error
     errorLogger->reportErr(errmsg);
 }
 
-#if (defined __cplusplus) && __cplusplus >= 201103L
 #define bailout2(type, tokenlist, errorLogger, tok, what) bailoutInternal(type, tokenlist, errorLogger, tok, what, __FILE__, __LINE__, __func__)
-#elif (defined __GNUC__) || (defined __clang__) || (defined _MSC_VER)
-#define bailout2(type, tokenlist, errorLogger, tok, what) bailoutInternal(type, tokenlist, errorLogger, tok, what, __FILE__, __LINE__, __FUNCTION__)
-#else
-#define bailout2(type, tokenlist, errorLogger, tok, what) bailoutInternal(type, tokenlist, errorLogger, tok, what, __FILE__, __LINE__, "(valueFlow)")
-#endif
 
 #define bailout(tokenlist, errorLogger, tok, what) bailout2("valueFlowBailout", tokenlist, errorLogger, tok, what)
 

--- a/oss-fuzz/main.cpp
+++ b/oss-fuzz/main.cpp
@@ -30,7 +30,9 @@ public:
                         const std::size_t) override {}
 };
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize)
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize);
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize)
 {
     if (dataSize < 10000) {
         const std::string code = generateCode2(data, dataSize);


### PR DESCRIPTION
`clang-tidy` will also report compiler warnings which we were currently suppressing since we treat all warnings as errors.

We should make sure our code is free of warnings. So we should fail the build in the CI (not by default) if one is encountered.

Leveraging the existing `clang-tidy` step saves us an additional explicit step in the CI for a `clang` build.