### PR TITLE
fixed `platforms` lookup / set proper platform type for `unix32-unsigned` and `unix64-unsigned` / copy `platforms` in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,11 @@ add_custom_target(copy_addons ALL
         "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/addons"
     COMMENT "Copying addons files to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
 
+add_custom_target(copy_platforms ALL
+    ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/platforms"
+    "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/platforms"
+    COMMENT "Copying platforms files to ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}")
+
 if(USE_BUNDLED_TINYXML2)
     message(STATUS "Using bundled version of tinyxml2")
     add_subdirectory(externals/tinyxml2)

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -47,6 +47,7 @@ target_link_libraries(cppcheck ${CMAKE_THREAD_LIBS_INIT})
 
 add_dependencies(cppcheck copy_cfg)
 add_dependencies(cppcheck copy_addons)
+add_dependencies(cppcheck copy_platforms)
 add_dependencies(cppcheck run-dmake)
 
 install(TARGETS cppcheck

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -591,6 +591,14 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printError(message);
                     return false;
                 }
+
+                // TODO: remove
+                // these are loaded via external files and thus have Settings::PlatformFile set instead.
+                // override the type so they behave like the regular platforms.
+                if (platform == "unix32-unsigned")
+                    mSettings->platformType = Settings::Unix32;
+                else if (platform == "unix64-unsigned")
+                    mSettings->platformType = Settings::Unix64;
             }
 
             // Write results in results.plist

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -584,7 +584,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     mSettings->platform(Settings::Native);
                 else if (platform == "unspecified")
                     mSettings->platform(Settings::Unspecified);
-                else if (!mSettings->loadPlatformFile(argv[0], platform)) {
+                else if (!mSettings->loadPlatformFile(argv[0], platform, mSettings->verbose)) {
                     std::string message("unrecognized platform: \"");
                     message += platform;
                     message += "\".";
@@ -656,7 +656,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                         mSettings->platform(Settings::Native);
                     else if (platform == "unspecified" || platform == "Unspecified" || platform.empty())
                         ;
-                    else if (!mSettings->loadPlatformFile(projectFile.c_str(), platform) && !mSettings->loadPlatformFile(argv[0], platform)) {
+                    else if (!mSettings->loadPlatformFile(projectFile.c_str(), platform, mSettings->verbose) && !mSettings->loadPlatformFile(argv[0], platform, mSettings->verbose)) {
                         std::string message("unrecognized platform: \"");
                         message += platform;
                         message += "\".";

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -21,6 +21,7 @@
 #include "path.h"
 
 #include <cstring>
+#include <iostream>
 #include <limits>
 #include <vector>
 
@@ -156,37 +157,45 @@ bool cppcheck::Platform::platform(cppcheck::Platform::PlatformType type)
     return false;
 }
 
-bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::string &filename)
+bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::string &filename, bool verbose)
 {
+    // TODO: only append .xml if missing
+    // TODO: use native separators
+    std::vector<std::string> filenames;
+    filenames.push_back(filename);
+    filenames.push_back(filename + ".xml");
+    filenames.push_back("platforms/" + filename);
+    filenames.push_back("platforms/" + filename + ".xml");
+    if (exename && (std::string::npos != Path::fromNativeSeparators(exename).find('/'))) {
+        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + filename);
+        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename);
+        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename + ".xml");
+    }
+#ifdef FILESDIR
+    std::string filesdir = FILESDIR;
+    if (!filesdir.empty() && filesdir[filesdir.size()-1] != '/')
+        filesdir += '/';
+    filenames.push_back(filesdir + ("platforms/" + filename));
+    filenames.push_back(filesdir + ("platforms/" + filename + ".xml"));
+#endif
+
     // open file..
     tinyxml2::XMLDocument doc;
-    if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_SUCCESS) {
-        std::vector<std::string> filenames;
-        filenames.push_back(filename + ".xml");
-        filenames.push_back("platforms/" + filename);
-        filenames.push_back("platforms/" + filename + ".xml");
-        if (exename && (std::string::npos != Path::fromNativeSeparators(exename).find('/'))) {
-            filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + filename);
-            filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename);
-            filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename + ".xml");
+    bool success = false;
+    for (const std::string & f : filenames) {
+        if (verbose)
+            std::cout << "try to load platform file '" << f << "' ... ";
+        if (doc.LoadFile(f.c_str()) == tinyxml2::XML_SUCCESS) {
+            if (verbose)
+                std::cout << "Success" << std::endl;
+            success = true;
+            break;
         }
-#ifdef FILESDIR
-        std::string filesdir = FILESDIR;
-        if (!filesdir.empty() && filesdir[filesdir.size()-1] != '/')
-            filesdir += '/';
-        filenames.push_back(filesdir + ("platforms/" + filename));
-        filenames.push_back(filesdir + ("platforms/" + filename + ".xml"));
-#endif
-        bool success = false;
-        for (const std::string & f : filenames) {
-            if (doc.LoadFile(f.c_str()) == tinyxml2::XML_SUCCESS) {
-                success = true;
-                break;
-            }
-        }
-        if (!success)
-            return false;
+        if (verbose)
+            std::cout << doc.ErrorStr() << std::endl;
     }
