### PR TITLE
Correctly interpret boolean literals in `execute()`

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -632,6 +632,8 @@ static ValueFlow::Value executeImpl(const Token* expr, ProgramMemory& pm, const 
         if (MathLib::isFloat(expr->str()))
             return unknown;
         return ValueFlow::Value{MathLib::toLongNumber(expr->str())};
+    } else if (expr->isBoolean()) {
+        return ValueFlow::Value{ expr->str() == "true" };
     } else if (Token::Match(expr->tokAt(-2), ". %name% (") && astIsContainer(expr->tokAt(-2)->astOperand1())) {
         const Token* containerTok = expr->tokAt(-2)->astOperand1();
         Library::Container::Yield yield = containerTok->valueType()->container->getYield(expr->strAt(-1));

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3623,6 +3623,17 @@ private:
                         "        if (a[i]) {}\n"
                         "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        valueFlowUninit("void f(void) {\n"
+                        "    char *c;\n"
+                        "    char x;\n"
+                        "    while (true) {\n"
+                        "        c = &x;\n"
+                        "        break;\n"
+                        "    }\n"
+                        "    ++c;\n"
+                        "}", "test.c");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void uninitStructMember() { // struct members


### PR DESCRIPTION
This fixes some false positives, e.g. in the following code
```c
void f(void) {
    char *c;
    char x;
    while (true) {
        c = &x;
        break;
    }
    ++c;
}
```
which originally resulted in
```
$ ./cppcheck --enable=warning x.c
Checking x.c ...
x.c:7:7: warning: Uninitialized variable: c [uninitvar]
    ++c;
      ^
x.c:3:12: note: Assuming condition is false
    while (true) {
           ^
x.c:7:7: note: Uninitialized variable: c
    ++c;
      ^
```

For some reason, I could not get the false positive to fire in a checkUninitVar testcase though.