### PR TITLE
Fix internal error "Unexpected tokens in initializer" with anonymous namespace

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -675,7 +675,7 @@ static bool iscpp11init_impl(const Token * const tok)
         return false;
     if (Token::simpleMatch(nameToken->previous(), ". void {") && nameToken->previous()->originalName() == "->")
         return false; // trailing return type. The only function body that can contain no semicolon is a void function.
-    if (Token::simpleMatch(nameToken->previous(), "namespace"))
+    if (Token::simpleMatch(nameToken->previous(), "namespace") || Token::simpleMatch(nameToken, "namespace") /*anonymous namespace*/)
         return false;
     if (endtok != nullptr && !Token::Match(nameToken, "return|:")) {
         // If there is semicolon between {..} this is not a initlist

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -7483,6 +7483,13 @@ private:
         testIsCpp11init("class X{}", // forgotten ; so not properly recognized as a class
                         "{ }",
                         TokenImpl::Cpp11init::CPP11INIT);
+
+        testIsCpp11init("namespace abc::def { TEST(a, b) {} }",
+                        "{ TEST",
+                        TokenImpl::Cpp11init::NOINIT);
+        testIsCpp11init("namespace { TEST(a, b) {} }", // anonymous namespace
+                        "{ TEST",
+                        TokenImpl::Cpp11init::NOINIT);
         #undef testIsCpp11init
     }
 };


### PR DESCRIPTION
Exception is thrown since 6a01fa9b (my own commit).
I found the issue by looking into http://cppcheck1.osuosl.org:8000/diff-internalAstError, checking a few cases there.
Example case where it failed: https://github.com/google/googletest/blob/main/googletest/test/gtest_main_unittest.cc
Possibly fixes some more cases