### PR TITLE
fixed some `modernize-use-emplace` false negatives and some `bugprone-assignment-in-if-condition` warnings

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -237,8 +237,8 @@ unsigned int ProcessExecutor::check()
                 std::exit(EXIT_FAILURE);
             }
 
-            int flags = 0;
-            if ((flags = fcntl(pipes[0], F_GETFL, 0)) < 0) {
+            int flags = fcntl(pipes[0], F_GETFL, 0);
+            if (flags < 0) {
                 std::cerr << "#### ThreadExecutor::check, fcntl(F_GETFL) failed: "<< std::strerror(errno) << std::endl;
                 std::exit(EXIT_FAILURE);
             }

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -816,8 +816,8 @@ void CheckCondition::oppositeInnerConditionError(const Token *tok1, const Token*
     const std::string s1(tok1 ? tok1->expressionString() : "x");
     const std::string s2(tok2 ? tok2->expressionString() : "!x");
     const std::string innerSmt = innerSmtString(tok2);
-    errorPath.emplace_back(ErrorPathItem(tok1, "outer condition: " + s1));
-    errorPath.emplace_back(ErrorPathItem(tok2, "opposite inner condition: " + s2));
+    errorPath.emplace_back(tok1, "outer condition: " + s1);
+    errorPath.emplace_back(tok2, "opposite inner condition: " + s2);
 
     const std::string msg("Opposite inner '" + innerSmt + "' condition leads to a dead code block.\n"
                           "Opposite inner '" + innerSmt + "' condition leads to a dead code block (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
@@ -831,8 +831,8 @@ void CheckCondition::identicalInnerConditionError(const Token *tok1, const Token
     const std::string s1(tok1 ? tok1->expressionString() : "x");
     const std::string s2(tok2 ? tok2->expressionString() : "x");
     const std::string innerSmt = innerSmtString(tok2);
-    errorPath.emplace_back(ErrorPathItem(tok1, "outer condition: " + s1));
-    errorPath.emplace_back(ErrorPathItem(tok2, "identical inner condition: " + s2));
+    errorPath.emplace_back(tok1, "outer condition: " + s1);
+    errorPath.emplace_back(tok2, "identical inner condition: " + s2);
 
     const std::string msg("Identical inner '" + innerSmt + "' condition is always true.\n"
                           "Identical inner '" + innerSmt + "' condition is always true (outer condition is '" + s1 + "' and inner condition is '" + s2 + "').");
@@ -849,8 +849,8 @@ void CheckCondition::identicalConditionAfterEarlyExitError(const Token *cond1, c
     const std::string cond(cond1 ? cond1->expressionString() : "x");
     const std::string value = (cond2 && cond2->valueType() && cond2->valueType()->type == ValueType::Type::BOOL) ? "false" : "0";
 
-    errorPath.emplace_back(ErrorPathItem(cond1, "If condition '" + cond + "' is true, the function will return/exit"));
-    errorPath.emplace_back(ErrorPathItem(cond2, (isReturnValue ? "Returning identical expression '" : "Testing identical condition '") + cond + "'"));
+    errorPath.emplace_back(cond1, "If condition '" + cond + "' is true, the function will return/exit");
+    errorPath.emplace_back(cond2, (isReturnValue ? "Returning identical expression '" : "Testing identical condition '") + cond + "'");
 
     reportError(errorPath,
                 Severity::warning,

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1635,9 +1635,9 @@ void CheckOther::constVariableError(const Variable *var, const Function *functio
     ErrorPath errorPath;
     std::string id = "const" + vartype;
     std::string message = "$symbol:" + varname + "\n" + vartype + " '$symbol' can be declared as " + ptrRefArray;
-    errorPath.push_back(ErrorPathItem(var ? var->nameToken() : nullptr, message));
+    errorPath.emplace_back(ErrorPathItem(var ? var->nameToken() : nullptr, message));
     if (var && var->isArgument() && function && function->functionPointerUsage) {
-        errorPath.push_front(ErrorPathItem(function->functionPointerUsage, "You might need to cast the function pointer here"));
+        errorPath.emplace_front(ErrorPathItem(function->functionPointerUsage, "You might need to cast the function pointer here"));
         id += "Callback";
         message += ". However it seems that '" + function->name() + "' is a callback function, if '$symbol' is declared with const you might also need to cast function pointer(s).";
     }
@@ -3467,8 +3467,8 @@ void CheckOther::checkShadowVariables()
 void CheckOther::shadowError(const Token *var, const Token *shadowed, std::string type)
 {
     ErrorPath errorPath;
-    errorPath.push_back(ErrorPathItem(shadowed, "Shadowed declaration"));
-    errorPath.push_back(ErrorPathItem(var, "Shadow variable"));
+    errorPath.emplace_back(ErrorPathItem(shadowed, "Shadowed declaration"));
+    errorPath.emplace_back(ErrorPathItem(var, "Shadow variable"));
     const std::string &varname = var ? var->str() : type;
     const std::string Type = char(std::toupper(type[0])) + type.substr(1);
     const std::string id = "shadow" + Type;

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1635,9 +1635,9 @@ void CheckOther::constVariableError(const Variable *var, const Function *functio
     ErrorPath errorPath;
     std::string id = "const" + vartype;
     std::string message = "$symbol:" + varname + "\n" + vartype + " '$symbol' can be declared as " + ptrRefArray;
-    errorPath.emplace_back(ErrorPathItem(var ? var->nameToken() : nullptr, message));
+    errorPath.emplace_back(var ? var->nameToken() : nullptr, message);
     if (var && var->isArgument() && function && function->functionPointerUsage) {
-        errorPath.emplace_front(ErrorPathItem(function->functionPointerUsage, "You might need to cast the function pointer here"));
+        errorPath.emplace_front(function->functionPointerUsage, "You might need to cast the function pointer here");
         id += "Callback";
         message += ". However it seems that '" + function->name() + "' is a callback function, if '$symbol' is declared with const you might also need to cast function pointer(s).";
     }
@@ -3467,8 +3467,8 @@ void CheckOther::checkShadowVariables()
 void CheckOther::shadowError(const Token *var, const Token *shadowed, std::string type)
 {
     ErrorPath errorPath;
-    errorPath.emplace_back(ErrorPathItem(shadowed, "Shadowed declaration"));
-    errorPath.emplace_back(ErrorPathItem(var, "Shadow variable"));
+    errorPath.emplace_back(shadowed, "Shadowed declaration");
+    errorPath.emplace_back(var, "Shadow variable");
     const std::string &varname = var ? var->str() : type;
     const std::string Type = char(std::toupper(type[0])) + type.substr(1);
     const std::string id = "shadow" + Type;

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -809,7 +809,7 @@ void CheckStl::mismatchingContainers()
                 if (!i)
                     continue;
                 const Token * const argTok = args[argnr - 1];
-                containers[i->container].push_back({argTok, i});
+                containers[i->container].emplace_back(ArgIteratorInfo{argTok, i});
             }
 
             // Lambda is used to escape the nested loops
@@ -1002,7 +1002,7 @@ struct InvalidContainerAnalyzer {
                 ep.emplace_front(ftok,
                                  "After calling '" + ftok->expressionString() +
                                  "', iterators or references to the container's data may be invalid .");
-                result.push_back(Info::Reference{tok, ep, ftok});
+                result.emplace_back(Info::Reference{tok, ep, ftok});
             }
         }
         return result;

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -110,7 +110,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
         std::vector<Suppressions::Suppression> suppressions = Suppressions::parseMultiSuppressComment(comment, &errmsg);
 
         if (!errmsg.empty())
-            bad->emplace_back(BadInlineSuppression(tok->location, errmsg));
+            bad->emplace_back(tok->location, errmsg);
 
         for (const Suppressions::Suppression &s : suppressions) {
             if (!s.errorId.empty())
@@ -127,7 +127,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
             inlineSuppressions.push_back(s);
 
         if (!errmsg.empty())
-            bad->emplace_back(BadInlineSuppression(tok->location, errmsg));
+            bad->emplace_back(tok->location, errmsg);
     }
 
     return true;

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -110,7 +110,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
         std::vector<Suppressions::Suppression> suppressions = Suppressions::parseMultiSuppressComment(comment, &errmsg);
 
         if (!errmsg.empty())
-            bad->push_back(BadInlineSuppression(tok->location, errmsg));
+            bad->emplace_back(BadInlineSuppression(tok->location, errmsg));
 
         for (const Suppressions::Suppression &s : suppressions) {
             if (!s.errorId.empty())
@@ -127,7 +127,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
             inlineSuppressions.push_back(s);
 
         if (!errmsg.empty())
-            bad->push_back(BadInlineSuppression(tok->location, errmsg));
+            bad->emplace_back(BadInlineSuppression(tok->location, errmsg));
     }
 
     return true;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5724,10 +5724,9 @@ const Type* SymbolDatabase::findType(const Token *startTok, const Scope *startSc
             }
         } else {
             const Type * type = scope->findType(tok->str());
-            const Scope *scope1;
             if (type)
                 return type;
-            else if ((scope1 = scope->findRecordInBase(tok->str()))) {
+            else if (const Scope *scope1 = scope->findRecordInBase(tok->str())) {
                 type = scope1->definedType;
                 if (type)
                     return type;
@@ -5764,10 +5763,9 @@ const Type* SymbolDatabase::findType(const Token *startTok, const Scope *startSc
                     }
                 } else {
                     const Type * type = scope->findType(tok->str());
-                    const Scope *scope1;
                     if (type)
                         return type;
-                    else if ((scope1 = scope->findRecordInBase(tok->str()))) {
+                    else if (const Scope *scope1 = scope->findRecordInBase(tok->str())) {
                         type = scope1->definedType;
                         if (type)
                             return type;

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -1069,7 +1069,7 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
         // default parameter value?
         else if (Token::Match(tok, "= !!>")) {
             if (defaultedArgPos.insert(templatepar).second) {
-                eq.push_back(Default{tok, nullptr});
+                eq.emplace_back(Default{tok, nullptr});
             } else {
                 // Ticket #5605: Syntax error (two equal signs for the same parameter), bail out
                 eq.clear();

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3492,13 +3492,13 @@ void VariableMap::addVariable(const std::string& varname, bool globalNamespace)
     }
     std::map<std::string, nonneg int>::iterator it = mVariableId.find(varname);
     if (it == mVariableId.end()) {
-        mScopeInfo.top().emplace_back(std::pair<std::string, nonneg int>(varname, 0));
+        mScopeInfo.top().emplace_back(varname, 0);
         mVariableId[varname] = ++mVarId;
         if (globalNamespace)
             mVariableId_global[varname] = mVariableId[varname];
         return;
     }
-    mScopeInfo.top().emplace_back(std::pair<std::string, nonneg int>(varname, it->second));
+    mScopeInfo.top().emplace_back(varname, it->second);
     it->second = ++mVarId;
 }
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3492,13 +3492,13 @@ void VariableMap::addVariable(const std::string& varname, bool globalNamespace)
     }
     std::map<std::string, nonneg int>::iterator it = mVariableId.find(varname);
     if (it == mVariableId.end()) {
-        mScopeInfo.top().push_back(std::pair<std::string, nonneg int>(varname, 0));
+        mScopeInfo.top().emplace_back(std::pair<std::string, nonneg int>(varname, 0));
         mVariableId[varname] = ++mVarId;
         if (globalNamespace)
             mVariableId_global[varname] = mVariableId[varname];
         return;
     }
-    mScopeInfo.top().push_back(std::pair<std::string, nonneg int>(varname, it->second));
+    mScopeInfo.top().emplace_back(std::pair<std::string, nonneg int>(varname, it->second));
     it->second = ++mVarId;
 }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3143,7 +3143,7 @@ struct SubExpressionAnalyzer : ExpressionAnalyzer {
     }
     void internalUpdate(Token* tok, const ValueFlow::Value& v, Direction) override
     {
-        partialReads->emplace_back(std::make_pair(tok, v));
+        partialReads->emplace_back(tok, v);
     }
 
     // No reanalysis for subexression

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2737,7 +2737,7 @@ struct ValueFlowAnalyzer : Analyzer {
         if (std::none_of(refs.begin(), refs.end(), [&](const ReferenceToken& ref) {
             return tok == ref.token;
         }))
-            refs.push_back(ReferenceToken{tok, {}});
+            refs.emplace_back(ReferenceToken{tok, {}});
         for (const ReferenceToken& ref:refs) {
             Action a = analyzeToken(ref.token, tok, d, inconclusiveRefs && ref.token != tok);
             if (internalMatch(ref.token))
@@ -3143,7 +3143,7 @@ struct SubExpressionAnalyzer : ExpressionAnalyzer {
     }
     void internalUpdate(Token* tok, const ValueFlow::Value& v, Direction) override
     {
-        partialReads->push_back(std::make_pair(tok, v));
+        partialReads->emplace_back(std::make_pair(tok, v));
     }
 
     // No reanalysis for subexression

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -175,8 +175,8 @@ std::string TestFixture::deleteLineNumber(const std::string &message)
     while ((pos = result.find(':', pos)) != std::string::npos) {
         // get number
         if (pos + 1 == result.find_first_of("0123456789", pos + 1)) {
-            std::string::size_type after;
-            if ((after = result.find_first_not_of("0123456789", pos + 1)) != std::string::npos
+            std::string::size_type after = result.find_first_not_of("0123456789", pos + 1);
+            if (after != std::string::npos
                 && result.at(after) == ':') {
                 // erase NUMBER
                 result.erase(pos + 1, after - pos - 1);


### PR DESCRIPTION
We are not interested in `bugprone-assignment-in-if-condition` as it's something we use intentionally. I did fix two cases where it was unnecessary though.
We also encountered two false positives with it. The first one is filed as https://github.com/llvm/llvm-project/issues/56729.

The `modernize-use-emplace` false negatives already have upstream tickets:
https://github.com/llvm/llvm-project/issues/56721
https://github.com/llvm/llvm-project/issues/55870
https://github.com/llvm/llvm-project/issues/55869
https://github.com/llvm/llvm-project/issues/55856