### PR TITLE
avoid unnecessary copies with `emplace_back()`

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -67,7 +67,7 @@ static void addFilesToList(const std::string& fileList, std::vector<std::string>
         std::string fileName;
         while (std::getline(*files, fileName)) { // next line
             if (!fileName.empty()) {
-                pathNames.emplace_back(fileName);
+                pathNames.emplace_back(std::move(fileName));
             }
         }
     }
@@ -87,7 +87,7 @@ static bool addIncludePathsToList(const std::string& fileList, std::list<std::st
                 if (!endsWith(pathName, '/'))
                     pathName += '/';
 
-                pathNames->emplace_back(pathName);
+                pathNames->emplace_back(std::move(pathName));
             }
         }
         return true;
@@ -200,7 +200,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (!endsWith(path,'/'))
                     path += '/';
 
-                mSettings->includePaths.emplace_back(path);
+                mSettings->includePaths.emplace_back(std::move(path));
             }
 
             // User undef
@@ -423,7 +423,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                         if (!endsWith(path, '/'))
                             path += '/';
                     }
-                    mIgnoredPaths.emplace_back(path);
+                    mIgnoredPaths.emplace_back(std::move(path));
                 }
             }
 
@@ -722,7 +722,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             else if (std::strncmp(argv[i], "--rule=", 7) == 0) {
                 Settings::Rule rule;
                 rule.pattern = 7 + argv[i];
-                mSettings->rules.emplace_back(rule);
+                mSettings->rules.emplace_back(std::move(rule));
             }
 
             // Rule file
@@ -760,7 +760,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                         }
 
                         if (!rule.pattern.empty())
