### PR TITLE
smallvector.h: bake `reserve()` into the non-boost `SmallVector` implementation

### DIFF
--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -42,7 +42,16 @@ struct TaggedAllocator : std::allocator<T>
 };
 
 template<typename T, std::size_t N = DefaultSmallVectorSize>
-using SmallVector = std::vector<T, TaggedAllocator<T, N>>;
+class SmallVector : public std::vector<T, TaggedAllocator<T, N>>
+{
+public:
+    template<class ... Ts>
+    SmallVector(Ts&&... ts)
+        : std::vector<T, TaggedAllocator<T, N>>(std::forward<Ts>(ts)...)
+    {
+        this->reserve(N);
+    }
+};
 #endif
 
 #endif


### PR DESCRIPTION
This changes bakes the `reserve()` call into the non-boost implementation `SmallVector` construction as it would cause a performance regression with the `boost::small_vector` implementation (see #3919).

I tested the build with Clang, GCC, MinGW and Visual Studio.

Replacing the `std::vector` + `resreve()` appraoch with `SmallVector` in `visitAstNodes()` will now yield the same performance when using Clang.
In case of GCC the code actually gets faster since (according to valgrind) it was previously using `std::vector<>::reserve(unsigned long)` whereas it now uses `operator new(unsigned long)` just like Clang does. Possibly another issue to report upstream.

Clang 14 `2,481,264,505` -> `2,481,270,375`
GCC 12 `2,388,141,113` -> `2,359,483,453`

This patch does not replace the usage yet - that still requires a few more tests and is handled via #3919.