### PR TITLE
Codeeditor: multi-line comment fix

### DIFF
--- a/gui/codeeditor.cpp
+++ b/gui/codeeditor.cpp
@@ -45,26 +45,26 @@ Highlighter::Highlighter(QTextDocument *parent,
                     << "case"
                     << "catch"
                     << "char"
-                    << "char8_­t"
-                    << "char16_­t"
-                    << "char32_­t"
+                    << "char8_t"
+                    << "char16_t"
+                    << "char32_t"
                     << "class"
                     << "concept"
                     << "const"
                     << "consteval"
                     << "constexpr"
                     << "constinit"
-                    << "const_­cast"
+                    << "const_cast"
                     << "continue"
-                    << "co_­await"
-                    << "co_­return"
-                    << "co_­yield"
+                    << "co_await"
+                    << "co_return"
+                    << "co_yield"
                     << "decltype"
                     << "default"
                     << "delete"
                     << "do"
                     << "double"
-                    << "dynamic_­cast"
+                    << "dynamic_cast"
                     << "else"
                     << "enum"
                     << "explicit"
@@ -92,19 +92,19 @@ Highlighter::Highlighter(QTextDocument *parent,
                     << "private"
                     << "protected"
                     << "public"
-                    << "reinterpret_­cast"
+                    << "reinterpret_cast"
                     << "requires"
                     << "return"
                     << "short"
                     << "signed"
                     << "static"
-                    << "static_­assert"
-                    << "static_­cast"
+                    << "static_assert"
+                    << "static_cast"
                     << "struct"
                     << "switch"
                     << "template"
                     << "this"
-                    << "thread_­local"
+                    << "thread_local"
                     << "throw"
                     << "true"
                     << "try"
@@ -116,7 +116,7 @@ Highlighter::Highlighter(QTextDocument *parent,
                     << "virtual"
                     << "void"
                     << "volatile"
-                    << "wchar_­t"
+                    << "wchar_t"
                     << "while";
     for (const QString &pattern : keywordPatterns) {
         rule.pattern = QRegularExpression("\\b" + pattern + "\\b");
@@ -157,7 +157,9 @@ Highlighter::Highlighter(QTextDocument *parent,
     mSymbolFormat.setBackground(mWidgetStyle->symbolBGColor);
     mSymbolFormat.setFontWeight(mWidgetStyle->symbolWeight);
 
-    mCommentStartExpression = QRegularExpression("/\\*");
+    // We use negative lookbehind assertion `(?<!/)`
+    // to ignore case: single line comment and line of asterisk
+    mCommentStartExpression = QRegularExpression("(?<!/)/\\*");
     mCommentEndExpression = QRegularExpression("\\*/");
 }
 


### PR DESCRIPTION
* Single line comment can be treated as multi-line in case of asterisk line: `//*****`
* Some keywords has an invisible Unicode char: `u+00ad`, which breaks keyword highlighting

Old:
![image](https://user-images.githubusercontent.com/4844306/177850900-6c5106d3-b556-411f-a8cd-d9b248d70cde.png)


New:
![image](https://user-images.githubusercontent.com/4844306/177850703-3926adae-c90f-4357-a33b-5d533586c514.png)
