### PR TITLE
avoid unnecessary copies with `push_back()` and `push_front()`

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1135,7 +1135,7 @@ static void followVariableExpressionError(const Token *tok1, const Token *tok2, 
     ErrorPathItem item = std::make_pair(tok2, "'" + tok1->str() + "' is assigned value '" + tok2->expressionString() + "' here.");
     if (std::find(errors->begin(), errors->end(), item) != errors->end())
         return;
-    errors->push_back(item);
+    errors->push_back(std::move(item));
 }
 
 std::vector<ReferenceToken> followAllReferences(const Token* tok,

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -3089,7 +3089,7 @@ Check::FileInfo *CheckClass::getFileInfo(const Tokenizer *tokenizer, const Setti
         }
         nameLoc.hash = std::hash<std::string> {}(def);
 
-        classDefinitions.push_back(nameLoc);
+        classDefinitions.push_back(std::move(nameLoc));
     }
 
     if (classDefinitions.empty())
@@ -3132,7 +3132,7 @@ Check::FileInfo * CheckClass::loadFileInfoFromXml(const tinyxml2::XMLElement *xm
             nameLoc.lineNumber = std::atoi(line);
             nameLoc.column = std::atoi(col);
             nameLoc.hash = MathLib::toULongNumber(hash);
-            fileInfo->classDefinitions.push_back(nameLoc);
+            fileInfo->classDefinitions.push_back(std::move(nameLoc));
         }
     }
     if (fileInfo->classDefinitions.empty()) {

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -346,7 +346,7 @@ void CheckUnusedFunctions::unusedFunctionError(ErrorLogger * const errorLogger,
         ErrorMessage::FileLocation fileLoc;
         fileLoc.setfile(filename);
         fileLoc.line = lineNumber;
-        locationList.push_back(fileLoc);
+        locationList.push_back(std::move(fileLoc));
     }
 
     const ErrorMessage errmsg(locationList, emptyString, Severity::style, "$symbol:" + funcname + "\nThe function '$symbol' is never used.", "unusedFunction", CWE561, Certainty::normal);

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -1607,9 +1607,9 @@ void clangimport::parseClangAstDump(Tokenizer *tokenizer, std::istream &f)
         AstNodePtr newNode = std::make_shared<AstNode>(nodeType, ext, &data);
         tree[level - 1]->children.push_back(newNode);
         if (level >= tree.size())
-            tree.push_back(newNode);
+            tree.push_back(std::move(newNode));
         else
-            tree[level] = newNode;
+            tree[level] = std::move(newNode);
     }
 
     if (!tree.empty())

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -417,7 +417,7 @@ static bool reportClangErrors(std::istream &is, std::function<void(const ErrorMe
                             Certainty::normal);
 
         if (line.compare(pos3, 10, ": warning:") == 0) {
-            warnings->push_back(errmsg);
+            warnings->push_back(std::move(errmsg));
             continue;
         }
 
@@ -909,13 +909,13 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 std::list<ErrorMessage::FileLocation> locationList;
                 if (e.token) {
                     ErrorMessage::FileLocation loc(e.token, &tokenizer.list);
-                    locationList.push_back(loc);
+                    locationList.push_back(std::move(loc));
                 } else {
                     ErrorMessage::FileLocation loc2(filename, 0, 0);
-                    locationList.push_back(loc2);
+                    locationList.push_back(std::move(loc2));
                     if (filename != tokenizer.list.getSourceFilePath()) {
                         ErrorMessage::FileLocation loc(tokenizer.list.getSourceFilePath(), 0, 0);
-                        locationList.push_back(loc);
+                        locationList.push_back(std::move(loc));
                     }
                 }
                 ErrorMessage errmsg(std::move(locationList),
@@ -1463,7 +1463,7 @@ void CppCheck::tooManyConfigsError(const std::string &file, const int numberOfCo
     if (!file.empty()) {
         ErrorMessage::FileLocation location;
         location.setfile(file);
-        loclist.push_back(location);
+        loclist.push_back(std::move(location));
     }
 
     std::ostringstream msg;
@@ -1501,7 +1501,7 @@ void CppCheck::purgedConfigurationMessage(const std::string &file, const std::st
     if (!file.empty()) {
         ErrorMessage::FileLocation location;
         location.setfile(file);
-        loclist.push_back(location);
+        loclist.push_back(std::move(location));
     }
 
     ErrorMessage errmsg(loclist,

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -334,7 +334,7 @@ bool ErrorMessage::deserialize(const std::string &data)
         if (substrings.size() == 5)
             loc.setinfo(substrings[4]);
 
-        callStack.push_back(loc);
+        callStack.push_back(std::move(loc));
 
         if (callStack.size() >= stackSize)
             break;

--- a/lib/infer.cpp
+++ b/lib/infer.cpp
@@ -321,21 +321,21 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
             ValueFlow::Value value(diff.getScalar());
             addToErrorPath(value, refs);
             setValueKind(value, refs);
-            result.push_back(value);
+            result.push_back(std::move(value));
         } else {
             if (!diff.minvalue.empty()) {
                 ValueFlow::Value value(diff.minvalue.front() - 1);
                 value.setImpossible();
                 value.bound = ValueFlow::Value::Bound::Upper;
                 addToErrorPath(value, diff.minRef);
-                result.push_back(value);
+                result.push_back(std::move(value));
             }
             if (!diff.maxvalue.empty()) {
                 ValueFlow::Value value(diff.maxvalue.front() + 1);
                 value.setImpossible();
                 value.bound = ValueFlow::Value::Bound::Lower;
                 addToErrorPath(value, diff.maxRef);
-                result.push_back(value);
+                result.push_back(std::move(value));
             }
         }
     } else if ((op == "!=" || op == "==") && lhs.isScalarOrEmpty() && rhs.isScalarOrEmpty()) {
@@ -344,7 +344,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
             ValueFlow::Value value(calculate(op, lhs.getScalar(), rhs.getScalar()));
             addToErrorPath(value, refs);
             setValueKind(value, refs);
-            result.push_back(value);
+            result.push_back(std::move(value));
         } else {
             std::vector<const ValueFlow::Value*> refs;
             if (lhs.isScalar() && inferNotEqual(rhsValues, lhs.getScalar()))
@@ -355,7 +355,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
                 ValueFlow::Value value(op == "!=");
                 addToErrorPath(value, refs);
                 setValueKind(value, refs);
-                result.push_back(value);
+                result.push_back(std::move(value));
             }
         }
     } else {
@@ -365,7 +365,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
             ValueFlow::Value value(r.front());
             addToErrorPath(value, refs);
             setValueKind(value, refs);
-            result.push_back(value);
+            result.push_back(std::move(value));
         }
     }
 

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -123,7 +123,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
             return false;
 
         if (!s.errorId.empty())
