### PR TITLE
astutils.h: reserve `std::vector` space in `visitAstNodes()` to avoid excess allocations

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -53,7 +53,11 @@ void visitAstNodes(T *ast, const TFunc &visitor)
     if (!ast)
         return;
 
-    std::stack<T *, std::vector<T *>> tokens;
+    std::vector<T *> tokensContainer;
+    // the size of 8 was determined in tests to be sufficient to avoid excess allocations. also add 1 as a buffer.
+    // we might need to increase that value in the future.
+    tokensContainer.reserve(8 + 1);
+    std::stack<T *, std::vector<T *>> tokens(std::move(tokensContainer));
     T *tok = ast;
     do {
         ChildrenToVisit c = visitor(tok);


### PR DESCRIPTION
This is an intermediate solution until `SmallVector` is able to avoid these allocation when not utilizing Boost. As it already provides a sizable improvement without the need for any external dependency I decided to go with this for now.

Testing an `-O2` build with `--enable=all --inconclusive` on `mame_regtest` code (with some additional local speed hacks applied):
GCC 11 `37,875,483,481` -> `33,842,501,109`
Clang 13 `35,459,791,724` -> `28,694,901,787`