### PR TITLE
selfcheck.yml: re-enable core checks in `callgrind` step

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -128,7 +128,6 @@ jobs:
           head -50 callgrind.annotated.log
         env:
           DISABLE_VALUEFLOW: 1
-          UNUSEDFUNCTION_ONLY: 1
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
I still wanted to remove this from #4362 but it suddenly got merged.

This re-enables all the core checks (i.e. the ones you cannot disable at all) and it makes sense to track the performance of those. Since it doesn't affect the runtime of the CI step that much you are able to do this. I also already have an optimization for one of those checks lined up.

This increases the Ir from `77,388,361,498` to `81,935,225,940` though.