### PR TITLE
Ignore copy/move constructors for function naming checks

### DIFF
--- a/addons/naming.py
+++ b/addons/naming.py
@@ -81,7 +81,7 @@ for arg in sys.argv[1:]:
             for scope in cfg.scopes:
                 if scope.type == 'Function':
                     function = scope.function
-                    if function is not None and function.type in ('Constructor', 'Destructor'):
+                    if function is not None and function.type in ('Constructor', 'Destructor', 'CopyConstructor', 'MoveConstructor'):
                         continue
                     res = re.match(RE_FUNCTIONNAME, scope.className)
                     if not res:

--- a/addons/namingng.py
+++ b/addons/namingng.py
@@ -182,7 +182,7 @@ def process(dumpfiles, configfile, debugprint=False):
             if "RE_FUNCTIONNAME" in conf and conf["RE_FUNCTIONNAME"]:
                 for token in cfg.tokenlist:
                     if token.function:
-                        if token.function.type == 'Constructor' or token.function.type == 'Destructor':
+                        if token.function.type in ('Constructor', 'Destructor', 'CopyConstructor', 'MoveConstructor'):
                             continue
                         retval = token.previous.str
                         prev = token.previous

--- a/addons/test/naming_test.cpp
+++ b/addons/test/naming_test.cpp
@@ -6,4 +6,6 @@ class TestClass1
 {
     TestClass1() {}
     ~TestClass1() {}
+    TestClass1(const TestClass1 &) {}
+    TestClass1(TestClass1 &&) {}
 };


### PR DESCRIPTION
Currently, move/copy constructors are checked as function names.
For example, if someone does not name their functions with the same standard as their class names, the tool will report an error.

This fix makes the function name-checking ignore both copy and move constructors.