### PR TITLE
CI-unixish.yml: removed deprecated `macos-10.15`

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11, macos-12]
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
       fail-fast: false # Prefer quick result
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It will be removed on 8/30/2022 and is currently having a scheduled brownout - see https://github.com/actions/virtual-environments/issues/5583.