### PR TITLE
fixed #6366 - some unique errors were omitted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,7 @@ TESTOBJ =     test/fixture.o \
               test/testcppcheck.o \
               test/testerrorlogger.o \
               test/testexceptionsafety.o \
+              test/testexecutor.o \
               test/testfilelister.o \
               test/testfilesettings.o \
               test/testfunctions.o \
@@ -750,6 +751,9 @@ test/testerrorlogger.o: test/testerrorlogger.cpp externals/tinyxml2/tinyxml2.h l
 
 test/testexceptionsafety.o: test/testexceptionsafety.cpp externals/simplecpp/simplecpp.h lib/addoninfo.h lib/check.h lib/checkers.h lib/checkexceptionsafety.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/tokenize.h lib/tokenlist.h lib/utils.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testexceptionsafety.cpp
+
+test/testexecutor.o: test/testexecutor.cpp cli/executor.h lib/addoninfo.h lib/check.h lib/checkers.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/filesettings.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testexecutor.cpp
 
 test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/addoninfo.h lib/check.h lib/checkers.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/filesettings.h lib/library.h lib/mathlib.h lib/path.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testfilelister.cpp

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -641,23 +641,24 @@ void StdLogger::reportErr(const ErrorMessage &msg)
     if (msg.severity == Severity::internal)
         return;
 
-    // TODO: we generate a different message here then we log below
-    // TODO: there should be no need for verbose and default messages here
-    // Alert only about unique errors
-    if (!mSettings.emitDuplicates && !mShownErrors.insert(msg.toString(mSettings.verbose)).second)
-        return;
-
     ErrorMessage msgCopy = msg;
     msgCopy.guideline = getGuideline(msgCopy.id, mSettings.reportType,
                                      mGuidelineMapping, msgCopy.severity);
     msgCopy.classification = getClassification(msgCopy.guideline, mSettings.reportType);
+
+    // TODO: there should be no need for verbose and default messages here
+    const std::string msgStr = msgCopy.toString(mSettings.verbose, mSettings.templateFormat, mSettings.templateLocation);
+
+    // Alert only about unique errors
+    if (!mSettings.emitDuplicates && !mShownErrors.insert(msgStr).second)
+        return;
 
     if (mSettings.outputFormat == Settings::OutputFormat::sarif)
         mSarifReport.addFinding(std::move(msgCopy));
     else if (mSettings.outputFormat == Settings::OutputFormat::xml)
         reportErr(msgCopy.toXML());
     else
