### PR TITLE
Update mfc.cfg with more MFC macros

### DIFF
--- a/cfg/mfc.cfg
+++ b/cfg/mfc.cfg
@@ -268,5 +268,4 @@
   <define name="ON_PROPNOTIFY(a,b,c,d,e)" value=""/>
   <define name="ON_PROPNOTIFY_RANGE(a,b,c,d,e,f)" value=""/>
   <define name="ON_PROPNOTIFY_REFLECT(a,b,c,d)" value=""/>
-  <define name="RUNTIME_CLASS(x)" value=""/>
 </def>

--- a/cfg/mfc.cfg
+++ b/cfg/mfc.cfg
@@ -253,4 +253,20 @@
   <define name="ON_THREAD_MESSAGE(x,y)" value=""/>
   <define name="ON_REGISTERED_THREAD_MESSAGE(x,y)" value=""/>
   <define name="END_MESSAGE_MAP()" value=""/>
+  <define name="DECLARE_DYNAMIC(x)" value=""/>
+  <define name="IMPLEMENT_DYNAMIC(x,y)" value=""/>
+  <define name="DECLARE_DYNCREATE(x)" value=""/>
+  <define name="IMPLEMENT_DYNCREATE(x,y)" value=""/>
+  <define name="DECLARE_SERIAL(x)" value=""/>
+  <define name="IMPLEMENT_SERIAL(x,y,z)" value=""/>
+  <define name="DECLARE_EVENTSINK_MAP()" value=""/>
+  <define name="END_EVENTSINK_MAP()" value=""/>
+  <define name="BEGIN_EVENTSINK_MAP(x,y)" value=""/>
+  <define name="ON_EVENT(a,b,c,d,e)" value=""/>
+  <define name="ON_EVENT_RANGE(a,b,c,d,e,f)" value=""/>
+  <define name="ON_EVENT_REFLECT(a,b,c,d)" value=""/>
+  <define name="ON_PROPNOTIFY(a,b,c,d,e)" value=""/>
+  <define name="ON_PROPNOTIFY_RANGE(a,b,c,d,e,f)" value=""/>
+  <define name="ON_PROPNOTIFY_REFLECT(a,b,c,d)" value=""/>
+  <define name="RUNTIME_CLASS(x)" value=""/>
 </def>


### PR DESCRIPTION
More MFC macros

These MFC macros are commonly used in C++ windows MFC code.
You can see the definition of this macros with below URLs:
https://learn.microsoft.com/en-us/cpp/mfc/reference/run-time-object-model-services?view=msvc-170
https://learn.microsoft.com/en-us/cpp/mfc/reference/event-sink-maps?view=msvc-170

Best regards