### PR TITLE
Suggestion for a new checker - Check Public Data Members

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -3141,4 +3141,33 @@ bool CheckClass::analyseWholeProgram(const CTU::FileInfo *ctu, const std::list<C
     return foundErrors;
 }
 
+//checkUnnecssaryPublicDataMembersStart---------------------------------------------------------------------------
+
+void CheckClass::checkUnnecssaryPublicDataMembers()
+{
+    //runs over all classes and structs
+    for (const Scope* scope : mSymbolDatabase->classAndStructScopes) {
+        //runs over all the variables
+        for (const Variable& var : scope->varlist)
+        {
+            //if the data member is public then report the error
+            if (var.accessControl() == AccessControl::Public)
+            {
+                bool isClass = scope->type == Scope::ScopeType::eClass;
+                checkUnnecssaryPublicDataMembersError(var.nameToken(), scope->className, var.name(), isClass);
+            }
+        }
+    }
+}
+
+void CheckClass::checkUnnecssaryPublicDataMembersError(const Token* tok, std::string className, std::string dataMember, bool isClass)
+{
+    std::string classOrStruct = (isClass) ? "class" : "struct";
+    // adding the types to the message
+    reportError(tok, Severity::style, "checkUnnecssaryPublicDataMembers",
+        "Found unnecssary public data member called : '" + dataMember + "', in " + classOrStruct + " : '" + className + "'",
+        CWE398, Certainty::normal);
+}
+
+//checkUnnecssaryPublicDataMembersEnd---------------------------------------------------------------------------
 

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -85,6 +85,7 @@ public:
         checkClass.checkOverride();
         checkClass.checkThisUseAfterFree();
         checkClass.checkUnsafeClassRefMember();
+        checkClass.checkUnnecssaryPublicDataMembers();
     }
 
     /** @brief %Check that all class constructors are ok */
@@ -231,6 +232,9 @@ private:
     void unsafeClassRefMemberError(const Token *tok, const std::string &varname);
     void checkDuplInheritedMembersRecursive(const Type* typeCurrent, const Type* typeBase);
 
+    void checkUnnecssaryPublicDataMembersError(const Token* tok, std::string className, std::string dataMember, bool isClass);
+    void checkUnnecssaryPublicDataMembers();
+
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
         CheckClass c(nullptr, settings, errorLogger);
         c.noConstructorError(nullptr, "classname", false);
@@ -270,6 +274,7 @@ private:
         c.overrideError(nullptr, nullptr);
         c.thisUseAfterFree(nullptr, nullptr, nullptr);
         c.unsafeClassRefMemberError(nullptr, "UnsafeClass::var");
+        c.checkUnnecssaryPublicDataMembersError(nullptr, nullptr, nullptr, false);
     }
 
     static std::string myName() {


### PR DESCRIPTION
Severity: Style
This checker is made to find data members which are defined as public in the code and to notify the user about them. 
Then, the user may consider the option to change their access control to private (if it is actually possible) or to keep the data members public. 