### PR TITLE
New check: throw keyword is missing

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -322,7 +322,7 @@ void CheckExceptionSafety::unhandledExceptionSpecification()
     const SymbolDatabase* const symbolDatabase = mTokenizer->getSymbolDatabase();
 
     for (const Scope * scope : symbolDatabase->functionScopes) {
-        // only check functions without exception epecification
+        // only check functions without exception specification
         if (scope->function && !scope->function->isThrow() &&
             scope->className != "main" && scope->className != "wmain" &&
             scope->className != "_tmain" && scope->className != "WinMain") {
@@ -398,21 +398,25 @@ void CheckExceptionSafety::rethrowNoCurrentExceptionError(const Token *tok)
 void CheckExceptionSafety::throwIsMissing()
 {
     static const std::unordered_set<std::string> stdExceptions{"exception",
-        "logic_error", "domain_error", "invalid_argument", "length_error", "out_of_range", "future_error",
-        "runtime_error", "range_error", "overflow_error", "underflow_error", "regex_error", "system_error",
-        "bad_typeid", "bad_cast", "bad_optional_access", "bad_expected_access", "bad_weak_ptr",
-        "bad_function_call", "bad_alloc", "bad_array_new_length", "bad_exception",
-        "ios_base::failure", "filesystem::filesystem_error", "bad_variant_access"};
+                                                               "logic_error", "domain_error", "invalid_argument", "length_error", "out_of_range", "future_error",
+                                                               "runtime_error", "range_error", "overflow_error", "underflow_error", "regex_error", "system_error",
+                                                               "bad_typeid", "bad_cast", "bad_optional_access", "bad_expected_access", "bad_weak_ptr",
+                                                               "bad_function_call", "bad_alloc", "bad_array_new_length", "bad_exception",
+                                                               "ios_base::failure", "filesystem::filesystem_error", "bad_variant_access"};
 
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
     for (const Scope *scope : symbolDatabase->functionScopes) {
         for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
             if (Token::simpleMatch(tok, "std ::")) {
-                const Token* tokException = tok->tokAt(2);
+                const Token* const tokException = tok->tokAt(2);
                 const bool isException = stdExceptions.find(tokException->str()) != stdExceptions.end();
                 if (isException && Token::simpleMatch(tokException->next(), "(")) {
+                    const Token* const topTok = tokException->astTop();
                     // "(" for nameless exception object; "?" for ternary operator w/o "throw" keyword
-                    if (Token::Match(tokException->astTop(), "(|?")) {
+                    if (Token::simpleMatch(topTok, "(") && topTok == tokException->next()) {
+                        throwIsMissingError(tok);
+                    }
+                    if (Token::simpleMatch(topTok, "?")) {
                         throwIsMissingError(tok);
                     }
                     tok = tokException->next()->link();

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -36,6 +36,7 @@ class Token;
 static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
 static const struct CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
 static const struct CWE CWE480(480U);   // Use of Incorrect Operator
+static const struct CWE CWE390(390U);   // Detection of Error Condition Without Action
 
 
 /// @addtogroup Checks
@@ -71,6 +72,7 @@ public:
         checkExceptionSafety.nothrowThrows();
         checkExceptionSafety.unhandledExceptionSpecification();
         checkExceptionSafety.rethrowNoCurrentException();
+        checkExceptionSafety.throwIsMissing();
     }
 
     /** Don't throw exceptions in destructors */
@@ -94,6 +96,9 @@ public:
     /** @brief %Check for rethrow not from catch scope */
     void rethrowNoCurrentException();
 
+    /** @brief %throw keyword is missing */
+    void throwIsMissing();
+
 private:
     /** Don't throw exceptions in destructors */
     void destructorsError(const Token * const tok, const std::string &className);
@@ -105,6 +110,7 @@ private:
     void unhandledExceptionSpecificationError(const Token * const tok1, const Token * const tok2, const std::string & funcname);
     /** Rethrow without currently handled exception */
     void rethrowNoCurrentExceptionError(const Token *tok);
+    void throwIsMissingError(const Token *tok);
 
     /** Generate all possible errors (for --errorlist) */
     void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const override {
@@ -116,6 +122,7 @@ private:
         c.noexceptThrowError(nullptr);
         c.unhandledExceptionSpecificationError(nullptr, nullptr, "funcname");
         c.rethrowNoCurrentExceptionError(nullptr);
+        c.throwIsMissingError(nullptr);
     }
 
     /** Short description of class (for --doc) */
@@ -132,7 +139,8 @@ private:
                "- Exception caught by value instead of by reference\n"
                "- Throwing exception in noexcept, nothrow(), __attribute__((nothrow)) or __declspec(nothrow) function\n"
                "- Unhandled exception specification when calling function foo()\n"
-               "- Rethrow without currently handled exception\n";
+               "- Rethrow without currently handled exception\n"
+               "- throw keyword is missing\n";
     }
 };
 /// @}

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -60,6 +60,7 @@ private:
         TEST_CASE(throwIsMissing3);
         TEST_CASE(throwIsMissing4);
         TEST_CASE(throwIsMissing5);
+        TEST_CASE(throwIsMissing6);
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -439,35 +440,47 @@ private:
 
     void throwIsMissing1() {
         check("void func1(const bool b) {\n"
-              "  if (b) { std::invalid_argument(\"True\"); }\n"
+              "   if (b) {\n"
+              "         std::invalid_argument(\"True\");\n"
+              "   }\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:2]: (error) 'throw' keyword is missing\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (error) 'throw' keyword is missing\n", errout.str());
     }
 
     void throwIsMissing2() {
         check("void func1(const bool b) {\n"
-              "  (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
+              "   (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
               "}");
         ASSERT_EQUALS("[test.cpp:2]: (error) 'throw' keyword is missing\n", errout.str());
     }
 
     void throwIsMissing3() {
         check("void func1(const bool b) {\n"
-              "  const auto ex = (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
-              "  throw ex;\n"
+              "   const auto ex = (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
+              "   throw ex;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }
 
     void throwIsMissing4() {
         check("void func1() {\n"
-              "  throw std::logic_error(\"b\");\n"
+              "   throw std::logic_error(\"b\");\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }
 
     void throwIsMissing5() {
         check("struct MyExcept : std::exception {};\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void throwIsMissing6() {
+        check("void notify(const std::exception& ex) {\n"
+              "   throw ex;\n"
+              "}\n"
+              "void func1() {\n"
+              "   notify(std::logic_error(\"b\"));\n"
+              "}");
         ASSERT_EQUALS("", errout.str());
     }
 };

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -55,6 +55,11 @@ private:
         TEST_CASE(rethrowNoCurrentException1);
         TEST_CASE(rethrowNoCurrentException2);
         TEST_CASE(rethrowNoCurrentException3);
+        TEST_CASE(throwIsMissing1);
+        TEST_CASE(throwIsMissing2);
+        TEST_CASE(throwIsMissing3);
+        TEST_CASE(throwIsMissing4);
+        TEST_CASE(throwIsMissing5);
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -429,6 +434,40 @@ private:
         check("void on_error() { try { throw; } catch (const int &) { ; } catch (...) { ; } }\n"      // exception dispatcher idiom
               "void func2() { try{ ; } catch (const int&) { throw; } ; }\n"
               "void func3() { throw 0; }");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void throwIsMissing1() {
+        check("void func1(const bool b) {\n"
+              "  if (b) { std::invalid_argument(\"True\"); }\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (error) 'throw' keyword is missing\n", errout.str());
+    }
+
+    void throwIsMissing2() {
+        check("void func1(const bool b) {\n"
+              "  (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:2]: (error) 'throw' keyword is missing\n", errout.str());
+    }
+
+    void throwIsMissing3() {
+        check("void func1(const bool b) {\n"
+              "  const auto ex = (b != true) ? std::runtime_error(\"a\") : std::runtime_error(\"b\");\n"
+              "  throw ex;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void throwIsMissing4() {
+        check("void func1() {\n"
+              "  throw std::logic_error(\"b\");\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void throwIsMissing5() {
+        check("struct MyExcept : std::exception {};\n");
         ASSERT_EQUALS("", errout.str());
     }
 };


### PR DESCRIPTION
This check are trying to detect std exceptions which was not thrown. Took idea from [PVS](https://pvs-studio.com/en/docs/warnings/v596/); their [finds](https://pvs-studio.com/en/blog/examples/v596/)

Unfortunately I met couple of limitations which limits the detection power.
1. Making a general check seems a complex problem, seems we can't detect an STL types automatically, correct me if I wrong; pattern `”%type% ( $ArgsSkipper ) ;"` could help but could produce FP or have an (over)complicated logic.

2. That's looks like a bug, actually. If we put `using namespace std;`, `std` won't be added for type name, but if we have a named object `std` will be added before type name (or my observations was skewed)