### PR TITLE
added command-line option `--valueflow-max-iterations` to control amount of valueflow iterations / also log debug warning when iterations are being exceeded

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -904,6 +904,21 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 }
             }
 
+            else if (std::strncmp(argv[i], "--valueflow-max-iterations=", 27) == 0) {
+                long tmp;
+                try {
+                    tmp = std::stol(argv[i] + 27);
+                } catch (const std::invalid_argument &) {
+                    printError("argument to '--valueflow-max-iteration' is invalid.");
+                    return false;
+                }
+                if (tmp < 0) {
+                    printError("argument to '--valueflow-max-iteration' needs to be at least 0.");
+                    return false;
+                }
+                mSettings->valueFlowMaxIterations = static_cast<std::size_t>(tmp);
+            }
+
             else if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--verbose") == 0)
                 mSettings->verbose = true;
 

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -66,6 +66,7 @@ Settings::Settings()
     relativePaths(false),
     reportProgress(false),
     showtime(SHOWTIME_MODES::SHOWTIME_NONE),
+    valueFlowMaxIterations(4),
     verbose(false),
     xml(false),
     xml_version(2)

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -350,6 +350,9 @@ public:
     /** @brief forced includes given by the user */
     std::list<std::string> userIncludes;
 
+    /** @brief the maximum iterations of valueflow (--valueflow-max-iterations=T) */
+    std::size_t valueFlowMaxIterations;
+
     /** @brief Is --verbose given? */
     bool verbose;
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -8887,7 +8887,7 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
     const std::uint64_t stopTime = getValueFlowStopTime(settings);
 
     std::size_t values = 0;
-    std::size_t n = 4;
+    std::size_t n = settings->valueFlowMaxIterations;
     while (n > 0 && values != getTotalValues(tokenlist)) {
         values = getTotalValues(tokenlist);
 
@@ -8947,6 +8947,18 @@ void ValueFlow::setValues(TokenList *tokenlist, SymbolDatabase* symboldatabase, 
         if (std::time(nullptr) < stopTime)
             valueFlowSafeFunctions(tokenlist, symboldatabase, settings);
         n--;
+    }
+
+    if (settings->debugwarnings) {
+        if (n == 0 && values != getTotalValues(tokenlist)) {
+            ErrorMessage errmsg({},
+                                emptyString,
+                                Severity::debug,
+                                "ValueFlow maximum iterations exceeded",
+                                "valueFlowMaxIterations",
+                                Certainty::normal);
+            errorLogger->reportErr(errmsg);
+        }
     }
 
     if (std::time(nullptr) < stopTime)

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -153,6 +153,11 @@ private:
         TEST_CASE(clang);
         TEST_CASE(clang2);
         TEST_CASE(clangInvalid);
+        TEST_CASE(valueFlowMaxIterations);
+        TEST_CASE(valueFlowMaxIterations2);
+        TEST_CASE(valueFlowMaxIterationsInvalid);
+        TEST_CASE(valueFlowMaxIterationsInvalid2);
+        TEST_CASE(valueFlowMaxIterationsInvalid3);
 
         // TODO
         // Disabling these tests since they use relative paths to the
@@ -1276,6 +1281,45 @@ private:
         const char * const argv[] = {"cppcheck", "--clang-foo"};
         ASSERT_EQUALS(false, defParser.parseFromArgs(2, argv));
         ASSERT_EQUALS("cppcheck: error: unrecognized command line option: \"--clang-foo\".\n", GET_REDIRECT_OUTPUT);
+    }
+
+    void valueFlowMaxIterations() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--valueflow-max-iterations=0"};
+        settings.valueFlowMaxIterations = -1;
+        ASSERT(defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS(0, settings.valueFlowMaxIterations);
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
+
+    void valueFlowMaxIterations2() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--valueflow-max-iterations=11"};
+        settings.valueFlowMaxIterations = -1;
+        ASSERT(defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS(11, settings.valueFlowMaxIterations);
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
+
+    void valueFlowMaxIterationsInvalid() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--valueflow-max-iterations"};
+        ASSERT(!defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("cppcheck: error: unrecognized command line option: \"--valueflow-max-iterations\".\n", GET_REDIRECT_OUTPUT);
+    }
+
+    void valueFlowMaxIterationsInvalid2() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--valueflow-max-iterations=seven"};
+        ASSERT(!defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("cppcheck: error: argument to '--valueflow-max-iteration' is invalid.\n", GET_REDIRECT_OUTPUT);
+    }
+
+    void valueFlowMaxIterationsInvalid3() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--valueflow-max-iterations=-1"};
+        ASSERT(!defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("cppcheck: error: argument to '--valueflow-max-iteration' needs to be at least 0.\n", GET_REDIRECT_OUTPUT);
     }
 
     /*


### PR DESCRIPTION
This would allow the user to fully leverage ValueFlow (given it already has a reasonable run-time).

It is intentionally left-out of the documentation (for now) since it might lead to false positives like `DISABLE_VALUEFLOW=1`.

Regarding the debug message. This is not that different from other ValueFlow bailouts so we should track this. With it we can check in daca how many packages are actually exceeding the ValueFlow iterations.

I also have some improvements for the existing experimental timeout code but I will tackle that in a different PR. If you have ideas/suggestion for other tunables feel free to mention them.