### PR TITLE
donate-cpu: added support for `mingw32-make` and improved support for `msbuild.exe`

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -284,8 +284,8 @@ while True:
         print(info_output)
         print('=========================================================')
     if do_upload:
-        upload_results(package, output, server_address)
-        upload_info(package, info_output, server_address)
+        if upload_results(package, output, server_address):
+            upload_info(package, info_output, server_address)
     if not max_packages or packages_processed < max_packages:
         print('Sleep 5 seconds..')
         if (client_version_head is not None) and (Version(client_version_head) > Version(get_client_version())):

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -229,7 +229,7 @@ while True:
             capture_callstack = True
 
             def get_client_version_head():
-                cmd = os.path.join(tree_path, 'tools', 'donate-cpu.py') + ' ' + '--version'
+                cmd = 'python3' + ' ' + os.path.join(tree_path, 'tools', 'donate-cpu.py') + ' ' + '--version'
                 p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
                 try:
                     comm = p.communicate()

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -172,11 +172,15 @@ def compile_cppcheck(cppcheck_path, jobs):
             subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=os.path.join(cppcheck_path, 'bin'))
         else:
+            rdynamic = ''
             build_env = os.environ
             if __make_cmd == 'mingw32-make':
+                # TODO: MinGW will always link even if no changes are present
                 # assume Python is in PATH for now
                 build_env['PYTHON_INTERPRETER'] = 'python3'
-            subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path, env=build_env)
+                # TODO: MinGW is not detected by Makefile - so work around it for now
+                rdynamic = 'RDYNAMIC=-lshlwapi'
+            subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w', rdynamic], cwd=cppcheck_path, env=build_env)
             subprocess.check_call([os.path.join(cppcheck_path, 'cppcheck'), '--version'], cwd=cppcheck_path)
     except:
         return False

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -675,6 +675,11 @@ class LibraryIncludes:
 
 
 def get_compiler_version():
+    if __make_cmd == 'msbuild.exe':
+        # TODO: shorted version string
+        _, _, stderr, _ = __run_command('cl.exe', False)
+        return stderr.split('\n')[0]
+
     _, stdout, _, _ = __run_command('g++ --version', False)
     return stdout.split('\n')[0]
 

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -50,7 +50,17 @@ def detect_make():
 def check_requirements():
     result = True
 
-    for app in ['g++', 'git', 'wget', 'gdb']:
+    global __make_cmd
+    __make_cmd = detect_make()
+    if not __make_cmd:
+        result = False
+
+    apps = ['git', 'wget']
+    if __make_cmd in ['make', 'mingw32-make']:
+        apps.append('g++')
+        apps.append('gdb')
+
+    for app in apps:
         try:
             print('{} --version'.format(app))
             subprocess.call([app, '--version'])
@@ -62,11 +72,6 @@ def check_requirements():
         import psutil
     except ImportError as e:
         print("Error: {}. Module is required.".format(e))
-        result = False
-
-    global __make_cmd
-    __make_cmd = detect_make()
-    if not __make_cmd:
         result = False
 
     return result

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -172,7 +172,11 @@ def compile_cppcheck(cppcheck_path, jobs):
             subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=os.path.join(cppcheck_path, 'bin'))
         else:
