### PR TITLE
Map MISRA severities

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -1485,7 +1485,7 @@ def reportError(location, severity, message, addon, errorId, extra=''):
                 'linenr': location.linenr,
                 'column': location.column,
                 'severity': severity,
-                'message': message,
+                'message': message + ' (' + extra + ')',
                 'addon': addon,
                 'errorId': errorId,
                 'extra': extra}

--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -1485,10 +1485,12 @@ def reportError(location, severity, message, addon, errorId, extra=''):
                 'linenr': location.linenr,
                 'column': location.column,
                 'severity': severity,
-                'message': message + ' (' + extra + ')',
+                'message': message,
                 'addon': addon,
                 'errorId': errorId,
                 'extra': extra}
+        if len(extra) > 0:
+            msg["message"] += ' (' + extra + ')'
         sys.stdout.write(json.dumps(msg) + '\n')
     else:
         if is_suppressed(location, message, '%s-%s' % (addon, errorId)):

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -4126,7 +4126,7 @@ class MisraChecker:
         expect_more = False
 
         Rule_pattern = re.compile(r'^Rule ([0-9]+).([0-9]+)')
-        severity_pattern = re.compile(r'.*[ ]*(Advisory|Required|Mandatory)$')
+        severity_pattern = re.compile(r'^.* *(Advisory|Required|Mandatory).*$')
         xA_Z_pattern = re.compile(r'^[#A-Z].*')
         a_z_pattern = re.compile(r'^[a-z].*')
         # Try to detect the file encoding

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -4659,16 +4659,17 @@ def main():
         generateTable()
         sys.exit(0)
 
+    severities = ["style", "warning", "error"]
     if args.map_severity:
         severities = args.map_severity.split(',')
         if len(severities) != 3:
             print("Please provide severities for all misra categories (advisory, required, mandatory)")
             sys.exit(1)
 
-        severityMap = {"advisory":  severities[0],
-                       "required":  severities[1],
-                       "mandatory": severities[2]}
-        checker.setSeverityMap(severityMap)
+    severityMap = {"advisory":  severities[0],
+                   "required":  severities[1],
+                   "mandatory": severities[2]}
+    checker.setSeverityMap(severityMap)
 
     if args.rule_texts:
         filename = os.path.expanduser(args.rule_texts)

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -4126,7 +4126,7 @@ class MisraChecker:
         expect_more = False
 
         Rule_pattern = re.compile(r'^Rule ([0-9]+).([0-9]+)')
-        severity_pattern = re.compile(r'^.* *(Advisory|Required|Mandatory).*$')
+        severity_pattern = re.compile(r'^.* *(Advisory|Required|Mandatory) *$')
         xA_Z_pattern = re.compile(r'^[#A-Z].*')
         a_z_pattern = re.compile(r'^[a-z].*')
         # Try to detect the file encoding

--- a/test/cli/test-helloworld.py
+++ b/test/cli/test-helloworld.py
@@ -60,7 +60,7 @@ def test_addon_local_path():
     ret, stdout, stderr = cppcheck_local(['--addon=misra', '--template=cppcheck1', '.'])
     assert ret == 0, stdout
     assert stderr == ('[main.c:5]: (error) Division by zero.\n'
-                      '[main.c:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n')
+                      '[main.c:1]: (style) misra violation (use --rule-texts=<file> to get proper output) (Undefined)\n')
 
 def test_addon_absolute_path():
     prjpath = getAbsoluteProjectPath()
@@ -68,7 +68,7 @@ def test_addon_absolute_path():
     filename = os.path.join(prjpath, 'main.c')
     assert ret == 0, stdout
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
-                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n' % (filename, filename))
+                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output) (Undefined)\n' % (filename, filename))
 
 def test_addon_relative_path():
     prjpath = getRelativeProjectPath()
@@ -78,7 +78,7 @@ def test_addon_relative_path():
     assert stdout == ('Checking %s ...\n'
                       'Checking %s: SOME_CONFIG...\n' % (filename, filename))
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
-                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n' % (filename, filename))
+                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output) (Undefined)\n' % (filename, filename))
 
 def test_addon_with_gui_project():
     project_file = 'helloworld/test.cppcheck'
@@ -88,7 +88,7 @@ def test_addon_with_gui_project():
     assert ret == 0, stdout
     assert stdout == 'Checking %s ...\n' % filename
     assert stderr == ('[%s:5]: (error) Division by zero.\n'
-                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output)\n' % (filename, filename))
+                      '[%s:1]: (style) misra violation (use --rule-texts=<file> to get proper output) (Undefined)\n' % (filename, filename))
 
 def test_basepath_relative_path():
     prjpath = getRelativeProjectPath()


### PR DESCRIPTION
# Context

When using the MISRA addon, a colleague found out the MISRA defects were all categorized as `style` by cppcheck. 

We use the [cppcheck_codequality](https://pypi.org/project/cppcheck-codequality/) script to convert the cppcheck xml results to the [GitLab CodeQuality format](https://docs.gitlab.com/ee/ci/testing/code_quality.html). As a consequence, all the defect were flagged as `Minor` in GitLab UI, which is not ideal. 

![MISRA1](https://user-images.githubusercontent.com/44053930/199507733-c8951ea8-84ae-43e2-8a80-8229233d3176.png)

The MISRA rules are defined over 3 severities : advisory, required and mandatory. The goal of this PR is to map the MISRA severities with cppcheck ones. That way, defects are labeled with the appropriate priority and ordered correctly in the GitLab results

![MISRA2](https://user-images.githubusercontent.com/44053930/199507765-0ff09ff9-5f0f-4640-8c94-dfd7ddc83d1a.png)

# Use
By default, the severities are mapped this way : 

| cppcheck | MISRA     |
| -------- | --------- |
| style    | advisory  |
| warning  | required  |
| error    | mandatory |

One can change this behavior with the `--map-serverity` CLI arguments : 

```bash
python misra.py --rule-texts=misra-rules.txt --map-severity "style,warning,error" main.cpp.dump
```

or 

```json
{
  "script": "misra.py",
  "args": [
      "--rule-texts=misra-rules.txt",
      "--map-severity style,warning,error"
  ]
}
```

```bash
cppcheck --addon=misra.json main.cpp
```

# Question

I have a question for cppcheck maintainers. In its current state, this PR would change the severity of some MISRA defects. It means some users might see a difference in their cppcheck MISRA analysis results after this PR is merged. 

If this is a problem, my last commit (7a7a3ae8a14d15dfcb1df014be10e70c4f1d24a1) can be reverted and the PR would take effect only when setting `--map-severity`.

If this issue is considered as a bug, I think this PR can be left as is. Indeed, MISRA defects are not related to "style". Users will see a change in their results but could consider it as beneficial.

Would you rather have this PR fixing the MISRA severities by default or opt-in ? 


PS: credits to my colleague Nicolas Couvreur for this PR.