### PR TITLE
Fix crash in checkPassByReference()

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1178,7 +1178,7 @@ static int estimateSize(const Type* type, const Settings* settings, const Symbol
             size = settings->sizeof_pointer;
         else if (var.type() && var.type()->classScope)
             size = estimateSize(var.type(), settings, symbolDatabase, recursionDepth+1);
-        else if (var.valueType()->type == ValueType::Type::CONTAINER)
+        else if (var.valueType() && var.valueType()->type == ValueType::Type::CONTAINER)
             size = 3 * settings->sizeof_pointer; // Just guess
         else
             size = symbolDatabase->sizeOfType(var.typeStartToken());

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1815,6 +1815,13 @@ private:
               "void f(S s) {}\n");
         ASSERT_EQUALS("[test.cpp:2]: (performance) Function parameter 's' should be passed by const reference.\n", errout.str());
 
+        check("union U {\n" // don't crash
+              "    int a;\n"
+              "    decltype(nullptr) b;\n"
+              "};\n"
+              "int* f(U u) { return u.b; }\n");
+        ASSERT_EQUALS("", errout.str());
+
         Settings settings1;
         settings1.platform(Settings::Win64);
         check("using ui64 = unsigned __int64;\n"


### PR DESCRIPTION
From `llvm-toolchain-snapshot_15~++20220509105605+460fc79a080b/clang/test/CXX/drs/dr21xx.cpp`