### PR TITLE
gtk.cfg: add more type definition macros

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -36,11 +36,17 @@
   <define name="G_STRINGIFY_ARG(contents)" value="#contents"/>
   <define name="G_STRLOC" value="__FILE__ &quot;:&quot; G_STRINGIFY (__LINE__)"/>
   <define name="G_STRFUNC" value="((const char*) (__FUNCTION__))"/>
+  <define name="G_DEFINE_TYPE(TN, t_n, T_P)" value=""/>
   <define name="G_DEFINE_TYPE_WITH_PRIVATE(TN, t_n, T_P)" value=""/>
   <define name="G_DEFINE_TYPE_WITH_CODE(TN, t_n, T_P, _C_)" value=""/>
+  <define name="G_DEFINE_FINAL_TYPE(TN, t_n, T_P)" value=""/>
+  <define name="G_DEFINE_FINAL_TYPE_WITH_PRIVATE(TN, t_n, T_P)" value=""/>
+  <define name="G_DEFINE_FINAL_TYPE_WITH_CODE(TN, t_n, T_P, _C_)" value=""/>
   <define name="G_DEFINE_ABSTRACT_TYPE(TN, t_n, T_P)" value=""/>
   <define name="G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(TN, t_n, T_P)" value=""/>
   <define name="G_DEFINE_ABSTRACT_TYPE_WITH_CODE(TN, t_n, T_P, _C_)" value=""/>
+  <define name="G_DEFINE_DYNAMIC_TYPE(TN, t_n, T_P)" value=""/>
+  <define name="G_DEFINE_DYNAMIC_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)" value=""/>
   <define name="G_DEFINE_BOXED_TYPE(TypeName,type_name,copy_func,free_func)" value=""/>
   <define name="G_DEFINE_BOXED_TYPE_WITH_CODE(TypeName,type_name,copy_func,free_func,_C_)" value=""/>
   <define name="G_ADD_PRIVATE(TypeName)" value=""/>
@@ -51,6 +57,9 @@
   <define name="G_DEFINE_INTERFACE_WITH_CODE(TN, t_n, T_P, _C_)" value=""/>
   <define name="G_DEFINE_TYPE_EXTENDED(TN, t_n, T_P, _f_, _C_)" value=""/>
   <define name="G_IMPLEMENT_INTERFACE(TYPE_IFACE, iface_init)" value=""/>
+  <define name="G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(TypeName, func)" value=""/>
+  <define name="G_DEFINE_AUTO_CLEANUP_FREE_FUNC(TypeName, func, none)" value=""/>
+  <define name="G_DEFINE_AUTOPTR_CLEANUP_FUNC(TypeName, func)" value=""/>
   <define name="MAX(a, b)" value="(((a) &gt; (b)) ? (a) : (b))"/>
   <define name="MIN(a, b)" value="(((a) &lt; (b)) ? (a) : (b))"/>
   <define name="ABS(a)" value="(((a) &lt; 0) ? -(a) : (a))"/>


### PR DESCRIPTION
Add a number of missing macros from the configuration, including:

* `G_DEFINE_TYPE()`
* `G_DEFINE_FINAL_TYPE()`
* `G_DEFINE_FINAL_TYPE_WITH_PRIVATE()`
* `G_DEFINE_FINAL_TYPE_WITH_CODE()`
* `G_DEFINE_DYNAMIC_TYPE()`
* `G_DEFINE_DYNAMIC_TYPE_EXTENDED()`
* `G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC()`
* `G_DEFINE_AUTO_CLEANUP_FREE_FUNC()`
* `G_DEFINE_AUTOPTR_CLEANUP_FUNC()`