### PR TITLE
added more missing `sstream` includes

### DIFF
--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class Test64BitPortability : public TestFixture {
 public:

--- a/test/testanalyzerinformation.cpp
+++ b/test/testanalyzerinformation.cpp
@@ -19,6 +19,7 @@
 
 #include "analyzerinfo.h"
 #include "testsuite.h"
+
 #include <sstream>
 
 class TestAnalyzerInformation : public TestFixture, private AnalyzerInformation {

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 
 class TestAssert : public TestFixture {

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -27,6 +27,7 @@
 
 #include <cstring>
 #include <iosfwd>
+#include <sstream>
 
 class TestAstUtils : public TestFixture {
 public:

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestAutoVariables : public TestFixture {
 public:

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestBool : public TestFixture {
 public:

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestBoost : public TestFixture {
 public:

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -31,6 +31,7 @@
 #include <iosfwd>
 #include <map>
 #include <list>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -25,6 +25,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestCharVar : public TestFixture {
 public:

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include <list>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -26,6 +26,7 @@
 
 #include <iosfwd>
 #include <list>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -27,6 +27,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -26,6 +26,7 @@
 
 #include <iosfwd>
 #include <list>
+#include <sstream>
 #include <string>
 
 

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestExceptionSafety : public TestFixture {
 public:

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -26,6 +26,7 @@
 
 #include <iosfwd>
 #include <list>
+#include <sstream>
 #include <string>
 
 #include <tinyxml2.h>

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -26,6 +26,7 @@
 
 #include <iosfwd>
 #include <list>
+#include <sstream>
 #include <string>
 
 

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -24,6 +24,7 @@
 #include <list>
 #include <memory>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -24,6 +24,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testinternal.cpp
+++ b/test/testinternal.cpp
@@ -22,6 +22,7 @@
 #include "checkinternal.h"
 #include "testsuite.h"
 
+#include <sstream>
 
 class TestInternal : public TestFixture {
 public:

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -26,6 +26,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 
 class TestIO : public TestFixture {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -26,6 +26,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -27,6 +27,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -27,6 +27,7 @@
 #include <iosfwd>
 #include <list>
 #include <memory>
+#include <sstream>
 #include <string>
 
 class TestMemleakInClass;

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -29,6 +29,7 @@
 #include <iosfwd>
 #include <list>
 #include <map>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -28,6 +28,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestPostfixOperator : public TestFixture {
 public:

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -35,6 +35,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <map>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -28,6 +28,7 @@
 
 #include <cstring>
 #include <iosfwd>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -25,6 +25,7 @@
 #include "tokenize.h"
 
 #include <istream>
+#include <sstream>
 #include <string>
 
 

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -25,6 +25,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 #include <string>
 
 

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -24,6 +24,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 #include <iosfwd>
+#include <sstream>
 #include <string>
 
 

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 
 class TestString : public TestFixture {

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <cctype>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 std::ostringstream errout;

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -22,7 +22,8 @@
 #include "testsuite.h"
 #include "tokenize.h"
 
-#include <iosfwd>       // for istringstream, ostringstream
+#include <iosfwd>
+#include <sstream>
 #include <string>
 
 

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -35,6 +35,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <map>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <iosfwd>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -22,6 +22,7 @@
 #include "tokenlist.h"
 
 #include <iosfwd>
+#include <sstream>
 #include <string>
 
 class TestTokenList : public TestFixture {

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -28,6 +28,7 @@
 #include <iterator>
 #include <list>
 #include <ostream>
+#include <sstream>
 #include <string>
 
 

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -25,6 +25,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 #include <string>
 
 class TestType : public TestFixture {

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -25,6 +25,7 @@
 
 #include <iosfwd>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -25,6 +25,7 @@
 
 #include <iosfwd>
 #include <list>
+#include <sstream>
 #include <string>
 
 class TestUnusedVar : public TestFixture {

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -30,6 +30,7 @@
 #include <iosfwd>
 #include <list>
 #include <ostream>
+#include <sstream>
 #include <string>
 
 class Token;

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -24,6 +24,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 
 class TestVaarg : public TestFixture {
 public:

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include <ostream>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -25,6 +25,7 @@
 #include "tokenize.h"
 
 #include <iosfwd>
+#include <sstream>
 #include <string>
 
 struct InternalError;


### PR DESCRIPTION
One was missing a build failure with Windows and the others are done via manual review.

FYI most of the `iosfwd` includes can probably be removed in the future as include-what-you-use incorrectly reports them as the source of `std::*stringstream`.