### PR TITLE
Use safe compile option

### DIFF
--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -58,7 +58,7 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # TODO: verify this regression still exists in clang-15
         if (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
             # work around performance regression - see https://github.com/llvm/llvm-project/issues/53555
-            add_compile_options(-mllvm -inline-deferral)
+            add_compile_options_safe(-mllvm -inline-deferral)
         endif()
 
         # use force DWARF 4 debug format since not all tools might be able to handle DWARF 5 yet - e.g. valgrind on ubuntu 20.04


### PR DESCRIPTION
Not all versions of clangs have this option.