### PR TITLE
LCppC backport: Removed compatibility hacks for outdated compilers

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -35,9 +35,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <windows.h>
-#ifndef __BORLANDC__
 #include <shlwapi.h>
-#endif
 
 // Here is the catch: cppcheck core is Ansi code (using char type).
 // When compiling Unicode targets WinAPI automatically uses *W Unicode versions
@@ -45,12 +43,8 @@
 
 static BOOL myIsDirectory(const std::string& path)
 {
-#ifdef __BORLANDC__
-    return (GetFileAttributes(path.c_str()) & FILE_ATTRIBUTE_DIRECTORY);
-#else
 // See http://msdn.microsoft.com/en-us/library/bb773621(VS.85).aspx
     return PathIsDirectoryA(path.c_str());
-#endif
 }
 
 static HANDLE myFindFirstFile(const std::string& path, LPWIN32_FIND_DATAA findData)
@@ -61,15 +55,7 @@ static HANDLE myFindFirstFile(const std::string& path, LPWIN32_FIND_DATAA findDa
 
 static BOOL myFileExists(const std::string& path)
 {
-#ifdef __BORLANDC__
-    DWORD fa = GetFileAttributes(path.c_str());
-    BOOL result = FALSE;
-    if (fa != INVALID_FILE_ATTRIBUTES && !(fa & FILE_ATTRIBUTE_DIRECTORY))
-        result = TRUE;
-#else
-    const BOOL result = PathFileExistsA(path.c_str()) && !PathIsDirectoryA(path.c_str());
-#endif
-    return result;
+    return PathFileExistsA(path.c_str()) && !PathIsDirectoryA(path.c_str());
 }
 
 std::string FileLister::recursiveAddFiles(std::map<std::string, std::size_t> &files, const std::string &path, const std::set<std::string> &extra, const PathMatch& ignored)

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -31,16 +31,6 @@
 
 #include <simplecpp.h>
 
-#if defined(_MSC_VER) && _MSC_VER <= 1700  // VS2012 doesn't have std::isinf and std::isnan
-#define ISINF(x)      (!_finite(x))
-#define ISNAN(x)      (_isnan(x))
-#elif defined(__INTEL_COMPILER)
-#define ISINF(x)      (isinf(x))
-#define ISNAN(x)      (isnan(x))
-#else  // Use C++11 functions
-#define ISINF(x)      (std::isinf(x))
-#define ISNAN(x)      (std::isnan(x))
-#endif
 
 const int MathLib::bigint_bits = 64;
 
@@ -83,9 +73,9 @@ std::string MathLib::value::str() const
 {
     std::ostringstream ostr;
     if (mType == MathLib::value::Type::FLOAT) {
-        if (ISNAN(mDoubleValue))
+        if (std::isnan(mDoubleValue))
             return "nan.0";
-        if (ISINF(mDoubleValue))
+        if (std::isinf(mDoubleValue))
             return (mDoubleValue > 0) ? "inf.0" : "-inf.0";
 
         ostr.precision(9);


### PR DESCRIPTION
As a follow-up to the discussion in PR4143, I am starting to provide a few fixes/improvements from LCppC to cppcheck.

MSVC 2012 is not supported anymore according to the readme. And Borland C++ should be irrelevant nowadays. Does anybody even know if cppcheck still compiles with it?