### PR TITLE
selfcheck.yml: added `callgrind` step for basic (core) performance tracking

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Self check (unusedFunction / corpus / no test / callgrind)
         run: |
           # TODO: fix -rp so the suppressions actually work
-          valgrind --tool=callgrind ./cppcheck -q --template=selfcheck --error-exitcode=0 --library=cppcheck-lib --library=qt -D__GNUC__ -DQT_VERSION=0x050000 -DQ_MOC_OUTPUT_REVISION=67  --enable=unusedFunction --exception-handling -rp=. --project=cmake.output.corpus/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr 2>callgrind.log || (cat callgrind.log && false)
+          valgrind --tool=callgrind ./cppcheck --template=selfcheck --error-exitcode=0 --library=cppcheck-lib --library=qt -D__GNUC__ -DQT_VERSION=0x050000 -DQ_MOC_OUTPUT_REVISION=67  --enable=unusedFunction --exception-handling -rp=. --project=cmake.output.corpus/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr 2>callgrind.log || (cat callgrind.log && false)
           cat callgrind.log
           callgrind_annotate --auto=no > callgrind.annotated.log
           head -50 callgrind.annotated.log

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install missing software
         run: |
           sudo apt-get update
-          sudo apt-get install valgrind
+          sudo apt-get install clang-14 valgrind
 
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt
@@ -51,7 +51,12 @@ jobs:
       - name: Self check (build)
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
-          make -j$(nproc) -s CXXFLAGS="-O2 -w -DHAVE_BOOST" MATCHCOMPILER=yes
+          # valgrind cannot handle DWARF 5 yet so force version 4
+          # work around performance regression with -inline-deferral
+          make -j$(nproc) -s CXXFLAGS="-O2 -w -DHAVE_BOOST -gdwarf-4 -mllvm -inline-deferral" MATCHCOMPILER=yes
+        env:
+          CC: clang-14
+          CXX: clang++-14
 
       - name: CMake
         run: |

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 
+      - name: Install missing software
+        run: |
+          sudo apt-get update
+          sudo apt-get install valgrind
+
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt
         uses: actions/cache@v1  # not v2!
@@ -88,3 +93,36 @@ jobs:
           ./cppcheck -q --template=selfcheck --error-exitcode=1 --library=cppcheck-lib --library=qt -D__CPPCHECK__ -D__GNUC__ -DQT_VERSION=0x050000 -DQ_MOC_OUTPUT_REVISION=67 --enable=unusedFunction --exception-handling -rp=. --project=cmake.output.notest/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr
         env:
           DISABLE_VALUEFLOW: 1
+
+      - name: Fetch corpus
+        run: |
+          wget https://github.com/danmar/cppcheck/archive/refs/tags/2.8.tar.gz
+          tar xvf 2.8.tar.gz
+
+      - name: CMake (corpus / no test)
+        run: |
+          cmake -S cppcheck-2.8 -B cmake.output.corpus -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=Off -DBUILD_GUI=ON -DWITH_QCHART=ON -DENABLE_CHECK_INTERNAL=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On
+
+      - name: Generate dependencies (corpus)
+        run: |
+          # make sure the precompiled headers exist
+          make -C cmake.output.notest lib/CMakeFiles/lib_objs.dir/cmake_pch.hxx.cxx
+          # make sure auto-generated GUI files exist
+          make -C cmake.output.corpus autogen
+          make -C cmake.output.corpus gui-build-deps
+
+      # TODO: find a way to report unmatched suppressions without need to add information checks
+      - name: Self check (unusedFunction / corpus / no test / callgrind)
+        run: |
+          # TODO: fix -rp so the suppressions actually work
+          valgrind --tool=callgrind ./cppcheck -q --template=selfcheck --error-exitcode=0 --library=cppcheck-lib --library=qt -D__GNUC__ -DQT_VERSION=0x050000 -DQ_MOC_OUTPUT_REVISION=67  --enable=unusedFunction --exception-handling -rp=. --project=cmake.output.corpus/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr 2>callgrind.log || (cat callgrind.log && false)
+          cat callgrind.log
+          callgrind_annotate --auto=no > callgrind.annotated.log
+          head -50 callgrind.annotated.log
+        env:
+          DISABLE_VALUEFLOW: 1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Callgrind Output
+          path: ./callgrind.*


### PR DESCRIPTION
Using the `unusedFunction` self-check for profiling gives us a very basic case which involves the core functionality without the valueflow or most of the checks which should be a pretty good canary for speed improvements/regressions. Although the Ir does not translate directly into actual real time speed it would affects other jobs like the sanitized builds and would give an indication if it has any impact at all.