### PR TITLE
Suggestion for a new checker - Check Different Variables Types

### DIFF
--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -101,6 +101,7 @@ public:
         checkOther.checkAccessOfMovedVariable();
         checkOther.checkModuloOfOne();
         checkOther.checkOverlappingWrite();
+        checkOther.checkDifferentVariablesTypes();
     }
 
     /** Is expression a comparison that checks if a nonzero (unsigned/pointer) expression is less than zero? */
@@ -229,6 +230,11 @@ public:
     void checkOverlappingWrite();
     void overlappingWriteUnion(const Token *tok);
     void overlappingWriteFunction(const Token *tok);
+
+    void checkDifferentVariablesTypes();
+    void checkDifferentVariablesTypesError(const Token* first_var, const Token* second_var, const Token* tok);
+    //gets enum and return its string
+    const char* getTypeName(enum ValueType::Type var_types);
 
 private:
     // Error messages..


### PR DESCRIPTION
Severity: Style
This checker checks whether there is an operation or an assignment of a variable represented by more bytes, in a variable represented by fewer bytes.
It is possible for implicit conversions to lose information.
The checker works according to the the following ladder - 
For example for the following line -
long long var2 = 0; 
 int var1 = var2;
 the checker will notify the user.
![image](https://user-images.githubusercontent.com/92310967/171140778-79f0f82c-830b-446e-85b9-9ea06de8bbaf.png)
