### PR TITLE
LCppC backport: Restored Check: Detect negative VLA and allocation (new[]) sizes

### DIFF
--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -75,6 +75,7 @@ public:
         checkBufferOverrun.stringNotZeroTerminated();
         checkBufferOverrun.objectIndex();
         checkBufferOverrun.argumentSize();
+        checkBufferOverrun.negativeArraySize();
     }
 
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
@@ -86,6 +87,9 @@ public:
         c.bufferOverflowError(nullptr, nullptr, Certainty::normal);
         c.objectIndexError(nullptr, nullptr, true);
         c.argumentSizeError(nullptr, "function", 1, "buffer", nullptr, nullptr);
+        c.negativeMemoryAllocationSizeError(nullptr);
+        c.negativeArraySizeError(nullptr);
+        c.negativeMemoryAllocationSizeError(nullptr);
     }
 
     /** @brief Parse current TU and extract file info */
@@ -118,6 +122,10 @@ private:
 
     void argumentSize();
     void argumentSizeError(const Token *tok, const std::string &functionName, nonneg int paramIndex, const std::string &paramExpression, const Variable *paramVar, const Variable *functionArg);
+
+    void negativeArraySize();
+    void negativeArraySizeError(const Token* tok);
+    void negativeMemoryAllocationSizeError(const Token* tok); // provide a negative value to memory allocation function
 
     void objectIndex();
     void objectIndexError(const Token *tok, const ValueFlow::Value *v, bool known);
@@ -159,7 +167,8 @@ private:
                "- Dangerous usage of strncat()\n"
                "- Using array index before checking it\n"
                "- Partial string write that leads to buffer that is not zero terminated.\n"
-               "- Check for large enough arrays being passed to functions\n";
+               "- Check for large enough arrays being passed to functions\n"
+               "- Allocating memory with a negative size\n";
     }
 };
 /// @}

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,2 +1,3 @@
 release notes for cppcheck-2.9
 
+- restored check for negative allocation (new[]) and negative VLA sizes from cppcheck 1.87 (LCppC backport)

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -4784,6 +4784,14 @@ private:
         check("void f()\n"
               "{\n"
               "   int *a;\n"
+              "   a = new int[-1];\n"
+              "   delete [] a;\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory allocation size is negative.\n", errout.str());
+
+        check("void f()\n"
+              "{\n"
+              "   int *a;\n"
               "   a = (int *)malloc( -10 );\n"
               "   free(a);\n"
               "}");
@@ -4810,7 +4818,7 @@ private:
               "   int a[sz];\n"
               "}\n"
               "void x() { f(-100); }");
-        TODO_ASSERT_EQUALS("[test.cpp:2]: (error) Declaration of array 'a' with negative size is undefined behaviour\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (error) Declaration of array 'a' with negative size is undefined behaviour\n", errout.str());
 
         // don't warn for constant sizes -> this is a compiler error so this is used for static assertions for instance
         check("int x, y;\n"

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -97,6 +97,8 @@ private:
         TEST_CASE(returnLocalStdMove4);
 
         TEST_CASE(returnLocalStdMove5);
+
+        TEST_CASE(negativeMemoryAllocationSizeError); // #389
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -1705,6 +1707,23 @@ private:
         check("struct A{} a; A f1() { return std::move(a); }\n"
               "A f2() { volatile A var; return std::move(var); }");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void negativeMemoryAllocationSizeError() { // #389
+        check("void f() {\n"
+              "   int *a;\n"
+              "   a = malloc( -10 );\n"
+              "   free(a);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Invalid malloc() argument nr 1. The value is -10 but the valid values are '0:'.\n", errout.str());
+
+        check("void f() {\n"
+              "   int *a;\n"
+              "   a = alloca( -10 );\n"
+              "   free(a);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Obsolete function 'alloca' called.\n"
+                      "[test.cpp:3]: (error) Invalid alloca() argument nr 1. The value is -10 but the valid values are '0:'.\n", errout.str());
     }
 };
 


### PR DESCRIPTION
As a follow-up to the discussion in PR4143, I am starting to provide a few fixes/improvements from LCppC to cppcheck.