-            inlineSuppressions.push_back(s);
+            inlineSuppressions.push_back(std::move(s));
 
         if (!errmsg.empty())
             bad->emplace_back(tok->location, errmsg);
@@ -231,7 +231,7 @@ void Preprocessor::setDirectives(const simplecpp::TokenList &tokens)
                 else
                     directive.str += tok2->str();
             }
-            mDirectives.push_back(directive);
+            mDirectives.push_back(std::move(directive));
         }
     }
 }
@@ -474,7 +474,7 @@ static void getConfigs(const simplecpp::TokenList &tokens, std::set<std::string>
                 std::string config = readcondition(cmdtok, defined, undefined);
                 if (isUndefined(config,undefined))
                     config.clear();
-                configs_if.push_back(config);
+                configs_if.push_back(std::move(config));
                 ret.insert(cfg(configs_if, userDefines));
             } else if (!configs_ifndef.empty()) {
                 configs_if.push_back(configs_ifndef.back());
@@ -588,7 +588,7 @@ static void splitcfg(const std::string &cfg, std::list<std::string> &defines, co
         std::string def = (defineEndPos == std::string::npos) ? cfg.substr(defineStartPos) : cfg.substr(defineStartPos, defineEndPos - defineStartPos);
         if (!defaultValue.empty() && def.find('=') == std::string::npos)
             def += '=' + defaultValue;
-        defines.push_back(def);
+        defines.push_back(std::move(def));
         if (defineEndPos == std::string::npos)
             break;
         defineStartPos = defineEndPos + 1U;
@@ -615,7 +615,7 @@ static simplecpp::DUI createDUI(const Settings &mSettings, const std::string &cf
         } else {
             s[s.find(')')+1] = '=';
         }
-        dui.defines.push_back(s);
+        dui.defines.push_back(std::move(s));
     }
 
     dui.undefined = mSettings.userUndefs; // -U
@@ -825,8 +825,8 @@ void Preprocessor::error(const std::string &filename, unsigned int linenr, const
         if (mSettings.relativePaths)
             file = Path::getRelativePath(file, mSettings.basePaths);
 
-        const ErrorMessage::FileLocation loc(file, linenr, 0);
-        locationList.push_back(loc);
+        ErrorMessage::FileLocation loc(file, linenr, 0);
+        locationList.push_back(std::move(loc));
     }
     mErrorLogger->reportErr(ErrorMessage(locationList,
                                          mFile0,
@@ -865,7 +865,7 @@ void Preprocessor::missingInclude(const std::string &filename, unsigned int line
             ErrorMessage::FileLocation loc;
             loc.line = linenr;
             loc.setfile(Path::toNativeSeparators(filename));
-            locationList.push_back(loc);
+            locationList.push_back(std::move(loc));
         }
         ErrorMessage errmsg(locationList, mFile0, Severity::information,
                             (headerType==SystemHeader) ?

--- a/lib/summaries.cpp
+++ b/lib/summaries.cpp
@@ -110,7 +110,7 @@ static std::vector<std::string> getSummaryFiles(const std::string &filename)
             continue;
         std::string f = line.substr(0,colon);
         f[dotA + 1] = 's';
-        ret.push_back(f);
+        ret.push_back(std::move(f));
     }
     return ret;
 }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -166,7 +166,7 @@ std::vector<Suppressions::Suppression> Suppressions::parseMultiSuppressComment(c
             }
         }
 
-        suppressions.push_back(s);
+        suppressions.push_back(std::move(s));
     }
 
     return suppressions;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3319,7 +3319,7 @@ const Token *Type::initBaseInfo(const Token *tok, const Token *tok1)
                 base.type = baseType;
 
             // save pattern for base class name
