### PR TITLE
Fix defaulted and deleted functions

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -577,14 +577,12 @@ void CheckMemoryLeakInClass::variable(const Scope *scope, const Token *tokVarnam
         const bool constructor = func.isConstructor();
         const bool destructor = func.isDestructor();
         if (!func.hasBody()) {
-            if (destructor) { // implementation for destructor is not seen => assume it deallocates all variables properly
+            if (destructor && !func.isDefault()) { // implementation for destructor is not seen and not defaulted => assume it deallocates all variables properly
                 deallocInDestructor = true;
                 memberDealloc = CheckMemoryLeak::Many;
             }
             continue;
         }
-        if (!func.functionScope) // defaulted destructor
-            continue;
         bool body = false;
         const Token *end = func.functionScope->bodyEnd;
         for (const Token *tok = func.arg->link(); tok != end; tok = tok->next()) {

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3241,6 +3241,8 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
             (*scope)->nestedList.push_back(newScope);
             *scope = newScope;
         }
+    } else if (tok1->tokAt(-2) && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
+        scopeList.pop_back();
     } else {
         scopeList.pop_back();
         *scope = nullptr;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3167,18 +3167,17 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
                 Function * func = const_cast<Function *>(it->second);
                 if (!func->hasBody()) {
                     if (func->argsMatch(scope1, func->argDef, (*tok)->next(), path, path_length)) {
-                        if (func->type == Function::eDestructor && destructor) {
-                            func->hasBody(true);
-                        } else if (func->type != Function::eDestructor && !destructor) {
-                            // normal function?
-                            const Token *closeParen = (*tok)->next()->link();
-                            if (closeParen) {
-                                const Token *eq = mTokenizer->isFunctionHead(closeParen, ";");
-                                if (eq && Token::simpleMatch(eq->tokAt(-2), "= default ;")) {
-                                    func->isDefault(true);
-                                    return;
-                                }
-
+                        const Token *closeParen = (*tok)->next()->link();
+                        if (closeParen) {
+                            const Token *eq = mTokenizer->isFunctionHead(closeParen, ";");
+                            if (eq && Token::simpleMatch(eq->tokAt(-2), "= default ;")) {
+                                func->isDefault(true);
+                                return;
+                            }
+                            if (func->type == Function::eDestructor && destructor) {
+                                func->hasBody(true);
+                            } else if (func->type != Function::eDestructor && !destructor) {
+                                // normal function?
                                 const bool hasConstKeyword = closeParen->next()->str() == "const";
                                 if ((func->isConst() == hasConstKeyword) &&
                                     (func->hasLvalRefQualifier() == lval) &&

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3241,7 +3241,7 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
             (*scope)->nestedList.push_back(newScope);
             *scope = newScope;
         }
-    } else if (tok1 && tok1->tokAt(-2) && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
+    } else if (tok1 && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
         scopeList.pop_back();
     } else {
         scopeList.pop_back();

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3246,7 +3246,6 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
     } else {
         scopeList.pop_back();
         *scope = nullptr;
-        tok1 = nullptr;
     }
     *tok = tok1;
 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3233,10 +3233,7 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
 
         // syntax error?
         if (!newScope->bodyEnd) {
-            scopeList.pop_back();
-            while (tok1->next())
-                tok1 = tok1->next();
-            *scope = nullptr;
+            mTokenizer->unmatchedToken(tok1);
         } else {
             (*scope)->nestedList.push_back(newScope);
             *scope = newScope;
@@ -3244,8 +3241,7 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
     } else if (tok1 && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
         scopeList.pop_back();
     } else {
-        scopeList.pop_back();
-        *scope = nullptr;
+        throw InternalError(*tok, "Analysis failed (function not recognized). If the code is valid then please report this failure.");
     }
     *tok = tok1;
 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3241,7 +3241,7 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
             (*scope)->nestedList.push_back(newScope);
             *scope = newScope;
         }
-    } else if (tok1->tokAt(-2) && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
+    } else if (tok1 && tok1->tokAt(-2) && Token::Match(tok1->tokAt(-2), "= default|delete ;")) {
         scopeList.pop_back();
     } else {
         scopeList.pop_back();

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3237,18 +3237,16 @@ void SymbolDatabase::addNewFunction(Scope **scope, const Token **tok)
             while (tok1->next())
                 tok1 = tok1->next();
             *scope = nullptr;
-            *tok = tok1;
-            return;
+        } else {
+            (*scope)->nestedList.push_back(newScope);
+            *scope = newScope;
         }
-
-        (*scope)->nestedList.push_back(newScope);
-        *scope = newScope;
-        *tok = tok1;
     } else {
         scopeList.pop_back();
         *scope = nullptr;
-        *tok = nullptr;
+        tok1 = nullptr;
     }
+    *tok = tok1;
 }
 
 bool Type::isClassType() const

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1613,7 +1613,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
             Token::Match(typetok->previous(), "%name% ( !!*") &&
             typetok->previous()->varId() == 0 &&
             !typetok->previous()->isKeyword() &&
-            Token::Match(typetok->link(), ") const|;|{"))
+            (Token::Match(typetok->link(), ") const|;|{") || Token::Match(typetok->link(), ") const| = delete ;")))
             return typetok;
     }
 

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -4581,6 +4581,25 @@ private:
             ASSERT(db->scopeList.back().functionList.size() == 1);
             ASSERT(db->scopeList.back().functionList.front().isDefault() == true);
         }
