### PR TITLE
added missing `sstream` includes

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <list>
 #include <set>
+#include <sstream>
 #include <utility>
 
 #ifdef HAVE_RULES

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -48,6 +48,7 @@
 #include <iostream>
 #include <list>
 #include <memory>
+#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -39,6 +39,7 @@
 #include <functional>
 #include <iostream>
 #include <list>
+#include <sstream>
 #include <sys/select.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <ostream>
 #include <set>
+#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -32,6 +32,7 @@
 
 #include <iomanip>
 #include <ostream>
+#include <sstream>
 #include <unordered_map>
 #include <vector>
 

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -35,6 +35,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -41,6 +41,7 @@
 #include <memory>
 #include <ostream>
 #include <set>
+#include <sstream>
 #include <utility>
 #include <numeric>
 

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <list>
 #include <ostream>
+#include <sstream>
 #include <vector>
 
 //---------------------------------------------------------------------------

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -36,7 +36,7 @@
 #include <cstring>
 #include <istream>
 #include <memory>
-
+#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -37,6 +37,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stack>
 #include <string>
 #include <utility>

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -49,6 +49,7 @@
 #include <memory>
 #include <new>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -34,6 +34,7 @@
 #include <cstring>
 #include <iterator>  // back_inserter
 #include <ostream>
+#include <sstream>
 #include <utility>
 
 #include <tinyxml2.h>

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -33,6 +33,7 @@
 #include <cstring>
 #include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -32,7 +32,7 @@
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
 #include <iterator>
-
+#include <sstream>
 #include <utility>
 
 #include <tinyxml2.h>

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -34,6 +34,7 @@
 #include <iosfwd>
 #include <list>
 #include <memory>
+#include <sstream>
 #include <stack>
 #include <string>
 

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -27,6 +27,7 @@
 #include <exception>
 #include <limits>
 #include <locale>
+#include <sstream>
 #include <stdexcept>
 
 #include <simplecpp.h>

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <iterator> // back_inserter
 #include <memory>
+#include <sstream>
 #include <utility>
 
 #include <simplecpp.h>

--- a/lib/summaries.cpp
+++ b/lib/summaries.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <fstream>
 #include <map>
+#include <sstream>
 #include <vector>
 
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional> // std::bind, std::placeholders
+#include <sstream>
 
 #include <tinyxml2.h>
 

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -41,6 +41,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <sstream>
 #include <stack>
 #include <string>
 #include <type_traits>

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <stack>
 #include <utility>
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -40,6 +40,7 @@
 #include <iterator>
 #include <map>
 #include <set>
+#include <sstream>
 #include <stack>
 #include <unordered_set>
 #include <utility>

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -44,6 +44,7 @@
 #include <exception>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <stack>
 #include <stdexcept>
 #include <type_traits>

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -117,6 +117,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
We currently get these transitively from a header.

These might have been erroneously removed in the past or have not been added since include-what-you-use is bad in determined from which include certain stream originate - see https://github.com/include-what-you-use/include-what-you-use/issues/683.