### PR TITLE
refs #11104: do not do C++ processing for C code in `parsedecl()`

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2914,7 +2914,7 @@ void CheckClass::checkThisUseAfterFree()
         for (const Variable &var : classScope->varlist) {
             // Find possible "self pointer".. pointer/smartpointer member variable of "self" type.
             if (var.valueType() && var.valueType()->smartPointerType != classScope->definedType && var.valueType()->typeScope != classScope) {
-                const ValueType valueType = ValueType::parseDecl(var.typeStartToken(), mSettings);
+                const ValueType valueType = ValueType::parseDecl(var.typeStartToken(), mSettings, true); // this is only called for C++
                 if (valueType.smartPointerType != classScope->definedType)
                     continue;
             }

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -410,7 +410,7 @@ void CheckType::checkFloatToIntegerOverflow()
             while (scope && scope->type != Scope::ScopeType::eLambda && scope->type != Scope::ScopeType::eFunction)
                 scope = scope->nestedIn;
             if (scope && scope->type == Scope::ScopeType::eFunction && scope->function && scope->function->retDef) {
-                const ValueType &valueType = ValueType::parseDecl(scope->function->retDef, mSettings);
+                const ValueType &valueType = ValueType::parseDecl(scope->function->retDef, mSettings, mTokenizer->isCPP());
                 vtfloat = tok->astOperand1()->valueType();
                 floatValues = &tok->astOperand1()->values();
                 checkFloatToIntegerOverflow(tok, &valueType, vtfloat, floatValues);

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -628,7 +628,7 @@ void clangimport::AstNode::setValueType(Token *tok)
         if (!decl.front())
             break;
 
-        ValueType valueType = ValueType::parseDecl(decl.front(), mData->mSettings);
+        ValueType valueType = ValueType::parseDecl(decl.front(), mData->mSettings, true); // TODO: set isCpp
         if (valueType.type != ValueType::Type::UNKNOWN_TYPE) {
             tok->setValueType(new ValueType(valueType));
             break;
@@ -1542,7 +1542,7 @@ static void setValues(Tokenizer *tokenizer, SymbolDatabase *symbolDatabase)
 
     for (Token *tok = const_cast<Token*>(tokenizer->tokens()); tok; tok = tok->next()) {
         if (Token::simpleMatch(tok, "sizeof (")) {
-            ValueType vt = ValueType::parseDecl(tok->tokAt(2), settings);
+            ValueType vt = ValueType::parseDecl(tok->tokAt(2), settings, tokenizer->isCPP());
             int sz = vt.typeSize(*settings, true);
             if (sz <= 0)
                 continue;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1320,7 +1320,7 @@ public:
         debugPath()
     {}
 
-    static ValueType parseDecl(const Token *type, const Settings *settings);
+    static ValueType parseDecl(const Token *type, const Settings *settings, bool isCpp);
 
     static Type typeFromString(const std::string &typestr, bool longType);
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -452,7 +452,7 @@ static std::vector<ValueType> getParentValueTypes(const Token* tok,
         const ValueType* vtCont = contTok->valueType();
         if (!vtCont->containerTypeToken)
             return {};
-        ValueType vtParent = ValueType::parseDecl(vtCont->containerTypeToken, settings);
+        ValueType vtParent = ValueType::parseDecl(vtCont->containerTypeToken, settings, true); // TODO: set isCpp
         return {std::move(vtParent)};
     }
     if (Token::Match(tok->astParent(), "return|(|{|%assign%") && parent) {
@@ -807,7 +807,7 @@ static void setTokenValue(Token* tok,
         if (contains({ValueFlow::Value::ValueType::INT, ValueFlow::Value::ValueType::SYMBOLIC}, value.valueType) &&
             Token::simpleMatch(parent->astOperand1(), "dynamic_cast"))
             return;
-        const ValueType &valueType = ValueType::parseDecl(castType, settings);
+        const ValueType &valueType = ValueType::parseDecl(castType, settings, true); // TODO: set isCpp
         if (value.isImpossible() && value.isIntValue() && value.intvalue < 0 && astIsUnsigned(tok) &&
             valueType.sign == ValueType::SIGNED && tok->valueType() &&
             ValueFlow::getSizeOf(*tok->valueType(), settings) >= ValueFlow::getSizeOf(valueType, settings))
@@ -1108,7 +1108,7 @@ static void setTokenValueCast(Token *parent, const ValueType &valueType, const V
 
 static nonneg int getSizeOfType(const Token *typeTok, const Settings *settings)
 {
-    const ValueType &valueType = ValueType::parseDecl(typeTok, settings);
+    const ValueType &valueType = ValueType::parseDecl(typeTok, settings, true); // TODO: set isCpp
     if (valueType.pointer > 0)
         return settings->sizeof_pointer;
     if (valueType.type == ValueType::Type::BOOL || valueType.type == ValueType::Type::CHAR)
@@ -1323,7 +1323,7 @@ static Token * valueFlowSetConstantValue(Token *tok, const Settings *settings, b
                 setTokenValue(tok->next(), value, settings);
             }
         } else if (!tok2->type()) {
-            const ValueType& vt = ValueType::parseDecl(tok2, settings);
+            const ValueType& vt = ValueType::parseDecl(tok2, settings, true); // TODO: set isCpp
             size_t sz = ValueFlow::getSizeOf(vt, settings);
             const Token* brac = tok2->astParent();
             while (Token::simpleMatch(brac, "[")) {
@@ -4670,7 +4670,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase*, ErrorLogger
             bool isContainerOfPointers = true;
             const Token* containerTypeToken = tok->valueType()->containerTypeToken;
             if (containerTypeToken) {
-                ValueType vt = ValueType::parseDecl(containerTypeToken, settings);
+                ValueType vt = ValueType::parseDecl(containerTypeToken, settings, true); // TODO: set isCpp
                 isContainerOfPointers = vt.pointer > 0;
             }
 
@@ -8050,7 +8050,7 @@ static std::vector<ValueFlow::Value> getInitListSize(const Token* tok,
         if (valueType->container->stdStringLike) {
             initList = astIsGenericChar(args[0]) && !astIsPointer(args[0]);
         } else if (containerTypeToken && settings) {
-            ValueType vt = ValueType::parseDecl(containerTypeToken, settings);
+            ValueType vt = ValueType::parseDecl(containerTypeToken, settings, true); // TODO: set isCpp
             if (vt.pointer > 0 && astIsPointer(args[0]))
                 initList = true;
             else if (vt.type == ValueType::ITERATOR && astIsIterator(args[0]))
@@ -8434,7 +8434,7 @@ static bool getMinMaxValues(const std::string &typestr, const Settings *settings
         return false;
     typeTokens.simplifyPlatformTypes();
     typeTokens.simplifyStdType();
-    const ValueType &vt = ValueType::parseDecl(typeTokens.front(), settings);
+    const ValueType &vt = ValueType::parseDecl(typeTokens.front(), settings, true); // TODO: set isCpp
     return getMinMaxValues(&vt, *settings, minvalue, maxvalue);
 }
 


### PR DESCRIPTION
This avoids the expensive C++-specific `Library::detect*()` calls in `parsedecl()` for C code. See https://trac.cppcheck.net/ticket/10663 and https://trac.cppcheck.net/ticket/11104 for more details of the underlying issues.

There's possibly more parsing which could be disabled as well as passing the `isCpp` flag in all cases (see remaining amount of unnecessary calls below).

Scanning https://github.com/firewave/mame_regtest with `DISABLE_VALUEFLOW=1` and `--enable=all --inconclusive`:

Clang 13 `2,469,788,235` -> `2,147,720,747`
`   14,138,979 ( 0.66%)  /mnt/s/GitHub/cppcheck-fw/lib/library.cpp:Library::detectContainerOrIterator(Token const*, bool*) const [/mnt/s/GitHub/cppcheck-fw/cmake-build-relwithdebinfo-wsl-kali-clang-13/bin/cppcheck]`

GCC 12 `2,374,494,090` -> `2,094,093,681`
`  14,080,692 ( 0.67%)  /mnt/s/GitHub/cppcheck-fw/lib/library.cpp:Library::detectContainer(Token const*, bool) const [/mnt/s/GitHub/cppcheck-fw/cmake-build-relwithdebinfo-wsl-kali-gcc-12/bin/cppcheck]`