-            derivedFrom.push_back(base);
+            derivedFrom.push_back(std::move(base));
         } else
             tok2 = tok2->next();
     }

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1164,8 +1164,8 @@ public:
 
     const Function *getDestructor() const;
 
-    void addFunction(const Function & func) {
-        functionList.push_back(func);
+    void addFunction(Function func) {
+        functionList.push_back(std::move(func));
 
         const Function * back = &functionList.back();
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2146,9 +2146,9 @@ bool Token::addValue(const ValueFlow::Value &value)
             if (v.varId == 0)
                 v.varId = mImpl->mVarId;
             if (v.isKnown() && v.isIntValue())
-                mImpl->mValues->push_front(v);
+                mImpl->mValues->push_front(std::move(v));
             else
-                mImpl->mValues->push_back(v);
+                mImpl->mValues->push_back(std::move(v));
         }
     } else {
         ValueFlow::Value v(value);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -656,7 +656,7 @@ void Tokenizer::simplifyTypedef()
                 info.className = className;
                 info.bodyEnd = tok->link();
                 info.bodyEnd2 = tok->link();
-                spaceInfo.push_back(info);
+                spaceInfo.push_back(std::move(info));
 
                 hasClass = false;
             } else if (spaceInfo.size() > 1 && tok->str() == "}" && spaceInfo.back().bodyEnd == tok) {
@@ -1070,7 +1070,7 @@ void Tokenizer::simplifyTypedef()
         typedefInfo.lineNumber = typeName->linenr();
         typedefInfo.column = typeName->column();
         typedefInfo.used = false;
-        mTypedefInfo.push_back(typedefInfo);
+        mTypedefInfo.push_back(std::move(typedefInfo));
 
         while (!done) {
             std::string pattern = typeName->str();
@@ -9395,7 +9395,7 @@ void Tokenizer::removeUnnecessaryQualification()
             if (!tok)
                 return;
             info.bodyEnd = tok->link();
-            classInfo.push_back(info);
+            classInfo.push_back(std::move(info));
         } else if (!classInfo.empty()) {
             if (tok == classInfo.back().bodyEnd)
                 classInfo.pop_back();

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -178,7 +178,7 @@ void TokenList::determineCppC()
     }
 }
 
