### PR TITLE
mitigated some clang-tidy warnings in headers

### DIFF
--- a/cli/processexecutor.h
+++ b/cli/processexecutor.h
@@ -39,7 +39,7 @@ class ProcessExecutor : public Executor {
 public:
     ProcessExecutor(const std::map<std::string, std::size_t> &files, Settings &settings, ErrorLogger &errorLogger);
     ProcessExecutor(const ProcessExecutor &) = delete;
-    ~ProcessExecutor();
+    ~ProcessExecutor() override;
     void operator=(const ProcessExecutor &) = delete;
 
     unsigned int check() override;

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -41,7 +41,7 @@ class ThreadExecutor : public Executor {
 public:
     ThreadExecutor(const std::map<std::string, std::size_t> &files, Settings &settings, ErrorLogger &errorLogger);
     ThreadExecutor(const ThreadExecutor &) = delete;
-    ~ThreadExecutor();
+    ~ThreadExecutor() override;
     void operator=(const ThreadExecutor &) = delete;
 
     unsigned int check() override;

--- a/gui/checkthread.h
+++ b/gui/checkthread.h
@@ -95,6 +95,7 @@ signals:
      */
     void done();
 
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void fileChecked(const QString &file);
 protected:
 

--- a/gui/codeeditstylecontrols.h
+++ b/gui/codeeditstylecontrols.h
@@ -40,6 +40,7 @@ public:
     const QColor& getColor();
 
 signals:
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void colorChanged(const QColor& newColor);
 
 public slots:
@@ -61,6 +62,7 @@ public:
     const QFont::Weight& getWeight();
 
 signals:
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void weightChanged(const QFont::Weight& newWeight);
 
 public slots:

--- a/gui/erroritem.h
+++ b/gui/erroritem.h
@@ -102,6 +102,7 @@ public:
     static bool sameCID(const ErrorItem &errorItem1, const ErrorItem &errorItem2);
 };
 
+// NOLINTNEXTLINE(performance-no-int-to-ptr)
 Q_DECLARE_METATYPE(ErrorItem)
 
 /**

--- a/gui/resultstree.h
+++ b/gui/resultstree.h
@@ -188,6 +188,7 @@ signals:
      *
      * @param hidden true if there are some hidden results, or false if there are not
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void resultsHidden(bool hidden);
 
     /**
@@ -195,6 +196,7 @@ signals:
      *
      * @param selectedItems list of selected files
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void checkSelected(QStringList selectedItems);
 
     /**
@@ -202,9 +204,11 @@ signals:
      *
      * @param current Model index to specify new selected item.
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void treeSelectionChanged(const QModelIndex &current);
 
     /** Suppress Ids */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void suppressIds(QStringList ids);
 
 public slots:

--- a/gui/resultsview.h
+++ b/gui/resultsview.h
@@ -212,6 +212,7 @@ signals:
      *
      * @param hidden true if there are some hidden results, or false if there are not
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void resultsHidden(bool hidden);
 
     /**
@@ -219,9 +220,11 @@ signals:
      *
      * @param selectedFilesList list of selected files
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void checkSelected(QStringList selectedFilesList);
 
     /** Suppress Ids */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void suppressIds(QStringList ids);
 
     /**
@@ -231,6 +234,7 @@ signals:
      * @param type Type of error to show/hide
      * @param show Should specified errors be shown (true) or hidden (false)
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void showResults(ShowTypes::ShowType type, bool show);
 
     /**
@@ -239,6 +243,7 @@ signals:
      *
      * @param show Should specified errors be shown (true) or hidden (false)
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void showCppcheckResults(bool show);
 
     /**
@@ -247,6 +252,7 @@ signals:
      *
      * @param show Should specified errors be shown (true) or hidden (false)
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void showClangResults(bool show);
 
     /**

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -184,8 +184,10 @@ signals:
      */
     void done();
 
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void log(const QString &msg);
 
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void debugError(const ErrorItem &item);
 
 public slots:

--- a/gui/threadresult.h
+++ b/gui/threadresult.h
@@ -93,6 +93,7 @@ signals:
      * @param value Current progress
      * @param description Description of the current stage
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void progress(int value, const QString& description);
 
     /**
@@ -100,6 +101,7 @@ signals:
      *
      * @param item Error data
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void error(const ErrorItem &item);
 
     /**
@@ -107,6 +109,7 @@ signals:
      *
      * @param logline Log line
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void log(const QString &logline);
 
     /**
@@ -114,6 +117,7 @@ signals:
      *
      * @param item Error data
      */
+    // NOLINTNEXTLINE(readability-inconsistent-declaration-parameter-name) - caused by generated MOC code
     void debugError(const ErrorItem &item);
 
 protected:

--- a/lib/check.h
+++ b/lib/check.h
@@ -26,6 +26,7 @@
 
 #include <list>
 #include <string>
+#include <utility>
 
 namespace tinyxml2 {
     class XMLElement;
@@ -61,8 +62,8 @@ public:
     explicit Check(const std::string &aname);
 
     /** This constructor is used when running checks. */
-    Check(const std::string &aname, const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
-        : mTokenizer(tokenizer), mSettings(settings), mErrorLogger(errorLogger), mName(aname) {}
+    Check(std::string aname, const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
+        : mTokenizer(tokenizer), mSettings(settings), mErrorLogger(errorLogger), mName(std::move(aname)) {}
 
     virtual ~Check() {
         if (!mTokenizer)

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -31,6 +31,7 @@
 #include <list>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 class Function;
@@ -57,7 +58,7 @@ namespace CTU {
         struct Location {
             Location() = default;
             Location(const Tokenizer *tokenizer, const Token *tok);
-            Location(const std::string &fileName, nonneg int lineNumber, nonneg int column) : fileName(fileName), lineNumber(lineNumber), column(column) {}
+            Location(std::string fileName, nonneg int lineNumber, nonneg int column) : fileName(std::move(fileName)), lineNumber(lineNumber), column(column) {}
             std::string fileName;
             nonneg int lineNumber{};
             nonneg int column{};
@@ -65,7 +66,7 @@ namespace CTU {
 
         struct UnsafeUsage {
             UnsafeUsage() = default;
-            UnsafeUsage(const std::string &myId, nonneg int myArgNr, const std::string &myArgumentName, const Location &location, MathLib::bigint value) : myId(myId), myArgNr(myArgNr), myArgumentName(myArgumentName), location(location), value(value) {}
+            UnsafeUsage(std::string myId, nonneg int myArgNr, std::string myArgumentName, Location location, MathLib::bigint value) : myId(std::move(myId)), myArgNr(myArgNr), myArgumentName(std::move(myArgumentName)), location(std::move(location)), value(value) {}
             std::string myId;
             nonneg int myArgNr{};
             std::string myArgumentName;
@@ -77,8 +78,8 @@ namespace CTU {
         class CallBase {
         public:
             CallBase() = default;
-            CallBase(const std::string &callId, int callArgNr, const std::string &callFunctionName, const Location &loc)
-                : callId(callId), callArgNr(callArgNr), callFunctionName(callFunctionName), location(loc)
+            CallBase(std::string callId, int callArgNr, std::string callFunctionName, Location loc)
+                : callId(std::move(callId)), callArgNr(callArgNr), callFunctionName(std::move(callFunctionName)), location(std::move(loc))
             {}
             CallBase(const Tokenizer *tokenizer, const Token *callToken);
             virtual ~CallBase() {}
@@ -107,9 +108,9 @@ namespace CTU {
         public:
             NestedCall() = default;
 
-            NestedCall(const std::string &myId, nonneg int myArgNr, const std::string &callId, nonneg int callArgnr, const std::string &callFunctionName, const Location &location)
+            NestedCall(std::string myId, nonneg int myArgNr, const std::string &callId, nonneg int callArgnr, const std::string &callFunctionName, const Location &location)
                 : CallBase(callId, callArgnr, callFunctionName, location),
-                myId(myId),
+                myId(std::move(myId)),
                 myArgNr(myArgNr) {}
 
             NestedCall(const Tokenizer *tokenizer, const Function *myFunction, const Token *callToken);

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <list>
 #include <string>
+#include <utility>
 #include <vector>
 
 /**
@@ -72,8 +73,8 @@ public:
         FileLocation(const std::string &file, int line, unsigned int column)
             : fileIndex(0), line(line), column(column), mOrigFileName(file), mFileName(file) {}
 
-        FileLocation(const std::string &file, const std::string &info, int line, unsigned int column)
-            : fileIndex(0), line(line), column(column), mOrigFileName(file), mFileName(file), mInfo(info) {}
+        FileLocation(const std::string &file, std::string info, int line, unsigned int column)
+            : fileIndex(0), line(line), column(column), mOrigFileName(file), mFileName(file), mInfo(std::move(info)) {}
 
         FileLocation(const Token* tok, const TokenList* tokenList);
         FileLocation(const Token* tok, std::string info, const TokenList* tokenList);

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 class Token;
 class Settings;
@@ -66,7 +67,7 @@ struct ProgramMemory {
 
     ProgramMemory() = default;
 
-    explicit ProgramMemory(const Map& values) : mValues(values) {}
+    explicit ProgramMemory(Map values) : mValues(std::move(values)) {}
 
     void setValue(const Token* expr, const ValueFlow::Value& value);
     const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -27,6 +27,7 @@
 #include <istream>
 #include <list>
 #include <string>
+#include <utility>
 #include <vector>
 
 /// @addtogroup Core
@@ -57,7 +58,7 @@ public:
         Suppression(const Suppression &other) {
             *this = other;
         }
-        Suppression(const std::string &id, const std::string &file, int line=NO_LINE) : errorId(id), fileName(file), lineNumber(line), hash(0), thisAndNextLine(false), matched(false), checked(false) {}
+        Suppression(std::string id, std::string file, int line=NO_LINE) : errorId(std::move(id)), fileName(std::move(file)), lineNumber(line), hash(0), thisAndNextLine(false), matched(false), checked(false) {}
 
         Suppression & operator=(const Suppression &other) {
             errorId = other.errorId;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1304,7 +1304,7 @@ public:
         containerTypeToken(nullptr),
         debugPath()
     {}
-    ValueType(enum Sign s, enum Type t, nonneg int p, nonneg int c, const std::string& otn)
+    ValueType(enum Sign s, enum Type t, nonneg int p, nonneg int c, std::string otn)
         : sign(s),
         type(t),
         bits(0),
@@ -1316,7 +1316,7 @@ public:
         smartPointer(nullptr),
         container(nullptr),
         containerTypeToken(nullptr),
-        originalTypeName(otn),
+        originalTypeName(std::move(otn)),
         debugPath()
     {}
 

--- a/lib/token.h
+++ b/lib/token.h
@@ -59,7 +59,7 @@ struct TokensFrontBack {
 };
 
 struct ScopeInfo2 {
-    ScopeInfo2(const std::string &name_, const Token *bodyEnd_, const std::set<std::string> &usingNamespaces_ = std::set<std::string>()) : name(name_), bodyEnd(bodyEnd_), usingNamespaces(usingNamespaces_) {}
+    ScopeInfo2(std::string name_, const Token *bodyEnd_, std::set<std::string> usingNamespaces_ = std::set<std::string>()) : name(std::move(name_)), bodyEnd(bodyEnd_), usingNamespaces(std::move(usingNamespaces_)) {}
     std::string name;
     const Token * const bodyEnd;
     std::set<std::string> usingNamespaces;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3348,7 +3348,7 @@ void Tokenizer::calculateScopes()
         tok->scopeInfo(nullptr);
 
     std::string nextScopeNameAddition;
-    std::shared_ptr<ScopeInfo2> primaryScope = std::make_shared<ScopeInfo2>(emptyString, nullptr);
+    std::shared_ptr<ScopeInfo2> primaryScope = std::make_shared<ScopeInfo2>("", nullptr);
     list.front()->scopeInfo(primaryScope);
 
     for (Token* tok = list.front(); tok; tok = tok->next()) {

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -116,6 +116,7 @@ public:
     const Token *front() const {
         return mTokensFrontBack.front;
     }
+    // NOLINTNEXTLINE(readability-make-member-function-const) - do not allow usage of mutable pointer from const object
     Token *front() {
         return mTokensFrontBack.front;
     }
@@ -124,6 +125,7 @@ public:
     const Token *back() const {
         return mTokensFrontBack.back;
     }
+    // NOLINTNEXTLINE(readability-make-member-function-const) - do not allow usage of mutable pointer from const object
     Token *back() {
         return mTokensFrontBack.back;
     }

--- a/test/testutils.h
+++ b/test/testutils.h
@@ -30,6 +30,7 @@
 #include <list>
 #include <sstream> // IWYU pragma: keep
 #include <string>
+#include <utility>
 
 class Token;
 
@@ -72,7 +73,7 @@ private:
 
 class ScopedFile {
 public:
-    ScopedFile(const std::string &name, const std::string &content) : mName(name) {
+    ScopedFile(std::string name, const std::string &content) : mName(std::move(name)) {
         std::ofstream of(mName);
         of << content;
     }


### PR DESCRIPTION
Unfortunately we still cannot enable the headers - see #5189 for more details.

The `modernize-pass-by-value` fixes possibly allow for more unnecessary copies to be eliminated but I was only able to review a part of the usage of those constructors.