### PR TITLE
std.cfg std exception types added to unusedvars section

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8669,16 +8669,41 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <suppress>std::unique_lock</suppress>
       <suppress>std::shared_lock</suppress>
       <suppress>std::fstream</suppress>
-      <suppress>std::wfstream</suppress>      
+      <suppress>std::wfstream</suppress>
       <suppress>std::ofstream</suppress>
       <suppress>std::wofstream</suppress>
       <suppress>std::basic_fstream</suppress>
-      <suppress>std::basic_ofstream</suppress>      
+      <suppress>std::basic_ofstream</suppress>
       <check>std::pair</check>
+      <check>std::exception</check>
+      <check>std::logic_error</check>
+      <check>std::domain_error</check>
+      <check>std::invalid_argument</check>
+      <check>std::length_error</check>
+      <check>std::out_of_range</check>
+      <check>std::future_error</check>
+      <check>std::runtime_error</check>
+      <check>std::range_error</check>
+      <check>std::overflow_error</check>
+      <check>std::underflow_error</check>
+      <check>std::regex_error</check>
+      <check>std::system_error</check>
+      <check>std::bad_typeid</check>
+      <check>std::bad_cast</check>
+      <check>std::bad_optional_access</check>
+      <check>std::bad_expected_access</check>
+      <check>std::bad_weak_ptr</check>
+      <check>std::bad_function_call</check>
+      <check>std::bad_alloc</check>
+      <check>std::bad_array_new_length</check>
+      <check>std::bad_exception</check>
+      <check>std::ios_base::failure</check>
+      <check>std::filesystem::filesystem_error</check>
+      <check>std::bad_variant_access</check>
     </unusedvar>
     <operatorEqVarError>
       <suppress>std::mutex</suppress>
-      <suppress>std::recursive_mutex</suppress>    
+      <suppress>std::recursive_mutex</suppress>
     </operatorEqVarError>
   </type-checks>
   <podtype name="char8_t,std::char8_t" sign="u" size="1"/>


### PR DESCRIPTION
As we discussed in #4495 with @chrchr-github, re-implemented it cfg file