### PR TITLE
Delete unused variable `lowMem`

### DIFF
--- a/cli/cppcheckexecutorsig.cpp
+++ b/cli/cppcheckexecutorsig.cpp
@@ -121,7 +121,6 @@ static void CppcheckSignalHandler(int signo, siginfo_t * info, void * context)
     const Signalmap_t::const_iterator it=listofsignals.find(signo);
     const char * const signame = (it==listofsignals.end()) ? "unknown" : it->second.c_str();
     bool printCallstack=true; // try to print a callstack?
-    bool lowMem=false; // was low-memory condition detected? Be careful then! Avoid allocating much more memory then.
     bool unexpectedSignal=true; // unexpected indicates program failure
     bool terminate=true; // exit process/thread
     const bool isAddressOnStack = IsAddressOnStack(info->si_addr);
@@ -137,7 +136,6 @@ static void CppcheckSignalHandler(int signo, siginfo_t * info, void * context)
             " - out of memory or assertion?\n",
 #endif
             output);
-        lowMem=true;     // educated guess
         break;
     case SIGBUS:
         fputs("Internal error: cppcheck received signal ", output);


### PR DESCRIPTION
It also removes a warning from the build :)