### PR TITLE
Library Data: Add support for optional smart pointer element 'unique'

### DIFF
--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -86,6 +86,7 @@ static CppcheckLibraryData::Container loadContainer(QXmlStreamReader &xmlReader)
                     struct CppcheckLibraryData::Container::RangeItemRecordType rangeItemRecordType;
                     rangeItemRecordType.name = xmlReader.attributes().value("name").toString();
                     rangeItemRecordType.templateParameter = xmlReader.attributes().value("templateParameter").toString();
+                    container.rangeItemRecordTypeList.append(rangeItemRecordType);
                 } else
                     container.otherFunctions.append(function);
             }
@@ -525,6 +526,20 @@ static void writeContainerFunctions(QXmlStreamWriter &xmlWriter, const QString &
     xmlWriter.writeEndElement();
 }
 
+static void writeContainerRangeItemRecords(QXmlStreamWriter &xmlWriter, const QList<struct CppcheckLibraryData::Container::RangeItemRecordType> &rangeItemRecords)
+{
+    if (rangeItemRecords.isEmpty())
+        return;
+    xmlWriter.writeStartElement("rangeItemRecordType");
+    for (const CppcheckLibraryData::Container::RangeItemRecordType &item : rangeItemRecords) {
+        xmlWriter.writeStartElement("member");
+        xmlWriter.writeAttribute("name", item.name);
+        xmlWriter.writeAttribute("templateParameter", item.templateParameter);
+        xmlWriter.writeEndElement();
+    }
+    xmlWriter.writeEndElement();
+}
+
 static void writeContainer(QXmlStreamWriter &xmlWriter, const CppcheckLibraryData::Container &container)
 {
     xmlWriter.writeStartElement("container");
@@ -551,6 +566,7 @@ static void writeContainer(QXmlStreamWriter &xmlWriter, const CppcheckLibraryDat
     writeContainerFunctions(xmlWriter, "size", container.size_templateParameter, container.sizeFunctions);
     writeContainerFunctions(xmlWriter, "access", container.access_arrayLike?1:-1, container.accessFunctions);
     writeContainerFunctions(xmlWriter, "other", -1, container.otherFunctions);
+    writeContainerRangeItemRecords(xmlWriter, container.rangeItemRecordTypeList);
     xmlWriter.writeEndElement();
 }
 

--- a/gui/cppchecklibrarydata.h
+++ b/gui/cppchecklibrarydata.h
@@ -22,6 +22,7 @@
 #include <QList>
 #include <QString>
 #include <QStringList>
+#include <QMap>
 
 class QIODevice;
 
@@ -47,6 +48,11 @@ public:
             QString string;
         } type;
 
+        struct RangeItemRecordType {
+            QString name;
+            QString templateParameter;
+        };
+
         struct Function {
             QString name;
             QString yields;
@@ -55,6 +61,7 @@ public:
         QList<struct Function> accessFunctions;
         QList<struct Function> otherFunctions;
         QList<struct Function> sizeFunctions;
+        QList<struct RangeItemRecordType> rangeItemRecordTypeList;
     };
 
     struct Define {
@@ -130,6 +137,9 @@ public:
                        msg.isEmpty();
             }
         } warn;
+
+        QMap<QString, QString> notOverlappingDataArgs;
+        QMap<QString, QString> containerAttributes;
     };
 
     struct MemoryResource {

--- a/gui/cppchecklibrarydata.h
+++ b/gui/cppchecklibrarydata.h
@@ -219,6 +219,15 @@ public:
         QList<Exporter> exporter;
     };
 
+    struct SmartPointer {
+        SmartPointer() :
+            unique {false}
+        {}
+
+        QString name;
+        bool unique;
+    };
+
     void clear() {
         containers.clear();
         defines.clear();
@@ -258,7 +267,7 @@ public:
     QList<TypeChecks> typeChecks;
     QList<struct PlatformType> platformTypes;
     QStringList undefines;
-    QStringList smartPointers;
+    QList<struct SmartPointer> smartPointers;
     QList<struct Reflection> reflections;
     QList<struct Markup> markups;
 };

--- a/gui/test/cppchecklibrarydata/files/container_valid.cfg
+++ b/gui/test/cppchecklibrarydata/files/container_valid.cfg
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<def format="2">  
+  <container id="stdMultiMap">
+    <rangeItemRecordType>
+      <member name="first" templateParameter="0"/>
+      <member name="second" templateParameter="1"/>
+    </rangeItemRecordType>
+  </container>
+</def>

--- a/gui/test/cppchecklibrarydata/files/smartptr_valid.cfg
+++ b/gui/test/cppchecklibrarydata/files/smartptr_valid.cfg
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <def format="2">
   <smart-pointer class-name="wxObjectDataPtr"/>
-  <smart-pointer class-name="wxScopedArray"/>
+  <smart-pointer class-name="wxScopedArray">
+    <unique/>
+  </smart-pointer>
   <smart-pointer class-name="wxScopedPtr"/>
 </def>

