### PR TITLE
refs # 11106 (optimize CheckUnusedVar::checkStructMemberUsage()) - added missing loop breaks

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1448,6 +1448,9 @@ void CheckUnusedVar::checkStructMemberUsage()
                     }
                 }
             }
+
+            if (bailout)
+                break;
         }
         if (bailout)
             continue;
@@ -1471,6 +1474,9 @@ void CheckUnusedVar::checkStructMemberUsage()
                         addrTok = addrTok->next();
                 } while (addrTok);
             }
+
+            if (bailout)
+                break;
         }
         if (bailout)
             continue;


### PR DESCRIPTION
Performing a `--enable=all --inconclusive` scan on `mame_regtest` with `DISABLE_VALUEFLOW=1`:

GCC 12 `2,391,227,591` -> `2,388,134,902`
Clang 14 `2,484,649,991` -> `2,481,264,565`