### PR TITLE
Fix 11396, doublefree on munmap in if-statement

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -477,9 +477,10 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 // check for function call
                 const Token * const openingPar = isFunctionCall(innerTok);
                 if (openingPar) {
+                    const Library::AllocFunc* allocFunc = mSettings->library.getDeallocFuncInfo(innerTok);
                     // innerTok is a function name
                     const VarInfo::AllocInfo allocation(0, VarInfo::NOALLOC);
-                    functionCall(innerTok, openingPar, varInfo, allocation, nullptr);
+                    functionCall(innerTok, openingPar, varInfo, allocation, allocFunc);
                     innerTok = openingPar->link();
                 }
             }


### PR DESCRIPTION
I ran 273 packages with `test-my-pr.py` with no differences (but if I run it on the package in trac ticket 11873 the doublefree warning is gone).