### PR TITLE
Refactor runtests to allow to specify files on command line

### DIFF
--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -508,20 +508,26 @@ do
     esac
 done
 
+
 # Check the syntax of the defines in the configuration files
-if ! xmlstarlet --version; then
-    echo "xmlstarlet needed to extract defines, skipping defines check."
-    exit_if_strict
-else
-    for configfile in ${CFG}*.cfg; do
-        echo "Checking defines in $configfile"
-        # Disable debugging output temporarily since there could be many defines
-        set +x
-        # XMLStarlet returns 1 if no elements were found which is no problem here
-        EXTRACTED_DEFINES=$(xmlstarlet sel -t -m '//define' -c . -n <$configfile || true)
-        EXTRACTED_DEFINES=$(echo "$EXTRACTED_DEFINES" | sed 's/<define name="/#define /g' | sed 's/" value="/ /g' | sed 's/"\/>//g')
-        echo "$EXTRACTED_DEFINES" | gcc -fsyntax-only -xc -Werror -
-    done
-fi
+function check_defines_syntax
+{
+    if ! xmlstarlet --version; then
+        echo "xmlstarlet needed to extract defines, skipping defines check."
+        exit_if_strict
+    else
+        for configfile in ${CFG}*.cfg; do
+            echo "Checking defines in $configfile"
+            # Disable debugging output temporarily since there could be many defines
+            set +x
+            # XMLStarlet returns 1 if no elements were found which is no problem here
+            EXTRACTED_DEFINES=$(xmlstarlet sel -t -m '//define' -c . -n <$configfile || true)
+            EXTRACTED_DEFINES=$(echo "$EXTRACTED_DEFINES" | sed 's/<define name="/#define /g' | sed 's/" value="/ /g' | sed 's/"\/>//g')
+            echo "$EXTRACTED_DEFINES" | gcc -fsyntax-only -xc -Werror -
+        done
+    fi
+}
+
+check_defines_syntax
 
 echo SUCCESS

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -507,10 +507,13 @@ function check_file {
     esac
 }
 
-for f in "${DIR}"*.{c,cpp}
+function check_files
+{
+for f in "$@"
 do
     check_file $f
 done
+}
 
 # Check the syntax of the defines in the configuration files
 function check_defines_syntax
@@ -531,6 +534,7 @@ function check_defines_syntax
     fi
 }
 
+check_files "${DIR}"*.{c,cpp}
 check_defines_syntax
 
 echo SUCCESS

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -406,9 +406,8 @@ function cppunit_fn {
     fi
 }
 
-for f in "${DIR}"*.{c,cpp}
-do
-    f=$(basename $f)
+function check_file {
+    f=$(basename $1)
     case $f in
         boost.cpp)
             boost_fn
@@ -506,8 +505,12 @@ do
           echo "Unhandled file $f"
           exit_if_strict
     esac
-done
+}
 
+for f in "${DIR}"*.{c,cpp}
+do
+    check_file $f
+done
 
 # Check the syntax of the defines in the configuration files
 function check_defines_syntax

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -534,7 +534,12 @@ function check_defines_syntax
     fi
 }
 
-check_files "${DIR}"*.{c,cpp}
-check_defines_syntax
+if [ $# -eq 0  ]
+then
+    check_files "${DIR}"*.{c,cpp}
+    check_defines_syntax
+else
+    check_files "$@"
+fi
 
 echo SUCCESS


### PR DESCRIPTION
Sometimes I find myself wanting to run the cfg-tests on a specific file (since running all of them takes time and it might be hard to spot a specific error message among all the output).

Refactor `runtests.sh` to accept optional arguments to make it possible to check just a few files without having to do local hacks. With these changes, you can run `runtests.sh bsd.c std.c` to just check those two files. The behavior of `make checkcfg` is unchanged.