### PR TITLE
misra 14_2, first clause, item 2

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -711,6 +711,7 @@ def getForLoopCounterVariables(forToken):
     if not tn or tn.str != '(':
         return None
     vars_defined = set()
+    vars_initialized = set()
     vars_exit = set()
     vars_modified = set()
     cur_clause = 1
@@ -726,10 +727,12 @@ def getForLoopCounterVariables(forToken):
                     vars_modified.add(tn.variable)
                 elif tn.previous and tn.previous.str in ('++', '--'):
                     vars_modified.add(tn.variable)
+        if cur_clause == 1 and tn.isAssignmentOp and tn.astOperand1.variable:
+            vars_initialized.add(tn.astOperand1.variable)
         if tn.str == ';':
             cur_clause += 1
         tn = tn.next
-    return vars_defined & vars_exit & vars_modified
+    return (vars_defined | vars_initialized) & vars_exit & vars_modified
 
 
 def findCounterTokens(cond):

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1186,6 +1186,10 @@ static void misra_14_2_fn1(bool b) {
   for (int i = x; i < 42; i++) {
       x++; // no warning
   }
+  // 1st clause item 2 + loop counter modification
+  for(x = 0; x < 10; x++) {
+    x++; // 14.2
+  }
   for (int i = (x - 3); i < 42; i++) {
       x ^= 3; // no warning
   }


### PR DESCRIPTION
A variable not declared inside the for loop 1st clause
was not seen as a loop counter. Modifying this variable
in the for loop body did not raise misra_14_2 error.