### PR TITLE
lib/sourcelocation.h: add missing <cstdint> include

### DIFF
--- a/lib/sourcelocation.h
+++ b/lib/sourcelocation.h
@@ -45,6 +45,7 @@ using SourceLocation = std::source_location;
 #include <experimental/source_location>
 using SourceLocation = std::experimental::source_location;
 #else
+#include <cstdint>
 struct SourceLocation {
     static SourceLocation current() {
         return SourceLocation();


### PR DESCRIPTION
Without the change build on upcoming gcc-13 fails as:

    In file included from lib/symboldatabase.h:28,
                     from lib/astutils.h:36,
                     from test/testastutils.cpp:20:
    lib/sourcelocation.h:52:10: error: 'uint_least32_t' in namespace 'std' does not name a type
       52 |     std::uint_least32_t m_line = 0;
          |          ^~~~~~~~~~~~~~