### PR TITLE
Investigation attempt for #10489: unmatchedSuppression missingInclude…

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -484,6 +484,9 @@ void CppCheckExecutor::reportInfo(const ErrorMessage &msg)
     reportErr(msg);
 }
 
+void CppCheckExecutor::suppress(const Suppressions::ErrorMessage&)
+{}
+
 void CppCheckExecutor::reportStatus(std::size_t fileindex, std::size_t filecount, std::size_t sizedone, std::size_t sizetotal)
 {
     if (filecount > 1) {

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -86,6 +86,8 @@ public:
      */
     void reportInfo(const ErrorMessage &msg) override;
 
+    void suppress(const Suppressions::ErrorMessage& msg) override;
+
     /**
      * Information about how many files have been checked
      *

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -76,6 +76,10 @@ public:
         report(msg, MessageType::REPORT_INFO);
     }
 
+    void suppress(const Suppressions::ErrorMessage& msg) override {
+        mThreadExecutor.mSettings.nomsg.isSuppressed(msg);
+    }
+
     ThreadExecutor &mThreadExecutor;
 
     std::map<std::string, std::size_t>::const_iterator mItNextFile;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1606,6 +1606,11 @@ void CppCheck::reportInfo(const ErrorMessage &msg)
         mErrorLogger.reportInfo(msg);
 }
 
+void CppCheck::suppress(const Suppressions::ErrorMessage& msg)
+{
+    mSettings.nomsg.isSuppressed(msg);
+}
+
 void CppCheck::reportStatus(unsigned int /*fileindex*/, unsigned int /*filecount*/, std::size_t /*sizedone*/, std::size_t /*sizetotal*/)
 {}
 

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -217,6 +217,8 @@ private:
      */
     void reportInfo(const ErrorMessage &msg) override;
 
+    void suppress(const Suppressions::ErrorMessage& msg) override;
+
     ErrorLogger &mErrorLogger;
 
     /** @brief Current preprocessor configuration */

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -238,6 +238,8 @@ public:
      */
     virtual void reportErr(const ErrorMessage &msg) = 0;
 
+    virtual void suppress(const Suppressions::ErrorMessage& msg) = 0;
+
     /**
      * Report progress to client
      * @param filename main file that is checked

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -848,10 +848,18 @@ void Preprocessor::missingInclude(const std::string &filename, unsigned int line
     errorMessage.setFileName(fname);
     errorMessage.lineNumber = linenr;
     if (mSettings.nomsg.isSuppressed(errorMessage))
+    {
+        if (mErrorLogger)
+            mErrorLogger->suppress(errorMessage);
         return;
+    }
     errorMessage.errorId = "missingIncludeSystem";
     if (headerType == SystemHeader && mSettings.nomsg.isSuppressed(errorMessage))
+    {
+        if (mErrorLogger)
+            mErrorLogger->suppress(errorMessage);
         return;
+    }
 
     if (headerType == SystemHeader)
         missingSystemIncludeFlag = true;

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -43,6 +43,8 @@ private:
         void reportErr(const ErrorMessage &msg) override {
             id.push_back(msg.id);
         }
+
+        void suppress(const Suppressions::ErrorMessage&) {}
     };
 
     void run() override {

--- a/test/testsuite.h
+++ b/test/testsuite.h
@@ -106,6 +106,7 @@ protected:
 public:
     void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
     void reportErr(const ErrorMessage &msg) override;
+    void suppress(const Suppressions::ErrorMessage&) override {}
     void run(const std::string &str);
     static void printHelp();
     const std::string classname;


### PR DESCRIPTION
Cross post from the forum (https://sourceforge.net/p/cppcheck/discussion/general/thread/847b8527de/)

I'm looking a bit into https://trac.cppcheck.net/ticket/10489 and I think I found the issue and a very hacky solution, but I'm looking for input for the _correct_ solution.

Problem: 
with this code
```cpp
#include <string>
```
and calling it with 
```
cppcheck.exe --suppress=missingIncludeSystem -j 2 --enable=information test.cpp
```
yields
```
Checking test.cpp ...
nofile:0:0: information: Unmatched suppression: missingIncludeSystem [unmatchedSuppression]
```

This is due to the `-j 2` flag. If I compare it with a suppressed regular error, I notice that those go through `ThreadExecutor::SyncLogForwarder`, which somehow synchonizes messages betwee threads (?). `missingInclude` (and `missingSystemInclude`) do _not_ go through `SyncLogForwarder`, and therefore its suppression-match-status gets lost when the thread ends.

I put together kind of a fix, but I think it is just a hack, and I have no idea if i really makes sense. Diff is added (based upon current main, 4ce76d0b).
Basically, I added a virtual function to `ErrorLogger` so that in `Preprocessor::missingInclude` I can call that function so the suppression-state get propagated through `SyncLogForwarder`.
Is this the right direction? What should be the implementations? Should all calls to `mSettings.nomsg.isSuppressed(errorMessage)` actually be calls to the new function?