### PR TITLE
install latest clang from `apt.llvm.org` repo

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,9 +9,6 @@ jobs:
 
     runs-on: ubuntu-22.04
 
-    container:
-      image: "ubuntu:22.04"
-
     env:
       ASAN_OPTIONS: detect_stack_use_after_return=1
 
@@ -25,9 +22,14 @@ jobs:
 
       - name: Install missing software on ubuntu
         run: |
-          apt-get update
-          apt-get install -y cmake make libpcre3-dev
-          apt-get install -y clang-14
+          sudo apt-get update
+          sudo apt-get install -y cmake make libpcre3-dev
+
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14
 
       - name: CMake
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -9,9 +9,6 @@ jobs:
 
     runs-on: ubuntu-22.04
 
-    container:
-      image: "ubuntu:22.04"
-
     env:
       QT_VERSION: 5.15.2
 
@@ -20,11 +17,16 @@ jobs:
 
       - name: Install missing software
         run: |
-          apt-get update
-          apt-get install -y cmake clang-14 make
-          apt-get install -y libpcre3-dev
-          apt-get install -y libffi7 # work around missing dependency for Qt install step
-          apt-get install -y clang-tidy-14
+          sudo apt-get update
+          sudo apt-get install -y cmake make
+          sudo apt-get install -y libpcre3-dev
+          sudo apt-get install -y libffi7 # work around missing dependency for Qt install step
+
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14
 
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt
@@ -36,7 +38,6 @@ jobs:
       - name: Install Qt ${{ env.QT_VERSION }}
         uses: jurplel/install-qt-action@v2
         with:
-          install-deps: 'nosudo'
           version: ${{ env.QT_VERSION }}
           modules: 'qtcharts'
           cached: ${{ steps.cache-qt.outputs.cache-hit }}

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -12,9 +12,6 @@ jobs:
     env:
       TSAN_OPTIONS: halt_on_error=1
 
-    container:
-      image: "ubuntu:22.04"
-
     steps:
       - uses: actions/checkout@v2
 
@@ -25,9 +22,14 @@ jobs:
 
       - name: Install missing software on ubuntu
         run: |
-          apt-get update
-          apt-get install -y cmake make libpcre3-dev
-          apt-get install -y clang-14
+          sudo apt-get update
+          sudo apt-get install -y cmake make libpcre3-dev
+
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14
 
       - name: CMake
         run: |

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -9,9 +9,6 @@ jobs:
 
     runs-on: ubuntu-22.04
 
-    container:
-      image: "ubuntu:22.04"
-
     env:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
@@ -25,9 +22,14 @@ jobs:
 
       - name: Install missing software on ubuntu
         run: |
-          apt-get update
-          apt-get install -y cmake make libpcre3-dev
-          apt-get install -y clang-14
+          sudo apt-get update
+          sudo apt-get install -y cmake make libpcre3-dev
+
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14
 
       - name: CMake
         run: |


### PR DESCRIPTION
http://apt.llvm.org provides the latest stable and nightly packages - so we can also use the latest stable one immediately instead of waiting for a distro to pick it up. This also gets rid of the need for docker to have a recent distro which provides the latest version. It might also speed up the build a bit since less dependencies need to be installed.

Since the resulting binaries are only used in the CI and not in production it should not cause any problems that we might use bleeding-edge stable builds.

The current version is already available in the images and the base repo but they are being updated with the ones from the other repo:
```
Unpacking clang-14 (1:14.0.6~++20220816122211+f28c006a5895-1~exp1~20220816122246.108) over (1:14.0.0-1ubuntu1) ...
...
Unpacking clang-tidy-14 (1:14.0.6~++20220816122211+f28c006a5895-1~exp1~20220816122246.108) over (1:14.0.0-1ubuntu1) ...
```