### PR TITLE
scriptcheck.yml: fixated pygments version and re-enabled all Python v…

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.5]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
 
     steps:
@@ -69,7 +69,8 @@ jobs:
           python -m pip install pylint
           python -m pip install unittest2
           python -m pip install pytest
-          python -m pip install pygments
+          # TODO: remove version limitation when cppcheck-htmlreport is adjusted
+          python -m pip install pygments==2.11.2
           python -m pip install requests
           python -m pip install psutil
 


### PR DESCRIPTION
…ersions

It turns out the failure is related to a change in Pygments which requires changes in the code using it according to https://pygments.org/docs/changelog/:
```
If you have subclassed HtmlFormatter.wrap, you may have to adjust the logic.
```

I filed https://trac.cppcheck.net/ticket/11022.