### PR TITLE
use `const_iterator` / modernized `erase()` calls

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -113,7 +113,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
 
     // Check that all include paths exist
     {
-        for (std::list<std::string>::iterator iter = settings.includePaths.begin();
+        for (std::list<std::string>::const_iterator iter = settings.includePaths.begin();
              iter != settings.includePaths.end();
              ) {
             const std::string path(Path::toNativeSeparators(*iter));

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -301,13 +301,13 @@ unsigned int ProcessExecutor::check()
             int r = select(*std::max_element(rpipes.begin(), rpipes.end()) + 1, &rfds, nullptr, nullptr, &tv);
 
             if (r > 0) {
-                std::list<int>::iterator rp = rpipes.begin();
+                std::list<int>::const_iterator rp = rpipes.begin();
                 while (rp != rpipes.end()) {
                     if (FD_ISSET(*rp, &rfds)) {
                         int readRes = handleRead(*rp, result);
                         if (readRes == -1) {
                             std::size_t size = 0;
-                            std::map<int, std::string>::iterator p = pipeFile.find(*rp);
+                            std::map<int, std::string>::const_iterator p = pipeFile.find(*rp);
                             if (p != pipeFile.end()) {
                                 std::string name = p->second;
                                 pipeFile.erase(p);
@@ -336,7 +336,7 @@ unsigned int ProcessExecutor::check()
             pid_t child = waitpid(0, &stat, WNOHANG);
             if (child > 0) {
                 std::string childname;
-                std::map<pid_t, std::string>::iterator c = childFile.find(child);
+                std::map<pid_t, std::string>::const_iterator c = childFile.find(child);
                 if (c != childFile.end()) {
                     childname = c->second;
                     childFile.erase(c);

--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -35,7 +35,7 @@
 Check::Check(const std::string &aname)
     : mTokenizer(nullptr), mSettings(nullptr), mErrorLogger(nullptr), mName(aname)
 {
-    for (std::list<Check*>::iterator i = instances().begin(); i != instances().end(); ++i) {
+    for (std::list<Check*>::const_iterator i = instances().begin(); i != instances().end(); ++i) {
         if ((*i)->name() > aname) {
             instances().insert(i, this);
             return;

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1257,7 +1257,7 @@ void CheckClass::privateFunctions()
             // Check virtual functions
             for (std::list<const Function*>::const_iterator it = privateFuncs.begin(); it != privateFuncs.end();) {
                 if ((*it)->isImplicitlyVirtual(true)) // Give true as default value to be returned if we don't see all base classes
-                    privateFuncs.erase(it++);
+                    it = privateFuncs.erase(it);
                 else
                     ++it;
             }

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1255,7 +1255,7 @@ void CheckClass::privateFunctions()
         // Bailout for overridden virtual functions of base classes
         if (!scope->definedType->derivedFrom.empty()) {
             // Check virtual functions
-            for (std::list<const Function*>::iterator it = privateFuncs.begin(); it != privateFuncs.end();) {
+            for (std::list<const Function*>::const_iterator it = privateFuncs.begin(); it != privateFuncs.end();) {
                 if ((*it)->isImplicitlyVirtual(true)) // Give true as default value to be returned if we don't see all base classes
                     privateFuncs.erase(it++);
                 else
@@ -1962,7 +1962,7 @@ void CheckClass::virtualDestructor()
                         if (baseDestructor->access == AccessControl::Public) {
                             virtualDestructorError(baseDestructor->token, derivedFrom->name(), derivedClass->str(), false);
                             // check for duplicate error and remove it if found
-                            const std::list<const Function *>::iterator found = find(inconclusiveErrors.begin(), inconclusiveErrors.end(), baseDestructor);
+                            const std::list<const Function *>::const_iterator found = find(inconclusiveErrors.begin(), inconclusiveErrors.end(), baseDestructor);
                             if (found != inconclusiveErrors.end())
                                 inconclusiveErrors.erase(found);
                         }

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -672,7 +672,7 @@ Scope *clangimport::AstNode::createScope(TokenList *tokenList, Scope::ScopeType 
                 const_cast<Token *>(vartok)->variable(replaceVar[vartok->variable()]);
         }
         std::list<Variable> &varlist = const_cast<Scope *>(def->scope())->varlist;
-        for (std::list<Variable>::iterator var = varlist.begin(); var != varlist.end();) {
+        for (std::list<Variable>::const_iterator var = varlist.begin(); var != varlist.end();) {
             if (replaceVar.find(&(*var)) != replaceVar.end())
                 varlist.erase(var++);
             else

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -674,7 +674,7 @@ Scope *clangimport::AstNode::createScope(TokenList *tokenList, Scope::ScopeType 
         std::list<Variable> &varlist = const_cast<Scope *>(def->scope())->varlist;
         for (std::list<Variable>::const_iterator var = varlist.begin(); var != varlist.end();) {
             if (replaceVar.find(&(*var)) != replaceVar.end())
-                varlist.erase(var++);
+                var = varlist.erase(var);
             else
                 ++var;
         }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -69,7 +69,7 @@ void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
             }
         }
         if (ignore)
-            fileSettings.erase(it++);
+            it = fileSettings.erase(it);
         else
             ++it;
     }
@@ -79,7 +79,7 @@ void ImportProject::ignoreOtherConfigs(const std::string &cfg)
 {
     for (std::list<FileSettings>::const_iterator it = fileSettings.begin(); it != fileSettings.end();) {
         if (it->cfg != cfg)
-            fileSettings.erase(it++);
+            it = fileSettings.erase(it);
         else
             ++it;
     }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -49,7 +49,7 @@ ImportProject::ImportProject()
 
 void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
 {
-    for (std::list<FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {
+    for (std::list<FileSettings>::const_iterator it = fileSettings.begin(); it != fileSettings.end();) {
         bool ignore = false;
         for (std::string i : ipaths) {
             if (it->filename.size() > i.size() && it->filename.compare(0,i.size(),i)==0) {
@@ -77,7 +77,7 @@ void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
 
 void ImportProject::ignoreOtherConfigs(const std::string &cfg)
 {
-    for (std::list<FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {
+    for (std::list<FileSettings>::const_iterator it = fileSettings.begin(); it != fileSettings.end();) {
         if (it->cfg != cfg)
             fileSettings.erase(it++);
         else
@@ -1270,7 +1270,7 @@ bool ImportProject::importCppcheckGuiProject(std::istream &istr, Settings *setti
 void ImportProject::selectOneVsConfig(Settings::PlatformType platform)
 {
     std::set<std::string> filenames;
-    for (std::list<ImportProject::FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {
+    for (std::list<ImportProject::FileSettings>::const_iterator it = fileSettings.begin(); it != fileSettings.end();) {
         if (it->cfg.empty()) {
             ++it;
             continue;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3081,11 +3081,11 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
         path.insert(0, ":: ");
     }
 
-    std::list<Scope>::iterator it1;
+    std::list<Scope>::const_iterator it1;
 
     // search for match
     for (it1 = scopeList.begin(); it1 != scopeList.end(); ++it1) {
-        Scope *scope1 = &(*it1);
+        const Scope *scope1 = &(*it1);
 
         bool match = false;
 
@@ -3143,7 +3143,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
                         continue;
                 }
 
-                Scope *scope2 = scope1;
+                const Scope *scope2 = scope1;
 
                 while (scope2 && count > 1) {
                     count--;

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -699,9 +699,9 @@ void TemplateSimplifier::addInstantiation(Token *token, const std::string &scope
     TokenAndName instantiation(token, scope);
 
     // check if instantiation already exists before adding it
-    std::list<TokenAndName>::iterator it = std::find(mTemplateInstantiations.begin(),
-                                                     mTemplateInstantiations.end(),
-                                                     instantiation);
+    std::list<TokenAndName>::const_iterator it = std::find(mTemplateInstantiations.begin(),
+                                                           mTemplateInstantiations.end(),
+                                                           instantiation);
 
     if (it == mTemplateInstantiations.end())
         mTemplateInstantiations.emplace_back(std::move(instantiation));
@@ -1206,9 +1206,9 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
             if (Token::Match(tok2, "(|{|["))
                 tok2 = tok2->link();
             else if (Token::Match(tok2, "%type% <") && (tok2->strAt(2) == ">" || templateParameters(tok2->next()))) {
-                std::list<TokenAndName>::iterator ti = std::find_if(mTemplateInstantiations.begin(),
-                                                                    mTemplateInstantiations.end(),
-                                                                    FindToken(tok2));
+                std::list<TokenAndName>::const_iterator ti = std::find_if(mTemplateInstantiations.begin(),
+                                                                          mTemplateInstantiations.end(),
+                                                                          FindToken(tok2));
                 if (ti != mTemplateInstantiations.end())
                     mTemplateInstantiations.erase(ti);
                 ++indentlevel;
@@ -1225,9 +1225,9 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
             continue;
 
         // don't strip args from uninstantiated templates
-        std::list<TokenAndName>::iterator ti2 = std::find_if(mTemplateInstantiations.begin(),
-                                                             mTemplateInstantiations.end(),
-                                                             FindName(declaration.name()));
+        std::list<TokenAndName>::const_iterator ti2 = std::find_if(mTemplateInstantiations.begin(),
+                                                                   mTemplateInstantiations.end(),
+                                                                   FindName(declaration.name()));
 
         if (ti2 == mTemplateInstantiations.end())
             continue;
@@ -1331,9 +1331,9 @@ void TemplateSimplifier::simplifyTemplateAliases()
                 if (aliasParameterNames.find(tok2->str()) == aliasParameterNames.end()) {
                     // Create template instance..
                     if (Token::Match(tok1, "%name% <")) {
-                        const std::list<TokenAndName>::iterator it = std::find_if(mTemplateInstantiations.begin(),
-                                                                                  mTemplateInstantiations.end(),
-                                                                                  FindToken(tok1));
+                        const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateInstantiations.begin(),
+                                                                                        mTemplateInstantiations.end(),
+                                                                                        FindToken(tok1));
                         if (it != mTemplateInstantiations.end())
                             addInstantiation(tok2, it->scope());
                     }
@@ -1627,9 +1627,9 @@ void TemplateSimplifier::expandTemplate(
             end = temp2->linkAt(1)->next();
         } else {
             if (it != mTemplateForwardDeclarationsMap.end()) {
-                std::list<TokenAndName>::iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
-                                                                     mTemplateForwardDeclarations.end(),
-                                                                     FindToken(it->second));
+                std::list<TokenAndName>::const_iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
+                                                                           mTemplateForwardDeclarations.end(),
+                                                                           FindToken(it->second));
                 if (it1 != mTemplateForwardDeclarations.end())
                     mMemberFunctionsToDelete.push_back(*it1);
             }
@@ -1817,7 +1817,7 @@ void TemplateSimplifier::expandTemplate(
                     if (Token::Match(start, "[|{|(")) {
                         links[start->link()] = dst->previous();
                     } else if (Token::Match(start, "]|}|)")) {
-                        std::map<const Token *, Token *>::iterator link = links.find(start);
+                        std::map<const Token *, Token *>::const_iterator link = links.find(start);
                         // make sure link is valid
                         if (link != links.end()) {
                             Token::createMutualLinks(link->second, dst->previous());
@@ -2015,9 +2015,9 @@ void TemplateSimplifier::expandTemplate(
             while (tok3 && tok3->str() != "::")
                 tok3 = tok3->next();
 
-            std::list<TokenAndName>::iterator it = std::find_if(mTemplateDeclarations.begin(),
-                                                                mTemplateDeclarations.end(),
-                                                                FindToken(startOfTemplateDeclaration));
+            std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateDeclarations.begin(),
+                                                                      mTemplateDeclarations.end(),
+                                                                      FindToken(startOfTemplateDeclaration));
             if (it != mTemplateDeclarations.end())
                 mMemberFunctionsToDelete.push_back(*it);
         }
@@ -3327,7 +3327,7 @@ void TemplateSimplifier::replaceTemplateUsage(
         // Foo < int >  =>  Foo<int>
         for (Token *tok = nameTok1->next(); tok != tok2; tok = tok->next()) {
             if (tok->isName() && tok->templateSimplifierPointers() && !tok->templateSimplifierPointers()->empty()) {
-                std::list<TokenAndName>::iterator ti;
+                std::list<TokenAndName>::const_iterator ti;
                 for (ti = mTemplateInstantiations.begin(); ti != mTemplateInstantiations.end();) {
                     if (ti->token() == tok) {
                         mTemplateInstantiations.erase(ti++);
@@ -3808,7 +3808,7 @@ void TemplateSimplifier::simplifyTemplates(
         }
 
         for (std::list<TokenAndName>::const_iterator it = mInstantiatedTemplates.begin(); it != mInstantiatedTemplates.end(); ++it) {
-            std::list<TokenAndName>::iterator decl;
+            std::list<TokenAndName>::const_iterator decl;
             for (decl = mTemplateDeclarations.begin(); decl != mTemplateDeclarations.end(); ++decl) {
                 if (decl->token() == it->token())
                     break;
@@ -3832,17 +3832,17 @@ void TemplateSimplifier::simplifyTemplates(
 
         // remove out of line member functions
         while (!mMemberFunctionsToDelete.empty()) {
-            const std::list<TokenAndName>::iterator it = std::find_if(mTemplateDeclarations.begin(),
-                                                                      mTemplateDeclarations.end(),
-                                                                      FindToken(mMemberFunctionsToDelete.begin()->token()));
+            const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateDeclarations.begin(),
+                                                                            mTemplateDeclarations.end(),
+                                                                            FindToken(mMemberFunctionsToDelete.begin()->token()));
             // multiple functions can share the same declaration so make sure it hasn't already been deleted
             if (it != mTemplateDeclarations.end()) {
                 removeTemplate(it->token());
                 mTemplateDeclarations.erase(it);
             } else {
-                const std::list<TokenAndName>::iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
-                                                                           mTemplateForwardDeclarations.end(),
-                                                                           FindToken(mMemberFunctionsToDelete.begin()->token()));
+                const std::list<TokenAndName>::const_iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
+                                                                                 mTemplateForwardDeclarations.end(),
+                                                                                 FindToken(mMemberFunctionsToDelete.begin()->token()));
                 // multiple functions can share the same declaration so make sure it hasn't already been deleted
                 if (it1 != mTemplateForwardDeclarations.end()) {
                     removeTemplate(it1->token());

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3330,7 +3330,7 @@ void TemplateSimplifier::replaceTemplateUsage(
                 std::list<TokenAndName>::const_iterator ti;
                 for (ti = mTemplateInstantiations.begin(); ti != mTemplateInstantiations.end();) {
                     if (ti->token() == tok) {
-                        mTemplateInstantiations.erase(ti++);
+                        ti = mTemplateInstantiations.erase(ti);
                         break;
                     } else {
                         ++ti;

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3663,7 +3663,7 @@ void Tokenizer::setVarIdStructMembers(Token **tok1,
                 tok = tok->link();
             if (Token::Match(tok->previous(), "[,{] . %name% =|{")) {
                 tok = tok->next();
-                const std::map<std::string, nonneg int>::iterator it = members.find(tok->str());
+                const std::map<std::string, nonneg int>::const_iterator it = members.find(tok->str());
                 if (it == members.end()) {
                     members[tok->str()] = ++(*varId);
                     tok->varId(*varId);
@@ -3697,7 +3697,7 @@ void Tokenizer::setVarIdStructMembers(Token **tok1,
             break;
 
         std::map<std::string, nonneg int>& members = structMembers[struct_varid];
-        const std::map<std::string, nonneg int>::iterator it = members.find(tok->str());
+        const std::map<std::string, nonneg int>::const_iterator it = members.find(tok->str());
         if (it == members.end()) {
             members[tok->str()] = ++(*varId);
             tok->varId(*varId);
@@ -4315,7 +4315,7 @@ void Tokenizer::setVarIdPass2()
             }
 
             if (tok->str() == "}") {
-                const std::map<const Token *, std::string>::iterator it = endOfScope.find(tok);
+                const std::map<const Token *, std::string>::const_iterator it = endOfScope.find(tok);
                 if (it != endOfScope.end())
                     scope.remove(it->second);
             }

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -81,10 +81,10 @@ private:
 
         // Check if there are duplicate error ids in errorLogger.id
         std::string duplicate;
-        for (std::list<std::string>::iterator it = errorLogger.id.begin();
+        for (std::list<std::string>::const_iterator it = errorLogger.id.begin();
              it != errorLogger.id.end();
              ++it) {
-            if (std::find(errorLogger.id.begin(), it, *it) != it) {
+            if (std::find(errorLogger.id.cbegin(), it, *it) != it) {
                 duplicate = "Duplicate ID: " + *it;
                 break;
             }

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -63,7 +63,7 @@ private:
         for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end();) {
             if (i->first.compare(0,2,"./") == 0) {
                 files[i->first.substr(2)] = i->second;
-                files.erase(i++);
+                i = files.erase(i);
             } else
                 ++i;
         }

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -60,7 +60,7 @@ private:
         ASSERT(err.empty());
 
         // In case there are leading "./"..
-        for (std::map<std::string, std::size_t>::iterator i = files.begin(); i != files.end();) {
+        for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end();) {
             if (i->first.compare(0,2,"./") == 0) {
                 files[i->first.substr(2)] = i->second;
                 files.erase(i++);


### PR DESCRIPTION
Most container operations work with a `const_iterator` so it can be used unless the object behind it is being modified. I filed https://trac.cppcheck.net/ticket/11339 about suggesting this.

Since C++11 the `erase()` call return the new iterator.