### PR TITLE
htmlreport/check.sh: use less heavy input for tests

### DIFF
--- a/htmlreport/check.sh
+++ b/htmlreport/check.sh
@@ -40,7 +40,7 @@ validate_html "$INDEX_HTML"
 validate_html "$STATS_HTML"
 
 
-../cppcheck ../test/cfg --enable=all --inconclusive --xml-version=2 2> "$GUI_TEST_XML"
+../cppcheck ../test/synthetic --enable=all --inconclusive --xml-version=2 2> "$GUI_TEST_XML"
 xmllint --noout "$GUI_TEST_XML"
 $PYTHON cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive test" --report-dir "$REPORT_DIR"
 echo ""
@@ -49,7 +49,7 @@ validate_html "$INDEX_HTML"
 validate_html "$STATS_HTML"
 
 
-../cppcheck ../test/cfg --enable=all --inconclusive --verbose --xml-version=2 2> "$GUI_TEST_XML"
+../cppcheck ../test/synthetic --enable=all --inconclusive --verbose --xml-version=2 2> "$GUI_TEST_XML"
 xmllint --noout "$GUI_TEST_XML"
 $PYTHON cppcheck-htmlreport --file "$GUI_TEST_XML" --title "xml2 + inconclusive + verbose test" --report-dir "$REPORT_DIR"
 echo -e "\n"


### PR DESCRIPTION
Two tests were using `test/cfg` as input which takes a minute to process which is almost the complete time the step consumes - so use the lighter `test/synthetic` instead. The actual input is irrelevant since we just verify the syntax of the output.