### PR TITLE
Fix the release function in the ValuePtr class

### DIFF
--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -52,7 +52,7 @@ public:
         }
     }
     ValuePtr(ValuePtr&& rhs) : mPtr(std::move(rhs.mPtr)), mClone(std::move(rhs.mClone)) {}
-    
+
     /**
      * Releases the shared_ptr's ownership of the managed object using the .reset() function
      */

--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -54,7 +54,7 @@ public:
     ValuePtr(ValuePtr&& rhs) : mPtr(std::move(rhs.mPtr)), mClone(std::move(rhs.mClone)) {}
 
     void release() {
-        return mPtr.reset();
+        mPtr.reset();
     }
 
     T* get() NOEXCEPT {

--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -53,8 +53,8 @@ public:
     }
     ValuePtr(ValuePtr&& rhs) : mPtr(std::move(rhs.mPtr)), mClone(std::move(rhs.mClone)) {}
 
-    pointer release() {
-        return mPtr.release();
+    void release() {
+        return mPtr.reset();
     }
 
     T* get() NOEXCEPT {

--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -52,7 +52,10 @@ public:
         }
     }
     ValuePtr(ValuePtr&& rhs) : mPtr(std::move(rhs.mPtr)), mClone(std::move(rhs.mClone)) {}
-
+    
+    /**
+     * Releases the shared_ptr's ownership of the managed object using the .reset() function
+     */
     void release() {
         mPtr.reset();
     }


### PR DESCRIPTION
A shared_ptr object does not have .release() member function, therefore .reset() should be used instead. More information on [https://en.cppreference.com/w/cpp/memory/shared_ptr](url).
We encountered the following error message when inspecting this file:

```
"c:\cppcheck-after\lib\valueptr.h", line 57: error: class "std::shared_ptr<Analyzer>" has no member "release"
          return mPtr.release();
                      ^
          detected during instantiation of "ValuePtr<T>::pointer ValuePtr<T>::release() [with T=Analyzer]" 

```