### PR TITLE
Fix couple issues with missing operatorEqVarError

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -694,7 +694,7 @@ void CheckClass::clearAllVar(std::vector<Usage> &usageList)
     }
 }
 
-bool CheckClass::isBaseClassFunc(const Token *tok, const Scope *scope)
+bool CheckClass::isBaseClassMutableMemberFunc(const Token *tok, const Scope *scope)
 {
     // Iterate through each base class...
     for (const Type::BaseInfo & i : scope->definedType->derivedFrom) {
@@ -705,11 +705,11 @@ bool CheckClass::isBaseClassFunc(const Token *tok, const Scope *scope)
             const std::list<Function>& functionList = derivedFrom->classScope->functionList;
 
             if (std::any_of(functionList.begin(), functionList.end(), [&](const Function& func) {
-                return func.tokenDef->str() == tok->str();
+                return func.tokenDef->str() == tok->str() && !func.isStatic() && !func.isConst();
             }))
                 return true;
 
-            if (isBaseClassFunc(tok, derivedFrom->classScope))
+            if (isBaseClassMutableMemberFunc(tok, derivedFrom->classScope))
                 return true;
         }
 
@@ -949,8 +949,8 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
                     }
                 }
 
-                // there is a called member function, but it has no implementation, so we assume it initializes everything
-                else {
+                // there is a called member function, but it has no implementation, so we assume it initializes everything (if it can mutate state)
+                else if (!member->isConst() && !member->isStatic()) {
                     assignAllVar(usage);
                 }
             }
@@ -958,7 +958,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
             // not member function
             else {
                 // could be a base class virtual function, so we assume it initializes everything
-                if (!func.isConstructor() && isBaseClassFunc(ftok, scope)) {
+                if (!func.isConstructor() && isBaseClassMutableMemberFunc(ftok, scope)) {
                     /** @todo False Negative: we should look at the base class functions to see if they
                      *  call any derived class virtual functions that change the derived class state
                      */

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -373,6 +373,13 @@ private:
     static void assignAllVar(std::vector<Usage> &usageList);
 
     /**
+     * @brief set all variable in list assigned, if visible from given scope
+     * @param usageList reference to usage vector
+     * @param scope scope from which usages must be visible
+     */
+    static void assignAllVarsVisibleFromScope(std::vector<Usage> &usageList, const Scope *scope);
+
+    /**
      * @brief set all variables in list not assigned and not initialized
      * @param usageList reference to usage vector
      */

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -336,7 +336,7 @@ private:
         bool init;
     };
 
-    static bool isBaseClassFunc(const Token *tok, const Scope *scope);
+    static bool isBaseClassMutableMemberFunc(const Token *tok, const Scope *scope);
 
     /**
      * @brief Create usage list that contains all scope members and also members

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -3324,6 +3324,38 @@ private:
               "};");
         ASSERT_EQUALS("[test.cpp:5]: (warning) Member variable 'Fred::i' is not initialized in the constructor.\n", errout.str());
 
+        // Unknown member functions and unknown static functions
+        check("class ABC {\n"
+              "  static void static_base_func();\n"
+              "  void const_base_func() const;\n"
+              "};\n"
+              "class Fred : private ABC {\n"
+              "public:\n"
+              "    Fred() {\n"
+              "        const_func();\n"
+              "        static_func();\n"
+              "        const_base_func();\n"
+              "        ABC::static_base_func();\n"
+              "    }\n"
+              "    void const_func() const;\n"
+              "    static void static_f();\n"
+              "private:\n"
+              "    int i;\n"
+              "};");
+
+        // Unknown overloaded member functions
+        check("class Fred : private ABC {\n"
+              "public:\n"
+              "    Fred() {\n"
+              "        func();\n"
+              "    }\n"
+              "    void func() const;\n"
+              "    void func();\n"
+              "private:\n"
+              "    int i;\n"
+              "};");
+        ASSERT_EQUALS("", errout.str());
+
     }
 
     void uninitVarEnum1() {

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -116,6 +116,7 @@ private:
         TEST_CASE(initvar_operator_eq5);     // ticket #4119
         TEST_CASE(initvar_operator_eq6);
         TEST_CASE(initvar_operator_eq7);
+        TEST_CASE(initvar_operator_eq8);
         TEST_CASE(initvar_same_classname);      // BUG 2208157
         TEST_CASE(initvar_chained_assign);      // BUG 2270433
         TEST_CASE(initvar_2constructors);       // BUG 2270353
@@ -979,6 +980,30 @@ private:
               "    return *this;\n"
               "}\n", true);
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void initvar_operator_eq8() {
+        check("struct B {\n"
+              "    int b;\n"
+              "};\n"
+              "struct D1 : B {\n"
+              "    D1& operator=(const D1& src);\n"
+              "    int d1;\n"
+              "};\n"
+              "struct D2 : D1 {\n"
+              "    D2& operator=(const D2& src);\n"
+              "    int d2;\n"
+              "};\n"
+              "struct D3 : D2 {\n"
+              "    D3& operator=(const D3& src) {\n"
+              "        D1::operator=(src);\n"
+              "        d3_1 = src.d3_1;\n"
+              "    }\n"
+              "    int d3_1;\n"
+              "    int d3_2;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:13]: (warning) Member variable 'D3::d3_2' is not assigned a value in 'D3::operator='.\n"
+                      "[test.cpp:13]: (warning) Member variable 'D3::d2' is not assigned a value in 'D3::operator='.\n", errout.str());
     }
 
     void initvar_same_classname() {


### PR DESCRIPTION
For check operatorEqVarError (members variables missing in an `operator=`), I cppcheck bails out when a member function without a body is encountered, reasoning that that function _might_ initialize some/all member variables.

However, I feel it bails out a bit too soon: 
- when such a function is `const` or `static`, it will probably not initialize member variables (although member variables could be `mutable` and thus be initialized in a `const` function; and a static function could be passed `*this` to initialize members, although this latter case isn't any different than calling any free function, in which case currently cppcheck doesn't bail out).
- when `operator=` of a base class is called, I think it is fair to say the base class will initialize its own members (and of its subsequent base classes), but it shall _not_ initialize members of the current object (although it is possible via a virtual function call, but then why are you implementing `operator=` when the base class takes care of it?)

Maybe some of these cases should be marked as inconclusive? I didn't yet look into that...