### PR TITLE
Fix syntaxError on lambda inside decltype

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -387,8 +387,12 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
 
             tok = tok->tokAt(3);
 
-            while (tok && tok->str() != ";")
-                tok = tok->next();
+            while (tok && tok->str() != ";") {
+                if (Token::simpleMatch(tok, "decltype ("))
+                    tok = tok->linkAt(1);
+                else
+                    tok = tok->next();
+            }
         }
 
         // unnamed struct and union

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -122,8 +122,12 @@ public:
         else if (classDef_ && classDef_->str() == "using") {
             typeStart = classDef->tokAt(3);
             typeEnd = typeStart;
-            while (typeEnd->next() && typeEnd->next()->str() != ";")
-                typeEnd = typeEnd->next();
+            while (typeEnd->next() && typeEnd->next()->str() != ";") {
+                if (Token::simpleMatch(typeEnd, "decltype ("))
+                    typeEnd = typeEnd->linkAt(1);
+                else
+                    typeEnd = typeEnd->next();
+            }
         }
     }
 

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -366,6 +366,7 @@ private:
         TEST_CASE(symboldatabase100); // #10174
         TEST_CASE(symboldatabase101);
         TEST_CASE(symboldatabase102);
+        TEST_CASE(symboldatabase103);
 
         TEST_CASE(createSymbolDatabaseFindAllScopes1);
         TEST_CASE(createSymbolDatabaseFindAllScopes2);
@@ -5058,6 +5059,15 @@ private:
         ASSERT(db->scopeList.size() == 2);
         ASSERT(db->scopeList.front().type == Scope::eGlobal);
         ASSERT(db->scopeList.back().className == "g");
+    }
+
+    void symboldatabase103() {
+        GET_SYMBOL_DB("void f() {\n"
+                      "using lambda = decltype([]() { return true; });\n"
+                      "lambda{}();\n"
+                      "}\n");
+        ASSERT(db != nullptr);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void createSymbolDatabaseFindAllScopes1() {


### PR DESCRIPTION
Got a syntax error on the following use case:

```cpp
void f() {
  using customComparator = decltype([] (const X& lhs, const X& rhs) { return lhs.CompareTo(rhs); });
  std::map<X, int, customComparator> m;
}
```

The issue being that the semicolon _inside_ the lambda was matched as the end of the `using`-statement, instead of the semicolon at the end of the line

This PR fixes this case