### PR TITLE
Update manpage to fix typo in --max-ctu-depth cli option.

### DIFF
--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -462,7 +462,7 @@ There are false positives with this option. Each result must be carefully invest
       </varlistentry>
       <varlistentry>
         <term>
-          <option>--max-ctu-depths=&lt;limit&gt;</option>
+          <option>--max-ctu-depth=&lt;limit&gt;</option>
         </term>
         <listitem>
           <para>Maximum depth in whole program analysis. Default is 2.</para>


### PR DESCRIPTION
As title says, there is a small typo in the manpage which made me scratch my head for a bit.