### PR TITLE
fixed `modernize-use-equals-delete` warnings in headers

### DIFF
--- a/lib/check.h
+++ b/lib/check.h
@@ -69,6 +69,9 @@ public:
             instances().remove(this);
     }
 
+    Check(const Check &) = delete;
+    Check& operator=(const Check &) = delete;
+
     /** List of registered check classes. This is used by Cppcheck to run checks and generate documentation */
     static std::list<Check *> &instances();
 
@@ -159,9 +162,6 @@ protected:
      */
     bool wrongData(const Token *tok, const char *str);
 
-    /** disabled assignment operator and copy constructor */
-    void operator=(const Check &) = delete;
-    Check(const Check &) = delete;
 private:
     const std::string mName;
 };

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -76,6 +76,9 @@ private:
         ArgumentInfo(const Token *arg, const Settings *settings, bool _isCPP);
         ~ArgumentInfo();
 
+        ArgumentInfo(const ArgumentInfo &) = delete;
+        ArgumentInfo& operator= (const ArgumentInfo &) = delete;
+
         bool isArrayOrPointer() const;
         bool isComplexType() const;
         bool isKnownType() const;
@@ -91,10 +94,6 @@ private:
         bool _template;
         bool address;
         bool isCPP;
-
-    private:
-        ArgumentInfo(const ArgumentInfo &); // not implemented
-        ArgumentInfo operator = (const ArgumentInfo &); // not implemented
     };
 
     void checkFormatString(const Token * const tok,

--- a/lib/timer.h
+++ b/lib/timer.h
@@ -69,12 +69,13 @@ class CPPCHECKLIB Timer {
 public:
     Timer(const std::string& str, SHOWTIME_MODES showtimeMode, TimerResultsIntf* timerResults = nullptr);
     ~Timer();
+
+    Timer(const Timer&) = delete;
+    Timer& operator=(const Timer&) = delete;
+
     void stop();
 
 private:
-    Timer(const Timer& other); // disallow copying
-    Timer& operator=(const Timer&); // disallow assignments
-
     const std::string mStr;
     TimerResultsIntf* mTimerResults;
     std::clock_t mStart;

--- a/lib/token.h
+++ b/lib/token.h
@@ -179,11 +179,10 @@ class CPPCHECKLIB Token {
 private:
     TokensFrontBack* mTokensFrontBack;
 
-    // Not implemented..
-    Token(const Token &);
-    Token operator=(const Token &);
-
 public:
+    Token(const Token &) = delete;
+    Token& operator=(const Token &) = delete;
+
     enum Type {
         eVariable, eType, eFunction, eKeyword, eName, // Names: Variable (varId), Type (typeId, later), Function (FuncId, later), Language keyword, Name (unknown identifier)
         eNumber, eString, eChar, eBoolean, eLiteral, eEnumerator, // Literals: Number, String, Character, Boolean, User defined literal (C++11), Enumerator

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -43,6 +43,9 @@ public:
     explicit TokenList(const Settings* settings);
     ~TokenList();
 
+    TokenList(const TokenList &) = delete;
+    TokenList &operator=(const TokenList &) = delete;
+
     void setSettings(const Settings *settings) {
         mSettings = settings;
     }
@@ -192,13 +195,6 @@ public:
     bool isKeyword(const std::string &str) const;
 
 private:
-
-    /** Disable copy constructor, no implementation */
-    TokenList(const TokenList &);
-
-    /** Disable assignment operator, no implementation */
-    TokenList &operator=(const TokenList &);
-
     void determineCppC();
 
     /** Token list */

--- a/test/options.h
+++ b/test/options.h
@@ -38,10 +38,9 @@ public:
 
     const std::string& exe() const;
 
-private:
-    options();
-    options(const options& non_copy);
-    const options& operator =(const options& non_assign);
+    options() = delete;
+    options(const options&) = delete;
+    options& operator =(const options&) = delete;
 
 private:
     std::set<std::string> mWhichTests;


### PR DESCRIPTION
This was not fixed in #4173 since the headers are still not included in the analysis (see #4100). They were also missed in #4175 since the checks wasn't enable then.

The fixed based on the check are using `= delete` and making the deleted members `public` so they are actually being applied. I also corrected some `operator=` signatures while at it.

I am not sure if we have checks related to any of this so I have not filed any ticket (yet).