### PR TITLE
avoid some unnecessary copies

### DIFF
--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -126,8 +126,7 @@ void strTolower(std::string& str)
 {
     // This wrapper exists because Sun's CC does not allow a static_cast
     // from extern "C" int(*)(int) to int(*)(int).
-    static auto tolowerWrapper = [](int c) {
+    std::transform(str.begin(), str.end(), str.begin(), [](int c) {
         return std::tolower(c);
-    };
-    std::transform(str.begin(), str.end(), str.begin(), tolowerWrapper);
+    });
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3777,8 +3777,8 @@ static void valueFlowForwardLifetime(Token * tok, TokenList *tokenlist, ErrorLog
         std::list<ValueFlow::Value> values = tok->values();
         // Only forward lifetime values
         values.remove_if(&isNotLifetimeValue);
-        for (const ValueFlow::Value& value:values)
-            setTokenValue(parent, value, tokenlist->getSettings());
+        for (ValueFlow::Value& value:values)
+            setTokenValue(parent, std::move(value), tokenlist->getSettings());
         valueFlowForwardLifetime(parent, tokenlist, errorLogger, settings);
     }
 }


### PR DESCRIPTION
Found while looking into the fixes for the upcoming `performance-unnecessary-copy-on-last-use` clang-tidy check.