### PR TITLE
LCppC backport: Restored and added new Check for memset third parameter

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -56,7 +56,6 @@ static const CWE CWE131(131U);  // Incorrect Calculation of Buffer Size
 static const CWE CWE170(170U);  // Improper Null Termination
 static const CWE CWE_ARGUMENT_SIZE(398U);  // Indicator of Poor Code Quality
 static const CWE CWE_ARRAY_INDEX_THEN_CHECK(398U);  // Indicator of Poor Code Quality
-static const CWE CWE682(682U);  // Incorrect Calculation
 static const CWE CWE758(758U);  // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 static const CWE CWE_POINTER_ARITHMETIC_OVERFLOW(758U); // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 static const CWE CWE_BUFFER_UNDERRUN(786U);  // Access of Memory Location Before Start of Buffer

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -71,7 +71,7 @@ public:
         checkFunctions.invalidFunctionUsage();
         checkFunctions.checkMathFunctions();
         checkFunctions.memsetZeroBytes();
-        checkFunctions.memsetInvalid2ndParam();
+        checkFunctions.memsetInvalid2nd3rdParam();
         checkFunctions.returnLocalStdMove();
     }
 
@@ -97,8 +97,8 @@ public:
     /** @brief %Check for filling zero bytes with memset() */
     void memsetZeroBytes();
 
-    /** @brief %Check for invalid 2nd parameter of memset() */
-    void memsetInvalid2ndParam();
+    /** @brief %Check for invalid 2nd or 3rd parameter of memset() */
+    void memsetInvalid2nd3rdParam();
 
     /** @brief %Check for copy elision by RVO|NRVO */
     void returnLocalStdMove();
@@ -120,6 +120,8 @@ private:
     void memsetZeroBytesError(const Token *tok);
     void memsetFloatError(const Token *tok, const std::string &var_value);
     void memsetValueOutOfRangeError(const Token *tok, const std::string &value);
+    void memsetSizeArgumentAsCharLiteralError(const Token* tok);
+    void memsetSizeArgumentAsCharError(const Token* tok);
     void missingReturnError(const Token *tok);
     void copyElisionError(const Token *tok);
 
@@ -139,6 +141,8 @@ private:
         c.memsetZeroBytesError(nullptr);
         c.memsetFloatError(nullptr,  "varname");
         c.memsetValueOutOfRangeError(nullptr,  "varname");
+        c.memsetSizeArgumentAsCharLiteralError(nullptr);
+        c.memsetSizeArgumentAsCharError(nullptr);
         c.missingReturnError(nullptr);
         c.copyElisionError(nullptr);
     }
@@ -156,6 +160,7 @@ private:
                "- memset() third argument is zero\n"
                "- memset() with a value out of range as the 2nd parameter\n"
                "- memset() with a float as the 2nd parameter\n"
+               "- memset() with a char as the 3nd parameter\n"
                "- copy elision optimization for returning value affected by std::move\n";
     }
 };

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3910,8 +3910,7 @@ private:
               "    char s[10];\n"
               "    mymemset(s, 0, '*');\n"
               "}", settings);
-        TODO_ASSERT_EQUALS("[test.cpp:3]: (warning) The size argument is given as a char constant.\n"
-                           "[test.cpp:3]: (error) Buffer is accessed out of bounds: s\n", "[test.cpp:3]: (error) Buffer is accessed out of bounds: s\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (error) Buffer is accessed out of bounds: s\n", errout.str());
 
         // ticket #836
         check("void f(void) {\n"

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -86,6 +86,7 @@ private:
         // memset..
         TEST_CASE(memsetZeroBytes);
         TEST_CASE(memsetInvalid2ndParam);
+        TEST_CASE(memsetInvalid3rdParam);
 
         // missing "return"
         TEST_CASE(checkMissingReturn);
@@ -1509,6 +1510,41 @@ private:
               "    memset(is, 1.0f + i, 40);\n"
               "}");
         ASSERT_EQUALS("[test.cpp:4]: (portability) The 2nd memset() argument '1.0f+i' is a float, its representation is implementation defined.\n", errout.str());
+    }
+
+    void memsetInvalid3rdParam() {
+        check("void foo() {\n"
+              "    char s[10];\n"
+              "    memset(s, 0, '*');\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) The size argument of memset() is given as a char constant.\n", errout.str());
+
+        check("void foo(char c) {\n"
+              "    char s[10];\n"
+              "    memset(s, 0, c);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo(char val, char c) {\n"
+              "    char s[10];\n"
+              "    memset(s, val, c);\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo(int val, char c) {\n"
+              "    char s[10];\n"
+              "    memset(s, val, c);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (warning, inconclusive) The size argument of memset() is given as a char while the value argument is of a larger type.\n", errout.str());
+    }
+
+    void negativeMemoryAllocationSizeError() { // #389
+        check("void f() {\n"
+              "   int *a;\n"
+              "   a = malloc( -10 );\n"
+              "   free(a);\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Invalid malloc() argument nr 1. The value is -10 but the valid values are '0:'.\n", errout.str());
     }
 
     void checkMissingReturn() {


### PR DESCRIPTION
As a follow-up to the discussion in PR4143, I am starting to provide a few fixes/improvements from LCppC to cppcheck.