### PR TITLE
fix html report generation with pygments >= 2.12.0

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -69,8 +69,7 @@ jobs:
           python -m pip install pylint
           python -m pip install unittest2
           python -m pip install pytest
-          # TODO: remove version limitation when cppcheck-htmlreport is adjusted
-          python -m pip install pygments==2.11.2
+          python -m pip install pygments
           python -m pip install requests
           python -m pip install psutil
 

--- a/htmlreport/cppcheck-htmlreport
+++ b/htmlreport/cppcheck-htmlreport
@@ -518,9 +518,9 @@ def to_css_selector(tag):
 class AnnotateCodeFormatter(HtmlFormatter):
     errors = []
 
-    def wrap(self, source, outfile):
+    def wrap(self, *args, **kwargs):
         line_no = 1
-        for i, t in HtmlFormatter.wrap(self, source, outfile):
+        for i, t in HtmlFormatter.wrap(self, *args, **kwargs):
             # If this is a source code line we want to add a span tag at the
             # end.
             if i == 1:


### PR DESCRIPTION
    pygments 2.12.0 changed the signature of the HtmlFormatter.wrap()
    method. As we don't actually care about the arguments to wrap we can
    use packing/unpacking to maintain compatability with older versions of
    pygments.