### PR TITLE
Fix #11319 - Internal error on constrained template (concept) with multiple type parameters

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4700,7 +4700,7 @@ void Tokenizer::createLinks2()
             } else {
                 type.pop();
                 if (Token::Match(token, "> %name%") && !token->next()->isKeyword() &&
-                    Token::Match(top1->tokAt(-2), "%op% %name% <") &&
+                    Token::Match(top1->tokAt(-2), "%op% %name% <") && top1->strAt(-2) != "<" &&
                     (templateTokens.empty() || top1 != templateTokens.top()))
                     continue;
                 Token::createMutualLinks(top1, token);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -3251,6 +3251,20 @@ private:
         }
 
         {
+            // #11319
+            const char code[] = "using std::same_as;\n"
+                                "template<same_as<int> T>\n"
+                                "void f();";
+            Tokenizer tokenizer(&settings0, this);
+            std::istringstream istr(code);
+            ASSERT(tokenizer.tokenize(istr, "test.cpp"));
+            const Token *tok1 = Token::findsimplematch(tokenizer.tokens(), "template <");
+            const Token *tok2 = Token ::findsimplematch(tokenizer.tokens(), "same_as <");
+            ASSERT(tok1->next()->link() == tok1->tokAt(7));
+            ASSERT(tok2->next()->link() == tok2->tokAt(3));
+        }
+
+        {
             // #9131 - template usage or comparison?
             const char code[] = "using std::list; list<t *> l;";
             Tokenizer tokenizer(&settings0, this);


### PR DESCRIPTION
The following example gave an internal error
```cpp
using namespace std;
//template<std::same_as<int> T> // <= works
template<same_as<int> T>        // <= didn't work
void f()
{}
```
The line I modified, used to match to `< same_as <`, and therefore skip creating links. The `%op% %name% <` already feels a bit like a workaround. So adding the condition that `$op$` shouldn't be `<` (so not a comparison operator, but part of the template), seemed reasonable to me