### PR TITLE
Try to stop range overflow in forwardRange()

### DIFF
--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -85,7 +85,7 @@ PathAnalysis::Progress PathAnalysis::forwardRecursive(const Token* tok, Info inf
 
 PathAnalysis::Progress PathAnalysis::forwardRange(const Token* startToken, const Token* endToken, Info info, const std::function<PathAnalysis::Progress(const Info&)>& f) const
 {
-    for (const Token *tok = startToken; tok && tok != endToken; tok = tok->next()) {
+    for (const Token *tok = startToken; precedes(tok, endToken); tok = tok->next()) {
         if (Token::Match(tok, "asm|goto|break|continue"))
             return Progress::Break;
         else if (Token::Match(tok, "return|throw")) {
@@ -166,8 +166,8 @@ PathAnalysis::Progress PathAnalysis::forwardRange(const Token* startToken, const
             if (f(info) == Progress::Break)
                 return Progress::Break;
         }
-        // Try to prevent range overflow and infinite recursion
-        if (tok == endToken || tok->next() == start)
+        // Prevent infinite recursion
+        if (tok->next() == start)
             break;
     }
     return Progress::Continue;

--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -166,8 +166,8 @@ PathAnalysis::Progress PathAnalysis::forwardRange(const Token* startToken, const
             if (f(info) == Progress::Break)
                 return Progress::Break;
         }
-        // Prevent infinite recursion
-        if (tok->next() == start)
+        // Try to prevent range overflow and infinite recursion
+        if (tok == endToken || tok->next() == start)
             break;
     }
     return Progress::Continue;


### PR DESCRIPTION
In some cases, like when you have an assignment in an if condition, the loop in PathAnalysis::forwardRange() will continue outside the condition it is supposed to check. That is because the assignment check will put and on the token ), which is also the end token, and then do a tok->next() and check against endToken. This is an extra check if we already on the endToken.

This is probably a solution for trac item #10933. Because that example contains 'many' if statements with assignment in the condition. This makes the run very recursive.

All tests sill passes.