### PR TITLE
CI-cygwin.yml: removed `x86` since it is no longer supported

### DIFF
--- a/.github/workflows/CI-cygwin.yml
+++ b/.github/workflows/CI-cygwin.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        arch: [x64, x86]
+        arch: [x64]
         include:
           - platform: 'x86_64'
             packages: |


### PR DESCRIPTION
```
Starting cygwin install, version 2.924
mbox : Cygwin is not supported on 32-bit Windows
```

It is a bit strange though since the support is being removed in 3.4.0 which has not yet been released. No idea which version it tries to install. It also doesn't seem to apply to all runners yet since some builds still succeeded.