### PR TITLE
cppcheck.cpp: only call `getFileInfo()` if necessary

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -971,8 +971,10 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         mExitCode=1; // e.g. reflect a syntax error
     }
 
-    mAnalyzerInformation.setFileInfo("CheckUnusedFunctions", checkUnusedFunctions.analyzerInfo());
-    mAnalyzerInformation.close();
+    if (!mSettings.buildDir.empty()) {
+        mAnalyzerInformation.setFileInfo("CheckUnusedFunctions", checkUnusedFunctions.analyzerInfo());
+        mAnalyzerInformation.close();
+    }
 
     // In jointSuppressionReport mode, unmatched suppressions are
     // collected after all files are processed
@@ -1044,14 +1046,16 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
     CTU::FileInfo *fi1 = CTU::getFileInfo(&tokenizer);
     if (fi1) {
         mFileInfo.push_back(fi1);
-        mAnalyzerInformation.setFileInfo("ctu", fi1->toString());
+        if (!mSettings.buildDir.empty())
+            mAnalyzerInformation.setFileInfo("ctu", fi1->toString());
     }
 
     for (const Check *check : Check::instances()) {
         Check::FileInfo *fi = check->getFileInfo(&tokenizer, &mSettings);
         if (fi != nullptr) {
             mFileInfo.push_back(fi);
-            mAnalyzerInformation.setFileInfo(check->name(), fi->toString());
+            if (!mSettings.buildDir.empty())
+                mAnalyzerInformation.setFileInfo(check->name(), fi->toString());
         }
     }
 
@@ -1535,7 +1539,8 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (std::find(mErrorList.begin(), mErrorList.end(), errmsg) != mErrorList.end())
         return;
 
-    mAnalyzerInformation.reportErr(msg, mSettings.verbose);
+    if (!mSettings.buildDir.empty())
+        mAnalyzerInformation.reportErr(msg, mSettings.verbose);
 
     const Suppressions::ErrorMessage errorMessage = msg.toSuppressionsErrorMessage();
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1045,7 +1045,8 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
 
     CTU::FileInfo *fi1 = CTU::getFileInfo(&tokenizer);
     if (fi1) {
-        mFileInfo.push_back(fi1);
+        if (mSettings.jobs == 1)
+            mFileInfo.push_back(fi1);
         if (!mSettings.buildDir.empty())
             mAnalyzerInformation.setFileInfo("ctu", fi1->toString());
     }
@@ -1053,7 +1054,8 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
     for (const Check *check : Check::instances()) {
         Check::FileInfo *fi = check->getFileInfo(&tokenizer, &mSettings);
         if (fi != nullptr) {
-            mFileInfo.push_back(fi);
+            if (mSettings.jobs == 1)
+                mFileInfo.push_back(fi);
             if (!mSettings.buildDir.empty())
                 mAnalyzerInformation.setFileInfo(check->name(), fi->toString());
         }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1041,23 +1041,26 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
         // TODO: Use CTU for Clang analysis
         return;
 
-    // Analyse the tokens..
 
-    CTU::FileInfo *fi1 = CTU::getFileInfo(&tokenizer);
-    if (fi1) {
-        if (mSettings.jobs == 1)
-            mFileInfo.push_back(fi1);
-        if (!mSettings.buildDir.empty())
-            mAnalyzerInformation.setFileInfo("ctu", fi1->toString());
-    }
+    if (mSettings.jobs == 1 || !mSettings.buildDir.empty()) {
+        // Analyse the tokens..
 
-    for (const Check *check : Check::instances()) {
-        Check::FileInfo *fi = check->getFileInfo(&tokenizer, &mSettings);
-        if (fi != nullptr) {
+        CTU::FileInfo *fi1 = CTU::getFileInfo(&tokenizer);
+        if (fi1) {
             if (mSettings.jobs == 1)
-                mFileInfo.push_back(fi);
+                mFileInfo.push_back(fi1);
             if (!mSettings.buildDir.empty())
-                mAnalyzerInformation.setFileInfo(check->name(), fi->toString());
+                mAnalyzerInformation.setFileInfo("ctu", fi1->toString());
+        }
+
+        for (const Check *check: Check::instances()) {
+            Check::FileInfo *fi = check->getFileInfo(&tokenizer, &mSettings);
+            if (fi != nullptr) {
+                if (mSettings.jobs == 1)
+                    mFileInfo.push_back(fi);
+                if (!mSettings.buildDir.empty())
+                    mAnalyzerInformation.setFileInfo(check->name(), fi->toString());
+            }
         }
     }
 


### PR DESCRIPTION
`mAnalyzerInformation` is only used in `CppCheck::checkFile()` if `!mSettings.buildDir.empty()`.
`mFileInfo` is only used in `CppCheck::analyseWholeProgram()` which is only called in `CppCheckExecutor::check_internal()` when `settings.jobs == 1`.

This obviously needs be to be gated away more clearly.