### PR TITLE
CI-unixish.yml: split workflow into parallel jobs

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -111,3 +111,10 @@ jobs:
         run: |
           ./cppcheck --addon=threadsafety addons/test/threadsafety
           ./cppcheck --addon=threadsafety --std=c++03 addons/test/threadsafety
+
+      - name: Generate Qt help file on ubuntu 18.04
+        if: false # matrix.os == 'ubuntu-18.04'
+        run: |
+          pushd gui/help
+          qcollectiongenerator online-help.qhcp -o online-help.qhc
+

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build_cmake_tinyxml2:
 
     strategy:
       matrix:
@@ -26,21 +26,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-utils libtinyxml2-dev qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
-      # packages for strict cfg checks
-      - name: Install missing software on ubuntu (cfg)
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          sudo apt-get install libcairo2-dev libcurl4-openssl-dev liblua5.3-dev libssl-dev libsqlite3-dev libcppunit-dev libsigc++-2.0-dev libgtk-3-dev libboost-all-dev libwxgtk3.0-gtk3-dev xmlstarlet
-
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install coreutils python3 qt@5
-
-      - name: Install missing Python packages
-        run: |
-          python3 -m pip install pip --upgrade
-          python3 -m pip install pytest
+          brew install qt@5
 
       - name: CMake build on ubuntu (with GUI / system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
@@ -55,6 +44,29 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           cmake --build cmake.output.tinyxml2 --target check -- -j$(nproc)
+
+  build_cmake:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install missing software on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-utils qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
+
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install qt@5
 
       - name: CMake build on ubuntu (with GUI)
         if: contains(matrix.os, 'ubuntu')
@@ -81,32 +93,197 @@ jobs:
           pushd cmake.output
           ctest -j$(nproc)
 
+  build_uchar:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Build with Unsigned char
         run: |
-          make clean
           make -j$(nproc) CXXFLAGS=-funsigned-char testrunner
 
       - name: Test with Unsigned char
         run: |
           ./testrunner TestSymbolDatabase
 
+  build_mathlib:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Build with TEST_MATHLIB_VALUE
         run: |
-          make clean
-          touch lib/mathlib.cpp test/testmathlib.cpp
           make -j$(nproc) CPPFLAGS=-DTEST_MATHLIB_VALUE all
 
       - name: Test with TEST_MATHLIB_VALUE
         run: |
           make -j$(nproc) CPPFLAGS=-DTEST_MATHLIB_VALUE check
 
+  check_nonneg:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # for g++
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install coreutils
+
+      # TODO: can we use c++ instead?
       - name: Check syntax with NONNEG
         run: |
           ls lib/*.cpp | xargs -n 1 -P $(nproc) g++ -fsyntax-only -std=c++0x -Ilib -Iexternals -Iexternals/picojson -Iexternals/simplecpp -Iexternals/tinyxml2 -DNONNEG
 
+  build_qmake:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install missing software on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
+
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install qt@5
+
+      - name: Build GUI on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pushd gui
+          qmake CONFIG+=debug HAVE_QCHART=yes
+          make -j$(nproc)
+
+      - name: Run GUI tests on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pushd gui/test/cppchecklibrarydata
+          qmake CONFIG+=debug
+          make -j$(nproc)
+          ./test-cppchecklibrarydata
+          popd
+          pushd gui/test/filelist
+          qmake CONFIG+=debug
+          make -j$(nproc)
+          # TODO: requires X session
+          #./test-filelist
+          popd
+          pushd gui/test/projectfile
+          qmake CONFIG+=debug
+          make -j$(nproc)
+          ./test-projectfile
+          popd
+          pushd gui/test/translationhandler
+          qmake CONFIG+=debug
+          make -j$(nproc)
+          # TODO: requires X session
+          #./test-translationhandler
+          popd
+          pushd gui/test/xmlreportv2
+          qmake CONFIG+=debug
+          make -j$(nproc)
+          # TODO: requires X session
+          #./test-xmlreportv2
+
+      - name: Generate Qt help file on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pushd gui/help
+          qhelpgenerator online-help.qhcp -o online-help.qhc
+
+      - name: Build triage on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pushd tools/triage
+          qmake CONFIG+=debug
+          make -j$(nproc)
+
+  build_fuzz:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Fuzzer
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          pushd oss-fuzz
+          make -j$(nproc) CXX=clang++ CXXFLAGS="-fsanitize=address" fuzz-client translate
+
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
+      fail-fast: false # Prefer quick result
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install missing software on ubuntu
+        if: contains(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install libxml2-utils
+
+      # packages for strict cfg checks
+      - name: Install missing software on ubuntu 22.04 (cfg)
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          sudo apt-get install libcairo2-dev libcurl4-openssl-dev liblua5.3-dev libssl-dev libsqlite3-dev libcppunit-dev libsigc++-2.0-dev libgtk-3-dev libboost-all-dev libwxgtk3.0-gtk3-dev xmlstarlet qtbase5-dev
+
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install python3
+
+      - name: Install missing Python packages
+        run: |
+          python3 -m pip install pip --upgrade
+          python3 -m pip install pytest
+
       - name: Build cppcheck
         run: |
-          make clean
           make -j$(nproc) HAVE_RULES=yes
 
       - name: Build test
@@ -192,75 +369,23 @@ jobs:
       - name: Ensure misra addon does not crash
         if: contains(matrix.os, 'ubuntu')
         run: |
-            ./cppcheck --addon=misra addons/test/misra/crash1.c | ( ! grep 'Bailing out from checking' )
+          ./cppcheck --addon=misra addons/test/misra/crash1.c | ( ! grep 'Bailing out from checking' )
 
-      - name: Build GUI on ubuntu
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          pushd gui
-          qmake CONFIG+=debug HAVE_QCHART=yes
-          make -j$(nproc)
+  selfcheck:
+    needs: build # wait for all tests to be successful first
 
-      - name: Run GUI tests on ubuntu
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          pushd gui/test/cppchecklibrarydata
-          qmake CONFIG+=debug
-          make -j$(nproc)
-          ./test-cppchecklibrarydata
-          popd
-          pushd gui/test/filelist
-          qmake CONFIG+=debug
-          make -j$(nproc)
-          # TODO: requires X session
-          #./test-filelist
-          popd
-          pushd gui/test/projectfile
-          qmake CONFIG+=debug
-          make -j$(nproc)
-          ./test-projectfile
-          popd
-          pushd gui/test/translationhandler
-          qmake CONFIG+=debug
-          make -j$(nproc)
-          # TODO: requires X session
-          #./test-translationhandler
-          popd
-          pushd gui/test/xmlreportv2
-          qmake CONFIG+=debug
-          make -j$(nproc)
-          # TODO: requires X session
-          #./test-xmlreportv2
+    runs-on: ubuntu-22.04 # run on the latest image only
 
-      - name: Generate Qt help file on ubuntu
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          pushd gui/help
-          qhelpgenerator online-help.qhcp -o online-help.qhc
-
-      - name: Build triage on ubuntu
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          pushd tools/triage
-          qmake CONFIG+=debug
-          make -j$(nproc)
-
-      - name: Build Fuzzer
-        if: contains(matrix.os, 'ubuntu')
-        run: |
-          pushd oss-fuzz
-          make -j$(nproc) CXX=clang++ CXXFLAGS="-fsanitize=address" fuzz-client translate
+    steps:
+      - uses: actions/checkout@v2
 
       - name: Self check (build)
-        if: matrix.os == 'ubuntu-22.04'
         run: |
           # compile with verification and ast matchers
-          make clean
           make -j$(nproc) -s CPPFLAGS="-DCHECK_INTERNAL" CXXFLAGS="-g -O2" MATCHCOMPILER=yes VERIFY=1
 
       # Run self check after "Build GUI" to include generated headers in analysis
       - name: Self check
-        if: matrix.os == 'ubuntu-22.04'
         run: |
           ec=0
           # self check lib/cli

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install libxml2-utils libtinyxml2-dev qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
       # packages for strict cfg checks
-      - name: Install missing software on ubuntu 22.04
+      - name: Install missing software on ubuntu (cfg)
         if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get install libcairo2-dev libcurl4-openssl-dev liblua5.3-dev libssl-dev libsqlite3-dev libcppunit-dev libsigc++-2.0-dev libgtk-3-dev libboost-all-dev libwxgtk3.0-gtk3-dev xmlstarlet
@@ -232,21 +232,21 @@ jobs:
           # TODO: requires X session
           #./test-xmlreportv2
 
-      - name: Generate Qt help file on ubuntu 20.04
-        if: matrix.os == 'ubuntu-22.04'
+      - name: Generate Qt help file on ubuntu
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd gui/help
           qhelpgenerator online-help.qhcp -o online-help.qhc
 
       - name: Build triage on ubuntu
-        if: matrix.os == 'ubuntu-22.04'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd tools/triage
           qmake CONFIG+=debug
           make -j$(nproc)
 
       - name: Build Fuzzer
-        if: matrix.os == 'ubuntu-22.04'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           pushd oss-fuzz
           make -j$(nproc) CXX=clang++ CXXFLAGS="-fsanitize=address" fuzz-client translate

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -234,12 +234,6 @@ jobs:
           # TODO: requires X session
           #./test-xmlreportv2
 
-      - name: Generate Qt help file on ubuntu 18.04
-        if: matrix.os == 'ubuntu-18.04'
-        run: |
-          pushd gui/help
-          qcollectiongenerator online-help.qhcp -o online-help.qhc
-
       - name: Generate Qt help file on ubuntu 20.04
         if: matrix.os == 'ubuntu-22.04'
         run: |

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -26,10 +26,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-utils libtinyxml2-dev qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
+      # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install qt@5
+          brew install coreutils qt@5
 
       - name: CMake build on ubuntu (with GUI / system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
@@ -63,10 +64,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install libxml2-utils qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
+      # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install qt@5
+          brew install coreutils qt@5
 
       - name: CMake build on ubuntu (with GUI)
         if: contains(matrix.os, 'ubuntu')
@@ -105,6 +107,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # coreutils contains "nproc"
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install coreutils
+
       - name: Build with Unsigned char
         run: |
           make -j$(nproc) CXXFLAGS=-funsigned-char testrunner
@@ -124,6 +132,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      # coreutils contains "nproc"
+      - name: Install missing software on macos
+        if: contains(matrix.os, 'macos')
+        run: |
+          brew install coreutils
 
       - name: Build with TEST_MATHLIB_VALUE
         run: |
@@ -145,7 +159,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # for g++
+      # coreutils contains "g++" and "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
@@ -174,10 +188,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
+      # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install qt@5
+          brew install coreutils qt@5
 
       - name: Build GUI on ubuntu
         if: contains(matrix.os, 'ubuntu')
@@ -272,10 +287,11 @@ jobs:
         run: |
           sudo apt-get install libcairo2-dev libcurl4-openssl-dev liblua5.3-dev libssl-dev libsqlite3-dev libcppunit-dev libsigc++-2.0-dev libgtk-3-dev libboost-all-dev libwxgtk3.0-gtk3-dev xmlstarlet qtbase5-dev
 
+      # coreutils contains "nproc"
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install python3
+          brew install coreutils python3
 
       - name: Install missing Python packages
         run: |

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -24,9 +24,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install libxml2-utils
-          sudo apt-get install libtinyxml2-dev
-          sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
+          sudo apt-get install libxml2-utils libtinyxml2-dev qtbase5-dev qttools5-dev libqt5charts5-dev qtchooser
 
       # packages for strict cfg checks
       - name: Install missing software on ubuntu 22.04

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -379,12 +379,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install missing software on ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev
+
       - name: Self check (build)
         run: |
           # compile with verification and ast matchers
           make -j$(nproc) -s CPPFLAGS="-DCHECK_INTERNAL" CXXFLAGS="-g -O2" MATCHCOMPILER=yes VERIFY=1
 
-      # Run self check after "Build GUI" to include generated headers in analysis
+      - name: Generate UI files
+        run: |
+          pushd gui
+          qmake CONFIG+=debug HAVE_QCHART=yes
+          make -j$(nproc) compiler_uic_make_all mocables
+
       - name: Self check
         run: |
           ec=0


### PR DESCRIPTION
More refactoring to enable more `ccache` usage later on.

`selfcheck` is being deferred until `build` is done so we know all the tests are successful. If we actually don't care about that we don't need to do that. In that case we could move it out of here into the selfcheck workflow.