-            subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path)
+            build_env = os.environ
+            if __make_cmd == 'mingw32-make':
+                # assume Python is in PATH for now
+                build_env['PYTHON_INTERPRETER'] = 'python3'
+            subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path, env=build_env)
             subprocess.check_call([os.path.join(cppcheck_path, 'cppcheck'), '--version'], cwd=cppcheck_path)
     except:
         return False

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.30"
+CLIENT_VERSION = "1.3.31"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -396,8 +396,11 @@ def scan_package(cppcheck_path, source_path, jobs, libraries, capture_callstack=
         cppcheck_cmd = os.path.join(cppcheck_path, 'bin', 'cppcheck.exe') + ' ' + options_rp
         cmd = cppcheck_cmd + ' ' + jobs + ' ' + dir_to_scan
     else:
+        nice_cmd = 'nice'
+        if __make_cmd == 'mingw32-make':
+            nice_cmd = ''
         cppcheck_cmd = os.path.join(cppcheck_path, 'cppcheck') + ' ' + options_rp
-        cmd = 'nice ' + cppcheck_cmd + ' ' + jobs + ' ' + dir_to_scan
+        cmd = nice_cmd + ' ' + cppcheck_cmd + ' ' + jobs + ' ' + dir_to_scan
     returncode, stdout, stderr, elapsed_time = __run_command(cmd)
 
     # collect messages

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -542,6 +542,10 @@ def __send_all(connection, data):
 
 
 def upload_results(package, results, server_address):
+    if not __make_cmd == 'make':
+        print('Error: Information upload not performed - only make build binaries are currently fully supported')
+        return False
+
     print('Uploading results.. ' + str(len(results)) + ' bytes')
     max_retries = 4
     for retry in range(max_retries):
@@ -562,6 +566,10 @@ def upload_results(package, results, server_address):
 
 
 def upload_info(package, info_output, server_address):
+    if not __make_cmd == 'make':
+        print('Error: Information upload not performed - only make build binaries are currently fully supported')
+        return False
+
     print('Uploading information output.. ' + str(len(info_output)) + ' bytes')
     max_retries = 3
     for retry in range(max_retries):

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -150,6 +150,9 @@ def compile_version(cppcheck_path, jobs):
     if __make_cmd == "msbuild.exe":
         if os.path.isfile(os.path.join(cppcheck_path, 'bin', 'cppcheck.exe')):
             return True
+    elif __make_cmd == 'mingw32-make':
+        if os.path.isfile(os.path.join(cppcheck_path, 'cppcheck.exe')):
+            return True
     elif os.path.isfile(os.path.join(cppcheck_path, 'cppcheck')):
         return True
     # Build

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -155,7 +155,11 @@ def compile_version(cppcheck_path, jobs):
     # Build
     ret = compile_cppcheck(cppcheck_path, jobs)
     # Clean intermediate build files
-    subprocess.call(['git', 'clean', '-f', '-d', '-x', '--exclude', 'cppcheck'], cwd=cppcheck_path)
+    if __make_cmd == "msbuild.exe":
+        exclude_bin = 'bin'
+    else:
+        exclude_bin = 'cppcheck'
+    subprocess.call(['git', 'clean', '-f', '-d', '-x', '--exclude', exclude_bin], cwd=cppcheck_path)
     return ret
 
 

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -160,7 +160,7 @@ def compile_cppcheck(cppcheck_path, jobs):
     print('Compiling {}'.format(os.path.basename(cppcheck_path)))
     try:
         if __make_cmd == 'msbuild.exe':
-            subprocess.check_call([__make_cmd, os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release', '/property:Platform=x64'], cwd=cppcheck_path)
+            subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release', '/property:Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=cppcheck_path)
         else:
             subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -147,7 +147,10 @@ def get_cppcheck_info(cppcheck_path):
 
 
 def compile_version(cppcheck_path, jobs):
-    if os.path.isfile(os.path.join(cppcheck_path, 'cppcheck')):
+    if __make_cmd == "msbuild.exe":
+        if os.path.isfile(os.path.join(cppcheck_path, 'bin', 'cppcheck.exe')):
+            return True
+    elif os.path.isfile(os.path.join(cppcheck_path, 'cppcheck')):
         return True
     # Build
     ret = compile_cppcheck(cppcheck_path, jobs)
@@ -371,7 +374,7 @@ def scan_package(cppcheck_path, source_path, jobs, libraries, capture_callstack=
     options = libs + ' --showtime=top5 --check-library --inconclusive --enable=style,information --inline-suppr --template=daca2'
     options += ' -D__GNUC__ --platform=unix64'
     options_rp = options + ' -rp={}'.format(dir_to_scan)
-    if sys.platform == 'win32':
+    if __make_cmd == 'msbuild.exe':
         cppcheck_cmd = os.path.join(cppcheck_path, 'bin', 'cppcheck.exe') + ' ' + options_rp
         cmd = cppcheck_cmd + ' ' + jobs + ' ' + dir_to_scan
     else:

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -164,6 +164,7 @@ def compile_cppcheck(cppcheck_path, jobs):
     try:
         if __make_cmd == 'msbuild.exe':
             # TODO: run matchcompiler
+            # TODO: always uses all available threads
             subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=os.path.join(cppcheck_path, 'bin'))
         else:

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -162,7 +162,7 @@ def compile_cppcheck(cppcheck_path, jobs):
         if __make_cmd == 'msbuild.exe':
             # TODO: run matchcompiler
             subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
-            subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=cppcheck_path)
+            subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=os.path.join(cppcheck_path, 'bin'))
         else:
             subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'cppcheck'), '--version'], cwd=cppcheck_path)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -157,6 +157,8 @@ def compile_version(cppcheck_path, jobs):
     # Clean intermediate build files
     if __make_cmd == "msbuild.exe":
         exclude_bin = 'bin'
+    elif __make_cmd == 'mingw32-make':
+        exclude_bin = 'cppcheck.exe'
     else:
         exclude_bin = 'cppcheck'
     subprocess.call(['git', 'clean', '-f', '-d', '-x', '--exclude', exclude_bin], cwd=cppcheck_path)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -52,7 +52,7 @@ def check_requirements():
 
     global __make_cmd
     __make_cmd = detect_make()
