### PR TITLE
CERT addon removal cleanup

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -984,7 +984,7 @@ void CmdLineParser::printHelp()
         "*.ixx, *.tpp, and *.txx files are checked recursively from the given directory.\n\n"
         "Options:\n"
         "    --addon=<addon>\n"
-        "                         Execute addon. i.e. --addon=cert. If options must be\n"
+        "                         Execute addon. i.e. --addon=misra. If options must be\n"
         "                         provided a json configuration is needed.\n"
         "    --addon-python=<python interpreter>\n"
         "                         You can specify the python interpreter either in the\n"

--- a/gui/help/projectfiledialog.html
+++ b/gui/help/projectfiledialog.html
@@ -167,8 +167,6 @@ overflow in year 2038. Check that the code does not use such timers.</p>
 
 <p><b>Thread safety</b><br>Check that the code is thread safe</p>
 
-<p><b>CERT</b><br>Ensure that the CERT coding standard is followed</p>
-
 <p><b>MISRA</b><br>Ensure that the MISRA coding standard is followed. Please
 note you need to have a textfile with the misra rule texts to get proper
 warning messages. Cppcheck is not legally allowed to distribute the misra

--- a/man/manual.md
+++ b/man/manual.md
@@ -873,10 +873,6 @@ Cppcheck is distributed with a few addons which are listed below.
 
 ## Supported addons
 
-### cert.py
-
-[cert.py](https://github.com/danmar/cppcheck/blob/main/addons/cert.py) checks for compliance with the safe programming standard [SEI CERT](http://www.cert.org/secure-coding/).
-
 ### misra.py
 
 [misra.py](https://github.com/danmar/cppcheck/blob/main/addons/misra.py) is used to verify compliance with MISRA C 2012, a proprietary set of guidelines to avoid questionable code, developed for embedded systems.


### PR DESCRIPTION
The CERT addon was removed in 92316b07c8.

Clean up a few places which still referenced the CERT addon.