### PR TITLE
added initial usage of `ccache` in the CI

### DIFF
--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: scriptcheck-${{ runner.os }}
+
       - name: Cache Cppcheck
         uses: actions/cache@v2
         with:
@@ -24,6 +29,7 @@ jobs:
 
       - name: build cppcheck
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) -s
           strip -s ./cppcheck
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: selfcheck-${{ runner.os }}
+
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt
         uses: actions/cache@v1  # not v2!
@@ -35,7 +40,7 @@ jobs:
       # TODO: cache this - perform same build as for the other self check
       - name: Self check (build)
         run: |
-          make clean
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) -s CXXFLAGS="-O2 -w" MATCHCOMPILER=yes
 
       - name: CMake


### PR DESCRIPTION
```
+ ccache -s
cache directory                     /home/runner/work/cppcheck/cppcheck/.ccache
primary config                      /home/runner/.ccache/ccache.conf
secondary config      (readonly)    /etc/ccache.conf
stats updated                       Sat Aug 27 08:31:25 2022
stats zeroed                        Sat Aug 27 08:31:21 2022
cache hit (direct)                    [67](https://github.com/danmar/cppcheck/runs/8049138565?check_suite_focus=true#step:9:68)
cache hit (preprocessed)               1
cache miss                             1
cache hit rate                     98.55 %
called for link                        1
cleanups performed                     0
files in cache                       139
cache size                          60.7 MB
max cache size                     500.0 MB
Save cache using key "ccache-scriptcheck-Linux-2022-08-27T08:31:31.[75](https://github.com/danmar/cppcheck/runs/8049138565?check_suite_focus=true#step:9:76)1Z".
```