-    if not __make_cmd:
+    if __make_cmd is None:
         result = False
 
     apps = ['git', 'wget']

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -34,6 +34,7 @@ def detect_make():
 
     for m in make_cmds:
         try:
+            print('{} --version'.format(m))
             subprocess.call([m, '--version'])
         except OSError as e:
             print("'{}' not found ({})".format(m, e))
@@ -51,6 +52,7 @@ def check_requirements():
 
     for app in ['g++', 'git', 'wget', 'gdb']:
         try:
+            print('{} --version'.format(app))
             subprocess.call([app, '--version'])
         except OSError:
             print("Error: '{}' is required".format(app))

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -164,6 +164,7 @@ def compile_version(cppcheck_path, jobs):
         exclude_bin = 'cppcheck.exe'
     else:
         exclude_bin = 'cppcheck'
+    # TODO: how to support multiple compiler on the same machine? this will clean msbuild.exe files in a mingw32-make build and vice versa
     subprocess.call(['git', 'clean', '-f', '-d', '-x', '--exclude', exclude_bin], cwd=cppcheck_path)
     return ret
 

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -160,6 +160,7 @@ def compile_cppcheck(cppcheck_path, jobs):
     print('Compiling {}'.format(os.path.basename(cppcheck_path)))
     try:
         if __make_cmd == 'msbuild.exe':
+            # TODO: run matchcompiler
             subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=cppcheck_path)
         else:

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -160,7 +160,7 @@ def compile_cppcheck(cppcheck_path, jobs):
     print('Compiling {}'.format(os.path.basename(cppcheck_path)))
     try:
         if __make_cmd == 'msbuild.exe':
-            subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release', '/property:Platform=x64'], cwd=cppcheck_path)
+            subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=cppcheck_path)
         else:
             subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -160,7 +160,7 @@ def compile_cppcheck(cppcheck_path, jobs):
     print('Compiling {}'.format(os.path.basename(cppcheck_path)))
     try:
         if __make_cmd == 'msbuild.exe':
-            subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
+            subprocess.check_call([__make_cmd, jobs.replace('j', 'm:', 1), '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path)
             subprocess.check_call([os.path.join(cppcheck_path, 'bin', 'cppcheck.exe'), '--version'], cwd=cppcheck_path)
         else:
             subprocess.check_call([__make_cmd, jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w'], cwd=cppcheck_path)


### PR DESCRIPTION
This allows both to build binaries and run the analysis successfully. Obviously they are not fully supported yet so I added a check which prevents uploads from happening for now.

A small assortments of TODOs (I will possibly file tickets for some of them):
- handling of crashes/asserts/signals - https://trac.cppcheck.net/ticket/11255
  - stack trace generation
  - proper `NDEBUG` configuration - https://trac.cppcheck.net/ticket/10736
  - exitcode handling
- handling of timeouts - https://trac.cppcheck.net/ticket/1124
  - process termination
- process vs. thread usage in binary
- proper coexistence of multiple build systems/compiler on same machine
  - possible `clang`, `clang-cl` support - https://trac.cppcheck.net/ticket/10542
- newly added source TODOs

`mingw32-make`
```
cppcheck-options: --library=posix --library=gnu  --showtime=top5 --check-library --inconclusive --enable=style,information --inline-suppr --template=daca2 -D__GNUC__ --platform=unix64 -j7
platform: Windows-10-10.0.19044-SP0
python: 3.9.13
client-version: 1.3.31
compiler: g++ (GCC) 11.2.0
cppcheck: head 2.8
head-info: bdbd84b (2022-08-09 13:13:16 +0200)
count: 0 0
elapsed-time: 0.2 0.1
```

`msbuild.exe`
```
cppcheck-options: --library=posix --library=gnu  --showtime=top5 --check-library --inconclusive --enable=style,information --inline-suppr --template=daca2 -D__GNUC__ --platform=unix64 -j7
platform: Windows-10-10.0.19044-SP0
python: 3.9.13
client-version: 1.3.31
compiler: Microsoft (R) C/C++ Optimizing Compiler Version 19.33.31629 for x64
cppcheck: head 2.8
head-info: bdbd84b (2022-08-09 13:13:16 +0200)
count: 0 0
elapsed-time: 0.2 0.2
```

@danmar 
It also highlights several of the still existing shortcomings of `Makefile`. I wonder if we should remove support for things like MinGW/Cygwin/Windows from `Makefile` and redirect to CMake for that. That would clean up the regular `Makefile` and give more stable support for those platforms.