### PR TITLE
fixed macos build by manually installing `pcre`

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install coreutils qt@5 tinyxml2
+          # pcre was removed from runner images in November 2022
+          brew install coreutils qt@5 tinyxml2 pcre
 
       - name: CMake build on ubuntu (with GUI / system tinyxml2)
         if: contains(matrix.os, 'ubuntu')
@@ -88,7 +89,8 @@ jobs:
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install coreutils qt@5
+          # pcre was removed from runner images in November 2022
+          brew install coreutils qt@5 pcre
 
       - name: CMake build on ubuntu (with GUI)
         if: contains(matrix.os, 'ubuntu')
@@ -330,7 +332,8 @@ jobs:
       - name: Install missing software on macos
         if: contains(matrix.os, 'macos')
         run: |
-          brew install coreutils python3
+          # pcre was removed from runner images in November 2022
+          brew install coreutils python3 pcre
 
       - name: Install missing Python packages
         run: |

--- a/Makefile
+++ b/Makefile
@@ -151,11 +151,15 @@ else ifeq ($(CXX), c++)
 endif
 
 ifeq ($(HAVE_RULES),yes)
-    override CXXFLAGS += -DHAVE_RULES -DTIXML_USE_STL $(shell pcre-config --cflags)
+    PCRE_CONFIG = $(shell which pcre-config)
+    ifeq ($(PCRE_CONFIG),)
+        $(error Did not find pcre-config)
+    endif
+    override CXXFLAGS += -DHAVE_RULES -DTIXML_USE_STL $(shell $(PCRE_CONFIG) --cflags)
     ifdef LIBS
-        LIBS += $(shell pcre-config --libs)
+        LIBS += $(shell $(PCRE_CONFIG) --libs)
     else
-        LIBS=$(shell pcre-config --libs)
+        LIBS=$(shell $(PCRE_CONFIG) --libs)
     endif
 endif
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -429,11 +429,15 @@ int main(int argc, char **argv)
          << "\n";
 
     fout << "ifeq ($(HAVE_RULES),yes)\n"
-         << "    override CXXFLAGS += -DHAVE_RULES -DTIXML_USE_STL $(shell pcre-config --cflags)\n"
+         << "    PCRE_CONFIG = $(shell which pcre-config)\n"
+         << "    ifeq ($(PCRE_CONFIG),)\n"
+         << "        $(error Did not find pcre-config)\n"
+         << "    endif\n"
+         << "    override CXXFLAGS += -DHAVE_RULES -DTIXML_USE_STL $(shell $(PCRE_CONFIG) --cflags)\n"
          << "    ifdef LIBS\n"
-         << "        LIBS += $(shell pcre-config --libs)\n"
+         << "        LIBS += $(shell $(PCRE_CONFIG) --libs)\n"
          << "    else\n"
-         << "        LIBS=$(shell pcre-config --libs)\n"
+         << "        LIBS=$(shell $(PCRE_CONFIG) --libs)\n"
          << "    endif\n"
          << "endif\n\n";
 


### PR DESCRIPTION
`pcre` suddenly disappeared from the `macos-*` runner images so install it manually.