### PR TITLE
test-my-pr, mark --c-only and --cpp-only mutually exclusive

### DIFF
--- a/tools/test-my-pr.py
+++ b/tools/test-my-pr.py
@@ -25,12 +25,14 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Run this script from your branch with proposed Cppcheck patch to verify your patch against current main. It will compare output of testing bunch of opensource packages')
     parser.add_argument('-j', default=1, type=int, help='Concurency execution threads')
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument('-p', default=256, type=int, help='Count of packages to check')
-    group.add_argument('--packages', nargs='+', help='Check specific packages and then stop.')
+    package_group = parser.add_mutually_exclusive_group()
+    package_group.add_argument('-p', default=256, type=int, help='Count of packages to check')
+    package_group.add_argument('--packages', nargs='+', help='Check specific packages and then stop.')
     parser.add_argument('-o', default='my_check_diff.log', help='Filename of result inside a working path dir')
-    parser.add_argument('--c-only', dest='c_only', help='Only process c packages', action='store_true')
-    parser.add_argument('--cpp-only', dest='cpp_only', help='Only process c++ packages', action='store_true')
+
+    language_group = parser.add_mutually_exclusive_group()
+    language_group.add_argument('--c-only', dest='c_only', help='Only process c packages', action='store_true')
+    language_group.add_argument('--cpp-only', dest='cpp_only', help='Only process c++ packages', action='store_true')
     parser.add_argument('--work-path', '--work-path=', default=__work_path, type=str, help='Working directory for reference repo')
     args = parser.parse_args()
 


### PR DESCRIPTION
It makes no sense to specify both arguments at the same time.