### PR TITLE
Load `cfg` files relative to executable before considering `FILESDIR`.

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -102,14 +102,14 @@ Library::Error Library::load(const char exename[], const char path[])
         }
 
         std::list<std::string> cfgfolders;
-#ifdef FILESDIR
-        cfgfolders.emplace_back(FILESDIR "/cfg");
-#endif
         if (exename) {
             const std::string exepath(Path::fromNativeSeparators(Path::getPathFromFilename(exename)));
             cfgfolders.push_back(exepath + "cfg");
             cfgfolders.push_back(exepath);
         }
+#ifdef FILESDIR
+        cfgfolders.emplace_back(FILESDIR "/cfg");
+#endif
 
         while (error == tinyxml2::XML_ERROR_FILE_NOT_FOUND && !cfgfolders.empty()) {
             const std::string cfgfolder(cfgfolders.back());


### PR DESCRIPTION
This is a very old change and after reviewing the code for the loading of non-`cfg` files it turns out that the existing behavior is actually a bug. All the other code was already preferring the application dir to the `FILESDIR`.

Original commit message:
```
Load cfg files relative to executable before considering
  FILESDIR, such that the testrunner uses the local files instead of those
  from an installed cppcheck.
```