### PR TITLE
Add ** to match until in addons

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -1385,6 +1385,15 @@ def match_atom(token, p):
         t = match_atom(token, p[1:])
         if not t:
             return token
+    elif p.startswith('**'):
+        a = p[1:]
+        t = token
+        while t:
+            if match_atom(t, a):
+                return t
+            if t.link and t.str in ['(', '[', '<', '{']:
+                t = t.link
+            t = t.next
     return None
 
 class MatchResult:

--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -1382,11 +1382,11 @@ def match_atom(token, p):
             if t:
                 return t
     elif p.startswith('!!'):
-        t = match_atom(token, p[1:])
+        t = match_atom(token, p[2:])
         if not t:
             return token
     elif p.startswith('**'):
-        a = p[1:]
+        a = p[2:]
         t = token
         while t:
             if match_atom(t, a):


### PR DESCRIPTION
Doing `match(tok, "**;")` will match until the semicolon. 

This also fixes the incorrect slicing for `!!` match as well.