### PR TITLE
Fix #11401 nullpointer dereference with alignof

### DIFF
--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -152,7 +152,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown) const
 
 static bool isUnevaluatedOperator(const Token* tok)
 {
-    return Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof|_Alignof (");
+    return Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof|_Alignof|_alignof|__alignof|__alignof__ (");
 }
 
 bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Settings *settings)

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -150,8 +150,9 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown) const
     return isPointerDeRef(tok, unknown, mSettings);
 }
 
-static bool isUnevaluated(const Token* tok) {
-    return tok && Token::Match(tok->previous(), "sizeof|decltype|alignof (");
+static bool isUnevaluatedOperator(const Token* tok)
+{
+    return Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof (");
 }
 
 bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Settings *settings)
@@ -190,7 +191,8 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Set
         return false;
 
     // Dereferencing pointer..
-    if (parent->isUnaryOp("*") && !isUnevaluated(parent->astParent())) {
+    const Token* grandParent = parent->astParent();
+    if (parent->isUnaryOp("*") && !(grandParent && isUnevaluatedOperator(grandParent->previous()))) {
         // declaration of function pointer
         if (tok->variable() && tok->variable()->nameToken() == tok)
             return false;
@@ -288,7 +290,7 @@ void CheckNullPointer::nullPointerByDeRefAndChec()
     const bool printInconclusive = (mSettings->certainty.isEnabled(Certainty::inconclusive));
 
     for (const Token *tok = mTokenizer->tokens(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof (")) {
+        if (isUnevaluatedOperator(tok)) {
             tok = tok->next()->link();
             continue;
         }
@@ -347,7 +349,7 @@ void CheckNullPointer::nullConstantDereference()
             tok = scope->function->token; // Check initialization list
 
         for (; tok != scope->bodyEnd; tok = tok->next()) {
-            if (Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof ("))
+            if (isUnevaluatedOperator(tok))
                 tok = tok->next()->link();
 
             else if (Token::simpleMatch(tok, "* 0")) {

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -152,7 +152,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown) const
 
 static bool isUnevaluatedOperator(const Token* tok)
 {
-    return Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof (");
+    return Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof|_Alignof (");
 }
 
 bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Settings *settings)

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -151,7 +151,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown) const
 }
 
 static bool isUnevaluated(const Token* tok) {
-    return tok && Token::Match(tok->previous(), "sizeof|decltype (");
+    return tok && Token::Match(tok->previous(), "sizeof|decltype|alignof (");
 }
 
 bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Settings *settings)
@@ -288,7 +288,7 @@ void CheckNullPointer::nullPointerByDeRefAndChec()
     const bool printInconclusive = (mSettings->certainty.isEnabled(Certainty::inconclusive));
 
     for (const Token *tok = mTokenizer->tokens(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "sizeof|decltype|typeid|typeof (")) {
+        if (Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof (")) {
             tok = tok->next()->link();
             continue;
         }
@@ -347,7 +347,7 @@ void CheckNullPointer::nullConstantDereference()
             tok = scope->function->token; // Check initialization list
 
         for (; tok != scope->bodyEnd; tok = tok->next()) {
-            if (Token::Match(tok, "sizeof|decltype|typeid|typeof ("))
+            if (Token::Match(tok, "sizeof|decltype|typeid|typeof|alignof ("))
                 tok = tok->next()->link();
 
             else if (Token::simpleMatch(tok, "* 0")) {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -3435,6 +3435,12 @@ private:
               "    return;\n"
               "}");
         ASSERT_EQUALS("", errout.str());
+
+        check("size_t foo() {\n"
+              "    char* c = 0;\n"
+              "    return _Alignof(*c);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void nullpointer_in_for_loop() {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -3441,6 +3441,21 @@ private:
               "    return _Alignof(*c);\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+
+        check("size_t foo() {\n"
+              "    return _alignof(*0);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("size_t foo() {\n"
+              "    return __alignof(*0);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("size_t foo() {\n"
+              "    return __alignof__(*0);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void nullpointer_in_for_loop() {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -153,6 +153,7 @@ private:
         TEST_CASE(scanf_with_invalid_va_argument);
         TEST_CASE(nullpointer_in_return);
         TEST_CASE(nullpointer_in_typeid);
+        TEST_CASE(nullpointer_in_alignof); // #11401
         TEST_CASE(nullpointer_in_for_loop);
         TEST_CASE(nullpointerDelete);
         TEST_CASE(nullpointerSubFunction);
@@ -3413,7 +3414,27 @@ private:
               "     return typeid(*c) == typeid(*c);\n"
               "}", true);
         ASSERT_EQUALS("", errout.str());
+    }
 
+    void nullpointer_in_alignof() // #11401
+    {
+        check("size_t foo() {\n"
+              "    char* c = 0;\n"
+              "    return alignof(*c);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("size_t foo() {\n"
+              "    return alignof(*0);\n"
+              "}", true);
+        ASSERT_EQUALS("", errout.str());
+
+        check("void foo(int *p) {\n"
+              "    f(alignof(*p));\n"
+              "    if (p) {}\n"
+              "    return;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void nullpointer_in_for_loop() {
@@ -4344,6 +4365,15 @@ private:
 
         ctu("size_t f(int* p) {\n"
             "    size_t len = sizeof(*p);\n"
+            "    return len;\n"
+            "}\n"
+            "void g() {\n"
+            "    f(NULL);\n"
+            "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        ctu("size_t f(int* p) {\n"
+            "    size_t len = alignof(*p);\n"
             "    return len;\n"
             "}\n"
             "void g() {\n"


### PR DESCRIPTION
Fix FP with nullpointer dereference in `alignof`. `alignof` is a compile time operator which only looks at the type of the variable (and therefore does not cause a nullpointer dereference, similar to `sizeof`).

To do this, unify the check for these types of operators in the various nullpointer checks. Then add `alignof`, the c version `_Alignof` and various compiler versions of it. Note that the report in #11401 is about the gcc extension `__alignof__`.