### PR TITLE
Fix #11020 FP arrayIndexOutOfBounds if string literals are assigned c…

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -1245,7 +1245,7 @@ static ValueFlow::Value executeImpl(const Token* expr, ProgramMemory& pm, const 
             auto tokvalue_it = std::find_if(expr->astOperand1()->values().begin(),
                                             expr->astOperand1()->values().end(),
                                             std::mem_fn(&ValueFlow::Value::isTokValue));
-            if (tokvalue_it == expr->astOperand1()->values().end()) {
+            if (tokvalue_it == expr->astOperand1()->values().end() || !tokvalue_it->isKnown()) {
                 return unknown;
             }
             tokvalue = tokvalue_it->tokvalue;

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -2524,6 +2524,15 @@ private:
               "    snprintf(str, sizeof(str), \"%hu\", port);\n"
               "}", settings0, "test.c");
         ASSERT_EQUALS("", errout.str());
+
+        check("int f(int x) {\n" // #11020
+              "    const char* p = (x == 0 ? \"12345\" : \"ABC\");\n"
+              "    int s = 0;\n"
+              "    for (int i = 0; p[i]; i++)\n"
+              "        s += p[i];\n"
+              "    return s;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void array_index_same_struct_and_var_name() {


### PR DESCRIPTION
…onditionally