### PR TITLE
use `ccache` for Linux gcc CMake CI builds

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ matrix.image }}
 
-      # tests require CMake 3.4
+      # tests require CMake 3.9 - no ccache available
       - name: Test CMake build (no tests)
         if: matrix.image == 'ubuntu:14.04'
         run: |
@@ -60,9 +60,9 @@ jobs:
           cmake -G "Unix Makefiles" -DHAVE_RULES=On ..
           cmake --build . -- -j$(nproc)
 
-      # tests require CMake 3.4
+      # tests require CMake 3.9 - ccache available
       - name: Test CMake build (no tests)
-        if: matrix.image != 'ubuntu:14.04' && matrix.image != 'ubuntu:22.10'
+        if: matrix.image == 'centos:7' || matrix.image == 'ubuntu:16:04'
         run: |
           mkdir cmake.output
           cd cmake.output
@@ -70,7 +70,7 @@ jobs:
           cmake --build . -- -j$(nproc)
 
       - name: Test CMake build
-        if: matrix.image == 'ubuntu:22.10'
+        if: matrix.image != 'centos:7' && matrix.image != 'ubuntu:14.04' && matrix.image != 'ubuntu:16.04'
         run: |
           mkdir cmake.output
           cd cmake.output

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -27,6 +27,8 @@ jobs:
         if: matrix.image == 'centos:7'
         run: |
           yum install -y cmake gcc-c++ make pcre-devel
+          yum --enablerepo=extras install -y epel-release
+          yum install -y ccache
 
       - name: Install missing software on ubuntu
         if: matrix.image != 'centos:7'
@@ -40,13 +42,31 @@ jobs:
         run: |
           sudo apt-get install qt5-default
 
+      # needs to be called after the package installation since
+      # - it doesn't call "apt-get update"
+      # - it doesn't support centos
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: matrix.image != 'ubuntu:14.04' # no support for --set-config
+        with:
+          key: ${{ github.workflow }}-${{ matrix.image }}
+
       # tests require CMake 3.4
       - name: Test CMake build (no tests)
-        if: matrix.image != 'ubuntu:22.10'
+        if: matrix.image == 'ubuntu:14.04'
         run: |
           mkdir cmake.output
           cd cmake.output
           cmake -G "Unix Makefiles" -DHAVE_RULES=On ..
+          cmake --build . -- -j$(nproc)
+
+      # tests require CMake 3.4
+      - name: Test CMake build (no tests)
+        if: matrix.image != 'ubuntu:14.04' && matrix.image != 'ubuntu:22.10'
+        run: |
+          mkdir cmake.output
+          cd cmake.output
+          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
           cmake --build . -- -j$(nproc)
 
       - name: Test CMake build

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -48,7 +48,6 @@ jobs:
           cd cmake.output
           cmake -G "Unix Makefiles" -DHAVE_RULES=On ..
           cmake --build . -- -j$(nproc)
-          cd ..
 
       - name: Test CMake build
         if: matrix.image == 'ubuntu:22.10'
@@ -57,7 +56,6 @@ jobs:
           cd cmake.output
           cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On ..
           cmake --build . --target check -- -j$(nproc)
-          cd ..
 
   build_make:
 

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -31,7 +31,7 @@ jobs:
           yum install -y ccache
 
       - name: Install missing software on ubuntu
-        if: matrix.image != 'centos:7'
+        if: contains(matrix.image, 'ubuntu')
         run: |
           apt-get update
           apt-get install -y cmake g++ make libxml2-utils libpcre3-dev
@@ -100,7 +100,7 @@ jobs:
           yum install -y ccache
 
       - name: Install missing software on ubuntu
