### PR TITLE
LCppC Backport: Improved calculation of CRC32.

### DIFF
--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1017,30 +1017,28 @@ static const std::uint32_t crc32Table[] = {
     0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
 };
 
-static std::uint32_t crc32(const std::string &data)
+static void crc32(const std::string &data, uint32_t& crc)
 {
-    std::uint32_t crc = ~0U;
     for (char c : data) {
         crc = crc32Table[(crc ^ (unsigned char)c) & 0xFF] ^ (crc >> 8);
     }
-    return crc ^ ~0U;
 }
 
-unsigned int Preprocessor::calculateChecksum(const simplecpp::TokenList &tokens1, const std::string &toolinfo) const
+uint32_t Preprocessor::calculateChecksum(const simplecpp::TokenList &tokens1, const std::string &toolinfo) const
 {
-    std::ostringstream ostr;
-    ostr << toolinfo << '\n';
+    std::uint32_t crc = ~0U;
+    crc32(toolinfo, crc);
     for (const simplecpp::Token *tok = tokens1.cfront(); tok; tok = tok->next) {
         if (!tok->comment)
-            ostr << tok->str();
+            crc32(tok->str(), crc);
     }
     for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
         for (const simplecpp::Token *tok = it->second->cfront(); tok; tok = tok->next) {
             if (!tok->comment)
-                ostr << tok->str();
+                crc32(tok->str(), crc);
         }
     }
-    return crc32(ostr.str());
+    return crc ^ ~0U;
 }
 
 void Preprocessor::simplifyPragmaAsm(simplecpp::TokenList *tokenList) const

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -170,7 +170,7 @@ public:
      * @param toolinfo   Arbitrary extra toolinfo
      * @return CRC32 checksum
      */
-    unsigned int calculateChecksum(const simplecpp::TokenList &tokens1, const std::string &toolinfo) const;
+    uint32_t calculateChecksum(const simplecpp::TokenList &tokens1, const std::string &toolinfo) const;
 
     void simplifyPragmaAsm(simplecpp::TokenList *tokenList) const;
 

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -460,20 +460,20 @@ void TokenList::createTokens(simplecpp::TokenList&& tokenList)
 
 //---------------------------------------------------------------------------
 
-unsigned long long TokenList::calculateChecksum() const
+uint64_t TokenList::calculateChecksum() const
 {
-    unsigned long long checksum = 0;
+    uint64_t checksum = 0;
     for (const Token* tok = front(); tok; tok = tok->next()) {
-        const unsigned int subchecksum1 = tok->flags() + tok->varId() + tok->tokType();
-        unsigned int subchecksum2 = 0;
+        const uint32_t subchecksum1 = tok->flags() + tok->varId() + tok->tokType();
+        uint32_t subchecksum2 = 0;
         for (char i : tok->str())
-            subchecksum2 += (unsigned int)i;
+            subchecksum2 += (uint32_t)i;
         if (!tok->originalName().empty()) {
             for (char i : tok->originalName())
-                subchecksum2 += (unsigned int) i;
+                subchecksum2 += (uint32_t)i;
         }
 
-        checksum ^= ((static_cast<unsigned long long>(subchecksum1) << 32) | subchecksum2);
+        checksum ^= ((static_cast<uint64_t>(subchecksum1) << 32) | subchecksum2);
 
         const bool bit1 = (checksum & 1) != 0;
         checksum >>= 1;

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -156,7 +156,7 @@ public:
      * Calculates a 64-bit checksum of the token list used to compare
      * multiple token lists with each other as quickly as possible.
      */
-    unsigned long long calculateChecksum() const;
+    uint64_t calculateChecksum() const;
 
     /**
      * Create abstract syntax tree.


### PR DESCRIPTION
As a follow-up to the discussion in PR4143, I am starting to provide a few fixes/improvements from LCppC to cppcheck, starting with those I backported and sent do danmar a year ago, but were not applied to cppcheck for unknown reasons.