### PR TITLE
specify `-pipe` for GCC to use pipes instead of temporary files - greatly reduces I/O usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ifndef CXXFLAGS
 endif
 
 ifeq (g++, $(findstring g++,$(CXX)))
-    override CXXFLAGS += -std=gnu++0x
+    override CXXFLAGS += -std=gnu++0x -pipe
 else ifeq (clang++, $(findstring clang++,$(CXX)))
     override CXXFLAGS += -std=c++0x
 else ifeq ($(CXX), c++)

--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -46,6 +46,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # use pipes instead of temporary files - greatly reduces I/O usage
+    add_compile_options(-pipe)
+
     add_compile_options(-Woverloaded-virtual)       # when a function declaration hides virtual functions from a base class
     add_compile_options(-Wno-maybe-uninitialized)   # there are some false positives
     add_compile_options(-Wsuggest-attribute=noreturn)

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
     }
 
     fout << "ifeq (g++, $(findstring g++,$(CXX)))\n"
-         << "    override CXXFLAGS += -std=gnu++0x\n"
+         << "    override CXXFLAGS += -std=gnu++0x -pipe\n"
          << "else ifeq (clang++, $(findstring clang++,$(CXX)))\n"
          << "    override CXXFLAGS += -std=c++0x\n"
          << "else ifeq ($(CXX), c++)\n"


### PR DESCRIPTION
This helps when using I/O limited systems (e.g. WSL) and just makes sense.

Using WSL1 Kali Linux on my system shows the following:

Before
```
real    3m21.765s
user    13m6.438s
sys     4m33.578s
```

After
```
real    2m54.161s
user    12m29.188s
sys     3m19.578s
```