### PR TITLE
moved deprecated `ubuntu-18.04` from `CI-unixish.yml` to `CI-unixish-docker.yml`

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04"]
+        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04", "ubuntu:18.04"]
       fail-fast: false # Prefer quick result
 
     runs-on: ubuntu-22.04
@@ -35,6 +35,12 @@ jobs:
           apt-get update
           apt-get install -y cmake g++ make python3 libxml2-utils
           apt-get install -y libpcre3-dev
+
+      # required so a default Qt installation is configured
+      - name: Install missing software on ubuntu 18.04
+        if: false # matrix.os == 'ubuntu-18.04'
+        run: |
+          sudo apt-get install qt5-default
 
       # tests require CMake 3.4
       - name: Test CMake build (no tests)

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
       fail-fast: false # Prefer quick result
 
     runs-on: ${{ matrix.os }}
@@ -27,12 +27,6 @@ jobs:
           sudo apt-get install libxml2-utils
           sudo apt-get install libtinyxml2-dev
           sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
-
-      # required so a default Qt installation is configured
-      - name: Install missing software on ubuntu 18.04
-        if: matrix.os == 'ubuntu-18.04'
-        run: |
-          sudo apt-get install qt5-default
 
       # packages for strict cfg checks
       - name: Install missing software on ubuntu 22.04


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/