-        reportErr(msgCopy.toString(mSettings.verbose, mSettings.templateFormat, mSettings.templateLocation));
+        reportErr(msgStr);
 }
 
 /**

--- a/cli/executor.cpp
+++ b/cli/executor.cpp
@@ -46,7 +46,7 @@ bool Executor::hasToLog(const ErrorMessage &msg)
     if (!mSuppressions.nomsg.isSuppressed(msg, {}))
     {
         // TODO: there should be no need for verbose and default messages here
-        std::string errmsg = msg.toString(mSettings.verbose);
+        std::string errmsg = msg.toString(mSettings.verbose, mSettings.templateFormat, mSettings.templateLocation);
         if (errmsg.empty())
             return false;
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -203,7 +203,7 @@ private:
         }
 
         // TODO: there should be no need for the verbose and default messages here
-        std::string errmsg = msg.toString(mSettings.verbose);
+        std::string errmsg = msg.toString(mSettings.verbose, mSettings.templateFormat, mSettings.templateLocation);
         if (errmsg.empty())
             return;
 

--- a/samples/unreadVariable/out.txt
+++ b/samples/unreadVariable/out.txt
@@ -1,3 +1,6 @@
 samples\unreadVariable\bad.cpp:5:34: style: Variable 's2' is assigned a value that is never used. [unreadVariable]
     std::string s1 = "test1", s2 = "test2";
                                  ^
+samples\unreadVariable\bad.cpp:5:31: style: Variable 's2' is assigned a value that is never used. [unreadVariable]
+    std::string s1 = "test1", s2 = "test2";
+                              ^

--- a/test/cli/whole-program_test.py
+++ b/test/cli/whole-program_test.py
@@ -372,7 +372,11 @@ def test_nullpointer_file0_builddir_j(tmpdir):
     os.mkdir(build_dir)
     __test_nullpointer_file0(['-j2', '--cppcheck-build-dir={}'.format(build_dir)])
 
-@pytest.mark.parametrize("single_file", (False,True))
+# TODO: this only succeeded because it depedent on the bugged unqiue message handling
+@pytest.mark.parametrize("single_file", [
+    False,
+    pytest.param(True, marks=pytest.mark.xfail(strict=True)),
+])
 def test_nullpointer_out_of_memory(tmpdir, single_file):
     """Ensure that there are not duplicate warnings related to memory/resource allocation failures
        https://trac.cppcheck.net/ticket/13521

--- a/test/testexecutor.cpp
+++ b/test/testexecutor.cpp
@@ -1,0 +1,104 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2025 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "executor.h"
+#include "filesettings.h"
+#include "fixture.h"
+#include "suppressions.h"
+
+#include <stdexcept>
+
+class DummyExecutor : public Executor
+{
+public:
+    DummyExecutor(const std::list<FileWithDetails> &files, const std::list<FileSettings>& fileSettings, const Settings &settings, Suppressions &suppressions, ErrorLogger &errorLogger)
+        : Executor(files, fileSettings, settings, suppressions, errorLogger)
+    {}
+
+    unsigned int check() override
+    {
+        throw std::runtime_error("not implemented");
+    }
+
+    bool hasToLog_(const ErrorMessage &msg)
+    {
+        return hasToLog(msg);
+    }
+};
+
+class TestExecutor : public TestFixture {
+public:
+    TestExecutor() : TestFixture("TestExecutor") {}
+
+private:
+    void run() override {
+        TEST_CASE(hasToLogDefault);
+        TEST_CASE(hasToLogSimple);
+    }
+
+    void hasToLogDefault() {
+        const std::list<FileWithDetails> files{FileWithDetails{"test.c"}};
+        const std::list<FileSettings> fileSettings;
+        Suppressions supprs;
+        DummyExecutor executor(files, fileSettings, settingsDefault, supprs, *this);
+
+        ErrorMessage::FileLocation loc1("test.c", 1, 2);
+        ErrorMessage msg({std::move(loc1)}, "test.c", Severity::error, "error", "id", Certainty::normal);
+
+        ASSERT(executor.hasToLog_(msg));
+        ASSERT(!executor.hasToLog_(msg));
+
+        ErrorMessage::FileLocation loc2("test.c", 1, 12);
+        msg.callStack = {std::move(loc2)};
+
+        // TODO: the default message does not include the column
+        TODO_ASSERT(executor.hasToLog_(msg));
+
+        msg.id = "id2";
+
+        // TODO: the default message does not include the id
+        TODO_ASSERT(executor.hasToLog_(msg));
+    }
+
+    void hasToLogSimple() {
+        const std::list<FileWithDetails> files{FileWithDetails{"test.c"}};
+        const std::list<FileSettings> fileSettings;
+        Settings settings;
+        // this is the "simple" format
+        settings.templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]";
+        Suppressions supprs;
+        DummyExecutor executor(files, fileSettings, settings, supprs, *this);
+
+        ErrorMessage::FileLocation loc1("test.c", 1, 2);
+        ErrorMessage msg({std::move(loc1)}, "test.c", Severity::error, "error", "id", Certainty::normal);
+
+        ASSERT(executor.hasToLog_(msg));
+        ASSERT(!executor.hasToLog_(msg));
+
+        ErrorMessage::FileLocation loc2("test.c", 1, 12);
+        msg.callStack = {std::move(loc2)};
+
+        ASSERT(executor.hasToLog_(msg));
+
+        msg.id = "id2";
+
+        ASSERT(executor.hasToLog_(msg));
+    }
+};
+
+REGISTER_TEST(TestExecutor)

--- a/test/testrunner.vcxproj
+++ b/test/testrunner.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="testcppcheck.cpp" />
     <ClCompile Include="testerrorlogger.cpp" />
     <ClCompile Include="testexceptionsafety.cpp" />
+    <ClCompile Include="testexecutor.cpp" />
     <ClCompile Include="testfilelister.cpp" />
     <ClCompile Include="testfilesettings.cpp" />
     <ClCompile Include="testfunctions.cpp" />


### PR DESCRIPTION
The code which checks for unique error messages did not apply the template configuration which lead to suppression of unique messages:

```
(information) Cppcheck cannot find all the include files (use --check-config for details)
nofile:0:0: information: Cppcheck cannot find all the include files (use --check-config for details) [missingInclude]
```

```
(information) Cppcheck cannot find all the include files (use --check-config for details)
nofile:0:0: information: Cppcheck cannot find all the include files (use --check-config for details) [missingIncludeSystem]
```

The latter was omitted since the messages are identical.

There is possibly a different approach which would be including the ID if no template is specified. Or use the same format as when no template is specified and added the ID.