### PR TITLE
greatly sped up `dmake`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -848,6 +848,6 @@ externals/simplecpp/simplecpp.o: externals/simplecpp/simplecpp.cpp externals/sim
 externals/tinyxml2/tinyxml2.o: externals/tinyxml2/tinyxml2.cpp externals/tinyxml2/tinyxml2.h
 	$(CXX)  $(CPPFLAGS) $(CXXFLAGS) -w -c -o $@ externals/tinyxml2/tinyxml2.cpp
 
-tools/dmake.o: tools/dmake.cpp cli/filelister.h lib/config.h lib/pathmatch.h
+tools/dmake.o: tools/dmake.cpp cli/filelister.h lib/config.h lib/pathmatch.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ tools/dmake.cpp
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -57,7 +57,7 @@ static std::string objfiles(const std::vector<std::string> &files)
 
 static void getDeps(const std::string &filename, std::vector<std::string> &depfiles)
 {
-    static const std::array<std::string, 4> externalfolders{"externals", "externals/picojson", "externals/simplecpp", "externals/tinyxml2"};
+    static const std::array<std::string, 3> externalfolders{"externals/picojson", "externals/simplecpp", "externals/tinyxml2"};
 
     // Is the dependency already included?
     if (std::find(depfiles.begin(), depfiles.end(), filename) != depfiles.end())

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -109,6 +109,9 @@ static void getDeps(const std::string &filename, std::vector<std::string> &depfi
         const std::string::size_type traverse_pos = hfile.find("/../");
         if (traverse_pos != std::string::npos)    // TODO: Ugly fix
             hfile.erase(0, 4 + traverse_pos);
+        // no need to look up extension-less headers
+        if (!endsWith(hfile, ".h"))
+            continue;
         getDeps(hfile, depfiles);
     }
 }

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -27,6 +27,7 @@
 
 #include "../cli/filelister.h"
 #include "../lib/pathmatch.h"
+#include "../lib/utils.h"
 
 static std::string builddir(std::string filename)
 {
@@ -136,7 +137,7 @@ static std::string getCppFiles(std::vector<std::string> &files, const std::strin
 
     // add *.cpp files to the "files" vector..
     for (const std::pair<const std::string&, size_t> file : filemap) {
-        if (file.first.find(".cpp") != std::string::npos)
+        if (endsWith(file.first, ".cpp"))
             files.push_back(file.first);
     }
     return "";

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -106,8 +106,9 @@ static void getDeps(const std::string &filename, std::vector<std::string> &depfi
         std::string hfile(path);
         hfile += line.substr(pos1, pos2 - pos1);
 
-        if (hfile.find("/../") != std::string::npos)    // TODO: Ugly fix
-            hfile.erase(0, 4 + hfile.find("/../"));
+        const std::string::size_type traverse_pos = hfile.find("/../");
+        if (traverse_pos != std::string::npos)    // TODO: Ugly fix
+            hfile.erase(0, 4 + traverse_pos);
         getDeps(hfile, depfiles);
     }
 }

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -103,7 +103,8 @@ static void getDeps(const std::string &filename, std::vector<std::string> &depfi
         pos1 += 10;
 
         const std::string::size_type pos2 = line.find(rightBracket, pos1);
-        std::string hfile = path + line.substr(pos1, pos2 - pos1);
+        std::string hfile(path);
+        hfile += line.substr(pos1, pos2 - pos1);
 
         if (hfile.find("/../") != std::string::npos)    // TODO: Ugly fix
             hfile.erase(0, 4 + hfile.find("/../"));


### PR DESCRIPTION
For some reason which I have not figured out yet `dmake` got much slower. Since it is a fixed dependency in CMake builds it slows things down quite a bit. These changes greatly improve the run-time of it without changing the output.

We still show figure out when it got slow to fix the actual root cause.

Before:
```
Benchmark 1: ./dmake
  Time (mean ± σ):     12.244 s ±  0.727 s    [User: 0.571 s, System: 11.501 s]
  Range (min … max):   11.643 s … 13.440 s    5 runs
```

After:
```
Benchmark 1: ./dmake
  Time (mean ± σ):      1.081 s ±  0.101 s    [User: 0.162 s, System: 0.911 s]
  Range (min … max):    0.989 s …  1.251 s    5 runs
```

This was tested using GCC 12 on WSL1 Kali Linux.