### PR TITLE
Suggestion for a new checker -Check Allocation Size

### DIFF
--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -60,6 +60,7 @@ public:
         checkSizeof.checkSizeofForPointerSize();
         checkSizeof.checkSizeofForNumericParameter();
         checkSizeof.sizeofVoid();
+        checkSizeof.checkAllocationSize();
     }
 
     /** @brief %Check for 'sizeof sizeof ..' */
@@ -86,6 +87,9 @@ public:
     /** @brief %Check for using sizeof(void) */
     void sizeofVoid();
 
+    void checkAllocationSize();
+
+
 private:
     // Error messages..
     void sizeofsizeofError(const Token* tok);
@@ -100,6 +104,7 @@ private:
     void sizeofVoidError(const Token *tok);
     void sizeofDereferencedVoidPointerError(const Token *tok, const std::string &varname);
     void arithOperationsOnVoidPointerError(const Token* tok, const std::string &varname, const std::string &vartype);
+    void checkAllocationSizeError(const Token* tok, std::string type);
 
     void getErrorMessages(ErrorLogger* errorLogger, const Settings* settings) const override {
         CheckSizeof c(nullptr, settings, errorLogger);
@@ -116,6 +121,7 @@ private:
         c.sizeofVoidError(nullptr);
         c.sizeofDereferencedVoidPointerError(nullptr, "varname");
         c.arithOperationsOnVoidPointerError(nullptr, "varname", "vartype");
+        c.checkAllocationSizeError(nullptr, "varname");
     }
 
     static std::string myName() {

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2417,6 +2417,20 @@ const ValueFlow::Value* Token::getValue(const MathLib::bigint val) const
     return it == mImpl->mValues->end() ? nullptr : &*it;
 }
 
+//---------------------------------------------------------------------
+const bool Token::valueDividedBy(const MathLib::bigint val) const
+{
+    if (!mImpl->mValues) {
+        return false;
+    }
+    const auto it = std::find_if(mImpl->mValues->begin(), mImpl->mValues->end(), [=](const ValueFlow::Value& value) {
+        return value.isIntValue() && !value.isImpossible() && value.intvalue >= 0 && val >= 0 && value.intvalue % val == 0;
+        });
+    return it == mImpl->mValues->end() ? false : true;
+}
+
+//----------------------------------------------------------------------
+
 const ValueFlow::Value* Token::getMaxValue(bool condition, MathLib::bigint path) const
 {
     if (!mImpl->mValues)

--- a/lib/token.h
+++ b/lib/token.h
@@ -1193,6 +1193,8 @@ public:
 
     const ValueFlow::Value* getValue(const MathLib::bigint val) const;
 
+    const bool valueDividedBy(const MathLib::bigint val) const;
+
     const ValueFlow::Value* getMaxValue(bool condition, MathLib::bigint path = 0) const;
 
     const ValueFlow::Value* getMovedValue() const;


### PR DESCRIPTION
In C language, we often allocate dynamic memory using functions such as malloc, realloc, calloc, ect. 
When using these functions, it is important to check that the size of the allocated memory matches the size of the variable. 
For instance, If we would like to allocate array of integers, the size must divide by 4 (because the size of integer is 4 bytes). 
Usually this problem can be solved by using the function sizeof(), but this checker we have created works also when there is no use of sizeof(). It works for numbers, variables and expressions. 