### PR TITLE
matchcompiler.py: small `%type%` optimization

### DIFF
--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -108,7 +108,7 @@ class MatchCompiler:
         elif tok == '%str%':
             return '(tok->tokType() == Token::eString)'
         elif tok == '%type%':
-            return '(tok->isName() && tok->varId() == 0U && (tok->str() != "delete" || !tok->isKeyword()))'
+            return '(tok->isName() && tok->varId() == 0U && (tok->str() != MatchCompiler::makeConstString("delete") || !tok->isKeyword()))'
         elif tok == '%name%':
             return 'tok->isName()'
         elif tok == '%var%':


### PR DESCRIPTION
This gets rid of all `std::__cxx11::basic_string<>::compare()` calls in `isSameConstantValue()` for instance.