-        if: matrix.image != 'centos:7'
+        if: contains(matrix.image, 'ubuntu')
         run: |
           apt-get update
           apt-get install -y g++ make python3 libxml2-utils libpcre3-dev

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -35,11 +35,8 @@ jobs:
       - name: CMake build on ubuntu (with GUI / system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
         run: |
-          mkdir cmake.output.tinyxml2
-          cd cmake.output.tinyxml2
-          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_BUNDLED_TINYXML2=Off ..
-          cmake --build . -- -j$(nproc)
-          cd ..
+          cmake -S . -B cmake.output.tinyxml2 -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_BUNDLED_TINYXML2=Off
+          cmake --build cmake.output.tinyxml2 -- -j$(nproc)
 
       - name: Run CMake test (system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
@@ -73,18 +70,14 @@ jobs:
       - name: CMake build on ubuntu (with GUI)
         if: contains(matrix.os, 'ubuntu')
         run: |
-          mkdir cmake.output
-          pushd cmake.output
-          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On ..
-          cmake --build . -- -j$(nproc)
+          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On
+          cmake --build cmake.output -- -j$(nproc)
 
       - name: CMake build on macos (with GUI)
         if: contains(matrix.os, 'macos')
         run: |
-          mkdir cmake.output
-          pushd cmake.output
-          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 ..
-          cmake --build . -- -j$(nproc)
+          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5
+          cmake --build cmake.output -- -j$(nproc)
 
       - name: Run CMake test
         run: |

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       - name: Install missing software on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -35,7 +41,7 @@ jobs:
       - name: CMake build on ubuntu (with GUI / system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
         run: |
-          cmake -S . -B cmake.output.tinyxml2 -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_BUNDLED_TINYXML2=Off
+          cmake -S . -B cmake.output.tinyxml2 -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_BUNDLED_TINYXML2=Off -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build cmake.output.tinyxml2 -- -j$(nproc)
 
       - name: Run CMake test (system tinyxml2)
@@ -55,6 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
+
       - name: Install missing software on ubuntu
         if: contains(matrix.os, 'ubuntu')
         run: |
@@ -70,7 +82,7 @@ jobs:
       - name: CMake build on ubuntu (with GUI)
         if: contains(matrix.os, 'ubuntu')
         run: |
-          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On
+          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DWITH_QCHART=On -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build cmake.output -- -j$(nproc)
 
       - name: CMake build on macos (with GUI)

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -121,10 +121,8 @@ jobs:
       - name: Build GUI release (CMake)
         if: startsWith(matrix.qt_ver, '6') && matrix.arch == 'x64'
         run: |
-          md build || exit /b !errorlevel!
-          cd build || exit /b !errorlevel!
-          cmake -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_QT6=On .. || exit /b !errorlevel!
-          cmake --build . --target cppcheck-gui || exit /b !errorlevel!
+          cmake -S . -B build -DBUILD_GUI=On -DWITH_QCHART=On -DUSE_QT6=On || exit /b !errorlevel!
+          cmake --build build --target cppcheck-gui || exit /b !errorlevel!
 
       # TODO: deploy with Qt6
 
@@ -135,9 +133,7 @@ jobs:
           if "${{ matrix.arch }}" == "x86" (
             set ARCH=Win32
           )
-          md build || exit /b !errorlevel!
-          cd build || exit /b !errorlevel!
-          cmake -DBUILD_TESTS=On .. || exit /b !errorlevel!
+          cmake -S . -B build -DBUILD_TESTS=On || exit /b !errorlevel!
 
       - name: Build CLI debug configuration using MSBuild
         if: matrix.qt_ver == ''

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,12 +28,10 @@ jobs:
         run: |
           wget https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
           tar xzvf uncrustify-0.72.0.tar.gz && cd uncrustify-uncrustify-0.72.0 
-          mkdir build 
-          cd build 
-          cmake -DCMAKE_BUILD_TYPE=Release ..
-          cmake --build . -- -j$(nproc) -s
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build -- -j$(nproc) -s
           mkdir ~/uncrustify 
-          cp uncrustify ~/uncrustify/
+          cd build && cp uncrustify ~/uncrustify/
 
       - name: Uncrustify check
         run: |

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -45,9 +45,7 @@ jobs:
 
       - name: CMake
         run: |
-          mkdir cmake.output
-          pushd cmake.output
-          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=ON -DWITH_QCHART=ON -DCMAKE_GLOBAL_AUTOGEN_TARGET=On ..
+          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=ON -DWITH_QCHART=ON -DCMAKE_GLOBAL_AUTOGEN_TARGET=On
 
       - name: Generate dependencies
         run: |
@@ -69,9 +67,7 @@ jobs:
       # the following steps are duplicated from above since setting up the build node in a parallel step takes longer than the actual steps
       - name: CMake (no test)
         run: |
-          mkdir cmake.output.notest
-          pushd cmake.output.notest
-          cmake -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=0 -DBUILD_GUI=ON -DWITH_QCHART=ON -DCMAKE_GLOBAL_AUTOGEN_TARGET=On ..
+          cmake -S . -B cmake.output.notest -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=0 -DBUILD_GUI=ON -DWITH_QCHART=ON -DCMAKE_GLOBAL_AUTOGEN_TARGET=On
 
       - name: Generate dependencies (no test)
         run: |


### PR DESCRIPTION
This currently only caches files which do not rely on precompiled headers. Apparently it can be configured to work with those.