### PR TITLE
fixed `valgrind` workflow

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -24,8 +24,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install debian-goodies ubuntu-dbgsym-keyring
-          # the key expired and the ubuntu-dbgsym-keyring package does not yet include the latest one - see https://bugs.launchpad.net/ubuntu/+source/ubuntu-keyring/+bug/1920640
-          wget -O - http://ddebs.ubuntu.com/dbgsym-release-key.asc | sudo apt-key add -
 
       - name: Add debug repos on ubuntu
         run:  |


### PR DESCRIPTION
```
W: GPG error: http://ddebs.ubuntu.com jammy-updates Release: The following signatures were invalid: BADSIG C8CAB6595FDFF622 Ubuntu Debug Symbol Archive Automatic Signing Key (2016) <ubuntu-archive@lists.ubuntu.com>
E: The repository 'http://ddebs.ubuntu.com jammy-updates Release' is not signed.
```