--- a/gui/test/cppchecklibrarydata/resources.qrc
+++ b/gui/test/cppchecklibrarydata/resources.qrc
@@ -19,5 +19,6 @@
         <file>files/markup_mandatory_attribute_missing.cfg</file>
         <file>files/markup_valid.cfg</file>
         <file>files/markup_unhandled_element.cfg</file>
+        <file>files/container_valid.cfg</file>
     </qresource>
 </RCC>

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -182,9 +182,12 @@ void TestCppcheckLibraryData::smartPointerValid()
     // Do size and content checks against swapped data.
     QCOMPARE(libraryData.smartPointers.size(), 3);
 
-    QCOMPARE(libraryData.smartPointers[0], QString("wxObjectDataPtr"));
-    QCOMPARE(libraryData.smartPointers[1], QString("wxScopedArray"));
-    QCOMPARE(libraryData.smartPointers[2], QString("wxScopedPtr"));
+    QCOMPARE(libraryData.smartPointers[0].name, QString("wxObjectDataPtr"));
+    QCOMPARE(libraryData.smartPointers[0].unique, false);
+    QCOMPARE(libraryData.smartPointers[1].name, QString("wxScopedArray"));
+    QCOMPARE(libraryData.smartPointers[1].unique, true);
+    QCOMPARE(libraryData.smartPointers[2].name, QString("wxScopedPtr"));
+    QCOMPARE(libraryData.smartPointers[2].unique, false);
 
     // Save library data to file
     saveCfgFile(TempCfgFile, libraryData);
@@ -199,7 +202,10 @@ void TestCppcheckLibraryData::smartPointerValid()
     // Verify no data got lost or modified
     QCOMPARE(libraryData.smartPointers.size(), fileLibraryData.smartPointers.size());
     QCOMPARE(libraryData.smartPointers.size(), 3);
-    QCOMPARE(libraryData.smartPointers, fileLibraryData.smartPointers);
+    for (int idx=0; idx < libraryData.smartPointers.size(); idx++) {
+        QCOMPARE(libraryData.smartPointers[idx].name, fileLibraryData.smartPointers[idx].name);
+        QCOMPARE(libraryData.smartPointers[idx].unique, fileLibraryData.smartPointers[idx].unique);
+    }
 }
 
 void TestCppcheckLibraryData::platformTypeValid()

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -549,6 +549,46 @@ void TestCppcheckLibraryData::markupValid()
     }
 }
 
+void TestCppcheckLibraryData::containerValid()
+{
+    // Load library data from file
+    loadCfgFile(":/files/container_valid.cfg", fileLibraryData, result);
+    QCOMPARE(result.isNull(), true);
+
+    // Swap library data read from file to other object
+    libraryData.swap(fileLibraryData);
+
+    // Do size and content checks against swapped data.
+    QCOMPARE(libraryData.containers.size(), 1);
+
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList.size(), 2);
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].name, "first");
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].templateParameter, "0");
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].name, "second");
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].templateParameter, "1");
+
+    // Save library data to file
+    saveCfgFile(TempCfgFile, libraryData);
+
+    fileLibraryData.clear();
+    QCOMPARE(fileLibraryData.containers.size(), 0);
+
+    // Reload library data from file
+    loadCfgFile(TempCfgFile, fileLibraryData, result, true);
+    QCOMPARE(result.isNull(), true);
+
+    // Verify no data got lost or modified
+    QCOMPARE(libraryData.containers.size(), fileLibraryData.containers.size());
+    for (int idx=0; idx < libraryData.containers.size(); idx++) {
+        CppcheckLibraryData::Container lhs = libraryData.containers[idx];
+        CppcheckLibraryData::Container rhs = fileLibraryData.containers[idx];
+        for (int num=0; num < lhs.rangeItemRecordTypeList.size(); num++) {
+            QCOMPARE(lhs.rangeItemRecordTypeList[num].name, rhs.rangeItemRecordTypeList[num].name);
+            QCOMPARE(lhs.rangeItemRecordTypeList[num].templateParameter, rhs.rangeItemRecordTypeList[num].templateParameter);
+        }
+    }
+}
+
 void TestCppcheckLibraryData::loadCfgFile(QString filename, CppcheckLibraryData &data, QString &res, bool removeFile)
 {
     QFile file(filename);

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -562,10 +562,10 @@ void TestCppcheckLibraryData::containerValid()
     QCOMPARE(libraryData.containers.size(), 1);
 
     QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList.size(), 2);
-    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].name, "first");
-    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].templateParameter, "0");
-    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].name, "second");
-    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].templateParameter, "1");
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].name, QString("first"));
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[0].templateParameter, QString("0"));
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].name, QString("second"));
+    QCOMPARE(libraryData.containers[0].rangeItemRecordTypeList[1].templateParameter, QString("1"));
 
     // Save library data to file
     saveCfgFile(TempCfgFile, libraryData);

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -39,6 +39,7 @@ private slots:
     void undefineValid();
     void reflectionValid();
     void markupValid();
+    void containerValid();
 
 private:
     void loadCfgFile(QString filename, CppcheckLibraryData &data, QString &res, bool removeFile = false);


### PR DESCRIPTION
Avoid configuration load failure due to unhandled element (e.g. qt.cfg).
Avoid data loss during configuration save.
Update smart pointer test.