### PR TITLE
modernized `erase()` calls

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -1257,7 +1257,7 @@ void CheckClass::privateFunctions()
             // Check virtual functions
             for (std::list<const Function*>::iterator it = privateFuncs.begin(); it != privateFuncs.end();) {
                 if ((*it)->isImplicitlyVirtual(true)) // Give true as default value to be returned if we don't see all base classes
-                    privateFuncs.erase(it++);
+                    it = privateFuncs.erase(it);
                 else
                     ++it;
             }

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -674,7 +674,7 @@ Scope *clangimport::AstNode::createScope(TokenList *tokenList, Scope::ScopeType 
         std::list<Variable> &varlist = const_cast<Scope *>(def->scope())->varlist;
         for (std::list<Variable>::iterator var = varlist.begin(); var != varlist.end();) {
             if (replaceVar.find(&(*var)) != replaceVar.end())
-                varlist.erase(var++);
+                var = varlist.erase(var);
             else
                 ++var;
         }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -69,7 +69,7 @@ void ImportProject::ignorePaths(const std::vector<std::string> &ipaths)
             }
         }
         if (ignore)
-            fileSettings.erase(it++);
+            it = fileSettings.erase(it);
         else
             ++it;
     }
@@ -79,7 +79,7 @@ void ImportProject::ignoreOtherConfigs(const std::string &cfg)
 {
     for (std::list<FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {
         if (it->cfg != cfg)
-            fileSettings.erase(it++);
+            it = fileSettings.erase(it);
         else
             ++it;
     }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3330,7 +3330,7 @@ void TemplateSimplifier::replaceTemplateUsage(
                 std::list<TokenAndName>::iterator ti;
                 for (ti = mTemplateInstantiations.begin(); ti != mTemplateInstantiations.end();) {
                     if (ti->token() == tok) {
-                        mTemplateInstantiations.erase(ti++);
+                        ti = mTemplateInstantiations.erase(ti);
                         break;
                     } else {
                         ++ti;

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -63,7 +63,7 @@ private:
         for (std::map<std::string, std::size_t>::iterator i = files.begin(); i != files.end();) {
             if (i->first.compare(0,2,"./") == 0) {
                 files[i->first.substr(2)] = i->second;
-                files.erase(i++);
+                i = files.erase(i);
             } else
                 ++i;
         }


### PR DESCRIPTION
Since C++11 the `erase()` call returns the new iterator.