### PR TITLE
config.h: implemented `NORETURN` for GCC < 5

### DIFF
--- a/lib/config.h
+++ b/lib/config.h
@@ -51,6 +51,8 @@
     || defined(__clang__) \
     || defined(__CPPCHECK__)
 #  define NORETURN [[noreturn]]
+#elif defined(__GNUC__)
+#  define NORETURN __attribute__((noreturn))
 #else
 #  define NORETURN
 #endif


### PR DESCRIPTION
Fixes `-Wsuggest-attribute=noreturn` warnings on CentOS 7 and Ubuntu 18.04.