### PR TITLE
misra 14_2, loop counter shall not be modified using pointer

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -711,6 +711,7 @@ def getForLoopCounterVariables(forToken):
     if not tn or tn.str != '(':
         return None
     vars_defined = set()
+    vars_initialized = set()
     vars_exit = set()
     vars_modified = set()
     cur_clause = 1
@@ -726,10 +727,12 @@ def getForLoopCounterVariables(forToken):
                     vars_modified.add(tn.variable)
                 elif tn.previous and tn.previous.str in ('++', '--'):
                     vars_modified.add(tn.variable)
+        if cur_clause == 1 and tn.isAssignmentOp and tn.astOperand1.variable:
+            vars_initialized.add(tn.astOperand1.variable)
         if tn.str == ';':
             cur_clause += 1
         tn = tn.next
-    return vars_defined & vars_exit & vars_modified
+    return (vars_defined | vars_initialized) & vars_exit & vars_modified
 
 
 def findCounterTokens(cond):

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2737,6 +2737,11 @@ class MisraChecker:
                 outer_scope = token.scope
                 body_scope = None
                 tn = token.next
+                if len(counter_vars) == 0:
+                    for idx in range(len(expressions)):
+                        if expressions[idx] != None:
+                            self.reportError(token, 14, 2)
+                            break
                 while tn and tn.next != outer_scope.bodyEnd:
                     if tn.scope and tn.scope.nestedIn == outer_scope:
                         body_scope = tn.scope

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2756,6 +2756,8 @@ class MisraChecker:
                             # TODO: Check modifications in function calls
                             if countSideEffectsRecursive(tn.next) > 0:
                                 self.reportError(tn, 14, 2)
+                        if tn.astParent and tn.astParent.isOp and tn.astParent.valueType and tn.astParent.valueType.pointer > 0 and tn.astParent.astOperand1 == tn:
+                            self.reportError(tn, 14, 2)
                     tn = tn.next
 
     def misra_14_4(self, data):

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1186,6 +1186,10 @@ static void misra_14_2_fn1(bool b) {
   for (int i = x; i < 42; i++) {
       x++; // no warning
   }
+  // 1st clause item 2 + loop counter modification
+  for(x = 0; x < 10; x++) {
+    x++; // 14.2
+  }
   for (int i = (x - 3); i < 42; i++) {
       x ^= 3; // no warning
   }

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1171,7 +1171,7 @@ static void misra_14_2_fn1(bool b) {
     if (i2 == 2) {
       g += g_arr[i2];
     }
-    misra_14_2_init_value(&i2); // TODO: Fix false negative in function call
+    misra_14_2_init_value(&i2); // 14.2
   }
 
   for (misra_14_2_init_value(&i); i < 10; ++i) {} // no-warning FIXME: False positive for 14.2 Trac #9491

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -1158,7 +1158,8 @@ static void misra_14_2_init_value(int32_t *var) {
 }
 static void misra_14_2_fn1(bool b) {
   for (;i++<10;) {} // 14.2
-  for (;i<10;dostuff()) {} // TODO
+  // no loop counter, should be for(;;)
+  for (;i<10;dostuff()) {} // 14.2
   int32_t g = 0;
   int g_arr[42];
   g += 2; // no-warning
@@ -1176,7 +1177,13 @@ static void misra_14_2_fn1(bool b) {
   for (misra_14_2_init_value(&i); i < 10; ++i) {} // no-warning FIXME: False positive for 14.2 Trac #9491
 
   bool abort = false;
-  for (i = 0; (i < 10) && !abort; ++i) { // no-warning
+  for (int i = 0; (i < 10) && !abort; ++i) {
+      if (b) {
+        abort = true;
+      }
+  }
+  // no loop counter, 'i' is not considered a variable (not declared)
+  for (i = 0; (i < 10) && !abort; ++i) { // 14.2
       if (b) {
         abort = true;
       }
@@ -1231,16 +1238,16 @@ static void misra_14_2_fn2(void)
     for (int i = 0, j = 19; y < 10, --j > 10; y++, j--) { // 14.2 12.3
         i++; // no warning
     }
-    for (int i = 0; y < 10; y++) { // TODO: 14.2
+    for (int i = 0; y < 10; y++) { // 14.2
         i++; // no warning
     }
-    for (int i = 0; i < 10; y++) { // TODO: 14.2
+    for (int i = 0; i < 10; y++) { // 14.2
         i++; // no warning
     }
-    for (int i = 0; y < 10; i++) { // TODO: 14.2
+    for (int i = 0; y < 10; i++) { // 14.2
         i++; // no warning
     }
-    for (int i = 0; i < 10; (y+=i)) {
+    for (int i = 0; i < 10; (y+=i)) { // 14.2
         i++; // no warning
     }
 
@@ -1336,7 +1343,7 @@ static void misra_15_4(void) {
       if (y==2) {
         break;
       }
-      for (z = 0; y < 42; ++z) {
+      for (z = 0; y < 42; ++z) { // 14.2
         if (z==1) {
           break;
         }

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -894,7 +894,8 @@ void misra_12_3(int a, int b, int c) {
 
   f((1,2),3); // TODO
 
-  for (i=0; i<10; i++, j++){} // 12.3
+  // third clause: 2 persistent side effects instead of 1 (14.2)
+  for (i=0; i<10; i++, j++){} // 12.3 14.2
   for (int i = 0, p = &a1;  // 12.3 14.2
           i < 42;
           ++i, ++p ) // 12.3
@@ -1190,6 +1191,14 @@ static void misra_14_2_fn1(bool b) {
   for(x = 0; x < 10; x++) {
     x++; // 14.2
   }
+  // third clause: 2 persistent side effects instead of 1 (14.2)
+  for (int i = 0; i < 10; i++, x++) { // 12.3 14.2
+  }
+
+  // 2 loop counters, there shall be only 1
+  for(int i=0, j=0; (i<10) && (j<10); i++, j++) { // 12.3 14.2
+  }
+
   for (int i = (x - 3); i < 42; i++) {
       x ^= 3; // no warning
   }


### PR DESCRIPTION
depends on https://github.com/danmar/cppcheck/pull/4317

Not strictly a direct misra check, but why would someone need a pointer to the loop counter ?