### PR TITLE
small `Token::Match()` optimizations

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -638,8 +638,11 @@ const char *Token::chrInFirstWord(const char *str, char c)
 
 bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
 {
+    if (!(*pattern))
+        return true;
+
     const char *p = pattern;
-    while (*p) {
+    while (true) {
         // Skip spaces in pattern..
         while (*p == ' ')
             ++p;

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -711,8 +711,9 @@ bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
             }
         }
 
-        while (*p && *p != ' ')
-            ++p;
+        // using strchr() for the other instances leads to a performance decrease
+        if (!(p = strchr(p, ' ')))
+            break;
 
         tok = tok->next();
     }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -687,8 +687,6 @@ bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
                 return false;
 
             p = temp;
-            while (*p && *p != ' ')
-                ++p;
         }
 
         // Parse "not" options. Token can be anything except the given one
@@ -696,8 +694,6 @@ bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
             p += 2;
             if (firstWordEquals(p, tok->str().c_str()))
                 return false;
-            while (*p && *p != ' ')
-                ++p;
         }
 
         // Parse multi options, such as void|int|char (accept token which is one of these 3)

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -654,8 +654,9 @@ bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
                 while (*p && *p != ' ')
                     ++p;
                 continue;
-            } else
-                return false;
+            }
+
+            return false;
         }
 
         // [.. => search for a one-character token..
@@ -707,7 +708,8 @@ bool Token::Match(const Token *tok, const char pattern[], nonneg int varid)
                 while (*p && *p != ' ')
                     ++p;
                 continue;
-            } else if (res == -1) {
+            }
+            if (res == -1) {
                 // No match
                 return false;
             }


### PR DESCRIPTION
Testing an `-O2` build with `--enable=all --inconclusive` on `mame_regtest` code (with some additional local speed hacks applied as well as Boost `SmallVector`):
GCC 11 `1,779,504,569` -> `1,779,385,063` -> `1,722,982,958` -> `1,720,215,885`
Clang 13 `1,767,925,002` -> `1,756,502,888` -> `1,699,929,669` -> `1,696,929,972`

Any further usage of `strchr()` or removal of the redundant code lead to reduced performance. So did changing the order of `strchr()` and the `tok->next()` calls. This and the difference in gains between the compilers is something to dig into and report upstream.

This is mainly to improve the performance of `CheckUnusedVar::checkStructMemberUsage()` - see https://trac.cppcheck.net/ticket/11106.