### PR TITLE
speed up MinGW and Cygwin CI builds by avoiding repeated linking

### DIFF
--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -14,7 +14,7 @@ jobs:
   build_cygwin:
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
         arch: [x64, x86]
         include:
           - platform: 'x86_64'

--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -33,15 +33,8 @@ jobs:
           platform: ${{ matrix.arch }}
           packages: ${{ matrix.packages }}
 
-      - name: Build cppcheck
-        run: |
-          C:\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2
-
-      - name: Build test
-        run: |
-          C:\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2 testrunner
-
-      - name: Run test
+      # Cygwin will always link the binaries even if they already exist. The linking is also extremely slow. So just run the "check" target which includes all the binaries.
+      - name: Build all and run test
         run: |
           C:\cygwin\bin\bash.exe -l -c cd %GITHUB_WORKSPACE% && make -j2 check
 

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -14,7 +14,7 @@ jobs:
   build_mingw:
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [windows-2019] # fails to download with "windows-2022"
         arch: [x64] # TODO: fix x86 build?
       fail-fast: false
 

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -28,14 +28,7 @@ jobs:
         with:
           platform: ${{ matrix.arch }}
 
-      - name: Build cppcheck
-        run: |
-          mingw32-make -j2
-
-      - name: Build test
-        run: |
-          mingw32-make -j2 testrunner
-
-      - name: Run test
+      # MinGW will always link the binaries even if they already exist. The linking is also extremely slow. So just run the "check" target which includes all the binaries.
+      - name: Build all and run test
         run: |
           mingw32-make -j2 check


### PR DESCRIPTION
This should shave a few minutes (4 for Cygwin / 2 for MinGW) off each build.

The linking itself could be sped up as well by using `lld` instead. Several projects (e.g. MAME) do that. That should save another minute or two.