+        {
+            GET_SYMBOL_DB("class C { ~C(); };\n"
+                          "C::~C() = default;");
+            ASSERT(db->scopeList.size() == 2);
+            ASSERT(db->scopeList.back().functionList.size() == 1);
+            ASSERT(db->scopeList.back().functionList.front().isDefault() == true);
+            ASSERT(db->scopeList.back().functionList.front().isDestructor() == true);
+        }
+        {
+            GET_SYMBOL_DB("namespace ns {\n"
+                          "class C { ~C(); };\n"
+                          "}\n"
+                          "using namespace ns;\n"
+                          "C::~C() = default;");
+            ASSERT(db->scopeList.size() == 3);
+            ASSERT(db->scopeList.back().functionList.size() == 1);
+            ASSERT(db->scopeList.back().functionList.front().isDefault() == true);
+            ASSERT(db->scopeList.back().functionList.front().isDestructor() == true);
+        }
     }
 
     void symboldatabase80() { // #9389

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -363,6 +363,7 @@ private:
         TEST_CASE(symboldatabase99); // #10864
         TEST_CASE(symboldatabase100); // #10174
         TEST_CASE(symboldatabase101);
+        TEST_CASE(symboldatabase102);
 
         TEST_CASE(createSymbolDatabaseFindAllScopes1);
         TEST_CASE(createSymbolDatabaseFindAllScopes2);
@@ -5030,6 +5031,14 @@ private:
         ASSERT(it);
         ASSERT(it->tokAt(2));
         ASSERT(it->tokAt(2)->variable());
+    }
+
+    void symboldatabase102() {
+        GET_SYMBOL_DB("std::string f() = delete;\n"
+                      "void g() {}");
+        ASSERT(db);
+        ASSERT(db->scopeList.size() == 1); // no scope for g! (and hence no analysis for g)
+        ASSERT(db->scopeList.front().type == Scope::eGlobal);
     }
 
     void createSymbolDatabaseFindAllScopes1() {

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -5037,8 +5037,9 @@ private:
         GET_SYMBOL_DB("std::string f() = delete;\n"
                       "void g() {}");
         ASSERT(db);
-        ASSERT(db->scopeList.size() == 1); // no scope for g! (and hence no analysis for g)
+        ASSERT(db->scopeList.size() == 2);
         ASSERT(db->scopeList.front().type == Scope::eGlobal);
+        ASSERT(db->scopeList.back().className == "g");
     }
 
     void createSymbolDatabaseFindAllScopes1() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6323,10 +6323,10 @@ private:
         ASSERT_EQUALS("argv[", testAst("int f(char argv[]);"));
         ASSERT_EQUALS("", testAst("void f();"));
         ASSERT_EQUALS("", testAst("void f() {}"));
-        ASSERT_EQUALS("f(delete=", testAst("int f() = delete;"));
+        ASSERT_EQUALS("", testAst("int f() = delete;"));
         ASSERT_EQUALS("", testAst("a::b f();"));
         ASSERT_EQUALS("", testAst("a::b f() {}"));
-        ASSERT_EQUALS("af::(delete=", testAst("a::b f() = delete;")); // where did b go? I'd expect at least `ab::` somewhere...
+        ASSERT_EQUALS("", testAst("a::b f() = delete;"));
         ASSERT_EQUALS("constdelete=", testAst("int f() const = delete;"));
         ASSERT_EQUALS("", testAst("extern unsigned f(const char *);"));
         ASSERT_EQUALS("charformat*...,", testAst("extern void f(const char *format, ...);"));

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6321,6 +6321,13 @@ private:
         ASSERT_EQUALS("1f23,(+4+", testAst("1+f(2,3)+4"));
         ASSERT_EQUALS("1f2a&,(+", testAst("1+f(2,&a)"));
         ASSERT_EQUALS("argv[", testAst("int f(char argv[]);"));
+        ASSERT_EQUALS("", testAst("void f();"));
+        ASSERT_EQUALS("", testAst("void f() {}"));
+        ASSERT_EQUALS("f(delete=", testAst("int f() = delete;"));
+        ASSERT_EQUALS("", testAst("a::b f();"));
+        ASSERT_EQUALS("", testAst("a::b f() {}"));
+        ASSERT_EQUALS("af::(delete=", testAst("a::b f() = delete;")); // where did b go? I'd expect at least `ab::` somewhere...
+        ASSERT_EQUALS("constdelete=", testAst("int f() const = delete;"));
         ASSERT_EQUALS("", testAst("extern unsigned f(const char *);"));
         ASSERT_EQUALS("charformat*...,", testAst("extern void f(const char *format, ...);"));
         ASSERT_EQUALS("int((void,", testAst("extern int for_each_commit_graft(int (*)(int*), void *);"));


### PR DESCRIPTION
All code after certain defaulted or deleted functions was skipped altogether, because in `SymbolDatabase::addNewFunction` it ended up setting `*tok = nullptr`, effectively skipping to the end.

Case 1:
```cpp
struct S { ~S(); };
S::~S() = default;
void g() {
  int j; ++j; // no warnings were shown on uninitialized values
}
```

Case 2:
```cpp
std::string f() = delete;
void g() {
  int j; ++j; // no warnings were shown on uninitialized values
}
```

Case 1 is an out-of-line defaulted destructor, which should behave similar to an out-of-line constructor.

Case 2 needed a scoped return type to fail. First, during tokenization, treat a deleted function similar to regular functions (skipping the function call from the AST). Then during the symboldatabase phase, make sure the token and scope continue from where they left off.