### PR TITLE
optimized `isSameConstantValue()` a bit

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1308,7 +1308,7 @@ static inline bool isSameConstantValue(bool macro, const Token* tok1, const Toke
         return false;
 
     auto adjustForCast = [](const Token* tok) {
-        if (Token::Match(tok->previous(), "%type% (|{") && tok->previous()->isStandardType() && tok->astOperand2())
+        if (tok->astOperand2() && Token::Match(tok->previous(), "%type% (|{") && tok->previous()->isStandardType())
             return tok->astOperand2();
         return tok;
     };


### PR DESCRIPTION
`tok` is known to be non-null since we check it at the beginning in the function so we can perform a lighter check first.

Scanning `mame_regtest` with `--enable=all --inconclusive` and `DISABLE_VALUEFLOW=1` it reduces the amount of calls (not instructions!) of the match function by almost half:

`match51(Token const*)` - `1 130 084` -> `690 156`

Clang 14 `1,901,904,224` -> `1,901,377,920`