### PR TITLE
Fix FP leakNoVarFunctionCall with Qt object

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -387,6 +387,7 @@
       <not-null/>
       <not-uninit/>
       <not-bool/>
+      <leak-ignore/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -418,6 +419,7 @@
       <not-null/>
       <not-uninit/>
       <not-bool/>
+      <leak-ignore/>
     </arg>
     <arg nr="2" default="0">
       <not-uninit/>
@@ -445,6 +447,7 @@
   <function name="QMenu::addAction">
     <noreturn>false</noreturn>
     <returnValue type="QAction *"/>
+    <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -383,11 +383,11 @@
   <!-- QMetaObject::Connection QObject::connect(const QObject *sender, PointerToMemberFunction signal, const QObject *context, Functor functor, Qt::ConnectionType type = Qt::AutoConnection) // static -->
   <function name="connect,QObject::connect">
     <noreturn>false</noreturn>
+    <leak-ignore/>	  
     <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <not-bool/>
-      <leak-ignore/>
     </arg>
     <arg nr="2">
       <not-uninit/>
@@ -415,11 +415,11 @@
   <!-- bool QObject::disconnect(const QObject *sender, PointerToMemberFunction signal, const QObject *receiver, PointerToMemberFunction method) // static -->
   <function name="disconnect,QObject::disconnect">
     <noreturn>false</noreturn>
+    <leak-ignore/>
     <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
       <not-bool/>
-      <leak-ignore/>
     </arg>
     <arg nr="2" default="0">
       <not-uninit/>

--- a/gui/helpdialog.cpp
+++ b/gui/helpdialog.cpp
@@ -112,4 +112,5 @@ HelpDialog::HelpDialog(QWidget *parent) :
 HelpDialog::~HelpDialog()
 {
     delete mUi;
+    delete mHelpEngine;
 }

--- a/gui/helpdialog.h
+++ b/gui/helpdialog.h
@@ -33,6 +33,10 @@ namespace Ui {
 class HelpBrowser : public QTextBrowser {
 public:
     explicit HelpBrowser(QWidget* parent = nullptr) : QTextBrowser(parent), mHelpEngine(nullptr) {}
+    HelpBrowser(const HelpBrowser&) = delete;
+    HelpBrowser(HelpBrowser&&) = delete;
+    HelpBrowser& operator=(const HelpBrowser&) = delete;
+    HelpBrowser& operator=(HelpBrowser&&) = delete;
     void setHelpEngine(QHelpEngine *helpEngine);
     QVariant loadResource(int type, const QUrl& name) override;
 private:

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1027,7 +1027,10 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
                     break;
                 arg = arg->astOperand1();
             }
-            if (getAllocationType(arg, 0) == No)
+            const AllocType alloc = getAllocationType(arg, 0);
+            if (alloc == No)
+                continue;
+            if ((alloc == New || alloc == NewArray) && arg->next() && !(arg->next()->isStandardType() || mSettings->library.detectContainerOrIterator(arg)))
                 continue;
             if (isReopenStandardStream(arg))
                 continue;

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -471,7 +471,7 @@ void nullPointer(int * pIntPtr)
     }
 }
 
-void leakNoVarFunctionCall() {
+namespace {
     class C : public QObject {
     public:
         explicit C(QObject* parent = nullptr) : QObject(parent) {}

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -19,7 +19,6 @@
 #include <cstdio>
 #include <QCoreApplication>
 #include <QLoggingCategory>
-#include <QShortcut>
 
 
 void QString1(QString s)
@@ -473,10 +472,20 @@ void nullPointer(int * pIntPtr)
 }
 
 void leakNoVarFunctionCall() {
-    struct S : public QObject {
-        S() {
-            connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
+    class C : public QObject {
+        Q_OBJECT
+    public:
+        C(QObject* parent = nullptr) : QObject(parent) {}
+    signals:
+        void signal() {}
+    };
+    class D : public QObject {
+        Q_OBJECT
+    public:
+        D() {
+            connect(new C(this), &C::signal, this, &S::slot);
         }
-        void f() {};
+    slots:
+        void slot() {};
     };
 }

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -475,7 +475,7 @@ void leakNoVarFunctionCall() {
     class C : public QObject {
         Q_OBJECT
     public:
-        C(QObject* parent = nullptr) : QObject(parent) {}
+        explicit C(QObject* parent = nullptr) : QObject(parent) {}
     signals:
         void signal() {}
     };

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -472,10 +472,10 @@ void nullPointer(int * pIntPtr)
 }
 
 void leakNoVarFunctionCall() {
-  struct S : public QObject {
-      S() {
-          connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
-      }
-      void f() {};
-  };
+    struct S : public QObject {
+        S() {
+            connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
+        }
+        void f() {};
+    };
 }

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -473,19 +473,15 @@ void nullPointer(int * pIntPtr)
 
 void leakNoVarFunctionCall() {
     class C : public QObject {
-        Q_OBJECT
     public:
         explicit C(QObject* parent = nullptr) : QObject(parent) {}
-    signals:
         void signal() {}
     };
     class D : public QObject {
-        Q_OBJECT
     public:
         D() {
-            connect(new C(this), &C::signal, this, &S::slot);
+            connect(new C(this), &C::signal, this, &C::slot);
         }
-    slots:
         void slot() {};
     };
 }

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -473,9 +473,9 @@ void nullPointer(int * pIntPtr)
 
 void leakNoVarFunctionCall() {
   struct S : public QObject {
-    S() {
-      connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
-    }
-    void f() {};
+      S() {
+          connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
+      }
+      void f() {};
   };
 }

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <QCoreApplication>
 #include <QLoggingCategory>
+#include <QShortcut>
 
 
 void QString1(QString s)

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -470,3 +470,12 @@ void nullPointer(int * pIntPtr)
         *pIntPtr = 3;
     }
 }
+
+void leakNoVarFunctionCall() {
+  struct S : public QObject {
+    S() {
+      connect(new QShortcut(QKeySequence::Refresh, this), &QShortcut::activated, this, &S::f);
+    }
+    void f() {};
+  };
+}

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -480,7 +480,7 @@ void leakNoVarFunctionCall() {
     class D : public QObject {
     public:
         D() {
-            connect(new C(this), &C::signal, this, &C::slot);
+            connect(new C(this), &C::signal, this, &D::slot);
         }
         void slot() {};
     };

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -473,11 +473,13 @@ void nullPointer(int * pIntPtr)
 
 namespace {
     class C : public QObject {
+        Q_OBJECT
     public:
         explicit C(QObject* parent = nullptr) : QObject(parent) {}
         void signal() {}
     };
     class D : public QObject {
+        Q_OBJECT
     public:
         D() {
             connect(new C(this), &C::signal, this, &D::slot);


### PR DESCRIPTION
Although `connect()` was missing leak-ignore, the FP came up since windows.cfg also has a `connect()`.

The warning for HelpDialog looks like a true positive to me.