### PR TITLE
mathlib.h: replaced slow `std::ostringstream` with `std::to_string()` in `MathLib::toString()`

### DIFF
--- a/lib/mathlib.h
+++ b/lib/mathlib.h
@@ -23,7 +23,6 @@
 
 #include "config.h"
 
-#include <sstream>
 #include <string>
 
 /// @addtogroup Core
@@ -74,9 +73,7 @@ public:
     static biguint toULongNumber(const std::string & str);
 
     template<class T> static std::string toString(T value) {
-        std::ostringstream result;
-        result << value;
-        return result.str();
+        return std::to_string(value);
     }
     static double toDoubleNumber(const std::string & str);
 

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -1217,11 +1217,19 @@ private:
         ASSERT_EQUALS("0.0", MathLib::toString(+0.0));
         ASSERT_EQUALS("0.0", MathLib::toString(-0.0));
         // float (trailing f or F)
-        ASSERT_EQUALS("0",  MathLib::toString(+0.0f));
-        ASSERT_EQUALS("-0", MathLib::toString(-0.0F));
+        ASSERT_EQUALS("0.000000", MathLib::toString(0.0f));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0f));
+        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0f));
+        ASSERT_EQUALS("0.000000", MathLib::toString(0.0F));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0F));
+        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0F));
         // double (tailing l or L)
-        ASSERT_EQUALS("0",  MathLib::toString(+0.0l));
-        ASSERT_EQUALS("-0", MathLib::toString(-0.0L));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(0.0l));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0l));
+        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0l));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(0.0L));
+        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0L));
+        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0L));
     }
 
     void CPP14DigitSeparators() const { // Ticket #7137, #7565


### PR DESCRIPTION
The hot calls are coming from `TokenList::calculateHash()`.

Scanning `mame_regtest` with `--enable=all --inconclusive` and `DISABLE_VALUEFLOW=1`:

Clang 14 `2,319,237,712` -> `2,091,818,009`
GCC 12 `2,251,016,968` -> `2,027,414,164`