### PR TITLE
donate-cpu: fixed resume of interrupted `main` branch compilation

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -184,7 +184,7 @@ while True:
         current_cppcheck_dir = os.path.join(work_path, 'tree-'+ver)
         print('Fetching Cppcheck-{}..'.format(ver))
         try:
-            hash_changes = lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
+            has_changes = lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
         except KeyboardInterrupt as e:
             # Passthrough for user abort
             raise e
@@ -192,7 +192,7 @@ while True:
             print('Failed to update Cppcheck ({}), retry later'.format(e))
             sys.exit(1)
         if ver == 'main':
-            if hash_changes and not lib.compile_cppcheck(current_cppcheck_dir):
+            if (has_changes or not lib.has_binary(current_cppcheck_dir)) and not lib.compile_cppcheck(current_cppcheck_dir):
                 print('Failed to compile Cppcheck-{}, retry later'.format(ver))
                 sys.exit(1)
         else:


### PR DESCRIPTION
This occurred if you cancelled the script while the `main` compilation was performed. If you start the script again and no changes were done in-between it would have used the old binary until the next changes occur.