-                            mSettings->rules.emplace_back(rule);
+                            mSettings->rules.emplace_back(std::move(rule));
                     }
                 } else {
                     printError("unable to load rule-file: " + std::string(12+argv[i]));

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -65,7 +65,9 @@ static void addFilesToList(const std::string& fileList, std::vector<std::string>
     }
     if (files && *files) {
         std::string fileName;
+        // cppcheck-suppress accessMoved - FP
         while (std::getline(*files, fileName)) { // next line
+            // cppcheck-suppress accessMoved - FP
             if (!fileName.empty()) {
                 pathNames.emplace_back(std::move(fileName));
             }
@@ -78,6 +80,7 @@ static bool addIncludePathsToList(const std::string& fileList, std::list<std::st
     std::ifstream files(fileList);
     if (files) {
         std::string pathName;
+        // cppcheck-suppress accessMoved - FP
         while (std::getline(files, pathName)) { // next line
             if (!pathName.empty()) {
                 pathName = Path::removeQuotationMarks(pathName);

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -171,7 +171,7 @@ int ProcessExecutor::handleRead(int rpipe, unsigned int &result)
             // Alert only about unique errors
             std::string errmsg = msg.toString(mSettings.verbose);
             if (std::find(mErrorList.begin(), mErrorList.end(), errmsg) == mErrorList.end()) {
-                mErrorList.emplace_back(errmsg);
+                mErrorList.emplace_back(std::move(errmsg));
                 if (type == PipeWriter::REPORT_ERROR)
                     mErrorLogger.reportErr(msg);
                 else

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -99,12 +99,13 @@ private:
 
         // Alert only about unique errors
         bool reportError = false;
-        const std::string errmsg = msg.toString(mThreadExecutor.mSettings.verbose);
 
         {
+            std::string errmsg = msg.toString(mThreadExecutor.mSettings.verbose);
+
             std::lock_guard<std::mutex> lg(mErrorSync);
             if (std::find(mThreadExecutor.mErrorList.begin(), mThreadExecutor.mErrorList.end(), errmsg) == mThreadExecutor.mErrorList.end()) {
-                mThreadExecutor.mErrorList.emplace_back(errmsg);
+                mThreadExecutor.mErrorList.emplace_back(std::move(errmsg));
                 reportError = true;
             }
         }

--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -96,20 +96,20 @@ std::string Check::getMessageId(const ValueFlow::Value &value, const char id[])
     return id;
 }
 
-ErrorPath Check::getErrorPath(const Token* errtok, const ValueFlow::Value* value, const std::string& bug) const
+ErrorPath Check::getErrorPath(const Token* errtok, const ValueFlow::Value* value, std::string bug) const
 {
     ErrorPath errorPath;
     if (!value) {
-        errorPath.emplace_back(errtok, bug);
+        errorPath.emplace_back(errtok, std::move(bug));
     } else if (mSettings->verbose || mSettings->xml || !mSettings->templateLocation.empty()) {
         errorPath = value->errorPath;
-        errorPath.emplace_back(errtok, bug);
+        errorPath.emplace_back(errtok, std::move(bug));
     } else {
         if (value->condition)
             errorPath.emplace_back(value->condition, "condition '" + value->condition->expressionString() + "'");
         //else if (!value->isKnown() || value->defaultArg)
         //    errorPath = value->callstack;
-        errorPath.emplace_back(errtok, bug);
+        errorPath.emplace_back(errtok, std::move(bug));
     }
     return errorPath;
 }

--- a/lib/check.h
+++ b/lib/check.h
@@ -154,7 +154,7 @@ protected:
 
     void reportError(const ErrorPath &errorPath, Severity::SeverityType severity, const char id[], const std::string &msg, const CWE &cwe, Certainty::CertaintyLevel certainty);
 
-    ErrorPath getErrorPath(const Token* errtok, const ValueFlow::Value* value, const std::string& bug) const;
+    ErrorPath getErrorPath(const Token* errtok, const ValueFlow::Value* value, std::string bug) const;
 
     /**
      * Use WRONG_DATA in checkers when you check for wrong data. That

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1388,18 +1388,18 @@ void CppCheck::executeAddons(const std::vector<std::string>& files)
             ErrorMessage errmsg;
 
             if (obj.count("file") > 0) {
-                const std::string fileName = obj["file"].get<std::string>();
+                std::string fileName = obj["file"].get<std::string>();
                 const int64_t lineNumber = obj["linenr"].get<int64_t>();
                 const int64_t column = obj["column"].get<int64_t>();
-                errmsg.callStack.emplace_back(fileName, lineNumber, column);
+                errmsg.callStack.emplace_back(std::move(fileName), lineNumber, column);
             } else if (obj.count("loc") > 0) {
                 for (const picojson::value &locvalue: obj["loc"].get<picojson::array>()) {
                     picojson::object loc = locvalue.get<picojson::object>();
-                    const std::string fileName = loc["file"].get<std::string>();
+                    std::string fileName = loc["file"].get<std::string>();
                     const int64_t lineNumber = loc["linenr"].get<int64_t>();
                     const int64_t column = loc["column"].get<int64_t>();
                     const std::string info = loc["info"].get<std::string>();
-                    errmsg.callStack.emplace_back(fileName, info, lineNumber, column);
+                    errmsg.callStack.emplace_back(std::move(fileName), info, lineNumber, column);
                 }
             }
 

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -521,7 +521,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
                         struct Container::RangeItemRecordTypeItem member;
                         member.name = memberName ? memberName : "";
                         member.templateParameter = memberTemplateParameter ? std::atoi(memberTemplateParameter) : -1;
-                        container.rangeItemRecordType.emplace_back(member);
+                        container.rangeItemRecordType.emplace_back(std::move(member));
                     }
                 } else
                     unknown_elements.insert(containerNodeName);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -109,7 +109,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
         std::vector<Suppressions::Suppression> suppressions = Suppressions::parseMultiSuppressComment(comment, &errmsg);
 
         if (!errmsg.empty())
-            bad->emplace_back(tok->location, errmsg);
+            bad->emplace_back(tok->location, std::move(errmsg));
 
         for (const Suppressions::Suppression &s : suppressions) {
             if (!s.errorId.empty())
@@ -126,7 +126,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
             inlineSuppressions.push_back(std::move(s));
 
         if (!errmsg.empty())
-            bad->emplace_back(tok->location, errmsg);
+            bad->emplace_back(tok->location, std::move(errmsg));
     }
 
     return true;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7334,7 +7334,7 @@ void ValueType::setDebugPath(const Token* tok, SourceLocation ctx, SourceLocatio
         return;
     std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name();
-    debugPath.emplace_back(tok, s);
+    debugPath.emplace_back(tok, std::move(s));
 }
 
 ValueType::MatchResult ValueType::matchParameter(const ValueType *call, const ValueType *func)

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -704,7 +704,7 @@ void TemplateSimplifier::addInstantiation(Token *token, const std::string &scope
                                                      instantiation);
 
     if (it == mTemplateInstantiations.end())
-        mTemplateInstantiations.emplace_back(instantiation);
+        mTemplateInstantiations.emplace_back(std::move(instantiation));
 }
 
 static void getFunctionArguments(const Token *nameToken, std::vector<const Token *> &args)
@@ -2207,9 +2207,9 @@ void TemplateSimplifier::expandTemplate(
                 }
 
                 if (copy)
-                    newInstantiations.emplace_back(mTokenList.back(), scope);
+                    newInstantiations.emplace_back(mTokenList.back(), std::move(scope));
                 else if (!inTemplateDefinition)
-                    newInstantiations.emplace_back(tok3, scope);
+                    newInstantiations.emplace_back(tok3, std::move(scope));
             }
 
             // link() newly tokens manually

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9496,7 +9496,7 @@ void Tokenizer::printUnknownTypes() const
             }
         }
 
-        unknowns.emplace_back(name, nameTok);
+        unknowns.emplace_back(std::move(name), nameTok);
     }
 
     if (!unknowns.empty()) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -169,7 +169,7 @@ static void setSourceLocation(ValueFlow::Value& v,
         return;
     std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name() + ": " + debugString(v);
-    v.debugPath.emplace_back(tok, s);
+    v.debugPath.emplace_back(tok, std::move(s));
 }
 
 static void changeKnownToPossible(std::list<ValueFlow::Value> &values, int indirect=-1)
@@ -5306,8 +5306,8 @@ static void valueFlowForwardAssign(Token* const tok,
                 else if (value.bound == ValueFlow::Value::Bound::Upper)
                     valueKind = "greater than ";
             }
-            const std::string info = "Assignment '" + tok->astParent()->expressionString() + "', assigned value is " + valueKind + value.infoString();
-            value.errorPath.emplace_back(tok, info);
+            std::string info = "Assignment '" + tok->astParent()->expressionString() + "', assigned value is " + valueKind + value.infoString();
+            value.errorPath.emplace_back(tok, std::move(info));
         }
     }
 


### PR DESCRIPTION
This is split from similar changes for `push_back()` as some of those caused sizable regressions which need to be investigated first :( This is another step in preparation of applying the `misc-const-correctness` clang-tidy-16 fixes.

The impact is neglectable but there are no regressions.

Performing a `--enable=all --inconclusive` scan on `mame_regtest`.

With `DISABLE_VALUEFLOW=1`:

GCC 12 `1,849,957,730` -> ` 1,849,441,950`
Clang 14 `1,901,388,783` -> `1,901,388,929`

With Valueflow enabled:

Clang 14 `50,981,418,024` -> `50,988,014,183`
GCC 12 `54,791,127,471` -> `54,794,443,556`

And scanning `cli` with `--enable=all --inconclusive -Ilib -D __GNUC__` and `DISABLE_VALUEFLOW=1`

GCC 12 `3,216,157,747` -> `3,215,371,284`
Clang 14 `3,178,610,619` -> `3,178,527,042`