### PR TITLE
Fix #9966: FP memleak with multiple assignments in if-statement

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -441,7 +441,8 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
                 if (!isLocalVarNoAutoDealloc(innerTok, mTokenizer->isCPP()))
                     continue;
 
-                if (Token::Match(innerTok, "%var% =") && innerTok->astParent() == innerTok->next()) {
+                // Check assignments in the if-statement. Skip multiple assignments since we don't track those
+                if (Token::Match(innerTok, "%var% =") && innerTok->astParent() == innerTok->next() && !innerTok->next()->astParent()->isAssignmentOp()) {
                     // allocation?
                     // right ast part (after `=` operator)
                     const Token* tokRightAstOperand = innerTok->next()->astOperand2();

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -164,6 +164,7 @@ private:
         TEST_CASE(ifelse22); // #10187
         TEST_CASE(ifelse23); // #5473
         TEST_CASE(ifelse24); // #1733
+        TEST_CASE(ifelse25); // #9966
 
         // switch
         TEST_CASE(switch1);
@@ -1825,6 +1826,17 @@ private:
               "    return fopen(temp, \"rt\");\n"
               "}\n", s);
         TODO_ASSERT_EQUALS("[test.cpp:3]: (error) Memory leak: temp\n", "", errout.str());
+    }
+
+    void ifelse25() { // #9966
+        check("void f() {\n"
+              "    void *p, *p2;\n"
+              "    if((p2 = p = malloc(10)) == NULL)\n"
+              "        return;\n"
+              "    (void)p;\n"
+              "    free(p2);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void switch1() {


### PR DESCRIPTION
Similar to how we do for assignments outside if-statements, bail out
since we do not track multiple variables.