### PR TITLE
donate-cpu: avoid unnecessary build invocation for `main`

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -184,7 +184,7 @@ while True:
         current_cppcheck_dir = os.path.join(work_path, 'tree-'+ver)
         print('Fetching Cppcheck-{}..'.format(ver))
         try:
-            lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
+            hash_changes = lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
         except KeyboardInterrupt as e:
             # Passthrough for user abort
             raise e
@@ -192,7 +192,7 @@ while True:
             print('Failed to update Cppcheck ({}), retry later'.format(e))
             sys.exit(1)
         if ver == 'main':
-            if not lib.compile_cppcheck(current_cppcheck_dir):
+            if hash_changes and not lib.compile_cppcheck(current_cppcheck_dir):
                 print('Failed to compile Cppcheck-{}, retry later'.format(ver))
                 sys.exit(1)
         else:

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -268,6 +268,7 @@ def __handle_remove_readonly(func, path, exc):
 def __remove_tree(folder_name):
     if not os.path.exists(folder_name):
         return
+    print('Removing existing temporary data...')
     count = 5
     while count > 0:
         count -= 1
@@ -310,7 +311,6 @@ def download_package(work_path, package, bandwidth_limit):
 
 
 def unpack_package(work_path, tgz, cpp_only=False, c_only=False, skip_files=None):
-    print('Unpacking..')
     temp_path = os.path.join(work_path, 'temp')
     __remove_tree(temp_path)
     os.mkdir(temp_path)
@@ -328,6 +328,7 @@ def unpack_package(work_path, tgz, cpp_only=False, c_only=False, skip_files=None
 
     source_found = False
     if tarfile.is_tarfile(tgz):
+        print('Unpacking..')
         with tarfile.open(tgz) as tf:
             total = 0
             extracted = 0


### PR DESCRIPTION
This avoids invoking the build for `main` when no changes were detected. The impact is low for `make` on Linux but on Windows with Visual Studio it has a bigger impact.

Below are some performance values. I bailed out before any of the analysis steps were started. I used WSL Kali Linux.

`hyperfine 'python3 donate-cpu.py -j6 --no-upload --package=ftp://ftp.de.debian.org/debian/pool/main/a/adns/adns_1.6.0.orig.tar.gz'`

When avoiding a build when there are no changes:
```
Benchmark 1: python3 donate-cpu.py -j6 --no-upload --package=ftp://ftp.de.debian.org/debian/pool/main/a/adns/adns_1.6.0.orig.tar.gz
  Time (mean ± σ):      2.557 s ±  0.375 s    [User: 0.409 s, System: 1.023 s]
  Range (min … max):    2.239 s …  3.505 s    10 runs
```

Still invoking a build with the `git rev-parse` calls intact:
```
Benchmark 1: python3 donate-cpu.py -j6 --no-upload --package=ftp://ftp.de.debian.org/debian/pool/main/a/adns/adns_1.6.0.orig.tar.gz
  Time (mean ± σ):      3.509 s ±  0.146 s    [User: 1.314 s, System: 1.095 s]
  Range (min … max):    3.371 s …  3.759 s    10 runs
```

The current code:
```
Benchmark 1: python3 donate-cpu.py -j6 --no-upload --package=ftp://ftp.de.debian.org/debian/pool/main/a/adns/adns_1.6.0.orig.tar.gz
  Time (mean ± σ):      3.426 s ±  0.204 s    [User: 1.250 s, System: 1.045 s]
  Range (min … max):    3.235 s …  3.965 s    10 runs
```

So even with the added process invocations it does save resources.