### PR TITLE
avoid returning `SmallVector` since it has sizable overhead

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -235,11 +235,12 @@ struct ReferenceToken {
     ErrorPath errors;
 };
 
-SmallVector<ReferenceToken> followAllReferences(const Token* tok,
-                                                bool temporary = true,
-                                                bool inconclusive = true,
-                                                ErrorPath errors = ErrorPath{},
-                                                int depth = 20);
+void followAllReferences(const Token* tok,
+                         SmallVectorBase<ReferenceToken>& refs_result,
+                         bool temporary = true,
+                         bool inconclusive = true,
+                         ErrorPath errors = ErrorPath{},
+                         int depth = 20);
 const Token* followReferences(const Token* tok, ErrorPath* errors = nullptr);
 
 CPPCHECKLIB bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);

--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -28,6 +28,9 @@ static constexpr std::size_t DefaultSmallVectorSize = 3;
 
 template<typename T, std::size_t N = DefaultSmallVectorSize>
 using SmallVector = boost::container::small_vector<T, N>;
+
+template<typename T>
+using SmallVectorBase = boost::container::small_vector_base<T>;
 #else
 #include <utility>
 #include <vector>
@@ -44,17 +47,20 @@ struct TaggedAllocator : std::allocator<T>
 };
 
 template<typename T, std::size_t N = DefaultSmallVectorSize>
-class SmallVector : public std::vector<T, TaggedAllocator<T, N>>
+class SmallVectorBase : public std::vector<T, TaggedAllocator<T, N>>
 {
 public:
     template<class ... Ts>
     // NOLINTNEXTLINE(google-explicit-constructor)
-    SmallVector(Ts&&... ts)
+    SmallVectorBase(Ts&&... ts)
         : std::vector<T, TaggedAllocator<T, N>>(std::forward<Ts>(ts)...)
     {
         this->reserve(N);
     }
 };
+
+template<typename T, std::size_t N = DefaultSmallVectorSize>
+using SmallVector = SmallVectorBase<T, N>;
 #endif
 
 #endif

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2827,7 +2827,8 @@ struct ValueFlowAnalyzer : Analyzer {
         if (invalid())
             return Action::Invalid;
         // Follow references
-        auto refs = followAllReferences(tok);
+        SmallVector<ReferenceToken> refs;
+        followAllReferences(tok, refs);
         const bool inconclusiveRefs = refs.size() != 1;
         if (std::none_of(refs.cbegin(), refs.cend(), [&](const ReferenceToken& ref) {
             return tok == ref.token;
@@ -4913,7 +4914,9 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase* /*db*/, Erro
             }
 
             for (const Token* tok2 : toks) {
-                for (const ReferenceToken& rt : followAllReferences(tok2, false)) {
+                SmallVector<ReferenceToken> refs;
+                followAllReferences(tok2, refs, false);
+                for (const ReferenceToken& rt : refs) {
                     ValueFlow::Value value = master;
                     value.tokvalue = rt.token;
                     value.errorPath.insert(value.errorPath.begin(), rt.errors.cbegin(), rt.errors.cend());
@@ -5566,7 +5569,8 @@ static void valueFlowForwardConst(Token* start,
         } else {
             [&] {
                 // Follow references
-                auto refs = followAllReferences(tok);
+                SmallVector<ReferenceToken> refs;
+                followAllReferences(tok, refs);
                 auto it = std::find_if(refs.cbegin(), refs.cend(), [&](const ReferenceToken& ref) {
                     return ref.token->varId() == var->declarationId();
                 });


### PR DESCRIPTION
Scanning `mame_regtest` with `--enable=all --inconclusive` and `DISABLE_VALUEFLOW=1`:

Clang 14 `2,082,292,106` -> `2,073,152,473`
Clang 14 `1,829,061,568` -> `1,766,615,436` (with Boost 1.74)