### PR TITLE
implemented move constructor for `TemplateSimplifier::TokenAndName`

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -234,6 +234,14 @@ TemplateSimplifier::TokenAndName::TokenAndName(const TokenAndName& other) :
         mToken->templateSimplifierPointer(this);
 }
 
+TemplateSimplifier::TokenAndName::TokenAndName(TokenAndName&& other) :
+    mToken(other.mToken), mScope(std::move(other.mScope)), mName(std::move(other.mName)), mFullName(std::move(other.mFullName)),
+    mNameToken(other.mNameToken), mParamEnd(other.mParamEnd), mFlags(other.mFlags)
+{
+    if (mToken)
+        mToken->templateSimplifierPointer(this);
+}
+
 TemplateSimplifier::TokenAndName::~TokenAndName()
 {
     if (mToken && mToken->templateSimplifierPointers())

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -148,6 +148,7 @@ public:
          */
         TokenAndName(Token *token, std::string scope, const Token *nameToken, const Token *paramEnd);
         TokenAndName(const TokenAndName& other);
+        TokenAndName(TokenAndName&& other);
         ~TokenAndName();
 
         bool operator == (const TokenAndName & rhs) const {


### PR DESCRIPTION
`TemplateSimplifier::TokenAndName` has a user-defined constructor so the implicit move constructor is deleted and `std::move()` will copy this instead. See https://github.com/llvm/llvm-project/issues/57266 and https://trac.cppcheck.net/ticket/11274.