### PR TITLE
address most Node.js 12 deprecation warnings in GitHub workflows

### DIFF
--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Cygwin
         uses: cygwin/cygwin-install-action@master

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up MinGW
         uses: egor-tensin/setup-mingw@v2

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -21,7 +21,7 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install missing software on CentOS 7
         if: matrix.image == 'centos:7'
@@ -95,7 +95,7 @@ jobs:
       image: ${{ matrix.image }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install missing software on CentOS 7
         if: matrix.image == 'centos:7'

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -22,7 +22,7 @@ jobs:
       CCACHE_SLOPPINESS: pch_defines,time_macros
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -71,7 +71,7 @@ jobs:
       CCACHE_SLOPPINESS: pch_defines,time_macros
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -153,7 +153,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -185,7 +185,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # coreutils contains "g++" (default is "c++") and "nproc"
       - name: Install missing software on macos
@@ -207,7 +207,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install missing software on ubuntu
         if: contains(matrix.os, 'ubuntu')
@@ -290,7 +290,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build Fuzzer
         run: |
@@ -307,7 +307,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -434,7 +434,7 @@ jobs:
     runs-on: ubuntu-22.04 # run on the latest image only
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Visual Studio environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -85,10 +85,10 @@ jobs:
       PCRE_VERSION: 8.45
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Cache PCRE
         id: cache-pcre
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             externals\pcre.h

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -16,10 +16,10 @@ jobs:
       ASAN_OPTIONS: detect_stack_use_after_return=1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/buildman.yml
+++ b/.github/workflows/buildman.yml
@@ -9,7 +9,7 @@ jobs:
   convert_via_pandoc:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: |
           mkdir output
@@ -22,7 +22,7 @@ jobs:
         with:
           args: --output=output/manual.pdf man/manual.md  
   
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: output
           path: output

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -16,7 +16,7 @@ jobs:
       QT_VERSION: 5.15.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install missing software
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Install missing software on ubuntu
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -47,7 +47,7 @@ jobs:
           lcov --extract lcov_tmp.info "$(pwd)/*" --output-file lcov.info
           genhtml lcov.info -o coverage_report --frame --legend --demangle-cpp
           
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
          name: Coverage results
          path: coverage_report

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache uncrustify
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-uncrustify
         with:
           path: |

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -16,7 +16,7 @@ jobs:
       image: "debian:unstable" # use latest debian image to get latest include-what-you-get
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # TODO: the necessary packages are excessive - mostly because of Qt - use a pre-built image
       - name: Install missing software
@@ -52,12 +52,12 @@ jobs:
           # do not fail for now so the output is being saved
           iwyu_tool -p cmake.output -j $(nproc) -- -w > iwyu.log || true
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Qt Mappings
           path: ./qt5.imp
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Logs
           path: ./*.log

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -31,14 +31,14 @@ jobs:
       QT_VERSION: 5.15.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Visual Studio environment
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Cache PCRE
         id: cache-pcre
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             externals\pcre.h
@@ -128,12 +128,12 @@ jobs:
           echo ProductVersion="%PRODUCTVER%" || exit /b !errorlevel!
           msbuild -m cppcheck.wixproj -p:Platform=x64,ProductVersion=%PRODUCTVER%.${{ github.run_number }} || exit /b !errorlevel!
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: installer
           path: win_installer/Build/
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: deploy
           path: win_installer\files

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -22,7 +22,7 @@ jobs:
           key: ${{ github.workflow }}-${{ runner.os }}
 
       - name: Cache Cppcheck
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: cppcheck
           key: ${{ runner.os }}-scriptcheck-cppcheck-${{ github.sha }}
@@ -44,16 +44,16 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Restore Cppcheck
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: cppcheck
           key: ${{ runner.os }}-scriptcheck-cppcheck-${{ github.sha }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -16,7 +16,7 @@ jobs:
       QT_VERSION: 5.15.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install missing software
         run: |
@@ -129,7 +129,7 @@ jobs:
         env:
           DISABLE_VALUEFLOW: 1
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Callgrind Output
           path: ./callgrind.*

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -16,10 +16,10 @@ jobs:
       TSAN_OPTIONS: halt_on_error=1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -16,10 +16,10 @@ jobs:
       UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -54,7 +54,7 @@ jobs:
           valgrind --error-limit=yes --leak-check=full --num-callers=50 --show-reachable=yes --track-origins=yes --suppressions=valgrind/testrunner.supp --gen-suppressions=all --log-fd=9 --error-exitcode=42 ./testrunner TestGarbage TestOther TestSimplifyTemplate 9>memcheck.log
           cat memcheck.log
           
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Logs
           path: ./*.log


### PR DESCRIPTION
This updates most of the actions used in our workflows to address the following warning:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16
```

I have not yet updated the following:
- `ilammy/msvc-dev-cmd@v1` - there appears to be no newer version
- `jurplel/install-qt-action@v2` - the caching configuration changed with `v3` so this needs some looking into
- `actions/cache@v1 # not v2` - these were mandated for the caching of `jurplel/install-qt-action@v2` 