+    if (!success)
+        return false;
 
     return loadFromXmlDocument(&doc);
 }

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -163,8 +163,9 @@ bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::strin
     if (doc.LoadFile(filename.c_str()) != tinyxml2::XML_SUCCESS) {
         std::vector<std::string> filenames;
         filenames.push_back(filename + ".xml");
+        filenames.push_back("platforms/" + filename);
+        filenames.push_back("platforms/" + filename + ".xml");
         if (exename && (std::string::npos != Path::fromNativeSeparators(exename).find('/'))) {
-            filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + filename);
             filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + filename);
             filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename);
             filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename + ".xml");

--- a/lib/platform.h
+++ b/lib/platform.h
@@ -120,9 +120,10 @@ namespace cppcheck {
          * load platform file
          * @param exename application path
          * @param filename platform filename
+         * @param verbose log verbose information about the lookup
          * @return returns true if file was loaded successfully
          */
-        bool loadPlatformFile(const char exename[], const std::string &filename);
+        bool loadPlatformFile(const char exename[], const std::string &filename, bool verbose = false);
 
         /** load platform from xml document, primarily for testing */
         bool loadFromXmlDocument(const tinyxml2::XMLDocument *doc);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ if (BUILD_TESTS)
 
     add_dependencies(testrunner copy_cfg)
     add_dependencies(testrunner copy_addons)
+    add_dependencies(testrunner copy_platforms)
     add_dependencies(testrunner run-dmake)
 
     if (LIBXML2_XMLLINT_EXECUTABLE)

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -120,7 +120,7 @@ private:
         TEST_CASE(platformUnix64Unsigned);
         TEST_CASE(platformNative);
         TEST_CASE(platformUnspecified);
-        //TEST_CASE(platformPlatformFile);
+        TEST_CASE(platformPlatformFile);
         TEST_CASE(platformUnknown);
         TEST_CASE(plistEmpty);
         TEST_CASE(plistDoesNotExist);
@@ -950,17 +950,14 @@ private:
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
     }
 
-    /*
-       // TODO: the file is not found because of a bug in the lookup code
-       void platformPlatformFile() {
+    void platformPlatformFile() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--platform=avr8", "file.cpp"};
         ASSERT(settings.platform(Settings::Unspecified));
-        TODO_ASSERT_EQUALS(true, false, defParser.parseFromArgs(3, argv));
-        TODO_ASSERT_EQUALS(Settings::PlatformFile, Settings::Unspecified, settings.platformType);
-        TODO_ASSERT_EQUALS("cppcheck: error: unrecognized platform: \"avr8\".\n", "", GET_REDIRECT_OUTPUT);
-       }
-     */
+        ASSERT_EQUALS(true, defParser.parseFromArgs(3, argv));
+        ASSERT_EQUALS(Settings::PlatformFile, settings.platformType);
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
 
     void platformUnknown() {
         REDIRECT;

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -115,7 +115,9 @@ private:
         TEST_CASE(platformWin32A);
         TEST_CASE(platformWin32W);
         TEST_CASE(platformUnix32);
+        TEST_CASE(platformUnix32Unsigned);
         TEST_CASE(platformUnix64);
+        TEST_CASE(platformUnix64Unsigned);
         TEST_CASE(platformNative);
         TEST_CASE(platformUnspecified);
         //TEST_CASE(platformPlatformFile);
@@ -903,12 +905,30 @@ private:
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
     }
 
+    void platformUnix32Unsigned() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--platform=unix32-unsigned", "file.cpp"};
+        ASSERT(settings.platform(Settings::Unspecified));
+        ASSERT(defParser.parseFromArgs(3, argv));
+        ASSERT(settings.platformType == Settings::Unix32);
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
+
     void platformUnix64() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--platform=unix64", "file.cpp"};
         ASSERT(settings.platform(Settings::Unspecified));
         ASSERT(defParser.parseFromArgs(3, argv));
         ASSERT_EQUALS(Settings::Unix64, settings.platformType);
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
+
+    void platformUnix64Unsigned() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--platform=unix64-unsigned", "file.cpp"};
+        ASSERT(settings.platform(Settings::Unspecified));
+        ASSERT(defParser.parseFromArgs(3, argv));
+        ASSERT(settings.platformType == Settings::Unix64);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
     }
 


### PR DESCRIPTION
Extracted from #4325.

This is the first step in getting rid of hard-coded platforms and should have no effect at all beside making it consistent (and uncovering issues).