### PR TITLE
mitigated most clang-tidy warnings in headers

### DIFF
--- a/gui/csvreport.h
+++ b/gui/csvreport.h
@@ -45,23 +45,23 @@ public:
      * @brief Create the report (file).
      * @return true if succeeded, false if file could not be created.
      */
-    virtual bool create() override;
+    bool create() override;
 
     /**
      * @brief Write report header.
      */
-    virtual void writeHeader() override;
+    void writeHeader() override;
 
     /**
      * @brief Write report footer.
      */
-    virtual void writeFooter() override;
+    void writeFooter() override;
 
     /**
      * @brief Write error to report.
      * @param error Error data.
      */
-    virtual void writeError(const ErrorItem &error) override;
+    void writeError(const ErrorItem &error) override;
 
 private:
 

--- a/gui/printablereport.h
+++ b/gui/printablereport.h
@@ -40,23 +40,23 @@ public:
      * @brief Create the report (file).
      * @return true if succeeded, false if file could not be created.
      */
-    virtual bool create() override;
+    bool create() override;
 
     /**
      * @brief Write report header.
      */
-    virtual void writeHeader() override;
+    void writeHeader() override;
 
     /**
      * @brief Write report footer.
      */
-    virtual void writeFooter() override;
+    void writeFooter() override;
 
     /**
      * @brief Write error to report.
      * @param error Error data.
      */
-    virtual void writeError(const ErrorItem &error) override;
+    void writeError(const ErrorItem &error) override;
 
     /**
      * @brief Returns the formatted report.

--- a/gui/scratchpad.h
+++ b/gui/scratchpad.h
@@ -37,7 +37,7 @@ class ScratchPad : public QDialog {
     Q_OBJECT
 public:
     explicit ScratchPad(MainWindow& mainWindow);
-    ~ScratchPad();
+    ~ScratchPad() override;
 
     /**
      * @brief Translate dialog

--- a/gui/txtreport.h
+++ b/gui/txtreport.h
@@ -46,23 +46,23 @@ public:
      * @brief Create the report (file).
      * @return true if succeeded, false if file could not be created.
      */
-    virtual bool create() override;
+    bool create() override;
 
     /**
      * @brief Write report header.
      */
-    virtual void writeHeader() override;
+    void writeHeader() override;
 
     /**
      * @brief Write report footer.
      */
-    virtual void writeFooter() override;
+    void writeFooter() override;
 
     /**
      * @brief Write error to report.
      * @param error Error data.
      */
-    virtual void writeError(const ErrorItem &error) override;
+    void writeError(const ErrorItem &error) override;
 
 private:
 

--- a/gui/xmlreportv2.h
+++ b/gui/xmlreportv2.h
@@ -45,33 +45,33 @@ public:
      * @brief Create the report (file).
      * @return true if succeeded, false if file could not be created.
      */
-    virtual bool create() override;
+    bool create() override;
 
     /**
      * @brief Open existing report file.
      */
-    virtual bool open() override;
+    bool open() override;
 
     /**
      * @brief Write report header.
      */
-    virtual void writeHeader() override;
+    void writeHeader() override;
 
     /**
      * @brief Write report footer.
      */
-    virtual void writeFooter() override;
+    void writeFooter() override;
 
     /**
      * @brief Write error to report.
      * @param error Error data.
      */
-    virtual void writeError(const ErrorItem &error) override;
+    void writeError(const ErrorItem &error) override;
 
     /**
      * @brief Read contents of the report file.
      */
-    virtual QList<ErrorItem> read() override;
+    QList<ErrorItem> read() override;
 
 protected:
     /**

--- a/lib/errortypes.h
+++ b/lib/errortypes.h
@@ -122,8 +122,8 @@ struct CWE {
     unsigned short id;
 };
 
-typedef std::pair<const Token *, std::string> ErrorPathItem;
-typedef std::list<ErrorPathItem> ErrorPath;
+using ErrorPathItem = std::pair<const Token *, std::string>;
+using ErrorPath = std::list<ErrorPathItem>;
 
 /// @}
 //---------------------------------------------------------------------------

--- a/lib/library.h
+++ b/lib/library.h
@@ -478,7 +478,7 @@ public:
     std::vector<std::string> defines; // to provide some library defines
 
     struct SmartPointer {
-        std::string name = "";
+        std::string name;
         bool unique = false;
     };
 

--- a/lib/mathlib.h
+++ b/lib/mathlib.h
@@ -66,8 +66,8 @@ public:
         value shiftRight(const value &v) const;
     };
 
-    typedef long long bigint;
-    typedef unsigned long long biguint;
+    using bigint = long long;
+    using biguint = unsigned long long;
     static const int bigint_bits;
 
     static bigint toLongNumber(const std::string & str);

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1490,8 +1490,8 @@ private:
     Function *findFunctionInScope(const Token *func, const Scope *ns, const std::string & path, nonneg int path_length);
     const Type *findVariableTypeInBase(const Scope *scope, const Token *typeTok) const;
 
-    typedef std::map<unsigned int, unsigned int> MemberIdMap;
-    typedef std::map<unsigned int, MemberIdMap> VarIdMap;
+    using MemberIdMap = std::map<unsigned int, unsigned int>;
+    using VarIdMap = std::map<unsigned int, MemberIdMap>;
 
     void fixVarId(VarIdMap & varIds, const Token * vartok, Token * membertok, const Variable * membervar);
 

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -242,7 +242,7 @@ public:
         bool isSameFamily(const TemplateSimplifier::TokenAndName &decl) const {
             // Make sure a family flag is set and matches.
             // This works because at most only one flag will be set.
-            return ((mFlags & fFamilyMask) & (decl.mFlags & fFamilyMask)) != 0;
+            return ((mFlags & fFamilyMask) && (decl.mFlags & fFamilyMask));
         }
     };
 

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -83,8 +83,8 @@ namespace ValueFlow {
     };
     class CPPCHECKLIB Value {
     public:
-        typedef std::pair<const Token *, std::string> ErrorPathItem;
-        typedef std::list<ErrorPathItem> ErrorPath;
+        using ErrorPathItem = std::pair<const Token *, std::string>;
+        using ErrorPath = std::list<ErrorPathItem>;
         enum class Bound { Upper, Lower, Point };
 
         explicit Value(long long val = 0, Bound b = Bound::Point)


### PR DESCRIPTION
I did not enable the headers in `.clang-tidy` yet since there are some warnings I am not sure how to suppress. This will be done within #4100.