### PR TITLE
donate-cpu: fixed library detection

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -195,7 +195,8 @@ while True:
     if package.find('/qtcreator/') > 0:
         # macro_pounder_fn.c is a preprocessor torture test that takes time to finish
         skip_files = ('macro_pounder_fn.c',)
-    if not unpack_package(work_path, tgz, skip_files=skip_files):
+    source_path, source_found = unpack_package(work_path, tgz, skip_files=skip_files)
+    if not source_found:
         print("No files to process")
         continue
     crash = False
@@ -208,7 +209,7 @@ while True:
     head_timing_info = ''
     old_timing_info = ''
     cppcheck_head_info = ''
-    libraries = get_libraries()
+    libraries = get_libraries(source_path)
 
     for ver in cppcheck_versions:
         tree_path = os.path.join(work_path, 'tree-'+ver)
@@ -217,7 +218,7 @@ while True:
             tree_path = os.path.join(work_path, 'tree-main')
             cppcheck_head_info = get_cppcheck_info(tree_path)
             capture_callstack = True
-        c, errout, info, t, cppcheck_options, timing_info = scan_package(work_path, tree_path, jobs, libraries, capture_callstack)
+        c, errout, info, t, cppcheck_options, timing_info = scan_package(work_path, tree_path, source_path, jobs, libraries, capture_callstack)
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)

--- a/tools/test-my-pr.py
+++ b/tools/test-my-pr.py
@@ -119,7 +119,8 @@ if __name__ == "__main__":
             print("No package downloaded")
             continue
 
-        if not lib.unpack_package(work_path, tgz, args.cpp_only):
+        source_path, source_found = lib.unpack_package(work_path, tgz, args.cpp_only)
+        if not source_found:
             print("No files to process")
             continue
 
@@ -131,8 +132,8 @@ if __name__ == "__main__":
         main_timeout = False
         your_timeout = False
 
-        libraries = lib.get_libraries()
-        c, errout, info, time_main, cppcheck_options, timing_info = lib.scan_package(work_path, main_dir, jobs, libraries)
+        libraries = lib.get_libraries(source_path)
+        c, errout, info, time_main, cppcheck_options, timing_info = lib.scan_package(work_path, main_dir, source_path, jobs, libraries)
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)
@@ -145,7 +146,7 @@ if __name__ == "__main__":
                 main_crashed = True
         results_to_diff.append(errout)
 
-        c, errout, info, time_your, cppcheck_options, timing_info = lib.scan_package(work_path, your_repo_dir, jobs, libraries)
+        c, errout, info, time_your, cppcheck_options, timing_info = lib.scan_package(work_path, your_repo_dir, source_path, jobs, libraries)
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)


### PR DESCRIPTION
`ftp://ftp.de.debian.org/debian/pool/main/v/vlc/vlc_3.0.17.4.orig.tar.xz`

Before:
`Found libraries: ['posix', 'gnu']`

After:
`Found libraries: ['posix', 'gnu', 'bsd', 'gtk', 'lua', 'motif', 'opencv2', 'opengl', 'qt', 'wxwidgets', 'zlib']`

This also gets rid of various hard-coded instances of the scan folder name.