### PR TITLE
Fix handling of std::optional, operator* might be non const

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8555,7 +8555,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
   <container id="stdBasicString" startPattern="std :: basic_string &lt;" inherits="stdAllString">
     <type templateParameter="0"/>
   </container>
-  <container id="stdString" startPattern="std :: string|wstring|u16string|u32string" endPattern="" inherits="stdAllString"/>
+  <container id="stdString" startPattern="std :: string|wstring|u16string|u32string" endPattern="" itEndPattern=":: iterator|const_iterator|reverse_iterator|const_reverse_iterator" inherits="stdAllString"/>
   <container id="stdAllStringView" inherits="stdAllString" view="true">
     <size>
       <function name="remove_prefix" action="change"/>

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -2220,6 +2220,9 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
     if (indirect == 0 && isConstVarExpression(tok))
         return false;
 
+    if (tok->astParent() && tok->astParent()->isUnaryOp("*") && tok->variable() && !tok->variable()->isPointer() && !astIsIterator(tok))
+        return true;
+
     const Token *tok2 = tok;
     int derefs = 0;
     while (Token::simpleMatch(tok2->astParent(), "*") ||

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1136,8 +1136,12 @@ const Library::Container* Library::detectContainer(const Token* typeStart, bool 
         if (container.startPattern.empty())
             continue;
 
-        if (!Token::Match(typeStart, container.startPattern2.c_str()))
-            continue;
+        if (!Token::Match(typeStart, container.startPattern2.c_str())) {
+            if (!iterator)
+                continue;
+            if (!Token::Match(typeStart, container.startPattern.c_str()))
+                continue;
+        }
 
         if (!iterator && container.endPattern.empty()) // If endPattern is undefined, it will always match, but itEndPattern has to be defined.
             return &container;
@@ -1148,6 +1152,9 @@ const Library::Container* Library::detectContainer(const Token* typeStart, bool 
                 if (Token::Match(tok->link(), endPattern.c_str()))
                     return &container;
                 break;
+            }
+            if (iterator && container.endPattern.empty() && Token::Match(tok, container.itEndPattern.c_str())) {
+                return &container;
             }
         }
     }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3261,12 +3261,9 @@ private:
               "    }\n"
               "    v.clear();\n"
               "}\n");
-        TODO_ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'p' can be declared as reference to const\n"
-                           "[test.cpp:5]: (style) Variable 'p' can be declared as reference to const\n",
-                           "[test.cpp:2]: (style) Variable 'p' can be declared as reference to const\n"
-                           "[test.cpp:5]: (style) Variable 'p' can be declared as reference to const\n"
-                           "[test.cpp:8]: (style) Variable 'p' can be declared as reference to const\n",
-                           errout.str());
+        ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'p' can be declared as reference to const\n"
+                      "[test.cpp:5]: (style) Variable 'p' can be declared as reference to const\n",
+                      errout.str());
     }
 
     void switchRedundantAssignmentTest() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3240,11 +3240,33 @@ private:
               "    for (auto* p : v) {\n"
               "        if (p) {}\n"
               "    }\n"
+              "    for (auto* p : v) {\n"
+              "        if (p) { *p = 42; }\n"
+              "    }\n"
               "    v.clear();\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'p' can be declared as pointer to const\n"
                       "[test.cpp:5]: (style) Variable 'p' can be declared as pointer to const\n",
                       errout.str());
+
+        check("void f(std::vector<std::optional<int>>& v) {\n"
+              "    for (std::optional<int> &p : v) {\n"
+              "        if (p) {}\n"
+              "    }\n"
+              "    for (auto& p : v) {\n"
+              "        if (p) {}\n"
+              "    }\n"
+              "    for (auto& p : v) {\n"
+              "        if (p) { *p = 42; }\n"
+              "    }\n"
+              "    v.clear();\n"
+              "}\n");
+        TODO_ASSERT_EQUALS("[test.cpp:2]: (style) Variable 'p' can be declared as reference to const\n"
+                           "[test.cpp:5]: (style) Variable 'p' can be declared as reference to const\n",
+                           "[test.cpp:2]: (style) Variable 'p' can be declared as reference to const\n"
+                           "[test.cpp:5]: (style) Variable 'p' can be declared as reference to const\n"
+                           "[test.cpp:8]: (style) Variable 'p' can be declared as reference to const\n",
+                           errout.str());
     }
 
     void switchRedundantAssignmentTest() {

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -494,6 +494,9 @@ private:
         TEST_CASE(unionWithConstructor);
 
         TEST_CASE(incomplete_type); // #9255 (infinite recursion)
+
+        TEST_CASE(iterator);
+        TEST_CASE(iterator2);
     }
 
     void array() {
@@ -8512,6 +8515,7 @@ private:
         ASSERT_EQUALS(0, autotok->valueType()->pointer);
         ASSERT_EQUALS(ValueType::UNKNOWN_SIGN, autotok->valueType()->sign);
         ASSERT_EQUALS(ValueType::ITERATOR, autotok->valueType()->type);
+        ASSERT_EQUALS(ValueType::ITERATOR, autotok->next()->valueType()->type);
     }
 
     void auto11() {
@@ -8629,6 +8633,37 @@ private:
 
         ASSERT_EQUALS("", errout.str());
     }
+
+    void iterator() {
+        GET_SYMBOL_DB("void f(std::string s) {\n"
+                      "    std::string::const_iterator iter = s.begin();\n"
+                      "}");
+        const Token *autotok = Token::findsimplematch(tokenizer.tokens(), "iter");
+
+        ASSERT(autotok);
+        ASSERT(autotok->valueType());
+        ASSERT_EQUALS(0, autotok->valueType()->constness);
+        ASSERT_EQUALS(0, autotok->valueType()->pointer);
+        ASSERT_EQUALS(ValueType::UNKNOWN_SIGN, autotok->valueType()->sign);
+        ASSERT_EQUALS(ValueType::ITERATOR, autotok->valueType()->type);
+    }
+
+
+    void iterator2() {
+        GET_SYMBOL_DB("void f(std::string s) {\n"
+                      "    auto iter = s.begin();\n"
+                      "}");
+        const Token *autotok = Token::findsimplematch(tokenizer.tokens(), "iter");
+
+        ASSERT(autotok);
+        ASSERT(autotok->valueType());
+        ASSERT_EQUALS(0, autotok->valueType()->constness);
+        ASSERT_EQUALS(0, autotok->valueType()->pointer);
+        ASSERT_EQUALS(ValueType::UNKNOWN_SIGN, autotok->valueType()->sign);
+        ASSERT_EQUALS(ValueType::ITERATOR, autotok->valueType()->type);
+    }
+
+
 };
 
 REGISTER_TEST(TestSymbolDatabase)


### PR DESCRIPTION
Fix handling of std::optional, operator* might be non const

Also, there was an issue in detecting string iterators, the detection
was relying on the container being templates, using the '>' as part
of the pattern, which is not the case with std::string for instance.

Without any change, TestSymbolDatabase::iterator would fail, while
TestSymbolDatabase::iterator2 (which is the same thing but with `auto`
instead of `std::string::const_iterator`) would succeed.

The changes in Library::detectContainer are a bit of a hack, I'm not 
very proud of them...
