### PR TITLE
avoid unnecessary copies with `insert()`

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -220,7 +220,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     undef = 2 + argv[i];
                 }
 
-                mSettings->userUndefs.insert(undef);
+                mSettings->userUndefs.insert(std::move(undef));
             }
 
             else if (std::strncmp(argv[i], "--addon=", 8) == 0)

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -277,7 +277,7 @@ bool ThreadHandler::needsReCheck(const QString &filename, std::set<QString> &mod
                 line.remove(i,line.length());
                 line = QFileInfo(filename).absolutePath() + "/" + line;
                 if (needsReCheck(line, modified, unmodified)) {
-                    modified.insert(line);
+                    modified.insert(std::move(line));
                     return true;
                 }
             }

--- a/lib/library.h
+++ b/lib/library.h
@@ -562,11 +562,11 @@ private:
 
     class ExportedFunctions {
     public:
-        void addPrefix(const std::string& prefix) {
-            mPrefixes.insert(prefix);
+        void addPrefix(std::string prefix) {
+            mPrefixes.insert(std::move(prefix));
         }
-        void addSuffix(const std::string& suffix) {
-            mSuffixes.insert(suffix);
+        void addSuffix(std::string suffix) {
+            mSuffixes.insert(std::move(suffix));
         }
         bool isPrefix(const std::string& prefix) const {
             return (mPrefixes.find(prefix) != mPrefixes.end());

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -525,7 +525,7 @@ static void getConfigs(const simplecpp::TokenList &tokens, std::set<std::string>
         }
     }
     if (!elseError.empty())
-        ret.insert(elseError);
+        ret.insert(std::move(elseError));
 }
 
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1973,7 +1973,7 @@ namespace {
                     nameSpace += tok1->str();
                     tok1 = tok1->next();
                 }
-                (*scopeInfo)->usingNamespaces.insert(nameSpace);
+                (*scopeInfo)->usingNamespaces.insert(std::move(nameSpace));
             }
             // check for member function
             else if (tok->str() == "{") {
@@ -2066,7 +2066,7 @@ namespace {
                         }
                     }
                 }
-                baseTypes.insert(base);
+                baseTypes.insert(std::move(base));
             } while (tok && !Token::Match(tok, ";|{"));
         }
 
@@ -3354,7 +3354,7 @@ void Tokenizer::calculateScopes()
                 }
                 if (!usingNamespaceName.empty())
                     usingNamespaceName.pop_back();
-                tok->scopeInfo()->usingNamespaces.insert(usingNamespaceName);
+                tok->scopeInfo()->usingNamespaces.insert(std::move(usingNamespaceName));
             } else if (Token::Match(tok, "namespace|class|struct|union %name% {|::|:|<")) {
                 for (Token* nameTok = tok->next(); nameTok && !Token::Match(nameTok, "{|:"); nameTok = nameTok->next()) {
                     if (Token::Match(nameTok, ";|<")) {


### PR DESCRIPTION
More things discovered by reviewing the suggestions of the upcoming `misc-const-correctness` clang-tidy check.