### PR TITLE
use `ubuntu-22.04` as main/base distro in CI

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -9,10 +9,10 @@ jobs:
 
     strategy:
       matrix:
-        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04", "ubuntu:22.04"]
+        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04"]
       fail-fast: false # Prefer quick result
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: ${{ matrix.image }}
@@ -35,7 +35,7 @@ jobs:
 
       # tests require CMake 3.4
       - name: Test CMake build (no tests)
-        if: matrix.image != 'ubuntu:22.04'
+        if: matrix.image != 'ubuntu:22.10'
         run: |
           mkdir cmake.output
           cd cmake.output
@@ -44,7 +44,7 @@ jobs:
           cd ..
 
       - name: Test CMake build
-        if: matrix.image == 'ubuntu:22.04'
+        if: matrix.image == 'ubuntu:22.10'
         run: |
           mkdir cmake.output
           cd cmake.output

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11, macos-12]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
       fail-fast: false # Prefer quick result
 
     runs-on: ${{ matrix.os }}
@@ -26,8 +26,8 @@ jobs:
           sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qt5-default
 
       # packages for strict cfg checks
-      - name: Install missing software on ubuntu 20.04
-        if: matrix.os == 'ubuntu-20.04'
+      - name: Install missing software on ubuntu 22.04
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get install libcairo2-dev libcurl4-openssl-dev liblua5.3-dev libssl-dev libsqlite3-dev libcppunit-dev libsigc++-2.0-dev libgtk-3-dev libboost-all-dev libwxgtk3.0-gtk3-dev xmlstarlet
 
@@ -123,12 +123,12 @@ jobs:
 
       # fails on macos since some includes (e.g. sys/epoll.h) are not available
       - name: Run cfg tests
-        if: contains(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-20.04'
+        if: contains(matrix.os, 'ubuntu') && matrix.os != 'ubuntu-22.04'
         run: |
           make -j$(nproc) checkcfg
 
       - name: Run cfg tests (strict)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           make -j$(nproc) checkcfg
         env:
@@ -208,26 +208,26 @@ jobs:
           qcollectiongenerator online-help.qhcp -o online-help.qhc
 
       - name: Generate Qt help file on ubuntu 20.04
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           pushd gui/help
           qhelpgenerator online-help.qhcp -o online-help.qhc
 
       - name: Build triage on ubuntu
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           pushd tools/triage
           qmake CONFIG+=debug
           make -j$(nproc)
 
       - name: Build Fuzzer
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           pushd oss-fuzz
           make -j$(nproc) CXX=clang++ CXXFLAGS="-fsanitize=address" fuzz-client translate
 
       - name: Self check (build)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           # compile with verification and ast matchers
           make clean
@@ -235,7 +235,7 @@ jobs:
 
       # Run self check after "Build GUI" to include generated headers in analysis
       - name: Self check
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           ec=0
           # self check lib/cli

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -25,6 +25,12 @@ jobs:
           sudo apt-get install libtinyxml2-dev
           sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
+      # required so a default Qt installation is configured
+      - name: Install missing software on ubuntu 18.04
+        if: matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt-get install qt5-default
+
       # packages for strict cfg checks
       - name: Install missing software on ubuntu 22.04
         if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-utils
           sudo apt-get install libtinyxml2-dev
-          sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qt5-default
+          sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
       # packages for strict cfg checks
       - name: Install missing software on ubuntu 22.04

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: "ubuntu:22.04"

--- a/.github/workflows/buildman.yml
+++ b/.github/workflows/buildman.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   convert_via_pandoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: "ubuntu:22.04"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -7,7 +7,7 @@ on: workflow_dispatch
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: "kalilinux/kali-rolling"

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
   scriptcheck:
 
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -7,7 +7,8 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    # 'ubuntu-22.04' removes Python 2.7, 3.6 and 3.6 so keep the previous LTS version
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +27,8 @@ jobs:
   scriptcheck:
 
     needs: build
-    runs-on: ubuntu-22.04
+    # 'ubuntu-22.04' removes Python 2.7, 3.5 and 3.6 so keep the previous LTS version
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       QT_VERSION: 5.15.2

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
       image: "ubuntu:22.04"

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -8,7 +8,7 @@ on: workflow_dispatch
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-22.04` is the new LTS release. Some jobs now start a 22.04 docker container on a 22.04 system but those will be updated with 22.10 when it becomes available.

I also already reference `ubuntu:22.10` in `CI-unixish-docker.yml` which is not yet ready to be used but will be in the future.