### PR TITLE
re-enabled valgrind in CI

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run tests
         run: ./cmake.output/bin/testrunner
 
-      # TODO: re-enable - was being killed because of increased memory usage
+      # TODO: this is currently way too slow (~60 minutes) to enable it
       # TODO: only fail the step on sanitizer issues
       - name: Self check
         if: false

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -2,8 +2,7 @@
 # Environment reference https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
 name: valgrind
 
-# on: [push, pull_request]
-on: workflow_dispatch
+on: [push, pull_request]
 
 permissions:
   contents: read


### PR DESCRIPTION
The valgrind workflow no longer experiences the package installation issues.

ASAN should have never been disabled. It being killed actually indicates excessive memory/CPU usage (this is what we experience as `-9` crashes in daca).
Edit: Turns out ASAN is way too slow to be enabled. It actually got much slower. It was once at around 20 minutes and the last time I checked it was 40 minutes but now we broke the one hour barrier. (I think we introduced another 10% Ir regression recently).