### PR TITLE
use `ccache` for Linux gcc make CI builds

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -78,6 +78,8 @@ jobs:
         if: matrix.image == 'centos:7'
         run: |
           yum install -y gcc-c++ make which python3 pcre-devel
+          yum --enablerepo=extras install -y epel-release
+          yum install -y ccache
 
       - name: Install missing software on ubuntu
         if: matrix.image != 'centos:7'
@@ -85,12 +87,25 @@ jobs:
           apt-get update
           apt-get install -y g++ make python3 libxml2-utils libpcre3-dev
 
+      # needs to be called after the package installation since
+      # - it doesn't call "apt-get update"
+      # - it doesn't support centos
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: matrix.image != 'ubuntu:14.04' # no support for --set-config
+        with:
+          key: ${{ github.workflow }}-${{ matrix.image }}
+
       - name: Build cppcheck
         run: |
+          # "/usr/lib64" for centos / "/usr/lib" for ubuntu
+          export PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) HAVE_RULES=yes
 
       - name: Build test
         run: |
+          # "/usr/lib64" for centos / "/usr/lib" for ubuntu
+          export PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) testrunner HAVE_RULES=yes
 
       - name: Run test

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -107,6 +107,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
@@ -115,6 +121,7 @@ jobs:
 
       - name: Build with Unsigned char
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) CXXFLAGS=-funsigned-char testrunner
 
       - name: Test with Unsigned char
@@ -133,6 +140,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
@@ -141,6 +154,7 @@ jobs:
 
       - name: Build with TEST_MATHLIB_VALUE
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) CPPFLAGS=-DTEST_MATHLIB_VALUE all
 
       - name: Test with TEST_MATHLIB_VALUE
@@ -194,9 +208,16 @@ jobs:
         run: |
           brew install coreutils qt@5
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       - name: Build GUI on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           pushd gui
           qmake CONFIG+=debug HAVE_QCHART=yes
           make -j$(nproc)
@@ -204,6 +225,7 @@ jobs:
       - name: Run GUI tests on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           pushd gui/test/cppchecklibrarydata
           qmake CONFIG+=debug
           make -j$(nproc)
@@ -241,6 +263,7 @@ jobs:
       - name: Build triage on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           pushd tools/triage
           qmake CONFIG+=debug
           make -j$(nproc)
@@ -275,6 +298,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       - name: Install missing software on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -300,10 +329,12 @@ jobs:
 
       - name: Build cppcheck
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) HAVE_RULES=yes
 
       - name: Build test
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) testrunner HAVE_RULES=yes
 
       - name: Run test
@@ -395,6 +426,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       - name: Install missing software on ubuntu
         run: |
           sudo apt-get update
@@ -402,6 +438,7 @@ jobs:
 
       - name: Self check (build)
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           # compile with verification and ast matchers
           make -j$(nproc) -s CPPFLAGS="-DCHECK_INTERNAL" CXXFLAGS="-g -O2" MATCHCOMPILER=yes VERIFY=1
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-${{ runner.os }}
+
       - name: Install missing software on ubuntu
         run: |
           sudo apt-get update
@@ -26,6 +31,7 @@ jobs:
 
       - name: Compile instrumented
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) test CXXFLAGS="-g -fprofile-arcs -ftest-coverage" HAVE_RULES=yes
           
       - name: Generate coverage report

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -19,7 +19,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: scriptcheck-${{ runner.os }}
+          key: ${{ github.workflow }}-${{ runner.os }}
 
       - name: Cache Cppcheck
         uses: actions/cache@v2

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -21,7 +21,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: selfcheck-${{ runner.os }}
+          key: ${{ github.workflow }}-${{ runner.os }}
 
       - name: Cache Qt ${{ env.QT_VERSION }}
         id: cache-qt

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -15,7 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ github.workflow }}-${{ runner.os }}
+
       - name: Prepare
         run: |
           sudo apt-get update
@@ -38,10 +43,12 @@ jobs:
 
       - name: Build cppcheck
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           CXXFLAGS="-O1 -g" make -j$(nproc) HAVE_RULES=yes MATCHCOMPILER=yes
 
       - name: Build test
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           CXXFLAGS="-O1 -g" make -j$(nproc) testrunner HAVE_RULES=yes MATCHCOMPILER=yes
 
       - name: Run valgrind


### PR DESCRIPTION
CMake builds currently don't work with it - possibly related to the matchcompiled files.

Windows support isn't straight-forward.

Macos I haven't looked into yet.

Support for custom compilers (i.e. clang) I haven't look into either.