### PR TITLE
Fix FP with ptr to ptr const

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1555,7 +1555,7 @@ void CheckOther::checkConstPointer()
             continue;
         if (!tok->valueType())
             continue;
-        if (tok->valueType()->pointer != 1 || (tok->valueType()->constness & 1))
+        if (tok->valueType()->pointer != 1 || (tok->valueType()->constness & 1) || tok->valueType()->reference != Reference::None)
             continue;
         if (nonConstPointers.find(tok->variable()) != nonConstPointers.end())
             continue;

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1555,7 +1555,7 @@ void CheckOther::checkConstPointer()
             continue;
         if (!tok->valueType())
             continue;
-        if (tok->valueType()->pointer == 0 || (tok->valueType()->constness & 1))
+        if (tok->valueType()->pointer != 1 || (tok->valueType()->constness & 1))
             continue;
         if (nonConstPointers.find(tok->variable()) != nonConstPointers.end())
             continue;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3035,6 +3035,13 @@ private:
               "    if (p == nullptr) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void g(int*);\n"
+              "void f(int* const* pp) {\n"
+              "    int* p = pp[0];\n"
+              "    g(p);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void switchRedundantAssignmentTest() {
@@ -9150,7 +9157,7 @@ private:
               "    int local_argc = 0;\n"
               "    local_argv[local_argc++] = argv[0];\n"
               "}\n", "test.c");
-        ASSERT_EQUALS("[test.c:1]: (style) Parameter 'argv' can be declared with const\n", errout.str());
+        ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "  int x = 0;\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3042,6 +3042,13 @@ private:
               "    g(p);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("template <typename T>\n"
+              "struct S {\n"
+              "    static bool f(const T& t) { return t != nullptr; }\n"
+              "};\n"
+              "S<int*> s;\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void switchRedundantAssignmentTest() {


### PR DESCRIPTION
The test case had only been changed in https://github.com/danmar/cppcheck/pull/4018. It seems that we cannot warn reliably about higher-order pointers