### PR TITLE
coverage.yml: updated `codecov/codecov-action` to `v3`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,7 @@ jobs:
          name: Coverage results
          path: coverage_report
          
-      - uses: codecov/codecov-action@v1.2.1
+      - uses: codecov/codecov-action@v3
         with:
           # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           # file: ./coverage.xml # optional


### PR DESCRIPTION
`v1` has been deprecated and is considered "no longer function[ing]" since February - see https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1