### PR TITLE
inlined `findAstNode()` calls

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -45,19 +45,6 @@
 #include <unordered_map>
 #include <utility>
 
-const Token* findAstNode(const Token* ast, const std::function<bool(const Token*)>& pred)
-{
-    const Token* result = nullptr;
-    visitAstNodes(ast, [&](const Token* tok) {
-        if (pred(tok)) {
-            result = tok;
-            return ChildrenToVisit::done;
-        }
-        return ChildrenToVisit::op1_and_op2;
-    });
-    return result;
-}
-
 const Token* findExpression(const nonneg int exprid,
                             const Token* start,
                             const Token* end,

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -79,7 +79,20 @@ void visitAstNodes(T *ast, const TFunc &visitor)
     } while (true);
 }
 
-const Token* findAstNode(const Token* ast, const std::function<bool(const Token*)>& pred);
+template<class TFunc>
+const Token* findAstNode(const Token* ast, const TFunc& pred)
+{
+    const Token* result = nullptr;
+    visitAstNodes(ast, [&](const Token* tok) {
+        if (pred(tok)) {
+            result = tok;
+            return ChildrenToVisit::done;
+        }
+        return ChildrenToVisit::op1_and_op2;
+    });
+    return result;
+}
+
 const Token* findExpression(const nonneg int exprid,
                             const Token* start,
                             const Token* end,


### PR DESCRIPTION
See https://blog.demofox.org/2015/02/25/avoiding-the-performance-hazzards-of-stdfunction/ - similar to #3828.

Testing an `-O2` build with `--enable=all --inconclusive` on `mame_regtest` code (with some additional local speed hacks applied as well as Boost `SmallVector`):
GCC 11 `32,597,380,507` -> `22,418,156,771`
Clang 13 `27,462,468,325` -> `18,463,123,276`