### PR TITLE
CI-unixish-docker.yml: perform make and CMake builds in parallel

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -26,15 +26,13 @@ jobs:
       - name: Install missing software on CentOS 7
         if: matrix.image == 'centos:7'
         run: |
-          yum install -y cmake gcc-c++ make which python3
-          yum install -y pcre-devel
+          yum install -y cmake gcc-c++ make which python3 pcre-devel
 
       - name: Install missing software on ubuntu
         if: matrix.image != 'centos:7'
         run: |
           apt-get update
-          apt-get install -y cmake g++ make python3 libxml2-utils
-          apt-get install -y libpcre3-dev
+          apt-get install -y cmake g++ make python3 libxml2-utils libpcre3-dev
 
       # required so a default Qt installation is configured
       - name: Install missing software on ubuntu 18.04
@@ -79,19 +77,16 @@ jobs:
       - name: Install missing software on CentOS 7
         if: matrix.image == 'centos:7'
         run: |
-          yum install -y gcc-c++ make which python3
-          yum install -y pcre-devel
+          yum install -y gcc-c++ make which python3 pcre-devel
 
       - name: Install missing software on ubuntu
         if: matrix.image != 'centos:7'
         run: |
           apt-get update
-          apt-get install -y g++ make python3 libxml2-utils
-          apt-get install -y libpcre3-dev
+          apt-get install -y g++ make python3 libxml2-utils libpcre3-dev
 
       - name: Build cppcheck
         run: |
-          make clean
           make -j$(nproc) HAVE_RULES=yes
 
       - name: Build test

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build_cmake:
 
     strategy:
       matrix:
@@ -60,6 +60,34 @@ jobs:
           cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On ..
           cmake --build . --target check -- -j$(nproc)
           cd ..
+
+  build_make:
+
+    strategy:
+      matrix:
+        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04", "ubuntu:18.04"]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ubuntu-22.04
+
+    container:
+      image: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install missing software on CentOS 7
+        if: matrix.image == 'centos:7'
+        run: |
+          yum install -y gcc-c++ make which python3
+          yum install -y pcre-devel
+
+      - name: Install missing software on ubuntu
+        if: matrix.image != 'centos:7'
+        run: |
+          apt-get update
+          apt-get install -y g++ make python3 libxml2-utils
+          apt-get install -y libpcre3-dev
 
       - name: Build cppcheck
         run: |

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Install missing software on CentOS 7
         if: matrix.image == 'centos:7'
         run: |
-          yum install -y cmake gcc-c++ make which python3 pcre-devel
+          yum install -y cmake gcc-c++ make pcre-devel
 
       - name: Install missing software on ubuntu
         if: matrix.image != 'centos:7'
         run: |
           apt-get update
-          apt-get install -y cmake g++ make python3 libxml2-utils libpcre3-dev
+          apt-get install -y cmake g++ make libxml2-utils libpcre3-dev
 
       # required so a default Qt installation is configured
       - name: Install missing software on ubuntu 18.04
@@ -97,10 +97,12 @@ jobs:
         run: |
           make -j$(nproc) check HAVE_RULES=yes
 
+      # requires python3
       - name: Run extra tests
         run: |
           tools/generate_and_run_more_tests.sh
 
+      # requires which
       - name: Validate
         run: |
           make -j$(nproc) checkCWEEntries validateXML


### PR DESCRIPTION
This is in preparation of #4411 to be able to use `ccache` in more cases. It also allows for more builds in parallel and separates parts of the workflow which do not depend on each other. The same should be done for `CI-unixish.yml`.

The refactoring is horrible and introduces lots of redundant code in terms of setting up things but it appears there's no better way to do it. You cannot use a prerequisite job to set up those things since all the jobs start with a clean filesystem and you need to transfer all files between them which is obviously a problem if you installed packages. There's also "composite actions" (see https://stackoverflow.com/a/71570847/532627) but those seem to require external files which doesn't improve things either.