### PR TITLE
refs #11342 - library.cpp: added simple caching to `getFunctionName(const Token*)`

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -661,9 +661,9 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             if (allocation.status == VarInfo::NOALLOC && Token::simpleMatch(tok, ") ; }")) {
                 if (ftok->isKeyword())
                     continue;
-                const std::string& functionName(mSettings->library.getFunctionName(ftok));
                 bool unknown = false;
                 if (mTokenizer->isScopeNoReturn(tok->tokAt(2), &unknown)) {
+                    const std::string& functionName(mSettings->library.getFunctionName(ftok));
                     if (!unknown)
                         varInfo->clear();
                     else if (!mSettings->library.isLeakIgnore(functionName) && !mSettings->library.isUse(functionName))

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -661,7 +661,7 @@ void CheckLeakAutoVar::checkScope(const Token * const startToken,
             if (allocation.status == VarInfo::NOALLOC && Token::simpleMatch(tok, ") ; }")) {
                 if (ftok->isKeyword())
                     continue;
-                const std::string functionName(mSettings->library.getFunctionName(ftok));
+                const std::string& functionName(mSettings->library.getFunctionName(ftok));
                 bool unknown = false;
                 if (mTokenizer->isScopeNoReturn(tok->tokAt(2), &unknown)) {
                     if (!unknown)

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1005,8 +1005,6 @@ const std::string& Library::getFunctionName(const Token * const ftok) const
     // Lookup function name without using AST..
     else if (Token::simpleMatch(ftok->previous(), ".")) {
     }
-    else if (!Token::Match(ftok->tokAt(-2), "%name% ::"))
-        ret = ftok->str();
     else {
         ret = ftok->str();
         const Token *tok = ftok->tokAt(-2);

--- a/lib/library.h
+++ b/lib/library.h
@@ -549,7 +549,7 @@ public:
     /**
      * Get function name for function call
      */
-    std::string getFunctionName(const Token *ftok) const;
+    const std::string& getFunctionName(const Token *ftok) const;
 
     static bool isContainerYield(const Token * const cond, Library::Container::Yield y, const std::string& fallback=emptyString);
 


### PR DESCRIPTION
This adds a simple thread local caching of the last result to prevent unnecessary lookups on repeated calls (see https://trac.cppcheck.net/ticket/11342 for a sample chain) with the same token.

This will increase the run-time memory usage of the GUI version slightly but I guess with at most some 10,000 threads it is still not that much compared to the analysis which might consume several gigabytes in the worst case.