### PR TITLE
Remove --std=posix option from the manpage

### DIFF
--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -537,8 +537,7 @@ There are false positives with this option. Each result must be carefully invest
         </term>
         <listitem>
           <para>Set standard. The available options are:
-            <glosslist><glossentry><glossterm>posix</glossterm><glossdef><para>POSIX compatible code</para></glossdef></glossentry><glossentry><glossterm>c89</glossterm><glossdef><para>C code is C89 compatible</para></glossdef></glossentry><glossentry><glossterm>c99</glossterm><glossdef><para>C code is C99 compatible</para></glossdef></glossentry><glossentry><glossterm>c11</glossterm><glossdef><para>C code is C11 compatible (default)</para></glossdef></glossentry><glossentry><glossterm>c++03</glossterm><glossdef><para>C++ code is C++03 compatible</para></glossdef></glossentry><glossentry><glossterm>c++11</glossterm><glossdef><para>C++ code is C++11 compatible (default)</para></glossdef></glossentry></glosslist>
-            Example to set more than one standards: 'cppcheck --std=c99 --std=posix file.cpp'
+            <glosslist><glossentry><glossterm>c89</glossterm><glossdef><para>C code is C89 compatible</para></glossdef></glossentry><glossentry><glossterm>c99</glossterm><glossdef><para>C code is C99 compatible</para></glossdef></glossentry><glossentry><glossterm>c11</glossterm><glossdef><para>C code is C11 compatible (default)</para></glossdef></glossentry><glossentry><glossterm>c++03</glossterm><glossdef><para>C++ code is C++03 compatible</para></glossdef></glossentry><glossentry><glossterm>c++11</glossterm><glossdef><para>C++ code is C++11 compatible (default)</para></glossdef></glossentry></glosslist>
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
The option --std=posix is was removed back in 2019 in commit cb06aebdab894c2ca767869889df8e1175aeb379.

The manpage as it is now is misleading, since the --std=posix is no longer supported.
BTW, in commit cb06aebdab894c2ca767869889df8e1175aeb379 it is suggested to use --library=posix instead. It will probably also be useful to add that to the manpage eventually.