### PR TITLE
Improve fix for #11383 FP selfAssignment: lambda capture

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2445,8 +2445,14 @@ void CheckOther::checkDuplicateExpression()
                     }
                 }
             }
+            auto isInsideLambdaCaptureList = [](const Token* tok) {
+                auto* parent = tok->astParent();
+                while (Token::simpleMatch(parent, ","))
+                    parent = parent->astParent();
+                return isLambdaCaptureList(parent);
+            };
             ErrorPath errorPath;
-            if (tok->isOp() && tok->astOperand1() && !Token::Match(tok, "+|*|<<|>>|+=|*=|<<=|>>=") && !isLambdaCaptureList(tok->astParent())) {
+            if (tok->isOp() && tok->astOperand1() && !Token::Match(tok, "+|*|<<|>>|+=|*=|<<=|>>=") && !isInsideLambdaCaptureList(tok)) {
                 if (Token::Match(tok, "==|!=|-") && astIsFloat(tok->astOperand1(), true))
                     continue;
                 const bool pointerDereference = (tok->astOperand1() && tok->astOperand1()->isUnaryOp("*")) ||

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2446,7 +2446,7 @@ void CheckOther::checkDuplicateExpression()
                 }
             }
             auto isInsideLambdaCaptureList = [](const Token* tok) {
-                auto* parent = tok->astParent();
+                const Token* parent = tok->astParent();
                 while (Token::simpleMatch(parent, ","))
                     parent = parent->astParent();
                 return isLambdaCaptureList(parent);

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -4853,7 +4853,8 @@ private:
 
         check("struct S {\n" // #11383
               "    void f() {\n"
-              "        auto l2 = [i = i]() { return i; };\n"
+              "        int x = 42;"
+              "        auto l2 = [i = i, x, y = 0]() { return i + x + y; };\n"
               "    }\n"
               "    int i;\n"
               "};\n");


### PR DESCRIPTION
Thanks for fixing 11383 so quick (#4581)!
However, when I ran the fix on my code base, the issue was still there, due to multiple captures in the lambda (which resulted in multiple `,`-ast-parents between `=` and `[`).

This PR fixes that