### PR TITLE
fix byte-order-marker handling when reading VS solution files

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -459,12 +459,10 @@ bool ImportProject::importSln(std::istream &istr, const std::string &path, const
         return false;
     }
 
-    if (line.find("Microsoft Visual Studio Solution File") != 0) {
-        // Skip BOM
-        if (!std::getline(istr, line) || line.find("Microsoft Visual Studio Solution File") != 0) {
-            printError("Visual Studio solution file header not found");
-            return false;
-        }
+    if (line.find("Microsoft Visual Studio Solution File") != 0 &&
+        line.find("\xEF\xBB\xBFMicrosoft Visual Studio Solution File") != 0) {
+      printError("Visual Studio solution file header not found");
+      return false;
     }
 
     std::map<std::string,std::string,cppcheck::stricmp> variables;


### PR DESCRIPTION
I think the handling of a possible byte order marker in a VS solution file is not correct. `std::getline` reads just the 3 bytes of the BOM as any other character till there is a new line. The BOM at the beginning of a file does _not_ cause `std::getline` returning an empty string. See also cfe23927097b64bc8ecaf702eaa0212d0a7e5c6f.