-int TokenList::appendFileIfNew(const std::string &fileName)
+int TokenList::appendFileIfNew(std::string fileName)
 {
     // Has this file been tokenized already?
     for (int i = 0; i < mFiles.size(); ++i)
@@ -186,7 +186,7 @@ int TokenList::appendFileIfNew(const std::string &fileName)
             return i;
 
     // The "mFiles" vector remembers what files have been tokenized..
-    mFiles.push_back(fileName);
+    mFiles.push_back(std::move(fileName));
 
     // Update mIsC and mIsCpp properties
     if (mFiles.size() == 1) { // Update only useful if first file added to _files

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -110,7 +110,7 @@ public:
     void deallocateTokens();
 
     /** append file name if seen the first time; return its index in any case */
-    int appendFileIfNew(const std::string &fileName);
+    int appendFileIfNew(std::string fileName);
 
     /** get first token of list */
     const Token *front() const {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5646,7 +5646,7 @@ static void insertNegateKnown(std::list<ValueFlow::Value>& values, const std::li
             continue;
         value.intvalue = !value.intvalue;
         value.setKnown();
-        values.push_back(value);
+        values.push_back(std::move(value));
     }
 }
 
@@ -6258,10 +6258,10 @@ struct SimpleConditionHandler : ConditionHandler {
             if (vartok->str() == "=" && vartok->astOperand1() && vartok->astOperand2())
                 vartok = vartok->astOperand1();
             Condition cond;
-            cond.true_values.push_back(true_value);
-            cond.false_values.push_back(false_value);
+            cond.true_values.push_back(std::move(true_value));
+            cond.false_values.push_back(std::move(false_value));
             cond.vartok = vartok;
-            conds.push_back(cond);
+            conds.push_back(std::move(cond));
         });
         if (!conds.empty())
             return conds;
@@ -6475,7 +6475,7 @@ struct SymbolicConditionHandler : SimpleConditionHandler {
                 cond.false_values = {false_value};
                 cond.vartok = vartok;
                 cond.inverted = inverted;
-                result.push_back(cond);
+                result.push_back(std::move(cond));
             }
         };
         addCond(tok->astOperand1(), tok->astOperand2(), false);
@@ -6920,7 +6920,7 @@ bool productParams(const std::unordered_map<Key, std::list<ValueFlow::Value>>& v
                     }
                 }
                 arg[p.first] = value;
-                new_args.push_back(arg);
+                new_args.push_back(std::move(arg));
             }
             std::copy(new_args.begin(), new_args.end(), std::back_inserter(args));
         });
@@ -7224,7 +7224,7 @@ static void valueFlowFunctionDefaultParameter(TokenList* tokenlist, SymbolDataba
                     v.defaultArg = true;
                     v.changeKnownToPossible();
                     if (v.isPossible())
-                        argvalues.push_back(v);
+                        argvalues.push_back(std::move(v));
                 }
                 if (!argvalues.empty())
                     valueFlowInjectParameter(tokenlist, var, scope, argvalues);
@@ -8158,10 +8158,10 @@ struct ContainerConditionHandler : ConditionHandler {
             true_value.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
             false_value.valueType = ValueFlow::Value::ValueType::CONTAINER_SIZE;
             Condition cond;
-            cond.true_values.push_back(true_value);
-            cond.false_values.push_back(false_value);
+            cond.true_values.push_back(std::move(true_value));
+            cond.false_values.push_back(std::move(false_value));
             cond.vartok = vartok;
-            conds.push_back(cond);
+            conds.push_back(std::move(cond));
         });
         if (!conds.empty())
             return conds;


### PR DESCRIPTION
It turns out this did not introduce any regressions. I accidentally used different sources for comparing runs.

This is the last step before trying to apply the `misc-const-correctness` fixes.

Performing a `--enable=all --inconclusive` scan on `mame_regtest`.

With `DISABLE_VALUEFLOW=1`:

Clang 14 `1,901,388,751` -> `1,901,336,996`
GCC 12 `1,849,957,590` -> `1,849,623,077 `

With Valueflow enabled:

Clang 14 `50,988,014,175` -> `50,979,722,552`
GCC 12 `54,791,127,461` -> `54,791,108,211`

And scanning `cli` with `--enable=all --inconclusive -Ilib -D __GNUC__` and `DISABLE_VALUEFLOW=1`

Clang 14 `3,172,193,354` -> `3,170,450,670`
GCC 12 `3,216,157,495` -> `3,214,864,491`