### PR TITLE
fix #10159 - donate-cpu: collect and avoid packages with no files to process

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.31"
+SERVER_VERSION = "1.3.32"
 
 OLD_VERSION = '2.9'
 

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1258,6 +1258,9 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 continue
 
             pos = data.find('\n')
+            if pos == -1:
+                print_ts('No newline found in data. Ignoring no-data data.')
+                continue
             if pos < 10:
                 print_ts('Data is less than 10 characters ({}). Ignoring no-data data.'.format(pos))
                 continue

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1253,10 +1253,13 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 print_ts('getPackageIdx: index is out of range')
             continue
         elif cmd.startswith('write_nodata\nftp://'):
-            data = cmd[cmd.find('\n') + 1:]
+            print(cmd)
+            data = cmd[pos_nl + 1:]
             pos = data.find('\n')
             if pos < 10:
-                print_ts('Data is less than 10 characters. Ignoring no-data data.')
+                # TODO: need to read until the second \n
+                # ftp://ftp.de.debian.org/debian/pool/main/a/android-platform-external-doclava/android-platform-external-doclava_9.0.0+r42.orig.tar.xz
+                print_ts('Data is less than 10 characters ({}). Ignoring no-data data.'.format(pos))
                 continue
             url = data[:pos]
 

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1266,7 +1266,9 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 if packages[currentIdx] == url:
                     packages[currentIdx] = None
                     print_ts('write_nodata:' + url)
-                    # TODO: persist package
+
+                    with open('packages_nodata.txt', 'at') as f:
+                        f.write(url + '\n')
                     break
                 if currentIdx == 0:
                     currentIdx = len(packages) - 1
@@ -1303,7 +1305,31 @@ if __name__ == "__main__":
     with open('packages.txt', 'rt') as f:
         packages = [val.strip() for val in f.readlines()]
 
-    print_ts('packages: ' + str(len(packages)))
+    print_ts('packages: {}'.format(len(packages)))
+
+    if os.path.isfile('packages_nodata.txt'):
+        with open('packages_nodata.txt', 'rt') as f:
+            packages_nodata = [val.strip() for val in f.readlines()]
+            packages_nodata.sort()
+
+        print_ts('packages_nodata: {}'.format(len(packages_nodata)))
+
+        print_ts('removing packages with no files to process'.format(len(packages_nodata)))
+        packages_nodata_clean = []
+        for pkg_n in packages_nodata:
+            if pkg_n in packages:
+                packages.remove(pkg_n)
+                packages_nodata_clean.append(pkg_n)
+
+        packages_nodata_diff = len(packages_nodata) - len(packages_nodata_clean)
+        if packages_nodata_diff:
+            with open('packages_nodata.txt', 'wt') as f:
+                for pkg in packages_nodata_clean:
+                    f.write(pkg + '\n')
+
+            print_ts('removed {} packages from packages_nodata.txt'.format(packages_nodata_diff))
+
+        print_ts('packages: {}'.format(len(packages)))
 
     if len(packages) == 0:
         print_ts('fatal: there are no packages')

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1253,12 +1253,12 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 print_ts('getPackageIdx: index is out of range')
             continue
         elif cmd.startswith('write_nodata\nftp://'):
-            print(cmd)
-            data = cmd[pos_nl + 1:]
+            data = read_data(connection, cmd, pos_nl, max_data_size=8 * 1024, check_done=False, cmd_name='write_nodata')
+            if data is None:
+                continue
+
             pos = data.find('\n')
             if pos < 10:
-                # TODO: need to read until the second \n
-                # ftp://ftp.de.debian.org/debian/pool/main/a/android-platform-external-doclava/android-platform-external-doclava_9.0.0+r42.orig.tar.xz
                 print_ts('Data is less than 10 characters ({}). Ignoring no-data data.'.format(pos))
                 continue
             url = data[:pos]

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1250,8 +1250,15 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 print_ts('getPackageIdx: index is out of range')
             continue
         elif cmd.startswith('write_nodata\nftp://'):
+            data = cmd[cmd.find('\n') + 1:]
+            pos = data.find('\n')
+            if pos < 10:
+                print_ts('Data is less than 10 characters. Ignoring no-data data.')
+                continue
+            url = data[:pos]
+
             connection.close()
-            print_ts('write_nodata')
+            print_ts('write_nodata:' + url)
         else:
             if pos_nl < 0:
                 print_ts('invalid command: "' + firstLine + '"')

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1249,6 +1249,9 @@ def server(server_address_port: int, packages: list, packageIndex: int, resultPa
                 connection.close()
                 print_ts('getPackageIdx: index is out of range')
             continue
+        elif cmd.startswith('write_nodata\nftp://'):
+            connection.close()
+            print_ts('write_nodata')
         else:
             if pos_nl < 0:
                 print_ts('invalid command: "' + firstLine + '"')

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -219,6 +219,8 @@ while True:
     if not source_found:
         print("No files to process")
         lib.upload_nodata(package)
+        print('Sleep 5 seconds..')
+        time.sleep(5)
         continue
     crash = False
     timeout = False

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -218,6 +218,7 @@ while True:
     source_path, source_found = lib.unpack_package(work_path, tgz, skip_files=skip_files)
     if not source_found:
         print("No files to process")
+        lib.upload_nodata(package)
         continue
     crash = False
     timeout = False

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.38"
+CLIENT_VERSION = "1.3.39"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -597,7 +597,7 @@ def upload_results(package, results):
     try:
         try_retry(__upload, fargs=('write\n' + package, results + '\nDONE', 'Result'), max_tries=4, sleep_duration=30, sleep_factor=1)
     except Exception as e:
-        print('Result upload permanently failed ({})!'.format(e))
+        print('Result upload failed ({})!'.format(e))
         return False
 
     return True
@@ -612,7 +612,17 @@ def upload_info(package, info_output):
     try:
         try_retry(__upload, fargs=('write_info\n' + package, info_output + '\nDONE', 'Information'), max_tries=3, sleep_duration=30, sleep_factor=1)
     except Exception as e:
-        print('Information upload permanently failed ({})!'.format(e))
+        print('Information upload failed ({})!'.format(e))
+        return False
+
+    return True
+
+def upload_nodata(package):
+    print('Uploading no-data status..')
+    try:
+        try_retry(__upload, fargs=('write_nodata\n' + package, '', 'No-data status'), max_tries=3, sleep_duration=30, sleep_factor=1)
+    except Exception as e:
+        print('No-data upload failed ({})!'.format(e))
         return False
 
     return True


### PR DESCRIPTION
This stores the list of packages which do not contain any files to process on the server so we don't keep handing them out.