### PR TITLE
use `cbegin()` and `cend()` with `const_ierator` loops

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -179,7 +179,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
         return false;
     } else if (!mSettings->fileFilters.empty() && settings.project.fileSettings.empty()) {
         std::map<std::string, std::size_t> newMap;
-        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i)
             if (matchglobs(mSettings->fileFilters, i->first)) {
                 newMap[i->first] = i->second;
             }
@@ -250,7 +250,7 @@ bool CppCheckExecutor::reportSuppressions(const Settings &settings, bool unusedF
 
     bool err = false;
     if (settings.jointSuppressionReport) {
-        for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end(); ++i) {
+        for (std::map<std::string, std::size_t>::const_iterator i = files.cbegin(); i != files.cend(); ++i) {
             err |= errorLogger.reportUnmatchedSuppressions(
                 settings.nomsg.getUnmatchedLocalSuppressions(i->first, unusedFunctionCheckEnabled));
         }
@@ -311,7 +311,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
         settings.loadSummaries();
 
         std::list<std::string> fileNames;
-        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i)
             fileNames.emplace_back(i->first);
         AnalyzerInformation::writeFilesTxt(settings.buildDir, fileNames, settings.userDefines, settings.project.fileSettings);
     }
@@ -328,7 +328,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
         std::size_t processedsize = 0;
         unsigned int c = 0;
         if (settings.project.fileSettings.empty()) {
-            for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i) {
+            for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i) {
                 if (!mSettings->library.markupFile(i->first)
                     || !mSettings->library.processMarkupAfterCode(i->first)) {
                     returnValue += cppcheck.check(i->first);
@@ -353,7 +353,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
 
         // second loop to parse all markup files which may not work until all
         // c/cpp files have been parsed and checked
-        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.begin(); i != mFiles.end(); ++i) {
+        for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i) {
             if (mSettings->library.markupFile(i->first) && mSettings->library.processMarkupAfterCode(i->first)) {
                 returnValue += cppcheck.check(i->first);
                 processedsize += i->second;

--- a/cli/cppcheckexecutorsig.cpp
+++ b/cli/cppcheckexecutorsig.cpp
@@ -317,7 +317,7 @@ int check_wrapper_sig(CppCheckExecutor& executor, int (CppCheckExecutor::*f)(Cpp
     memset(&act, 0, sizeof(act));
     act.sa_flags=SA_SIGINFO|SA_ONSTACK;
     act.sa_sigaction=CppcheckSignalHandler;
-    for (std::map<int, std::string>::const_iterator sig=listofsignals.begin(); sig!=listofsignals.end(); ++sig) {
+    for (std::map<int, std::string>::const_iterator sig=listofsignals.cbegin(); sig!=listofsignals.cend(); ++sig) {
         sigaction(sig->first, &act, nullptr);
     }
     return (&executor->*f)(cppcheck);

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -226,12 +226,12 @@ unsigned int ProcessExecutor::check()
     std::map<pid_t, std::string> childFile;
     std::map<int, std::string> pipeFile;
     std::size_t processedsize = 0;
-    std::map<std::string, std::size_t>::const_iterator iFile = mFiles.begin();
-    std::list<ImportProject::FileSettings>::const_iterator iFileSettings = mSettings.project.fileSettings.begin();
+    std::map<std::string, std::size_t>::const_iterator iFile = mFiles.cbegin();
+    std::list<ImportProject::FileSettings>::const_iterator iFileSettings = mSettings.project.fileSettings.cbegin();
     for (;;) {
         // Start a new child
         const size_t nchildren = childFile.size();
-        if ((iFile != mFiles.end() || iFileSettings != mSettings.project.fileSettings.end()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
+        if ((iFile != mFiles.cend() || iFileSettings != mSettings.project.fileSettings.cend()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
             int pipes[2];
             if (pipe(pipes) == -1) {
                 std::cerr << "#### ThreadExecutor::check, pipe() failed: "<< std::strerror(errno) << std::endl;
@@ -293,7 +293,7 @@ unsigned int ProcessExecutor::check()
         if (!rpipes.empty()) {
             fd_set rfds;
             FD_ZERO(&rfds);
-            for (std::list<int>::const_iterator rp = rpipes.begin(); rp != rpipes.end(); ++rp)
+            for (std::list<int>::const_iterator rp = rpipes.cbegin(); rp != rpipes.cend(); ++rp)
                 FD_SET(*rp, &rfds);
             struct timeval tv; // for every second polling of load average condition
             tv.tv_sec = 1;

--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -162,9 +162,9 @@ void CheckThread::runAddonsAndTools(const ImportProject::FileSettings *fileSetti
                 continue;
 
             QStringList args;
-            for (std::list<std::string>::const_iterator incIt = fileSettings->includePaths.begin(); incIt != fileSettings->includePaths.end(); ++incIt)
+            for (std::list<std::string>::const_iterator incIt = fileSettings->includePaths.cbegin(); incIt != fileSettings->includePaths.cend(); ++incIt)
                 args << ("-I" + QString::fromStdString(*incIt));
-            for (std::list<std::string>::const_iterator i = fileSettings->systemIncludePaths.begin(); i != fileSettings->systemIncludePaths.end(); ++i)
+            for (std::list<std::string>::const_iterator i = fileSettings->systemIncludePaths.cbegin(); i != fileSettings->systemIncludePaths.cend(); ++i)
                 args << "-isystem" << QString::fromStdString(*i);
             for (const QString& def : QString::fromStdString(fileSettings->defines).split(";")) {
                 args << ("-D" + def);

--- a/gui/erroritem.cpp
+++ b/gui/erroritem.cpp
@@ -52,8 +52,8 @@ ErrorItem::ErrorItem(const ErrorMessage &errmsg)
     , hash(errmsg.hash)
     , symbolNames(QString::fromStdString(errmsg.symbolNames()))
 {
-    for (std::list<ErrorMessage::FileLocation>::const_iterator loc = errmsg.callStack.begin();
-         loc != errmsg.callStack.end();
+    for (std::list<ErrorMessage::FileLocation>::const_iterator loc = errmsg.callStack.cbegin();
+         loc != errmsg.callStack.cend();
          ++loc) {
         errorPath << QErrorPathItem(*loc);
     }

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -681,7 +681,7 @@ void MainWindow::analyzeFiles()
 
         if (file0.endsWith(".sln")) {
             QStringList configs;
-            for (std::list<ImportProject::FileSettings>::const_iterator it = p.fileSettings.begin(); it != p.fileSettings.end(); ++it) {
+            for (std::list<ImportProject::FileSettings>::const_iterator it = p.fileSettings.cbegin(); it != p.fileSettings.cend(); ++it) {
                 const QString cfg(QString::fromStdString(it->cfg));
                 if (!configs.contains(cfg))
                     configs.push_back(cfg);

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -131,7 +131,7 @@ static bool isAutoVarArray(const Token *tok)
 
     // ValueFlow
     if (var->isPointer() && !var->isArgument()) {
-        for (std::list<ValueFlow::Value>::const_iterator it = tok->values().begin(); it != tok->values().end(); ++it) {
+        for (std::list<ValueFlow::Value>::const_iterator it = tok->values().cbegin(); it != tok->values().cend(); ++it) {
             const ValueFlow::Value &val = *it;
             if (val.isTokValue() && isAutoVarArray(val.tokvalue))
                 return true;

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -451,7 +451,7 @@ void CheckClass::copyconstructors()
             }
             if (!funcDestructor || funcDestructor->isDefault()) {
                 const Token * mustDealloc = nullptr;
-                for (std::map<int, const Token*>::const_iterator it = allocatedVars.begin(); it != allocatedVars.end(); ++it) {
+                for (std::map<int, const Token*>::const_iterator it = allocatedVars.cbegin(); it != allocatedVars.cend(); ++it) {
                     if (!Token::Match(it->second, "%var% [(=] new %type%")) {
                         mustDealloc = it->second;
                         break;
@@ -1198,7 +1198,7 @@ static bool checkFunctionUsage(const Function *privfunc, const Scope* scope)
     if (!scope)
         return true; // Assume it is used, if scope is not seen
 
-    for (std::list<Function>::const_iterator func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
+    for (std::list<Function>::const_iterator func = scope->functionList.cbegin(); func != scope->functionList.cend(); ++func) {
         if (func->functionScope) {
             if (Token::Match(func->tokenDef, "%name% (")) {
                 for (const Token *ftok = func->tokenDef->tokAt(2); ftok && ftok->str() != ")"; ftok = ftok->next()) {
@@ -1220,8 +1220,8 @@ static bool checkFunctionUsage(const Function *privfunc, const Scope* scope)
             return true;
     }
 
-    const std::map<std::string, Type*>::const_iterator end = scope->definedTypesMap.end();
-    for (std::map<std::string, Type*>::const_iterator iter = scope->definedTypesMap.begin(); iter != end; ++iter) {
+    const std::map<std::string, Type*>::const_iterator end = scope->definedTypesMap.cend();
+    for (std::map<std::string, Type*>::const_iterator iter = scope->definedTypesMap.cbegin(); iter != end; ++iter) {
         const Type *type = (*iter).second;
         if (type->enclosingScope == scope && checkFunctionUsage(privfunc, type->classScope))
             return true;
@@ -1534,7 +1534,7 @@ void CheckClass::operatorEqRetRefThis()
         return;
 
     for (const Scope * scope : mSymbolDatabase->classAndStructScopes) {
-        for (std::list<Function>::const_iterator func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
+        for (std::list<Function>::const_iterator func = scope->functionList.cbegin(); func != scope->functionList.cend(); ++func) {
             if (func->type == Function::eOperatorEqual && func->hasBody()) {
                 // make sure return signature is correct
                 if (func->retType == func->nestedIn->definedType && func->tokenDef->strAt(-1) == "&") {
@@ -1582,7 +1582,7 @@ void CheckClass::checkReturnPtrThis(const Scope *scope, const Function *func, co
         if (tok->strAt(2) == "(" &&
             tok->linkAt(2)->next()->str() == ";") {
             // check if it is a member function
-            for (std::list<Function>::const_iterator it = scope->functionList.begin(); it != scope->functionList.end(); ++it) {
+            for (std::list<Function>::const_iterator it = scope->functionList.cbegin(); it != scope->functionList.cend(); ++it) {
                 // check for a regular function with the same name and a body
                 if (it->type == Function::eFunction && it->hasBody() &&
                     it->token->str() == tok->next()->str()) {
@@ -2523,7 +2523,7 @@ void CheckClass::initializerListOrder()
     for (const Scope * scope : mSymbolDatabase->classAndStructScopes) {
 
         // iterate through all member functions looking for constructors
-        for (std::list<Function>::const_iterator func = scope->functionList.begin(); func != scope->functionList.end(); ++func) {
+        for (std::list<Function>::const_iterator func = scope->functionList.cbegin(); func != scope->functionList.cend(); ++func) {
             if (func->isConstructor() && func->hasBody()) {
                 // check for initializer list
                 const Token *tok = func->arg->link()->next();
@@ -2861,7 +2861,7 @@ void CheckClass::checkCopyCtorAndEqOperator()
     for (const Scope * scope : mSymbolDatabase->classAndStructScopes) {
 
         bool hasNonStaticVars = false;
-        for (std::list<Variable>::const_iterator var = scope->varlist.begin(); var != scope->varlist.end(); ++var) {
+        for (std::list<Variable>::const_iterator var = scope->varlist.cbegin(); var != scope->varlist.cend(); ++var) {
             if (!var->isStatic()) {
                 hasNonStaticVars = true;
                 break;

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -600,7 +600,7 @@ void CheckIO::checkFormatString(const Token * const tok,
     bool percent = false;
     const Token* argListTok2 = argListTok;
     std::set<int> parameterPositionsUsed;
-    for (std::string::const_iterator i = formatString.begin(); i != formatString.end(); ++i) {
+    for (std::string::const_iterator i = formatString.cbegin(); i != formatString.cend(); ++i) {
         if (*i == '%') {
             percent = !percent;
         } else if (percent && *i == '[') {

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -92,7 +92,7 @@ static bool isVarTokComparison(const Token * tok, const Token ** vartok,
 void VarInfo::print()
 {
     std::cout << "size=" << alloctype.size() << std::endl;
-    for (std::map<int, AllocInfo>::const_iterator it = alloctype.begin(); it != alloctype.end(); ++it) {
+    for (std::map<int, AllocInfo>::const_iterator it = alloctype.cbegin(); it != alloctype.cend(); ++it) {
         std::string strusage;
         const std::map<int, std::string>::const_iterator use =
             possibleUsage.find(it->first);
@@ -134,7 +134,7 @@ void VarInfo::print()
 void VarInfo::possibleUsageAll(const std::string &functionName)
 {
     possibleUsage.clear();
-    for (std::map<int, AllocInfo>::const_iterator it = alloctype.begin(); it != alloctype.end(); ++it)
+    for (std::map<int, AllocInfo>::const_iterator it = alloctype.cbegin(); it != alloctype.cend(); ++it)
         possibleUsage[it->first] = functionName;
 }
 
@@ -551,7 +551,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
 
                 std::map<int, VarInfo::AllocInfo>::const_iterator it;
 
-                for (it = old.alloctype.begin(); it != old.alloctype.end(); ++it) {
+                for (it = old.alloctype.cbegin(); it != old.alloctype.cend(); ++it) {
                     const int varId = it->first;
                     if (old.conditionalAlloc.find(varId) == old.conditionalAlloc.end())
                         continue;
@@ -563,7 +563,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 }
 
                 // Conditional allocation in varInfo1
-                for (it = varInfo1.alloctype.begin(); it != varInfo1.alloctype.end(); ++it) {
+                for (it = varInfo1.alloctype.cbegin(); it != varInfo1.alloctype.cend(); ++it) {
                     if (varInfo2.alloctype.find(it->first) == varInfo2.alloctype.end() &&
                         old.alloctype.find(it->first) == old.alloctype.end()) {
                         varInfo->conditionalAlloc.insert(it->first);
@@ -571,7 +571,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 }
 
                 // Conditional allocation in varInfo2
-                for (it = varInfo2.alloctype.begin(); it != varInfo2.alloctype.end(); ++it) {
+                for (it = varInfo2.alloctype.cbegin(); it != varInfo2.alloctype.cend(); ++it) {
                     if (varInfo1.alloctype.find(it->first) == varInfo1.alloctype.end() &&
                         old.alloctype.find(it->first) == old.alloctype.end()) {
                         varInfo->conditionalAlloc.insert(it->first);
@@ -579,13 +579,13 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 }
 
                 // Conditional allocation/deallocation
-                for (it = varInfo1.alloctype.begin(); it != varInfo1.alloctype.end(); ++it) {
+                for (it = varInfo1.alloctype.cbegin(); it != varInfo1.alloctype.cend(); ++it) {
                     if (it->second.managed() && conditionalAlloc.find(it->first) != conditionalAlloc.end()) {
                         varInfo->conditionalAlloc.erase(it->first);
                         varInfo2.erase(it->first);
                     }
                 }
-                for (it = varInfo2.alloctype.begin(); it != varInfo2.alloctype.end(); ++it) {
+                for (it = varInfo2.alloctype.cbegin(); it != varInfo2.alloctype.cend(); ++it) {
                     if (it->second.managed() && conditionalAlloc.find(it->first) != conditionalAlloc.end()) {
                         varInfo->conditionalAlloc.erase(it->first);
                         varInfo1.erase(it->first);
@@ -1024,7 +1024,7 @@ void CheckLeakAutoVar::ret(const Token *tok, VarInfo &varInfo, const bool isEndO
     std::vector<int> toRemove;
 
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
-    for (std::map<int, VarInfo::AllocInfo>::const_iterator it = alloctype.begin(); it != alloctype.end(); ++it) {
+    for (std::map<int, VarInfo::AllocInfo>::const_iterator it = alloctype.cbegin(); it != alloctype.cend(); ++it) {
         // don't warn if variable is conditionally allocated, unless it leaves the scope
         if (!isEndOfScope && !it->second.managed() && varInfo.conditionalAlloc.find(it->first) != varInfo.conditionalAlloc.end())
             continue;

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -97,7 +97,7 @@ void CheckNullPointer::parseFunctionCall(const Token &tok, std::list<const Token
         const bool scan = library->formatstr_scan(&tok);
 
         bool percent = false;
-        for (std::string::const_iterator i = formatString.begin(); i != formatString.end(); ++i) {
+        for (std::string::const_iterator i = formatString.cbegin(); i != formatString.cend(); ++i) {
             if (*i == '%') {
                 percent = !percent;
             } else if (percent) {

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -306,7 +306,7 @@ static bool isOperatorFunction(const std::string & funcName)
 bool CheckUnusedFunctions::check(ErrorLogger * const errorLogger, const Settings& settings) const
 {
     bool errors = false;
-    for (std::unordered_map<std::string, FunctionUsage>::const_iterator it = mFunctions.begin(); it != mFunctions.end(); ++it) {
+    for (std::unordered_map<std::string, FunctionUsage>::const_iterator it = mFunctions.cbegin(); it != mFunctions.cend(); ++it) {
         const FunctionUsage &func = it->second;
         if (func.usedOtherFile || func.filename.empty())
             continue;
@@ -443,7 +443,7 @@ void CheckUnusedFunctions::analyseWholeProgram(ErrorLogger * const errorLogger, 
         }
     }
 
-    for (std::map<std::string, Location>::const_iterator decl = decls.begin(); decl != decls.end(); ++decl) {
+    for (std::map<std::string, Location>::const_iterator decl = decls.cbegin(); decl != decls.cend(); ++decl) {
         const std::string &functionName = decl->first;
 
         // TODO: move to configuration files

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -199,7 +199,7 @@ void Variables::alias(nonneg int varid1, nonneg int varid2, bool replace)
 
     if (replace) {
         // remove var1 from all aliases
-        for (std::set<nonneg int>::const_iterator i = var1->_aliases.begin(); i != var1->_aliases.end(); ++i) {
+        for (std::set<nonneg int>::const_iterator i = var1->_aliases.cbegin(); i != var1->_aliases.cend(); ++i) {
             VariableUsage *temp = find(*i);
 
             if (temp)
@@ -211,7 +211,7 @@ void Variables::alias(nonneg int varid1, nonneg int varid2, bool replace)
     }
 
     // var1 gets all var2s aliases
-    for (std::set<nonneg int>::const_iterator i = var2->_aliases.begin(); i != var2->_aliases.end(); ++i) {
+    for (std::set<nonneg int>::const_iterator i = var2->_aliases.cbegin(); i != var2->_aliases.cend(); ++i) {
         if (*i != varid1)
             var1->_aliases.insert(*i);
     }
@@ -250,7 +250,7 @@ void Variables::eraseAliases(nonneg int varid)
     VariableUsage *usage = find(varid);
 
     if (usage) {
-        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.begin(); aliases != usage->_aliases.end(); ++aliases)
+        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.cbegin(); aliases != usage->_aliases.cend(); ++aliases)
             erase(*aliases);
     }
 }
@@ -330,7 +330,7 @@ void Variables::writeAliases(nonneg int varid, const Token* tok)
     VariableUsage *usage = find(varid);
 
     if (usage) {
-        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.begin(); aliases != usage->_aliases.end(); ++aliases) {
+        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.cbegin(); aliases != usage->_aliases.cend(); ++aliases) {
             VariableUsage *aliased = find(*aliases);
 
             if (aliased) {
@@ -355,7 +355,7 @@ void Variables::use(nonneg int varid, const Token* tok)
         usage->use();
         usage->_lastAccess = tok;
 
-        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.begin(); aliases != usage->_aliases.end(); ++aliases) {
+        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.cbegin(); aliases != usage->_aliases.cend(); ++aliases) {
             VariableUsage *aliased = find(*aliases);
 
             if (aliased) {
@@ -376,7 +376,7 @@ void Variables::modified(nonneg int varid, const Token* tok)
         usage->_modified = true;
         usage->_lastAccess = tok;
 
-        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.begin(); aliases != usage->_aliases.end(); ++aliases) {
+        for (std::set<nonneg int>::const_iterator aliases = usage->_aliases.cbegin(); aliases != usage->_aliases.cend(); ++aliases) {
             VariableUsage *aliased = find(*aliases);
 
             if (aliased) {
@@ -695,7 +695,7 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
     // Find declarations if the scope is executable..
     if (scope->isExecutable()) {
         // Find declarations
-        for (std::list<Variable>::const_iterator i = scope->varlist.begin(); i != scope->varlist.end(); ++i) {
+        for (std::list<Variable>::const_iterator i = scope->varlist.cbegin(); i != scope->varlist.cend(); ++i) {
             if (i->isThrow() || i->isExtern())
                 continue;
             Variables::VariableType type = Variables::none;
@@ -1308,8 +1308,8 @@ void CheckUnusedVar::checkFunctionVariableUsage()
 
 
         // Check usage of all variables in the current scope..
-        for (std::map<nonneg int, Variables::VariableUsage>::const_iterator it = variables.varUsage().begin();
-             it != variables.varUsage().end();
+        for (std::map<nonneg int, Variables::VariableUsage>::const_iterator it = variables.varUsage().cbegin();
+             it != variables.varUsage().cend();
              ++it) {
             const Variables::VariableUsage &usage = it->second;
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1640,7 +1640,7 @@ void CppCheck::getErrorMessages()
     tooManyConfigsError(emptyString,0U);
 
     // call all "getErrorMessages" in all registered Check classes
-    for (std::list<Check *>::const_iterator it = Check::instances().begin(); it != Check::instances().end(); ++it)
+    for (std::list<Check *>::const_iterator it = Check::instances().cbegin(); it != Check::instances().cend(); ++it)
         (*it)->getErrorMessages(this, &s);
 
     Preprocessor::getErrorMessages(this, &s);

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -75,7 +75,7 @@ ErrorMessage::ErrorMessage(const std::list<const Token*>& callstack, const Token
     : id(std::move(id)), severity(severity), cwe(0U), certainty(certainty), hash(0)
 {
     // Format callstack
-    for (std::list<const Token *>::const_iterator it = callstack.begin(); it != callstack.end(); ++it) {
+    for (std::list<const Token *>::const_iterator it = callstack.cbegin(); it != callstack.cend(); ++it) {
         // --errorlist can provide null values here
         if (!(*it))
             continue;
@@ -247,7 +247,7 @@ std::string ErrorMessage::serialize() const
     oss << saneVerboseMessage.length() << " " << saneVerboseMessage;
     oss << callStack.size() << " ";
 
-    for (std::list<ErrorMessage::FileLocation>::const_iterator loc = callStack.begin(); loc != callStack.end(); ++loc) {
+    for (std::list<ErrorMessage::FileLocation>::const_iterator loc = callStack.cbegin(); loc != callStack.cend(); ++loc) {
         std::ostringstream smallStream;
         smallStream << (*loc).line << '\t' << (*loc).column << '\t' << (*loc).getfile(false) << '\t' << loc->getOrigFile(false) << '\t' << loc->getinfo();
         oss << smallStream.str().length() << " " << smallStream.str();
@@ -417,8 +417,8 @@ std::string ErrorMessage::fixInvalidChars(const std::string& raw)
 {
     std::string result;
     result.reserve(raw.length());
-    std::string::const_iterator from=raw.begin();
-    while (from!=raw.end()) {
+    std::string::const_iterator from=raw.cbegin();
+    while (from!=raw.cend()) {
         if (std::isprint(static_cast<unsigned char>(*from))) {
             result.push_back(*from);
         } else {
@@ -451,7 +451,7 @@ std::string ErrorMessage::toXML() const
     if (!file0.empty())
         printer.PushAttribute("file0", file0.c_str());
 
-    for (std::list<FileLocation>::const_reverse_iterator it = callStack.rbegin(); it != callStack.rend(); ++it) {
+    for (std::list<FileLocation>::const_reverse_iterator it = callStack.crbegin(); it != callStack.crend(); ++it) {
         printer.OpenElement("location", false);
         printer.PushAttribute("file", (*it).getfile().c_str());
         printer.PushAttribute("line", std::max((*it).line,0));
@@ -669,7 +669,7 @@ bool ErrorLogger::reportUnmatchedSuppressions(const std::list<Suppressions::Supp
 std::string ErrorLogger::callStackToString(const std::list<ErrorMessage::FileLocation> &callStack)
 {
     std::string str;
-    for (std::list<ErrorMessage::FileLocation>::const_iterator tok = callStack.begin(); tok != callStack.end(); ++tok) {
+    for (std::list<ErrorMessage::FileLocation>::const_iterator tok = callStack.cbegin(); tok != callStack.cend(); ++tok) {
         str += (tok == callStack.begin() ? "" : " -> ");
         str += tok->stringify();
     }
@@ -789,9 +789,9 @@ std::string ErrorLogger::plistData(const ErrorMessage &msg)
           << "   <key>path</key>\r\n"
           << "   <array>\r\n";
 
-    std::list<ErrorMessage::FileLocation>::const_iterator prev = msg.callStack.begin();
+    std::list<ErrorMessage::FileLocation>::const_iterator prev = msg.callStack.cbegin();
 
-    for (std::list<ErrorMessage::FileLocation>::const_iterator it = msg.callStack.begin(); it != msg.callStack.end(); ++it) {
+    for (std::list<ErrorMessage::FileLocation>::const_iterator it = msg.callStack.cbegin(); it != msg.callStack.cend(); ++it) {
         if (prev != it) {
             plist << "    <dict>\r\n"
                   << "     <key>kind</key><string>control</string>\r\n"

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -906,7 +906,7 @@ bool ImportProject::importBcb6Prj(const std::string &projectFilename)
             { "-tWV","-WV" }
         };
 
-        for (std::map<std::string, std::string>::const_iterator i = synonyms.begin(); i != synonyms.end(); ++i) {
+        for (std::map<std::string, std::string>::const_iterator i = synonyms.cbegin(); i != synonyms.cend(); ++i) {
             if (cflags.erase(i->first) > 0) {
                 cflags.insert(i->second);
             }

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -648,7 +648,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
     }
     if (!unknown_elements.empty()) {
         std::string str;
-        for (std::set<std::string>::const_iterator i = unknown_elements.begin(); i != unknown_elements.end();) {
+        for (std::set<std::string>::const_iterator i = unknown_elements.cbegin(); i != unknown_elements.cend();) {
             str += *i;
             if (++i != unknown_elements.end())
                 str += ", ";

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -546,10 +546,10 @@ bool MathLib::isDecimalFloat(const std::string &str)
     enum class State {
         START, BASE_DIGITS1, LEADING_DECIMAL, TRAILING_DECIMAL, BASE_DIGITS2, E, MANTISSA_PLUSMINUS, MANTISSA_DIGITS, SUFFIX_F, SUFFIX_L
     } state = State::START;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case State::START:
             if (*it=='.')
@@ -748,10 +748,10 @@ bool MathLib::isOct(const std::string& str)
     } state = Status::START;
     if (str.empty())
         return false;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case Status::START:
             if (*it == '0')
@@ -783,10 +783,10 @@ bool MathLib::isIntHex(const std::string& str)
     } state = Status::START;
     if (str.empty())
         return false;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case Status::START:
             if (*it == '0')
@@ -824,10 +824,10 @@ bool MathLib::isFloatHex(const std::string& str)
     } state = Status::START;
     if (str.empty())
         return false;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case Status::START:
             if (*it == '0')
@@ -914,10 +914,10 @@ bool MathLib::isBin(const std::string& str)
     } state = Status::START;
     if (str.empty())
         return false;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case Status::START:
             if (*it == '0')
@@ -955,10 +955,10 @@ bool MathLib::isDec(const std::string & str)
     } state = Status::START;
     if (str.empty())
         return false;
-    std::string::const_iterator it = str.begin();
+    std::string::const_iterator it = str.cbegin();
     if ('+' == *it || '-' == *it)
         ++it;
-    for (; it != str.end(); ++it) {
+    for (; it != str.cend(); ++it) {
         switch (state) {
         case Status::START:
             if (isdigit(static_cast<unsigned char>(*it)))

--- a/lib/pathmatch.cpp
+++ b/lib/pathmatch.cpp
@@ -38,7 +38,7 @@ bool PathMatch::match(const std::string &path) const
     if (path.empty())
         return false;
 
-    for (std::vector<std::string>::const_iterator i = mExcludedPaths.begin(); i != mExcludedPaths.end(); ++i) {
+    for (std::vector<std::string>::const_iterator i = mExcludedPaths.cbegin(); i != mExcludedPaths.cend(); ++i) {
         const std::string excludedPath((!Path::isAbsolute(path) && Path::isAbsolute(*i)) ? Path::getRelativePath(*i, mWorkingDirectory) : *i);
 
         std::string findpath = Path::fromNativeSeparators(path);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -193,7 +193,7 @@ void Preprocessor::inlineSuppressions(const simplecpp::TokenList &tokens)
         return;
     std::list<BadInlineSuppression> err;
     ::addinlineSuppressions(tokens, mSettings, &err);
-    for (std::map<std::string,simplecpp::TokenList*>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
+    for (std::map<std::string,simplecpp::TokenList*>::const_iterator it = mTokenLists.cbegin(); it != mTokenLists.cend(); ++it) {
         if (it->second)
             ::addinlineSuppressions(*it->second, mSettings, &err);
     }
@@ -210,7 +210,7 @@ void Preprocessor::setDirectives(const simplecpp::TokenList &tokens)
     std::vector<const simplecpp::TokenList *> list;
     list.reserve(1U + mTokenLists.size());
     list.push_back(&tokens);
-    for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
+    for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.cbegin(); it != mTokenLists.cend(); ++it) {
         list.push_back(it->second);
     }
 
@@ -538,7 +538,7 @@ std::set<std::string> Preprocessor::getConfigs(const simplecpp::TokenList &token
 
     ::getConfigs(tokens, defined, mSettings.userDefines, mSettings.userUndefs, ret);
 
-    for (std::map<std::string, simplecpp::TokenList*>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
+    for (std::map<std::string, simplecpp::TokenList*>::const_iterator it = mTokenLists.cbegin(); it != mTokenLists.cend(); ++it) {
         if (!mSettings.configurationExcluded(it->first))
             ::getConfigs(*(it->second), defined, mSettings.userDefines, mSettings.userUndefs, ret);
     }
@@ -631,7 +631,7 @@ static simplecpp::DUI createDUI(const Settings &mSettings, const std::string &cf
 
 static bool hasErrors(const simplecpp::OutputList &outputList)
 {
-    for (simplecpp::OutputList::const_iterator it = outputList.begin(); it != outputList.end(); ++it) {
+    for (simplecpp::OutputList::const_iterator it = outputList.cbegin(); it != outputList.cend(); ++it) {
         switch (it->type) {
         case simplecpp::Output::ERROR:
         case simplecpp::Output::INCLUDE_NESTED_TOO_DEEPLY:
@@ -980,7 +980,7 @@ std::size_t Preprocessor::calculateHash(const simplecpp::TokenList &tokens1, con
         if (!tok->comment)
             hashData += tok->str();
     }
-    for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.begin(); it != mTokenLists.end(); ++it) {
+    for (std::map<std::string, simplecpp::TokenList *>::const_iterator it = mTokenLists.cbegin(); it != mTokenLists.cend(); ++it) {
         for (const simplecpp::Token *tok = it->second->cfront(); tok; tok = tok->next) {
             if (!tok->comment)
                 hashData += tok->str();

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1940,7 +1940,7 @@ namespace {
 
 void SymbolDatabase::validateVariables() const
 {
-    for (std::vector<const Variable *>::const_iterator iter = mVariableList.begin(); iter!=mVariableList.end(); ++iter) {
+    for (std::vector<const Variable *>::const_iterator iter = mVariableList.cbegin(); iter!=mVariableList.cend(); ++iter) {
         const Variable * const var = *iter;
         if (var) {
             if (!var->scope()) {
@@ -3103,7 +3103,7 @@ void SymbolDatabase::addClassFunction(Scope **scope, const Token **tok, const To
         // check in namespace if using found
         if (*scope == scope1 && !scope1->usingList.empty()) {
             std::vector<Scope::UsingInfo>::const_iterator it2;
-            for (it2 = scope1->usingList.begin(); it2 != scope1->usingList.end(); ++it2) {
+            for (it2 = scope1->usingList.cbegin(); it2 != scope1->usingList.cend(); ++it2) {
                 if (it2->scope) {
                     Function * func = findFunctionInScope(tok1, it2->scope, path, path_length);
                     if (func) {
@@ -3414,7 +3414,7 @@ bool Type::hasCircularDependencies(std::set<BaseInfo>* ancestors) const
     if (!ancestors) {
         ancestors=&knownAncestors;
     }
-    for (std::vector<BaseInfo>::const_iterator parent=derivedFrom.begin(); parent!=derivedFrom.end(); ++parent) {
+    for (std::vector<BaseInfo>::const_iterator parent=derivedFrom.cbegin(); parent!=derivedFrom.cend(); ++parent) {
         if (!parent->type)
             continue;
         else if (this==parent->type)
@@ -3439,7 +3439,7 @@ bool Type::findDependency(const Type* ancestor) const
 
 bool Type::isDerivedFrom(const std::string & ancestor) const
 {
-    for (std::vector<BaseInfo>::const_iterator parent=derivedFrom.begin(); parent!=derivedFrom.end(); ++parent) {
+    for (std::vector<BaseInfo>::const_iterator parent=derivedFrom.cbegin(); parent!=derivedFrom.cend(); ++parent) {
         if (parent->name == ancestor)
             return true;
         if (parent->type && parent->type->isDerivedFrom(ancestor))
@@ -3836,7 +3836,7 @@ void SymbolDatabase::printOut(const char *title) const
         std::cout << std::endl;
     }
 
-    for (std::list<Type>::const_iterator type = typeList.begin(); type != typeList.end(); ++type) {
+    for (std::list<Type>::const_iterator type = typeList.cbegin(); type != typeList.cend(); ++type) {
         std::cout << "Type: " << &(*type) << std::endl;
         std::cout << "    name: " << type->name() << std::endl;
         std::cout << "    classDef: " << tokenToString(type->classDef, mTokenizer) << std::endl;
@@ -3911,7 +3911,7 @@ void SymbolDatabase::printXml(std::ostream &out) const
 
     // Scopes..
     out << "  <scopes>" << std::endl;
-    for (std::list<Scope>::const_iterator scope = scopeList.begin(); scope != scopeList.end(); ++scope) {
+    for (std::list<Scope>::const_iterator scope = scopeList.cbegin(); scope != scopeList.cend(); ++scope) {
         out << "    <scope";
         out << " id=\"" << &*scope << "\"";
         out << " type=\"" << scope->type << "\"";
@@ -3933,7 +3933,7 @@ void SymbolDatabase::printXml(std::ostream &out) const
             out << '>' << std::endl;
             if (!scope->functionList.empty()) {
                 out << "      <functionList>" << std::endl;
-                for (std::list<Function>::const_iterator function = scope->functionList.begin(); function != scope->functionList.end(); ++function) {
+                for (std::list<Function>::const_iterator function = scope->functionList.cbegin(); function != scope->functionList.cend(); ++function) {
                     out << "        <function id=\"" << &*function
                         << "\" token=\"" << function->token
                         << "\" tokenDef=\"" << function->tokenDef
@@ -3978,7 +3978,7 @@ void SymbolDatabase::printXml(std::ostream &out) const
             }
             if (!scope->varlist.empty()) {
                 out << "      <varlist>" << std::endl;
-                for (std::list<Variable>::const_iterator var = scope->varlist.begin(); var != scope->varlist.end(); ++var)
+                for (std::list<Variable>::const_iterator var = scope->varlist.cbegin(); var != scope->varlist.cend(); ++var)
                     out << "        <var id=\""   << &*var << "\"/>" << std::endl;
                 out << "      </varlist>" << std::endl;
             }
@@ -4393,7 +4393,7 @@ bool Scope::hasDefaultConstructor() const
     if (numConstructors) {
         std::list<Function>::const_iterator func;
 
-        for (func = functionList.begin(); func != functionList.end(); ++func) {
+        for (func = functionList.cbegin(); func != functionList.cend(); ++func) {
             if (func->type == Function::eConstructor && func->argCount() == 0)
                 return true;
         }
@@ -4869,7 +4869,7 @@ const Enumerator * SymbolDatabase::findEnumerator(const Token * tok, std::set<st
                     return enumerator;
                 // enum
                 else {
-                    for (std::vector<Scope *>::const_iterator it = scope->nestedList.begin(), end = scope->nestedList.end(); it != end; ++it) {
+                    for (std::vector<Scope *>::const_iterator it = scope->nestedList.cbegin(), end = scope->nestedList.cend(); it != end; ++it) {
                         enumerator = (*it)->findEnumerator(tokStr);
 
                         if (enumerator && !(enumerator->scope && enumerator->scope->enumClass))
@@ -4884,7 +4884,7 @@ const Enumerator * SymbolDatabase::findEnumerator(const Token * tok, std::set<st
         if (enumerator && !(enumerator->scope && enumerator->scope->enumClass))
             return enumerator;
 
-        for (std::vector<Scope *>::const_iterator s = scope->nestedList.begin(); s != scope->nestedList.end(); ++s) {
+        for (std::vector<Scope *>::const_iterator s = scope->nestedList.cbegin(); s != scope->nestedList.cend(); ++s) {
             enumerator = (*s)->findEnumerator(tokStr);
 
             if (enumerator && !(enumerator->scope && enumerator->scope->enumClass))
@@ -4915,7 +4915,7 @@ const Enumerator * SymbolDatabase::findEnumerator(const Token * tok, std::set<st
             if (enumerator && !(enumerator->scope && enumerator->scope->enumClass))
                 return enumerator;
 
-            for (std::vector<Scope*>::const_iterator s = scope->nestedList.begin(); s != scope->nestedList.end(); ++s) {
+            for (std::vector<Scope*>::const_iterator s = scope->nestedList.cbegin(); s != scope->nestedList.cend(); ++s) {
                 enumerator = (*s)->findEnumerator(tokStr);
 
                 if (enumerator && !(enumerator->scope && enumerator->scope->enumClass))
@@ -5782,8 +5782,8 @@ const Type* SymbolDatabase::findType(const Token *startTok, const Scope *startSc
 
     // check using namespaces
     while (startScope) {
-        for (std::vector<Scope::UsingInfo>::const_iterator it = startScope->usingList.begin();
-             it != startScope->usingList.end(); ++it) {
+        for (std::vector<Scope::UsingInfo>::const_iterator it = startScope->usingList.cbegin();
+             it != startScope->usingList.cend(); ++it) {
             tok = startTok;
             scope = it->scope;
             start_scope = startScope;
@@ -6249,7 +6249,7 @@ void SymbolDatabase::setValueType(Token* tok, const ValueType& valuetype, Source
             const Scope *typeScope = vt1->typeScope;
             if (!typeScope)
                 return;
-            for (std::list<Variable>::const_iterator it = typeScope->varlist.begin(); it != typeScope->varlist.end(); ++it) {
+            for (std::list<Variable>::const_iterator it = typeScope->varlist.cbegin(); it != typeScope->varlist.cend(); ++it) {
                 if (it->nameToken()->str() == name) {
                     var = &*it;
                     break;

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -2899,7 +2899,7 @@ bool TemplateSimplifier::matchSpecialization(
     const std::list<const Token *> & specializations)
 {
     // Is there a matching specialization?
-    for (std::list<const Token *>::const_iterator it = specializations.begin(); it != specializations.end(); ++it) {
+    for (std::list<const Token *>::const_iterator it = specializations.cbegin(); it != specializations.cend(); ++it) {
         if (!Token::Match(*it, "%name% <"))
             continue;
         const Token *startToken = (*it);
@@ -3239,18 +3239,18 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
 
 static bool matchTemplateParameters(const Token *nameTok, const std::list<std::string> &strings)
 {
-    std::list<std::string>::const_iterator it = strings.begin();
+    std::list<std::string>::const_iterator it = strings.cbegin();
     const Token *tok = nameTok->tokAt(2);
     const Token *end = nameTok->next()->findClosingBracket();
     if (!end)
         return false;
-    while (tok && tok != end && it != strings.end()) {
+    while (tok && tok != end && it != strings.cend()) {
         if (tok->isUnsigned()) {
             if (*it != "unsigned")
                 return false;
             else {
                 ++it;
-                if (it == strings.end())
+                if (it == strings.cend())
                     return false;
             }
         } else if (tok->isSigned()) {
@@ -3258,7 +3258,7 @@ static bool matchTemplateParameters(const Token *nameTok, const std::list<std::s
                 return false;
             else {
                 ++it;
-                if (it == strings.end())
+                if (it == strings.cend())
                     return false;
             }
         }
@@ -3267,7 +3267,7 @@ static bool matchTemplateParameters(const Token *nameTok, const std::list<std::s
                 return false;
             else {
                 ++it;
-                if (it == strings.end())
+                if (it == strings.cend())
                     return false;
             }
         }
@@ -3276,7 +3276,7 @@ static bool matchTemplateParameters(const Token *nameTok, const std::list<std::s
         tok = tok->next();
         ++it;
     }
-    return it == strings.end() && tok && tok->str() == ">";
+    return it == strings.cend() && tok && tok->str() == ">";
 }
 
 void TemplateSimplifier::replaceTemplateUsage(
@@ -3774,7 +3774,7 @@ void TemplateSimplifier::simplifyTemplates(
 
             // get specializations..
             std::list<const Token *> specializations;
-            for (std::list<TokenAndName>::const_iterator iter2 = mTemplateDeclarations.begin(); iter2 != mTemplateDeclarations.end(); ++iter2) {
+            for (std::list<TokenAndName>::const_iterator iter2 = mTemplateDeclarations.cbegin(); iter2 != mTemplateDeclarations.cend(); ++iter2) {
                 if (iter2->isAlias() || iter2->isFriend())
                     continue;
 
@@ -3793,7 +3793,7 @@ void TemplateSimplifier::simplifyTemplates(
             }
         }
 
-        for (std::list<TokenAndName>::const_iterator it = mInstantiatedTemplates.begin(); it != mInstantiatedTemplates.end(); ++it) {
+        for (std::list<TokenAndName>::const_iterator it = mInstantiatedTemplates.cbegin(); it != mInstantiatedTemplates.cend(); ++it) {
             std::list<TokenAndName>::iterator decl;
             for (decl = mTemplateDeclarations.begin(); decl != mTemplateDeclarations.end(); ++decl) {
                 if (decl->token() == it->token())

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -56,7 +56,7 @@ void TimerResults::showResults(SHOWTIME_MODES mode) const
     std::sort(data.begin(), data.end(), more_second_sec);
 
     size_t ordinal = 1; // maybe it would be nice to have an ordinal in output later!
-    for (std::vector<dataElementType>::const_iterator iter=data.begin(); iter!=data.end(); ++iter) {
+    for (std::vector<dataElementType>::const_iterator iter=data.cbegin(); iter!=data.cend(); ++iter) {
         const double sec = iter->second.seconds();
         const double secAverage = sec / (double)(iter->second.mNumberOfResults);
         overallData.mClocks += iter->second.mClocks;

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -766,8 +766,8 @@ nonneg int Token::getStrLength(const Token *tok)
 
     int len = 0;
     const std::string str(getStringLiteral(tok->str()));
-    std::string::const_iterator it = str.begin();
-    const std::string::const_iterator end = str.end();
+    std::string::const_iterator it = str.cbegin();
+    const std::string::const_iterator end = str.cend();
 
     while (it != end) {
         if (*it == '\\') {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -4242,11 +4242,11 @@ static std::string getScopeName(const std::list<ScopeInfo2> &scopeInfo)
 
 static Token * matchMemberName(const std::list<std::string> &scope, const Token *nsToken, Token *memberToken, const std::list<ScopeInfo2> &scopeInfo)
 {
-    std::list<ScopeInfo2>::const_iterator scopeIt = scopeInfo.begin();
+    std::list<ScopeInfo2>::const_iterator scopeIt = scopeInfo.cbegin();
 
     // Current scope..
-    for (std::list<std::string>::const_iterator it = scope.begin(); it != scope.end(); ++it) {
-        if (scopeIt == scopeInfo.end() || scopeIt->name != *it)
+    for (std::list<std::string>::const_iterator it = scope.cbegin(); it != scope.cend(); ++it) {
+        if (scopeIt == scopeInfo.cend() || scopeIt->name != *it)
             return nullptr;
         ++scopeIt;
     }

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -41,7 +41,7 @@ int caseInsensitiveStringCompare(const std::string &lhs, const std::string &rhs)
 
 bool isValidGlobPattern(const std::string& pattern)
 {
-    for (std::string::const_iterator i = pattern.begin(); i != pattern.end(); ++i) {
+    for (std::string::const_iterator i = pattern.cbegin(); i != pattern.cend(); ++i) {
         if (*i == '*' || *i == '?') {
             const std::string::const_iterator j = i + 1;
             if (j != pattern.end() && (*j == '*' || *j == '?')) {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7197,7 +7197,7 @@ static void valueFlowSwitchVariable(TokenList *tokenlist, SymbolDatabase* symbol
                     values.back().condition = tok;
                     values.back().errorPath.emplace_back(tok, "case " + tok->next()->str() + ": " + vartok->str() + " is " + tok->next()->str() + " here.");
                 }
-                for (std::list<ValueFlow::Value>::const_iterator val = values.begin(); val != values.end(); ++val) {
+                for (std::list<ValueFlow::Value>::const_iterator val = values.cbegin(); val != values.cend(); ++val) {
                     valueFlowReverse(tokenlist,
                                      const_cast<Token*>(scope.classDef),
                                      vartok,

--- a/test/options.cpp
+++ b/test/options.cpp
@@ -22,7 +22,7 @@ options::options(int argc, const char* const argv[])
     ,mHelp(mWhichTests.count("-h") != 0 || mWhichTests.count("--help"))
     ,mExe(argv[0])
 {
-    for (std::set<std::string>::const_iterator it = mWhichTests.begin(); it != mWhichTests.end();) {
+    for (std::set<std::string>::const_iterator it = mWhichTests.cbegin(); it != mWhichTests.cend();) {
         if (!(*it).empty() && (((*it)[0] == '-') || ((*it).find("::") != std::string::npos && mWhichTests.count((*it).substr(0, (*it).find("::"))))))
             it = mWhichTests.erase(it);
         else

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -52,17 +52,17 @@ private:
     }
 
     void instancesSorted() const {
-        for (std::list<Check *>::const_iterator i = Check::instances().begin(); i != Check::instances().end(); ++i) {
+        for (std::list<Check *>::const_iterator i = Check::instances().cbegin(); i != Check::instances().cend(); ++i) {
             std::list<Check *>::const_iterator j = i;
             ++j;
-            if (j != Check::instances().end()) {
+            if (j != Check::instances().cend()) {
                 ASSERT_EQUALS(true, (*i)->name() < (*j)->name());
             }
         }
     }
 
     void classInfoFormat() const {
-        for (std::list<Check *>::const_iterator i = Check::instances().begin(); i != Check::instances().end(); ++i) {
+        for (std::list<Check *>::const_iterator i = Check::instances().cbegin(); i != Check::instances().cend(); ++i) {
             const std::string info = (*i)->classInfo();
             if (!info.empty()) {
                 ASSERT('\n' != info[0]);         // No \n in the beginning

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -292,7 +292,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // call all "runChecks" in all registered Check classes
-        for (std::list<Check *>::const_iterator it = Check::instances().begin(); it != Check::instances().end(); ++it) {
+        for (std::list<Check *>::const_iterator it = Check::instances().cbegin(); it != Check::instances().cend(); ++it) {
             (*it)->runChecks(&tokenizer, &settings, this);
         }
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -58,7 +58,7 @@ private:
         ProcessExecutor executor(filemap, settings, *this);
         std::vector<ScopedFile> scopedfiles;
         scopedfiles.reserve(filemap.size());
-        for (std::map<std::string, std::size_t>::const_iterator i = filemap.begin(); i != filemap.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = filemap.cbegin(); i != filemap.cend(); ++i)
             scopedfiles.emplace_back(i->first, data);
 
         ASSERT_EQUALS(result, executor.check());

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -117,7 +117,7 @@ static std::string writestr(const std::string &str, bool gccStyle = false)
     std::ostringstream ostr;
     if (gccStyle)
         ostr << '\"';
-    for (std::string::const_iterator i = str.begin(); i != str.end(); ++i) {
+    for (std::string::const_iterator i = str.cbegin(); i != str.cend(); ++i) {
         if (*i == '\n') {
             ostr << "\\n";
             if ((i+1) != str.end() && !gccStyle)

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -203,7 +203,7 @@ private:
             exitCode |= settings.exitCode;
 
         std::map<std::string, std::size_t> files_for_report;
-        for (std::map<std::string, std::string>::const_iterator file = files.begin(); file != files.end(); ++file)
+        for (std::map<std::string, std::string>::const_iterator file = files.cbegin(); file != files.cend(); ++file)
             files_for_report[file->first] = file->second.size();
 
         CppCheckExecutor::reportSuppressions(settings, false, files_for_report, *this);
@@ -228,7 +228,7 @@ private:
         ThreadExecutor executor(files, settings, *this);
         std::vector<ScopedFile> scopedfiles;
         scopedfiles.reserve(files.size());
-        for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = files.cbegin(); i != files.cend(); ++i)
             scopedfiles.emplace_back(i->first, code);
 
         const unsigned int exitCode = executor.check();
@@ -256,7 +256,7 @@ private:
         ProcessExecutor executor(files, settings, *this);
         std::vector<ScopedFile> scopedfiles;
         scopedfiles.reserve(files.size());
-        for (std::map<std::string, std::size_t>::const_iterator i = files.begin(); i != files.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = files.cbegin(); i != files.cend(); ++i)
             scopedfiles.emplace_back(i->first, code);
 
         const unsigned int exitCode = executor.check();

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -1864,7 +1864,7 @@ private:
 
         bool seen_something = false;
         for (const Scope & scope : db->scopeList) {
-            for (std::list<Function>::const_iterator func = scope.functionList.begin(); func != scope.functionList.end(); ++func) {
+            for (std::list<Function>::const_iterator func = scope.functionList.cbegin(); func != scope.functionList.cend(); ++func) {
                 ASSERT_EQUALS("Sub", func->token->str());
                 ASSERT_EQUALS(true, func->hasBody());
                 ASSERT_EQUALS(Function::eConstructor, func->type);
@@ -2471,7 +2471,7 @@ private:
                       "Fred::Fred(Whitespace whitespace) { }");
         ASSERT_EQUALS(true, db != nullptr);
         ASSERT_EQUALS(3, db->scopeList.size());
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
         ASSERT_EQUALS(1, scope->functionList.size());
@@ -2489,7 +2489,7 @@ private:
                       "void Fred::foo(char b[16]) { }");
         ASSERT_EQUALS(true, db != nullptr);
         ASSERT_EQUALS(3, db->scopeList.size());
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
         ASSERT_EQUALS(1, scope->functionList.size());
@@ -3076,7 +3076,7 @@ private:
                       "class Sub;");
         ASSERT(db && db->typeList.size() == 5);
 
-        std::list<Type>::const_iterator i = db->typeList.begin();
+        std::list<Type>::const_iterator i = db->typeList.cbegin();
         const Type* Foo = &(*i++);
         const Type* Bar = &(*i++);
         const Type* Sub = &(*i++);
@@ -3144,7 +3144,7 @@ private:
                       "};");
         ASSERT(db && db->typeList.size() == 3);
 
-        std::list<Type>::const_iterator i = db->typeList.begin();
+        std::list<Type>::const_iterator i = db->typeList.cbegin();
         const Type* Fred = &(*i++);
         const Type* Wilma = &(*i++);
         const Type* Barney = &(*i++);
@@ -3233,7 +3233,7 @@ private:
             ASSERT(db->getVariableFromVarId(i) != nullptr);
 
         ASSERT_EQUALS(4U, db->scopeList.size());
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eStruct, scope->type);
@@ -3251,7 +3251,7 @@ private:
 
         ASSERT(db != nullptr);
         ASSERT_EQUALS(4U, db->scopeList.size());
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eStruct, scope->type);
@@ -3441,7 +3441,7 @@ private:
                       "}");
         ASSERT(db != nullptr);
         ASSERT(db->scopeList.size() == 4U);
-        std::list<Scope>::const_iterator it = db->scopeList.begin();
+        std::list<Scope>::const_iterator it = db->scopeList.cbegin();
         ASSERT(it->type == Scope::eGlobal);
         ASSERT((++it)->type == Scope::eFunction);
         ASSERT((++it)->type == Scope::eIf);
@@ -3461,7 +3461,7 @@ private:
                       "};");
         ASSERT(db != nullptr);
         ASSERT(db->typeList.size() == 3U);
-        std::list<Type>::const_iterator it = db->typeList.begin();
+        std::list<Type>::const_iterator it = db->typeList.cbegin();
         const Type * classB = &(*it);
         const Type * classC = &(*(++it));
         const Type * classA = &(*(++it));
@@ -5178,7 +5178,7 @@ private:
         ASSERT_EQUALS(3U, db->scopeList.size());
 
         // Assert that all enum values are known
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
 
         // Offsets
         ++scope;
@@ -5266,7 +5266,7 @@ private:
         ASSERT_EQUALS(2U, db->scopeList.size());
 
         // Assert that all enum values are known
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
 
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eEnum, (unsigned int)scope->type);
@@ -5563,7 +5563,7 @@ private:
                       "    void g();\n"
                       "};");
         ASSERT(db && db->scopeList.back().functionList.size() == 4);
-        std::list<Function>::const_iterator it = db->scopeList.back().functionList.begin();
+        std::list<Function>::const_iterator it = db->scopeList.back().functionList.cbegin();
         ASSERT((it++)->isPure());
         ASSERT((it++)->isPure());
         ASSERT(!(it++)->isPure());
@@ -7354,7 +7354,7 @@ private:
                       "}");
 
         ASSERT(db && db->scopeList.size() == 3);
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eFunction, scope->type);
@@ -7373,7 +7373,7 @@ private:
                       "}");
 
         ASSERT(db && db->scopeList.size() == 3);
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eFunction, scope->type);
@@ -7388,7 +7388,7 @@ private:
                       "}");
 
         ASSERT(db && db->scopeList.size() == 3);
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eFunction, scope->type);
@@ -7419,7 +7419,7 @@ private:
                       "Fred::foo(const std::string & b) { }");
 
         ASSERT(db && db->scopeList.size() == 3);
-        std::list<Scope>::const_iterator scope = db->scopeList.begin();
+        std::list<Scope>::const_iterator scope = db->scopeList.cbegin();
         ASSERT_EQUALS(Scope::eGlobal, scope->type);
         ++scope;
         ASSERT_EQUALS(Scope::eClass, scope->type);

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -58,7 +58,7 @@ private:
         ThreadExecutor executor(filemap, settings, *this);
         std::vector<ScopedFile> scopedfiles;
         scopedfiles.reserve(filemap.size());
-        for (std::map<std::string, std::size_t>::const_iterator i = filemap.begin(); i != filemap.end(); ++i)
+        for (std::map<std::string, std::size_t>::const_iterator i = filemap.cbegin(); i != filemap.cend(); ++i)
             scopedfiles.emplace_back(i->first, data);
 
         ASSERT_EQUALS(result, executor.check());


### PR DESCRIPTION
This is in preparation of potentially enabling the `modernize-use-auto` clang-tidy check to ensure the type stays the same. I did not check the existing `auto` iterators - will do that later on.

I already filed a ticket about detecting this: https://trac.cppcheck.net/ticket/11209.

There's more cases where the `c*()` methods should/can be used. That will be addressed in later PRs.