### PR TITLE
replaced `static const`/fixed `std::vector` containers with `std::array`

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -32,6 +32,7 @@
 #include "token.h"
 #include "tokenize.h"
 
+#include <array>
 #include <iostream>
 #include <list>
 #include <memory>
@@ -52,8 +53,8 @@ static const CWE CWE415(415U);
 static const int NEW_ARRAY = -2;
 static const int NEW = -1;
 
-static const std::vector<std::pair<std::string, std::string>> alloc_failed_conds {{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}};
-static const std::vector<std::pair<std::string, std::string>> alloc_success_conds {{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}};
+static const std::array<std::pair<std::string, std::string>, 4> alloc_failed_conds {{{"==", "0"}, {"<", "0"}, {"==", "-1"}, {"<=", "-1"}}};
+static const std::array<std::pair<std::string, std::string>, 4> alloc_success_conds {{{"!=", "0"}, {">", "0"}, {"!=", "-1"}, {">=", "0"}}};
 
 /**
  * @brief Is variable type some class with automatic deallocation?
@@ -77,8 +78,9 @@ static bool isAutoDealloc(const Variable *var)
     return true;
 }
 
+template<std::size_t N>
 static bool isVarTokComparison(const Token * tok, const Token ** vartok,
-                               const std::vector<std::pair<std::string, std::string>>& ops)
+                               const std::array<std::pair<std::string, std::string>, N>& ops)
 {
     for (const auto & op : ops) {
         if (astIsVariableComparison(tok, op.first, op.second, vartok))

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -28,6 +28,7 @@
 #include "suppressions.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <iterator> // back_inserter
 #include <memory>
@@ -417,7 +418,7 @@ static void getConfigs(const simplecpp::TokenList &tokens, std::set<std::string>
             if (cmdtok->str() == "ifndef")
                 ifndef = true;
             else {
-                const std::vector<std::string> match{"if", "!", "defined", "(", config, ")"};
+                const std::array<std::string, 6> match{"if", "!", "defined", "(", config, ")"};
                 int i = 0;
                 ifndef = true;
                 for (const simplecpp::Token *t = cmdtok; i < match.size(); t = t->next) {

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <initializer_list>
 #include <string>
@@ -97,7 +98,7 @@ inline static bool isPrefixStringCharLiteral(const std::string &str, char q, con
 
 inline static bool isStringCharLiteral(const std::string &str, char q)
 {
-    static const std::vector<std::string> suffixes{"", "u8", "u", "U", "L"};
+    static const std::array<std::string, 5> suffixes{"", "u8", "u", "U", "L"};
     for (const std::string & p: suffixes) {
         if (isPrefixStringCharLiteral(str, q, p))
             return true;

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -19,6 +19,7 @@
 // Generate Makefile for cppcheck
 
 #include <algorithm>
+#include <array>
 #include <fstream> // IWYU pragma: keep
 #include <iostream>
 #include <string>
@@ -55,7 +56,7 @@ static std::string objfiles(const std::vector<std::string> &files)
 
 static void getDeps(const std::string &filename, std::vector<std::string> &depfiles)
 {
-    static const std::vector<std::string> externalfolders{"externals", "externals/picojson", "externals/simplecpp", "externals/tinyxml2" };
+    static const std::array<std::string, 4> externalfolders{"externals", "externals/picojson", "externals/simplecpp", "externals/tinyxml2"};
 
     // Is the dependency already included?
     if (std::find(depfiles.begin(), depfiles.end(), filename) != depfiles.end())


### PR DESCRIPTION
Scanning `mame_regtest` with `--enable=all --inconclusive` and `DISABLE_VALUEFLOW=1`:`

Clang 14 `1,901,904,224` -> `1,899,570,897` -> `1,899,550,337`