### PR TITLE
LCppC backport: Improved CheckStl::string_c_str()

### DIFF
--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -192,6 +192,7 @@ private:
     void string_c_strThrowError(const Token* tok);
     void string_c_strError(const Token* tok);
     void string_c_strReturn(const Token* tok);
+    void string_c_strAssign(const Token* tok);
     void string_c_strParam(const Token* tok, nonneg int number);
 
     void outOfBoundsError(const Token *tok, const std::string &containerName, const ValueFlow::Value *containerSize, const std::string &index, const ValueFlow::Value *indexValue);
@@ -256,6 +257,7 @@ private:
         c.checkFindInsertError(nullptr);
         c.string_c_strError(nullptr);
         c.string_c_strReturn(nullptr);
+        c.string_c_strAssign(nullptr);
         c.string_c_strParam(nullptr, 0);
         c.string_c_strThrowError(nullptr);
         c.sizeError(nullptr);

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -3749,6 +3749,12 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:3]: (error) Dangerous usage of c_str(). The value returned by c_str() is invalid after this call.\n", errout.str());
 
+        check("namespace A { namespace B { std::ostringstream errmsg; } }\n"
+              "void f() {\n"
+              "    const char *c = A::B::errmsg.str().c_str();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (error) Dangerous usage of c_str(). The value returned by c_str() is invalid after this call.\n", errout.str());
+
         check("std::string f();\n"
               "\n"
               "void foo() {\n"
@@ -4006,6 +4012,22 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("void func(const std::string& b) {\n"
+              "    std::string a = b.c_str();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (performance) Assigning the result of c_str() to a variable of type std::string is slow and redundant.\n", errout.str());
+
+        check("void func(const std::string* b) {\n"
+              "    std::string a = b[2].c_str();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (performance) Assigning the result of c_str() to a variable of type std::string is slow and redundant.\n", errout.str());
+
+        check("std::string func2();\n"
+              "void func(const std::string& b) {\n"
+              "    std::string a = func2().c_str();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:3]: (performance) Assigning the result of c_str() to a variable of type std::string is slow and redundant.\n", errout.str());
     }
 
     void uselessCalls() {


### PR DESCRIPTION
As a follow-up to the discussion in PR4143, I am starting to provide a few fixes/improvements from LCppC to cppcheck.