### PR TITLE
use `const_iterator` where possible

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -106,7 +106,7 @@ static bool addPathsToSet(const std::string& fileName, std::set<std::string>* se
     std::list<std::string> templist;
     if (!addIncludePathsToList(fileName, &templist))
         return false;
-    set->insert(templist.begin(), templist.end());
+    set->insert(templist.cbegin(), templist.cend());
     return true;
 }
 
@@ -647,7 +647,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                         mSettings->libraries.emplace_back(lib);
 
                     const auto& excludedPaths = mSettings->project.guiProject.excludedPaths;
-                    std::copy(excludedPaths.begin(), excludedPaths.end(), std::back_inserter(mIgnoredPaths));
+                    std::copy(excludedPaths.cbegin(), excludedPaths.cend(), std::back_inserter(mIgnoredPaths));
 
                     const std::string platform(mSettings->project.guiProject.platform);
 
@@ -839,8 +839,8 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     std::string message("couldn't open the file: \"");
                     message += filename;
                     message += "\".";
-                    if (std::count(filename.begin(), filename.end(), ',') > 0 ||
-                        std::count(filename.begin(), filename.end(), '.') > 1) {
+                    if (std::count(filename.cbegin(), filename.cend(), ',') > 0 ||
+                        std::count(filename.cbegin(), filename.cend(), '.') > 1) {
                         // If user tried to pass multiple files (we can only guess that)
                         // e.g. like this: --suppressions-list=a.txt,b.txt
                         // print more detailed error message to tell user how he can solve the problem

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -131,7 +131,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
 
     // Output a warning for the user if he tries to exclude headers
     const std::vector<std::string>& ignored = parser.getIgnoredPaths();
-    const bool warn = std::any_of(ignored.begin(), ignored.end(), [](const std::string& i) {
+    const bool warn = std::any_of(ignored.cbegin(), ignored.cend(), [](const std::string& i) {
         return Path::isHeader(i);
     });
     if (warn) {
@@ -152,7 +152,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
         std::list<ImportProject::FileSettings> newList;
 
         const std::list<ImportProject::FileSettings>& fileSettings = settings.project.fileSettings;
-        std::copy_if(fileSettings.begin(), fileSettings.end(), std::back_inserter(newList), [&](const ImportProject::FileSettings& fs) {
+        std::copy_if(fileSettings.cbegin(), fileSettings.cend(), std::back_inserter(newList), [&](const ImportProject::FileSettings& fs) {
             return matchglobs(mSettings->fileFilters, fs.filename);
         });
         if (!newList.empty())
@@ -321,7 +321,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
         // Single process
         settings.jointSuppressionReport = true;
 
-        const std::size_t totalfilesize = std::accumulate(mFiles.begin(), mFiles.end(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& f) {
+        const std::size_t totalfilesize = std::accumulate(mFiles.cbegin(), mFiles.cend(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& f) {
             return v + f.second;
         });
 

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -171,7 +171,7 @@ int ProcessExecutor::handleRead(int rpipe, unsigned int &result)
         if (!mSettings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage())) {
             // Alert only about unique errors
             std::string errmsg = msg.toString(mSettings.verbose);
-            if (std::find(mErrorList.begin(), mErrorList.end(), errmsg) == mErrorList.end()) {
+            if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) == mErrorList.cend()) {
                 mErrorList.emplace_back(std::move(errmsg));
                 if (type == PipeWriter::REPORT_ERROR)
                     mErrorLogger.reportErr(msg);
@@ -218,7 +218,7 @@ unsigned int ProcessExecutor::check()
     unsigned int fileCount = 0;
     unsigned int result = 0;
 
-    const std::size_t totalfilesize = std::accumulate(mFiles.begin(), mFiles.end(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& p) {
+    const std::size_t totalfilesize = std::accumulate(mFiles.cbegin(), mFiles.cend(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& p) {
         return v + p.second;
     });
 
@@ -298,7 +298,7 @@ unsigned int ProcessExecutor::check()
             struct timeval tv; // for every second polling of load average condition
             tv.tv_sec = 1;
             tv.tv_usec = 0;
-            const int r = select(*std::max_element(rpipes.begin(), rpipes.end()) + 1, &rfds, nullptr, nullptr, &tv);
+            const int r = select(*std::max_element(rpipes.cbegin(), rpipes.cend()) + 1, &rfds, nullptr, nullptr, &tv);
 
             if (r > 0) {
                 std::list<int>::iterator rp = rpipes.begin();

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -56,7 +56,7 @@ public:
         mItNextFileSettings = mThreadExecutor.mSettings.project.fileSettings.begin();
 
         mTotalFiles = files.size() + mThreadExecutor.mSettings.project.fileSettings.size();
-        mTotalFileSize = std::accumulate(files.begin(), files.end(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& p) {
+        mTotalFileSize = std::accumulate(files.cbegin(), files.cend(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& p) {
             return v + p.second;
         });
     }
@@ -105,7 +105,7 @@ private:
             std::string errmsg = msg.toString(mThreadExecutor.mSettings.verbose);
 
             std::lock_guard<std::mutex> lg(mErrorSync);
-            if (std::find(mThreadExecutor.mErrorList.begin(), mThreadExecutor.mErrorList.end(), errmsg) == mThreadExecutor.mErrorList.end()) {
+            if (std::find(mThreadExecutor.mErrorList.cbegin(), mThreadExecutor.mErrorList.cend(), errmsg) == mThreadExecutor.mErrorList.cend()) {
                 mThreadExecutor.mErrorList.emplace_back(std::move(errmsg));
                 reportError = true;
             }
@@ -159,7 +159,7 @@ unsigned int STDCALL ThreadExecutor::threadProc(SyncLogForwarder* logForwarder)
     logForwarder->mFileSync.lock();
 
     for (;;) {
-        if (itFile == logForwarder->mThreadExecutor.mFiles.end() && itFileSettings == logForwarder->mThreadExecutor.mSettings.project.fileSettings.end()) {
+        if (itFile == logForwarder->mThreadExecutor.mFiles.cend() && itFileSettings == logForwarder->mThreadExecutor.mSettings.project.fileSettings.cend()) {
             logForwarder->mFileSync.unlock();
             break;
         }

--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -398,7 +398,7 @@ void CheckThread::parseClangErrors(const QString &tool, const QString &file0, QS
             continue;
 
         std::list<ErrorMessage::FileLocation> callstack;
-        std::transform(e.errorPath.begin(), e.errorPath.end(), std::back_inserter(callstack), [](const QErrorPathItem& path) {
+        std::transform(e.errorPath.cbegin(), e.errorPath.cend(), std::back_inserter(callstack), [](const QErrorPathItem& path) {
             return ErrorMessage::FileLocation(path.file.toStdString(), path.info.toStdString(), path.line, path.column);
         });
         const std::string f0 = file0.toStdString();
@@ -411,7 +411,7 @@ void CheckThread::parseClangErrors(const QString &tool, const QString &file0, QS
 
 bool CheckThread::isSuppressed(const Suppressions::ErrorMessage &errorMessage) const
 {
-    return std::any_of(mSuppressions.begin(), mSuppressions.end(), [&](const Suppressions::Suppression& s) {
+    return std::any_of(mSuppressions.cbegin(), mSuppressions.cend(), [&](const Suppressions::Suppression& s) {
         return s.isSuppressed(errorMessage);
     });
 }

--- a/gui/filelist.cpp
+++ b/gui/filelist.cpp
@@ -110,7 +110,7 @@ void FileList::addExcludeList(const QStringList &paths)
 static std::vector<std::string> toStdStringList(const QStringList &stringList)
 {
     std::vector<std::string> ret;
-    std::transform(stringList.begin(), stringList.end(), std::back_inserter(ret), [](const QString& s) {
+    std::transform(stringList.cbegin(), stringList.cend(), std::back_inserter(ret), [](const QString& s) {
         return s.toStdString();
     });
     return ret;

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
     // Set data dir..
     const QStringList args = QApplication::arguments();
-    auto it = std::find_if(args.begin(), args.end(), [](const QString& arg) {
+    auto it = std::find_if(args.cbegin(), args.cend(), [](const QString& arg) {
         return arg.startsWith("--data-dir=");
     });
     if (it != args.end()) {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -466,7 +466,7 @@ void MainWindow::doAnalyzeProject(ImportProject p, const bool checkLibrary, cons
     if (mProjectFile) {
         std::vector<std::string> v;
         const QStringList excluded = mProjectFile->getExcludedPaths();
-        std::transform(excluded.begin(), excluded.end(), std::back_inserter(v), [](const QString& e) {
+        std::transform(excluded.cbegin(), excluded.cend(), std::back_inserter(v), [](const QString& e) {
             return e.toStdString();
         });
         p.ignorePaths(v);
@@ -569,7 +569,7 @@ void MainWindow::doAnalyzeFiles(const QStringList &files, const bool checkLibrar
     if (!checkSettings.buildDir.empty()) {
         checkSettings.loadSummaries();
         std::list<std::string> sourcefiles;
-        std::transform(fileNames.begin(), fileNames.end(), std::back_inserter(sourcefiles), [](const QString& s) {
+        std::transform(fileNames.cbegin(), fileNames.cend(), std::back_inserter(sourcefiles), [](const QString& s) {
             return s.toStdString();
         });
         AnalyzerInformation::writeFilesTxt(checkSettings.buildDir, sourcefiles, checkSettings.userDefines, checkSettings.project.fileSettings);

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -2714,7 +2714,7 @@ bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp,
 bool isVariablesChanged(const Token* start,
                         const Token* end,
                         int indirect,
-                        std::vector<const Variable*> vars,
+                        const std::vector<const Variable*> &vars,
                         const Settings* settings,
                         bool cpp)
 {

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -590,7 +590,7 @@ static std::vector<const Token*> getParentMembers(const Token* tok)
     for (const Token* tok2 : astFlatten(parent, ".")) {
         if (Token::simpleMatch(tok2, "(") && Token::simpleMatch(tok2->astOperand1(), ".")) {
             std::vector<const Token*> sub = getParentMembers(tok2->astOperand1());
-            result.insert(result.end(), sub.begin(), sub.end());
+            result.insert(result.end(), sub.cbegin(), sub.cend());
         }
         result.push_back(tok2);
     }
@@ -603,7 +603,7 @@ const Token* getParentLifetime(bool cpp, const Token* tok, const Library* librar
     if (members.size() < 2)
         return tok;
     // Find the first local variable or temporary
-    auto it = std::find_if(members.rbegin(), members.rend(), [&](const Token* tok2) {
+    auto it = std::find_if(members.crbegin(), members.crend(), [&](const Token* tok2) {
         const Variable* var = tok2->variable();
         if (var) {
             return var->isLocal() || var->isArgument();
@@ -614,7 +614,7 @@ const Token* getParentLifetime(bool cpp, const Token* tok, const Library* librar
     if (it == members.rend())
         return tok;
     // If any of the submembers are borrowed types then stop
-    if (std::any_of(it.base() - 1, members.end() - 1, [&](const Token* tok2) {
+    if (std::any_of(it.base() - 1, members.cend() - 1, [&](const Token* tok2) {
         if (astIsPointer(tok2) || astIsContainerView(tok2) || astIsIterator(tok2))
             return true;
         if (!astIsUniqueSmartPointer(tok2)) {
@@ -700,7 +700,7 @@ std::vector<ValueType> getParentValueTypes(const Token* tok, const Settings* set
                 if (scope && scope->numConstructors == 0 && t->derivedFrom.empty() &&
                     (t->isClassType() || t->isStructType()) && numberOfArguments(ftok) < scope->varlist.size()) {
                     assert(argn < scope->varlist.size());
-                    auto it = std::next(scope->varlist.begin(), argn);
+                    auto it = std::next(scope->varlist.cbegin(), argn);
                     if (it->valueType())
                         return {*it->valueType()};
                 }
@@ -1141,7 +1141,7 @@ static void followVariableExpressionError(const Token *tok1, const Token *tok2, 
     if (!tok2)
         return;
     ErrorPathItem item = std::make_pair(tok2, "'" + tok1->str() + "' is assigned value '" + tok2->expressionString() + "' here.");
-    if (std::find(errors->begin(), errors->end(), item) != errors->end())
+    if (std::find(errors->cbegin(), errors->cend(), item) != errors->cend())
         return;
     errors->push_back(std::move(item));
 }
@@ -1201,9 +1201,9 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
         const Token* tok2 = tok->astOperand2();
 
         auto refs = followAllReferences(tok2->astOperand1(), temporary, inconclusive, errors, depth - 1);
-        result.insert(refs.begin(), refs.end());
+        result.insert(refs.cbegin(), refs.cend());
         refs = followAllReferences(tok2->astOperand2(), temporary, inconclusive, errors, depth - 1);
-        result.insert(refs.begin(), refs.end());
+        result.insert(refs.cbegin(), refs.cend());
 
         if (!inconclusive && result.size() != 1) {
             refs_result.push_back({tok, std::move(errors)});
@@ -1211,7 +1211,7 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
         }
 
         if (!result.empty()) {
-            refs_result.insert(refs_result.end(), result.begin(), result.end());
+            refs_result.insert(refs_result.end(), result.cbegin(), result.cend());
             return refs_result;
         }
 
@@ -1251,7 +1251,7 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
                         er.emplace_back(tok->previous(), "Called function passing '" + argTok->expressionString() + "'.");
                         auto refs =
                             followAllReferences(argTok, temporary, inconclusive, std::move(er), depth - returns.size());
-                        result.insert(refs.begin(), refs.end());
+                        result.insert(refs.cbegin(), refs.cend());
                         if (!inconclusive && result.size() > 1) {
                             refs_result.push_back({tok, std::move(errors)});
                             return refs_result;
@@ -1260,7 +1260,7 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
                 }
             }
             if (!result.empty()) {
-                refs_result.insert(refs_result.end(), result.begin(), result.end());
+                refs_result.insert(refs_result.end(), result.cbegin(), result.cend());
                 return refs_result;
             }
         }
@@ -1297,13 +1297,13 @@ static bool compareKnownValue(const Token * const tok1, const Token * const tok2
 {
     static const auto isKnownFn = std::mem_fn(&ValueFlow::Value::isKnown);
 
-    const auto v1 = std::find_if(tok1->values().begin(), tok1->values().end(), isKnownFn);
+    const auto v1 = std::find_if(tok1->values().cbegin(), tok1->values().cend(), isKnownFn);
     if (v1 == tok1->values().end()) {
         return false;
     }
     if (v1->isNonValue() || v1->isContainerSizeValue() || v1->isSymbolicValue())
         return false;
-    const auto v2 = std::find_if(tok2->values().begin(), tok2->values().end(), isKnownFn);
+    const auto v2 = std::find_if(tok2->values().cbegin(), tok2->values().cend(), isKnownFn);
     if (v2 == tok2->values().end()) {
         return false;
     }
@@ -1419,7 +1419,7 @@ bool isUsedAsBool(const Token* const tok)
         return true;
     if (!Token::Match(parent, "%cop%")) {
         std::vector<ValueType> vtParents = getParentValueTypes(tok);
-        return std::any_of(vtParents.begin(), vtParents.end(), [&](const ValueType& vt) {
+        return std::any_of(vtParents.cbegin(), vtParents.cend(), [&](const ValueType& vt) {
             return vt.pointer == 0 && vt.type == ValueType::BOOL;
         });
     }
@@ -1837,7 +1837,7 @@ bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * cons
 
 static bool functionModifiesArguments(const Function* f)
 {
-    return std::any_of(f->argumentList.begin(), f->argumentList.end(), [](const Variable& var) {
+    return std::any_of(f->argumentList.cbegin(), f->argumentList.cend(), [](const Variable& var) {
         if (var.isReference() || var.isPointer())
             return !var.isConst();
         return true;
@@ -1865,7 +1865,7 @@ bool isConstFunctionCall(const Token* ftok, const Library& library)
             // Check for const overloaded function that just return the const version
             if (!Function::returnsConst(f)) {
                 std::vector<const Function*> fs = f->getOverloadedFunctions();
-                if (std::any_of(fs.begin(), fs.end(), [&](const Function* g) {
+                if (std::any_of(fs.cbegin(), fs.cend(), [&](const Function* g) {
                     if (f == g)
                         return false;
                     if (f->argumentList.size() != g->argumentList.size())
@@ -1914,7 +1914,7 @@ bool isConstFunctionCall(const Token* ftok, const Library& library)
         std::vector<const Token*> args = getArguments(ftok);
         if (args.empty())
             return false;
-        return constMember && std::all_of(args.begin(), args.end(), [](const Token* tok) {
+        return constMember && std::all_of(args.cbegin(), args.cend(), [](const Token* tok) {
             const Variable* var = tok->variable();
             if (var)
                 return var->isConst();
@@ -2265,7 +2265,7 @@ std::vector<const Variable*> getArgumentVars(const Token* tok, int argnr)
         const bool tokIsBrace = Token::simpleMatch(tok, "{");
         // Aggregate constructor
         if (tokIsBrace && typeScope->numConstructors == 0 && argnr < typeScope->varlist.size()) {
-            auto it = std::next(typeScope->varlist.begin(), argnr);
+            auto it = std::next(typeScope->varlist.cbegin(), argnr);
             return {&*it};
         }
         const int argCount = numberOfArguments(tok);
@@ -2719,10 +2719,10 @@ bool isVariablesChanged(const Token* start,
                         bool cpp)
 {
     std::set<int> varids;
-    std::transform(vars.begin(), vars.end(), std::inserter(varids, varids.begin()), [](const Variable* var) {
+    std::transform(vars.cbegin(), vars.cend(), std::inserter(varids, varids.begin()), [](const Variable* var) {
         return var->declarationId();
     });
-    const bool globalvar = std::any_of(vars.begin(), vars.end(), [](const Variable* var) {
+    const bool globalvar = std::any_of(vars.cbegin(), vars.cend(), [](const Variable* var) {
         return var->isGlobal();
     });
     for (const Token* tok = start; tok != end; tok = tok->next()) {
@@ -2840,12 +2840,12 @@ std::vector<const Token*> getArguments(const Token* ftok) {
 
 int getArgumentPos(const Variable* var, const Function* f)
 {
-    auto arg_it = std::find_if(f->argumentList.begin(), f->argumentList.end(), [&](const Variable& v) {
+    auto arg_it = std::find_if(f->argumentList.cbegin(), f->argumentList.cend(), [&](const Variable& v) {
         return v.nameToken() == var->nameToken();
     });
     if (arg_it == f->argumentList.end())
         return -1;
-    return std::distance(f->argumentList.begin(), arg_it);
+    return std::distance(f->argumentList.cbegin(), arg_it);
 }
 
 bool isIteratorPair(std::vector<const Token*> args)
@@ -2954,7 +2954,7 @@ bool isConstVarExpression(const Token *tok, std::function<bool(const Token*)> sk
         std::vector<const Token *> args = getArguments(tok);
         if (args.empty() && tok->previous()->function() && tok->previous()->function()->isConstexpr())
             return true;
-        return !args.empty() && std::all_of(args.begin(), args.end(), [&](const Token* t) {
+        return !args.empty() && std::all_of(args.cbegin(), args.cend(), [&](const Token* t) {
             return isConstVarExpression(t, skipPredicate);
         });
     }

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -323,7 +323,7 @@ bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp,
 bool isVariablesChanged(const Token* start,
                         const Token* end,
                         int indirect,
-                        std::vector<const Variable*> vars,
+                        const std::vector<const Variable*> &vars,
                         const Settings* settings,
                         bool cpp);
 

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -418,7 +418,7 @@ static bool isInScope(const Token * tok, const Scope * scope)
         const Scope * tokScope = tok->scope();
         if (!tokScope)
             return false;
-        if (std::any_of(tokScope->nestedList.begin(), tokScope->nestedList.end(), [&](const Scope* argScope) {
+        if (std::any_of(tokScope->nestedList.cbegin(), tokScope->nestedList.cend(), [&](const Scope* argScope) {
             return argScope && argScope->isNestedIn(scope);
         }))
             return true;

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -67,8 +67,8 @@ static const CWE CWE_BUFFER_OVERRUN(788U);   // Access of Memory Location After 
 static const ValueFlow::Value *getBufferSizeValue(const Token *tok)
 {
     const std::list<ValueFlow::Value> &tokenValues = tok->values();
-    const auto it = std::find_if(tokenValues.begin(), tokenValues.end(), std::mem_fn(&ValueFlow::Value::isBufferSizeValue));
-    return it == tokenValues.end() ? nullptr : &*it;
+    const auto it = std::find_if(tokenValues.cbegin(), tokenValues.cend(), std::mem_fn(&ValueFlow::Value::isBufferSizeValue));
+    return it == tokenValues.cend() ? nullptr : &*it;
 }
 
 static int getMinFormatStringOutputLength(const std::vector<const Token*> &parameters, nonneg int formatStringArgNr)
@@ -385,7 +385,7 @@ static std::string arrayIndexMessage(const Token* tok,
     auto add_dim = [](const std::string &s, const Dimension &dim) {
         return s + "[" + MathLib::toString(dim.num) + "]";
     };
-    const std::string array = std::accumulate(dimensions.begin(), dimensions.end(), tok->astOperand1()->expressionString(), add_dim);
+    const std::string array = std::accumulate(dimensions.cbegin(), dimensions.cend(), tok->astOperand1()->expressionString(), add_dim);
 
     std::ostringstream errmsg;
     if (condition)
@@ -557,7 +557,7 @@ ValueFlow::Value CheckBufferOverrun::getBufferSize(const Token *bufTok) const
     if (!var)
         return ValueFlow::Value(-1);
 
-    const MathLib::bigint dim = std::accumulate(var->dimensions().begin(), var->dimensions().end(), 1LL, [](MathLib::bigint i1, const Dimension &dim) {
+    const MathLib::bigint dim = std::accumulate(var->dimensions().cbegin(), var->dimensions().cend(), 1LL, [](MathLib::bigint i1, const Dimension &dim) {
         return i1 * dim.num;
     });
 
@@ -762,7 +762,7 @@ void CheckBufferOverrun::stringNotZeroTerminated()
                 continue;
             if (Token::simpleMatch(args[1], "(") && Token::simpleMatch(args[1]->astOperand1(), ". c_str") && args[1]->astOperand1()->astOperand1()) {
                 const std::list<ValueFlow::Value>& contValues = args[1]->astOperand1()->astOperand1()->values();
-                auto it = std::find_if(contValues.begin(), contValues.end(), [](const ValueFlow::Value& value) {
+                auto it = std::find_if(contValues.cbegin(), contValues.cend(), [](const ValueFlow::Value& value) {
                     return value.isContainerSizeValue() && !value.isImpossible();
                 });
                 if (it != contValues.end() && it->intvalue < sizeToken->getKnownIntValue())
@@ -1063,15 +1063,15 @@ void CheckBufferOverrun::objectIndex()
                 }
                 if (v.path != 0) {
                     std::vector<ValueFlow::Value> idxValues;
-                    std::copy_if(idx->values().begin(),
-                                 idx->values().end(),
+                    std::copy_if(idx->values().cbegin(),
+                                 idx->values().cend(),
                                  std::back_inserter(idxValues),
                                  [&](const ValueFlow::Value& vidx) {
                         if (!vidx.isIntValue())
                             return false;
                         return vidx.path == v.path || vidx.path == 0;
                     });
-                    if (std::any_of(idxValues.begin(), idxValues.end(), [&](const ValueFlow::Value& vidx) {
+                    if (std::any_of(idxValues.cbegin(), idxValues.cend(), [&](const ValueFlow::Value& vidx) {
                         if (vidx.isImpossible())
                             return (vidx.intvalue == 0);
                         else

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -104,7 +104,7 @@ static bool isVariableCopyNeeded(const Variable &var, Function::Type type)
 
 static bool isVcl(const Settings *settings)
 {
-    return std::any_of(settings->libraries.begin(), settings->libraries.end(), [](const std::string& library) {
+    return std::any_of(settings->libraries.cbegin(), settings->libraries.cend(), [](const std::string& library) {
         return library == "vcl";
     });
 }
@@ -146,10 +146,10 @@ void CheckClass::constructors()
 
         const bool unusedTemplate = Token::simpleMatch(scope->classDef->previous(), ">");
 
-        const bool usedInUnion = std::any_of(mSymbolDatabase->scopeList.begin(), mSymbolDatabase->scopeList.end(), [&](const Scope& unionScope) {
+        const bool usedInUnion = std::any_of(mSymbolDatabase->scopeList.cbegin(), mSymbolDatabase->scopeList.cend(), [&](const Scope& unionScope) {
             if (unionScope.type != Scope::eUnion)
                 return false;
-            return std::any_of(unionScope.varlist.begin(), unionScope.varlist.end(), [&](const Variable& var) {
+            return std::any_of(unionScope.varlist.cbegin(), unionScope.varlist.cend(), [&](const Variable& var) {
                 return var.type() && var.type()->classScope == scope;
             });
         });
@@ -184,7 +184,7 @@ void CheckClass::constructors()
         // #3196 => bailout if there are nested unions
         // TODO: handle union variables better
         {
-            const bool bailout = std::any_of(scope->nestedList.begin(), scope->nestedList.end(), [](const Scope* nestedScope) {
+            const bool bailout = std::any_of(scope->nestedList.cbegin(), scope->nestedList.cend(), [](const Scope* nestedScope) {
                 return nestedScope->type == Scope::eUnion;
             });
             if (bailout)
@@ -342,7 +342,7 @@ void CheckClass::checkExplicitConstructors()
 
         // Is class abstract? Maybe this test is over-simplification, but it will suffice for simple cases,
         // and it will avoid false positives.
-        const bool isAbstractClass = std::any_of(scope->functionList.begin(), scope->functionList.end(), [](const Function& func) {
+        const bool isAbstractClass = std::any_of(scope->functionList.cbegin(), scope->functionList.cend(), [](const Function& func) {
             return func.isPure();
         });
 
@@ -442,12 +442,12 @@ void CheckClass::copyconstructors()
             if (!funcCopyCtor || funcCopyCtor->isDefault()) {
                 bool unknown = false;
                 if (!hasNonCopyableBase(scope, &unknown) && !unknown)
-                    noCopyConstructorError(scope, funcCopyCtor, allocatedVars.begin()->second, unknown);
+                    noCopyConstructorError(scope, funcCopyCtor, allocatedVars.cbegin()->second, unknown);
             }
             if (!funcOperatorEq || funcOperatorEq->isDefault()) {
                 bool unknown = false;
                 if (!hasNonCopyableBase(scope, &unknown) && !unknown)
-                    noOperatorEqError(scope, funcOperatorEq, allocatedVars.begin()->second, unknown);
+                    noOperatorEqError(scope, funcOperatorEq, allocatedVars.cbegin()->second, unknown);
             }
             if (!funcDestructor || funcDestructor->isDefault()) {
                 const Token * mustDealloc = nullptr;
@@ -619,7 +619,7 @@ bool CheckClass::canNotMove(const Scope *scope)
 
 static void getAllVariableMembers(const Scope *scope, std::vector<const Variable *>& varList)
 {
-    std::transform(scope->varlist.begin(), scope->varlist.end(), std::back_inserter(varList), [](const Variable& var) {
+    std::transform(scope->varlist.cbegin(), scope->varlist.cend(), std::back_inserter(varList), [](const Variable& var) {
         return &var;
     });
     if (scope->definedType) {
@@ -639,7 +639,7 @@ std::vector<CheckClass::Usage> CheckClass::createUsageList(const Scope *scope)
     std::vector<const Variable *> varlist;
     getAllVariableMembers(scope, varlist);
     ret.reserve(varlist.size());
-    std::transform(varlist.begin(), varlist.end(), std::back_inserter(ret), [](const Variable* var) {
+    std::transform(varlist.cbegin(), varlist.cend(), std::back_inserter(ret), [](const Variable* var) {
         return Usage(var);
     });
     return ret;
@@ -720,7 +720,7 @@ bool CheckClass::isBaseClassMutableMemberFunc(const Token *tok, const Scope *sco
         if (derivedFrom && derivedFrom->classScope) {
             const std::list<Function>& functionList = derivedFrom->classScope->functionList;
 
-            if (std::any_of(functionList.begin(), functionList.end(), [&](const Function& func) {
+            if (std::any_of(functionList.cbegin(), functionList.cend(), [&](const Function& func) {
                 return func.tokenDef->str() == tok->str() && !func.isStatic() && !func.isConst();
             }))
                 return true;
@@ -762,7 +762,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
 
                     // recursive call
                     // assume that all variables are initialized
-                    if (std::find(callstack.begin(), callstack.end(), member) != callstack.end()) {
+                    if (std::find(callstack.cbegin(), callstack.cend(), member) != callstack.cend()) {
                         /** @todo false negative: just bail */
                         assignAllVar(usage);
                         return;
@@ -826,7 +826,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
 
         // Calling member variable function?
         if (Token::Match(ftok->next(), "%var% . %name% (") && !(ftok->next()->valueType() && ftok->next()->valueType()->pointer)) {
-            if (std::any_of(scope->varlist.begin(), scope->varlist.end(), [&](const Variable& var) {
+            if (std::any_of(scope->varlist.cbegin(), scope->varlist.cend(), [&](const Variable& var) {
                 return var.declarationId() == ftok->next()->varId();
             }))
                 /** @todo false negative: we assume function changes variable state */
@@ -896,7 +896,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
                 const Function *member = ftok->function();
                 // recursive call
                 // assume that all variables are initialized
-                if (std::find(callstack.begin(), callstack.end(), member) != callstack.end()) {
+                if (std::find(callstack.cbegin(), callstack.cend(), member) != callstack.cend()) {
                     /** @todo false negative: just bail */
                     assignAllVar(usage);
                     return;
@@ -945,7 +945,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
 
                 // recursive call
                 // assume that all variables are initialized
-                if (std::find(callstack.begin(), callstack.end(), member) != callstack.end()) {
+                if (std::find(callstack.cbegin(), callstack.cend(), member) != callstack.cend()) {
                     assignAllVar(usage);
                     return;
                 }
@@ -1694,7 +1694,7 @@ void CheckClass::operatorEqToSelf()
                 // make sure return signature is correct
                 if (Token::Match(func.retDef, "%type% &") && func.retDef->str() == scope->className) {
                     // find the parameter name
-                    const Token *rhs = func.argumentList.begin()->nameToken();
+                    const Token *rhs = func.argumentList.cbegin()->nameToken();
                     const Token* out_ifStatementScopeStart = nullptr;
                     if (!hasAssignSelf(&func, rhs, &out_ifStatementScopeStart)) {
                         if (hasAllocation(&func, scope))
@@ -1878,7 +1878,7 @@ void CheckClass::virtualDestructor()
             if (printInconclusive) {
                 const Function *destructor = scope->getDestructor();
                 if (destructor && !destructor->hasVirtualSpecifier() && destructor->access == AccessControl::Public) {
-                    if (std::any_of(scope->functionList.begin(), scope->functionList.end(), [](const Function& func) {
+                    if (std::any_of(scope->functionList.cbegin(), scope->functionList.cend(), [](const Function& func) {
                         return func.hasVirtualSpecifier();
                     }))
                         inconclusiveErrors.push_back(destructor);
@@ -2361,7 +2361,7 @@ bool CheckClass::checkConstFunc(const Scope *scope, const Function *func, bool& 
                             if (assignVar->isPointer() && !assignVar->isConst() && var->typeScope()) {
                                 const auto& funcMap = var->typeScope()->functionMap;
                                 // if there is no operator that is const and returns a non-const pointer, func cannot be const
-                                if (std::none_of(funcMap.begin(), funcMap.end(), [](const std::pair<std::string, const Function*>& fm) {
+                                if (std::none_of(funcMap.cbegin(), funcMap.cend(), [](const std::pair<std::string, const Function*>& fm) {
                                     return fm.second->isConst() && fm.first == "operator[]" && !Function::returnsConst(fm.second);
                                 }))
                                     return false;
@@ -2715,11 +2715,11 @@ void CheckClass::getFirstVirtualFunctionCallStack(
         return;
     }
     std::map<const Function *, std::list<const Token *>>::const_iterator found = virtualFunctionCallsMap.find(callFunction);
-    if (found == virtualFunctionCallsMap.end() || found->second.empty()) {
+    if (found == virtualFunctionCallsMap.cend() || found->second.empty()) {
         pureFuncStack.clear();
         return;
     }
-    const Token * firstCall = *found->second.begin();
+    const Token * firstCall = *found->second.cbegin();
     pureFuncStack.push_back(firstCall);
     getFirstVirtualFunctionCallStack(virtualFunctionCallsMap, firstCall, pureFuncStack);
 }
@@ -2732,7 +2732,7 @@ void CheckClass::virtualFunctionCallInConstructorError(
     const char * scopeFunctionTypeName = scopeFunction ? getFunctionTypeName(scopeFunction->type) : "constructor";
 
     ErrorPath errorPath;
-    std::transform(tokStack.begin(), tokStack.end(), std::back_inserter(errorPath), [](const Token* tok) {
+    std::transform(tokStack.cbegin(), tokStack.cend(), std::back_inserter(errorPath), [](const Token* tok) {
         return ErrorPathItem(tok, "Calling " + tok->str());
     });
     int lineNumber = 1;
@@ -2767,7 +2767,7 @@ void CheckClass::pureVirtualFunctionCallInConstructorError(
     const char * scopeFunctionTypeName = scopeFunction ? getFunctionTypeName(scopeFunction->type) : "constructor";
 
     ErrorPath errorPath;
-    std::transform(tokStack.begin(), tokStack.end(), std::back_inserter(errorPath), [](const Token* tok) {
+    std::transform(tokStack.cbegin(), tokStack.cend(), std::back_inserter(errorPath), [](const Token* tok) {
         return ErrorPathItem(tok, "Calling " + tok->str());
     });
     if (!errorPath.empty())
@@ -3094,8 +3094,8 @@ Check::FileInfo *CheckClass::getFileInfo(const Tokenizer *tokenizer, const Setti
             continue;
 
         // the full definition must be compared
-        const bool fullDefinition = std::all_of(classScope->functionList.begin(),
-                                                classScope->functionList.end(),
+        const bool fullDefinition = std::all_of(classScope->functionList.cbegin(),
+                                                classScope->functionList.cend(),
                                                 [](const Function& f) {
             return f.hasBody();
         });

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -651,7 +651,7 @@ void CheckCondition::multiCondition2()
                       [&varsInCond](const Token *cond) {
             if (cond->variable()) {
                 const Variable *var = cond->variable();
-                if (std::find(varsInCond.begin(), varsInCond.end(), var) == varsInCond.end())
+                if (std::find(varsInCond.cbegin(), varsInCond.cend(), var) == varsInCond.cend())
                     varsInCond.push_back(var);
             }
             return ChildrenToVisit::op1_and_op2;
@@ -752,7 +752,7 @@ void CheckCondition::multiCondition2()
                         // Incomplete code
                         break;
                     }
-                    const bool changed = std::any_of(vars.begin(), vars.end(), [&](int varid) {
+                    const bool changed = std::any_of(vars.cbegin(), vars.cend(), [&](int varid) {
                         return isVariableChanged(tok1, tok2, varid, nonlocal, mSettings, mTokenizer->isCPP());
                     });
                     if (changed)

--- a/lib/checkinternal.cpp
+++ b/lib/checkinternal.cpp
@@ -227,8 +227,8 @@ void CheckInternal::checkMissingPercentCharacter()
 
             const std::string pattern = patternTok->strValue();
 
-            std::set<std::string>::const_iterator knownPattern, knownPatternsEnd = knownPatterns.end();
-            for (knownPattern = knownPatterns.begin(); knownPattern != knownPatternsEnd; ++knownPattern) {
+            std::set<std::string>::const_iterator knownPattern, knownPatternsEnd = knownPatterns.cend();
+            for (knownPattern = knownPatterns.cbegin(); knownPattern != knownPatternsEnd; ++knownPattern) {
                 const std::string brokenPattern = (*knownPattern).substr(0, (*knownPattern).size() - 1);
 
                 std::string::size_type pos = 0;
@@ -333,7 +333,7 @@ void CheckInternal::checkExtraWhitespace()
                 continue;
 
             const std::string pattern = patternTok->strValue();
-            if (!pattern.empty() && (pattern[0] == ' ' || *pattern.rbegin() == ' '))
+            if (!pattern.empty() && (pattern[0] == ' ' || *pattern.crbegin() == ' '))
                 extraWhitespaceError(tok, pattern, funcname);
 
             // two whitespaces or more

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -497,8 +497,8 @@ static bool findFormat(nonneg int arg, const Token *firstArg,
         *formatArgTok = argTok->nextArgument();
         if (!argTok->values().empty()) {
             const std::list<ValueFlow::Value>::const_iterator value = std::find_if(
-                argTok->values().begin(), argTok->values().end(), std::mem_fn(&ValueFlow::Value::isTokValue));
-            if (value != argTok->values().end() && value->isTokValue() && value->tokvalue &&
+                argTok->values().cbegin(), argTok->values().cend(), std::mem_fn(&ValueFlow::Value::isTokValue));
+            if (value != argTok->values().cend() && value->isTokValue() && value->tokvalue &&
                 value->tokvalue->tokType() == Token::eString) {
                 *formatStringTok = value->tokvalue;
             }
@@ -604,7 +604,7 @@ void CheckIO::checkFormatString(const Token * const tok,
         if (*i == '%') {
             percent = !percent;
         } else if (percent && *i == '[') {
-            while (i != formatString.end()) {
+            while (i != formatString.cend()) {
                 if (*i == ']') {
                     numFormat++;
                     if (argListTok)
@@ -620,7 +620,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                     argListTok = argListTok->nextArgument();
                 }
             }
-            if (i == formatString.end())
+            if (i == formatString.cend())
                 break;
         } else if (percent) {
             percent = false;
@@ -630,7 +630,7 @@ void CheckIO::checkFormatString(const Token * const tok,
             std::string width;
             int parameterPosition = 0;
             bool hasParameterPosition = false;
-            while (i != formatString.end() && *i != '[' && !std::isalpha((unsigned char)*i)) {
+            while (i != formatString.cend() && *i != '[' && !std::isalpha((unsigned char)*i)) {
                 if (*i == '*') {
                     skip = true;
                     if (scan)
@@ -649,10 +649,10 @@ void CheckIO::checkFormatString(const Token * const tok,
                 }
                 ++i;
             }
-            auto bracketBeg = formatString.end();
-            if (i != formatString.end() && *i == '[') {
+            auto bracketBeg = formatString.cend();
+            if (i != formatString.cend() && *i == '[') {
                 bracketBeg = i;
-                while (i != formatString.end()) {
+                while (i != formatString.cend()) {
                     if (*i == ']')
                         break;
 
@@ -665,7 +665,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                     }
                 }
             }
-            if (i == formatString.end())
+            if (i == formatString.cend())
                 break;
             if (_continue)
                 continue;
@@ -923,13 +923,13 @@ void CheckIO::checkFormatString(const Token * const tok,
                                 done = true;
                                 break;
                             case 'I':
-                                if ((i+1 != formatString.end() && *(i+1) == '6' &&
-                                     i+2 != formatString.end() && *(i+2) == '4') ||
-                                    (i+1 != formatString.end() && *(i+1) == '3' &&
-                                     i+2 != formatString.end() && *(i+2) == '2')) {
+                                if ((i+1 != formatString.cend() && *(i+1) == '6' &&
+                                     i+2 != formatString.cend() && *(i+2) == '4') ||
+                                    (i+1 != formatString.cend() && *(i+1) == '3' &&
+                                     i+2 != formatString.cend() && *(i+2) == '2')) {
                                     specifier += *i++;
                                     specifier += *i++;
-                                    if ((i+1) != formatString.end() && !isalpha(*(i+1))) {
+                                    if ((i+1) != formatString.cend() && !isalpha(*(i+1))) {
                                         specifier += *i;
                                         invalidLengthModifierError(tok, numFormat, specifier);
                                         done = true;
@@ -937,7 +937,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                                         specifier += *i++;
                                     }
                                 } else {
-                                    if ((i+1) != formatString.end() && !isalpha(*(i+1))) {
+                                    if ((i+1) != formatString.cend() && !isalpha(*(i+1))) {
                                         specifier += *i;
                                         invalidLengthModifierError(tok, numFormat, specifier);
                                         done = true;
@@ -948,7 +948,7 @@ void CheckIO::checkFormatString(const Token * const tok,
                                 break;
                             case 'h':
                             case 'l':
-                                if (i+1 != formatString.end() && *(i+1) == *i)
+                                if (i+1 != formatString.cend() && *(i+1) == *i)
                                     specifier += *i++;
                                 FALLTHROUGH;
                             case 'j':

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -82,7 +82,7 @@ template<std::size_t N>
 static bool isVarTokComparison(const Token * tok, const Token ** vartok,
                                const std::array<std::pair<std::string, std::string>, N>& ops)
 {
-    return std::any_of(ops.begin(), ops.end(), [&](const std::pair<std::string, std::string>& op) {
+    return std::any_of(ops.cbegin(), ops.cend(), [&](const std::pair<std::string, std::string>& op) {
         return astIsVariableComparison(tok, op.first, op.second, vartok);
     });
 }
@@ -592,11 +592,11 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                     }
                 }
 
-                alloctype.insert(varInfo1.alloctype.begin(), varInfo1.alloctype.end());
-                alloctype.insert(varInfo2.alloctype.begin(), varInfo2.alloctype.end());
+                alloctype.insert(varInfo1.alloctype.cbegin(), varInfo1.alloctype.cend());
+                alloctype.insert(varInfo2.alloctype.cbegin(), varInfo2.alloctype.cend());
 
-                possibleUsage.insert(varInfo1.possibleUsage.begin(), varInfo1.possibleUsage.end());
-                possibleUsage.insert(varInfo2.possibleUsage.begin(), varInfo2.possibleUsage.end());
+                possibleUsage.insert(varInfo1.possibleUsage.cbegin(), varInfo1.possibleUsage.cend());
+                possibleUsage.insert(varInfo2.possibleUsage.cbegin(), varInfo2.possibleUsage.cend());
             }
         }
 
@@ -1007,7 +1007,7 @@ void CheckLeakAutoVar::leakIfAllocated(const Token *vartok,
     const std::map<int, std::string> &possibleUsage = varInfo.possibleUsage;
 
     const std::map<int, VarInfo::AllocInfo>::const_iterator var = alloctype.find(vartok->varId());
-    if (var != alloctype.end() && var->second.status == VarInfo::ALLOC) {
+    if (var != alloctype.cend() && var->second.status == VarInfo::ALLOC) {
         const std::map<int, std::string>::const_iterator use = possibleUsage.find(vartok->varId());
         if (use == possibleUsage.end()) {
             leakError(vartok, vartok->str(), var->second.type);

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -154,7 +154,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::getAllocationType(const Token *tok2,
         return No;
 
     // Prevent recursion
-    if (callstack && std::find(callstack->begin(), callstack->end(), func) != callstack->end())
+    if (callstack && std::find(callstack->cbegin(), callstack->cend(), func) != callstack->cend())
         return No;
 
     std::list<const Function*> cs;

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -170,7 +170,7 @@ bool CheckNullPointer::isPointerDeRef(const Token *tok, bool &unknown, const Set
         if (ftok && ftok->previous()) {
             std::list<const Token *> varlist;
             parseFunctionCall(*ftok->previous(), varlist, &settings->library);
-            if (std::find(varlist.begin(), varlist.end(), tok) != varlist.end()) {
+            if (std::find(varlist.cbegin(), varlist.cend(), tok) != varlist.cend()) {
                 return true;
             }
         }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -452,7 +452,7 @@ void CheckOther::checkRedundantAssignment()
                     if (tok->astOperand1()->valueType()->typeScope) {
                         const std::string op = "operator" + tok->str();
                         const std::list<Function>& fList = tok->astOperand1()->valueType()->typeScope->functionList;
-                        inconclusive = std::any_of(fList.begin(), fList.end(), [&](const Function& f) {
+                        inconclusive = std::any_of(fList.cbegin(), fList.cend(), [&](const Function& f) {
                             return f.name() == op;
                         });
                     }
@@ -1177,13 +1177,13 @@ static int estimateSize(const Type* type, const Settings* settings, const Symbol
             size = symbolDatabase->sizeOfType(var.typeStartToken());
 
         if (var.isArray())
-            size *= std::accumulate(var.dimensions().begin(), var.dimensions().end(), 1, [](int v, const Dimension& d) {
+            size *= std::accumulate(var.dimensions().cbegin(), var.dimensions().cend(), 1, [](int v, const Dimension& d) {
                 return v *= d.num;
             });
 
         accumulateSize(cumulatedSize, size, isUnion);
     }
-    return std::accumulate(type->derivedFrom.begin(), type->derivedFrom.end(), cumulatedSize, [&](int v, const Type::BaseInfo& baseInfo) {
+    return std::accumulate(type->derivedFrom.cbegin(), type->derivedFrom.cend(), cumulatedSize, [&](int v, const Type::BaseInfo& baseInfo) {
         if (baseInfo.type && baseInfo.type->classScope)
             v += estimateSize(baseInfo.type, settings, symbolDatabase, recursionDepth + 1);
         return v;
@@ -1447,7 +1447,7 @@ void CheckOther::checkConstVariable()
         }
         if (function && Function::returnsReference(function) && !Function::returnsConst(function)) {
             std::vector<const Token*> returns = Function::findReturns(function);
-            if (std::any_of(returns.begin(), returns.end(), [&](const Token* retTok) {
+            if (std::any_of(returns.cbegin(), returns.cend(), [&](const Token* retTok) {
                 if (retTok->varId() == var->declarationId())
                     return true;
                 while (retTok && retTok->isCast())
@@ -1567,7 +1567,7 @@ void CheckOther::checkConstPointer()
             continue;
         if ((vt->pointer != 1 && !(vt->pointer == 2 && var->isArray())) || (vt->constness & 1) || vt->reference != Reference::None)
             continue;
-        if (std::find(nonConstPointers.begin(), nonConstPointers.end(), var) != nonConstPointers.end())
+        if (std::find(nonConstPointers.cbegin(), nonConstPointers.cend(), var) != nonConstPointers.cend())
             continue;
         pointers.emplace_back(var);
         const Token* const parent = tok->astParent();
@@ -1611,7 +1611,7 @@ void CheckOther::checkConstPointer()
             if (!p->scope() || !p->scope()->function || p->scope()->function->isImplicitlyVirtual(true) || p->scope()->function->hasVirtualSpecifier())
                 continue;
         }
-        if (std::find(nonConstPointers.begin(), nonConstPointers.end(), p) == nonConstPointers.end()) {
+        if (std::find(nonConstPointers.cbegin(), nonConstPointers.cend(), p) == nonConstPointers.cend()) {
             const Token *start = (p->isArgument()) ? p->scope()->bodyStart : p->nameToken()->next();
             const int indirect = p->isArray() ? p->dimensions().size() : 1;
             if (isVariableChanged(start, p->scope()->bodyEnd, indirect, p->declarationId(), false, mSettings, mTokenizer->isCPP()))
@@ -2354,8 +2354,8 @@ namespace {
                 functionsByName[func.tokenDef->str()].push_back(&func);
             }
             for (std::pair<const std::string, std::list<const Function*>>& it : functionsByName) {
-                const std::list<const Function*>::const_iterator nc = std::find_if(it.second.begin(), it.second.end(), notconst);
-                if (nc == it.second.end()) {
+                const std::list<const Function*>::const_iterator nc = std::find_if(it.second.cbegin(), it.second.cend(), notconst);
+                if (nc == it.second.cend()) {
                     // ok to add all of them
                     constFunctions.splice(constFunctions.end(), it.second);
                 }
@@ -3482,7 +3482,7 @@ static const Token *findShadowed(const Scope *scope, const std::string &varname,
         if (var.name() == varname)
             return var.nameToken();
     }
-    auto it = std::find_if(scope->functionList.begin(), scope->functionList.end(), [&](const Function& f) {
+    auto it = std::find_if(scope->functionList.cbegin(), scope->functionList.cend(), [&](const Function& f) {
         return f.type == Function::Type::eFunction && f.name() == varname;
     });
     if (it != scope->functionList.end())
@@ -3513,7 +3513,7 @@ void CheckOther::checkShadowVariables()
 
             if (functionScope && functionScope->type == Scope::ScopeType::eFunction && functionScope->function) {
                 const auto argList = functionScope->function->argumentList;
-                auto it = std::find_if(argList.begin(), argList.end(), [&](const Variable& arg) {
+                auto it = std::find_if(argList.cbegin(), argList.cend(), [&](const Variable& arg) {
                     return arg.nameToken() && var.name() == arg.name();
                 });
                 if (it != argList.end()) {
@@ -3695,11 +3695,11 @@ void CheckOther::comparePointersError(const Token *tok, const ValueFlow::Value *
         verb = "Subtracting";
     if (v1) {
         errorPath.emplace_back(v1->tokvalue->variable()->nameToken(), "Variable declared here.");
-        errorPath.insert(errorPath.end(), v1->errorPath.begin(), v1->errorPath.end());
+        errorPath.insert(errorPath.end(), v1->errorPath.cbegin(), v1->errorPath.cend());
     }
     if (v2) {
         errorPath.emplace_back(v2->tokvalue->variable()->nameToken(), "Variable declared here.");
-        errorPath.insert(errorPath.end(), v2->errorPath.begin(), v2->errorPath.end());
+        errorPath.insert(errorPath.end(), v2->errorPath.cbegin(), v2->errorPath.cend());
     }
     errorPath.emplace_back(tok, "");
     reportError(

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -728,7 +728,7 @@ static bool isSameIteratorContainerExpression(const Token* tok1,
 static ValueFlow::Value getLifetimeIteratorValue(const Token* tok, MathLib::bigint path = 0)
 {
     std::vector<ValueFlow::Value> values = getLifetimeObjValues(tok, false, path);
-    auto it = std::find_if(values.begin(), values.end(), [](const ValueFlow::Value& v) {
+    auto it = std::find_if(values.cbegin(), values.cend(), [](const ValueFlow::Value& v) {
         return v.lifetimeKind == ValueFlow::Value::LifetimeKind::Iterator;
     });
     if (it != values.end())
@@ -950,7 +950,7 @@ struct InvalidContainerAnalyzer {
 
         std::vector<Reference> invalidTokens() const {
             std::vector<Reference> result;
-            std::transform(expressions.begin(), expressions.end(), std::back_inserter(result), SelectMapValues{});
+            std::transform(expressions.cbegin(), expressions.cend(), std::back_inserter(result), SelectMapValues{});
             return result;
         }
     };
@@ -967,7 +967,7 @@ struct InvalidContainerAnalyzer {
             auto it = invalidMethods.find(f);
             if (it != invalidMethods.end()) {
                 std::vector<Info::Reference> refs = it->second.invalidTokens();
-                std::copy_if(refs.begin(), refs.end(), std::back_inserter(result), [&](const Info::Reference& r) {
+                std::copy_if(refs.cbegin(), refs.cend(), std::back_inserter(result), [&](const Info::Reference& r) {
                     const Variable* var = r.tok->variable();
                     if (!var)
                         return false;
@@ -1056,7 +1056,7 @@ static const ValueFlow::Value* getInnerLifetime(const Token* tok,
             if (val.capturetok)
                 return getInnerLifetime(val.capturetok, id, errorPath, depth - 1);
             if (errorPath)
-                errorPath->insert(errorPath->end(), val.errorPath.begin(), val.errorPath.end());
+                errorPath->insert(errorPath->end(), val.errorPath.cbegin(), val.errorPath.cend());
             return getInnerLifetime(val.tokvalue, id, errorPath, depth - 1);
         }
         if (!val.tokvalue->variable())
@@ -1179,8 +1179,8 @@ void CheckStl::invalidContainer()
                     });
                     if (!info.tok)
                         continue;
-                    errorPath.insert(errorPath.end(), info.errorPath.begin(), info.errorPath.end());
-                    errorPath.insert(errorPath.end(), r.errorPath.begin(), r.errorPath.end());
+                    errorPath.insert(errorPath.end(), info.errorPath.cbegin(), info.errorPath.cend());
+                    errorPath.insert(errorPath.end(), r.errorPath.cbegin(), r.errorPath.cend());
                     if (v) {
                         invalidContainerError(info.tok, r.tok, v, errorPath);
                     } else {
@@ -1211,7 +1211,7 @@ void CheckStl::invalidContainerError(const Token *tok, const Token * /*contTok*/
 {
     const bool inconclusive = val ? val->isInconclusive() : false;
     if (val)
-        errorPath.insert(errorPath.begin(), val->errorPath.begin(), val->errorPath.end());
+        errorPath.insert(errorPath.begin(), val->errorPath.cbegin(), val->errorPath.cend());
     std::string msg = "Using " + lifetimeMessage(tok, val, errorPath);
     errorPath.emplace_back(tok, "");
     reportError(errorPath, Severity::error, "invalidContainer", msg + " that may be invalid.", CWE664, inconclusive ? Certainty::inconclusive : Certainty::normal);
@@ -2375,7 +2375,7 @@ void CheckStl::checkDereferenceInvalidIterator2()
             continue;
 
         std::vector<ValueFlow::Value> contValues;
-        std::copy_if(tok->values().begin(), tok->values().end(), std::back_inserter(contValues), [&](const ValueFlow::Value& value) {
+        std::copy_if(tok->values().cbegin(), tok->values().cend(), std::back_inserter(contValues), [&](const ValueFlow::Value& value) {
             if (value.isImpossible())
                 return false;
             if (!printInconclusive && value.isInconclusive())
@@ -2399,7 +2399,7 @@ void CheckStl::checkDereferenceInvalidIterator2()
             } else if (value.isIteratorStartValue() && value.intvalue < 0) {
                 isInvalidIterator = true;
             } else {
-                auto it = std::find_if(contValues.begin(), contValues.end(), [&](const ValueFlow::Value& c) {
+                auto it = std::find_if(contValues.cbegin(), contValues.cend(), [&](const ValueFlow::Value& c) {
                     if (value.path != c.path)
                         return false;
                     if (value.isIteratorStartValue() && value.intvalue >= c.intvalue)

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -451,7 +451,7 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                 ;
             else if (astIsVariableComparison(tok->next()->astOperand2(), "!=", "0", &condVarTok)) {
                 const std::map<nonneg int,VariableValue>::const_iterator it = variableValue.find(condVarTok->varId());
-                if (it != variableValue.end() && it->second != 0)
+                if (it != variableValue.cend() && it->second != 0)
                     return true;   // this scope is not fully analysed => return true
                 else {
                     condVarId = condVarTok->varId();
@@ -467,7 +467,7 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                     vartok = vartok->astOperand2();
                 if (vartok && vartok->varId() && numtok && numtok->hasKnownIntValue()) {
                     const std::map<nonneg int,VariableValue>::const_iterator it = variableValue.find(vartok->varId());
-                    if (it != variableValue.end() && it->second != numtok->getKnownIntValue())
+                    if (it != variableValue.cend() && it->second != numtok->getKnownIntValue())
                         return true;   // this scope is not fully analysed => return true
                     condVarId = vartok->varId();
                     condVarValue = VariableValue(numtok->getKnownIntValue());
@@ -559,9 +559,9 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                     if (initif || initelse || possibleInitElse)
                         ++number_of_if;
                     if (!initif && !noreturnIf)
-                        variableValue.insert(varValueIf.begin(), varValueIf.end());
+                        variableValue.insert(varValueIf.cbegin(), varValueIf.cend());
                     if (!initelse && !noreturnElse)
-                        variableValue.insert(varValueElse.begin(), varValueElse.end());
+                        variableValue.insert(varValueElse.cbegin(), varValueElse.cend());
                 }
             }
         }
@@ -1604,8 +1604,8 @@ void CheckUninitVar::valueFlowUninit()
                 if (isVoidCast(parent))
                     continue;
                 auto v = std::find_if(
-                    tok->values().begin(), tok->values().end(), std::mem_fn(&ValueFlow::Value::isUninitValue));
-                if (v == tok->values().end())
+                    tok->values().cbegin(), tok->values().cend(), std::mem_fn(&ValueFlow::Value::isUninitValue));
+                if (v == tok->values().cend())
                     continue;
                 if (v->tokvalue && ids.count(v->tokvalue->exprId()) > 0)
                     continue;

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -298,7 +298,7 @@ static bool isOperatorFunction(const std::string & funcName)
     };
 
 
-    return std::find(additionalOperators.begin(), additionalOperators.end(), funcName.substr(operatorPrefix.length())) != additionalOperators.end();
+    return std::find(additionalOperators.cbegin(), additionalOperators.cend(), funcName.substr(operatorPrefix.length())) != additionalOperators.cend();
 }
 
 

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -233,7 +233,7 @@ void Variables::clearAliases(nonneg int varid)
         // remove usage from all aliases
         std::set<nonneg int>::const_iterator i;
 
-        for (i = usage->_aliases.begin(); i != usage->_aliases.end(); ++i) {
+        for (i = usage->_aliases.cbegin(); i != usage->_aliases.cend(); ++i) {
             VariableUsage *temp = find(*i);
 
             if (temp)
@@ -776,7 +776,7 @@ void CheckUnusedVar::checkFunctionVariableUsage_iterateScopes(const Scope* const
         tok = scope->classDef->next();
     for (; tok && tok != scope->bodyEnd; tok = tok->next()) {
         if (tok->str() == "{" && tok != scope->bodyStart && !tok->previous()->varId()) {
-            if (std::any_of(scope->nestedList.begin(), scope->nestedList.end(), [&](const Scope* s) {
+            if (std::any_of(scope->nestedList.cbegin(), scope->nestedList.cend(), [&](const Scope* s) {
                 return s->bodyStart == tok;
             })) {
                 checkFunctionVariableUsage_iterateScopes(tok->scope(), variables); // Scan child scope
@@ -1423,7 +1423,7 @@ void CheckUnusedVar::checkStructMemberUsage()
             continue;
         if (const Preprocessor *preprocessor = mTokenizer->getPreprocessor()) {
             const auto& directives = preprocessor->getDirectives();
-            const bool isPacked = std::any_of(directives.begin(), directives.end(), [&](const Directive& d) {
+            const bool isPacked = std::any_of(directives.cbegin(), directives.cend(), [&](const Directive& d) {
                 return d.linenr < scope.bodyStart->linenr() && d.str == "#pragma pack(1)" && d.file == mTokenizer->list.getFiles().front();
             });
             if (isPacked)
@@ -1439,9 +1439,9 @@ void CheckUnusedVar::checkStructMemberUsage()
             continue;
 
         // bail out if struct is inherited
-        bool bailout = std::any_of(symbolDatabase->scopeList.begin(), symbolDatabase->scopeList.end(), [&](const Scope& derivedScope) {
+        bool bailout = std::any_of(symbolDatabase->scopeList.cbegin(), symbolDatabase->scopeList.cend(), [&](const Scope& derivedScope) {
             const Type* dType = derivedScope.definedType;
-            return dType && std::any_of(dType->derivedFrom.begin(), dType->derivedFrom.end(), [&](const Type::BaseInfo& derivedFrom) {
+            return dType && std::any_of(dType->derivedFrom.cbegin(), dType->derivedFrom.cend(), [&](const Type::BaseInfo& derivedFrom) {
                 return derivedFrom.type == scope.definedType;
             });
         });
@@ -1581,7 +1581,7 @@ bool CheckUnusedVar::isRecordTypeWithoutSideEffects(const Type* type)
     }
 
     // Derived from type that has side effects?
-    if (std::any_of(type->derivedFrom.begin(), type->derivedFrom.end(), [this](const Type::BaseInfo& derivedFrom) {
+    if (std::any_of(type->derivedFrom.cbegin(), type->derivedFrom.cend(), [this](const Type::BaseInfo& derivedFrom) {
         return !isRecordTypeWithoutSideEffects(derivedFrom.type);
     }))
         return (withoutSideEffects = false);
@@ -1630,7 +1630,7 @@ bool CheckUnusedVar::isEmptyType(const Type* type)
 
     if (type && type->classScope && type->classScope->numConstructors == 0 &&
         (type->classScope->varlist.empty())) {
-        return (emptyType = std::all_of(type->derivedFrom.begin(), type->derivedFrom.end(), [this](const Type::BaseInfo& bi) {
+        return (emptyType = std::all_of(type->derivedFrom.cbegin(), type->derivedFrom.cend(), [this](const Type::BaseInfo& bi) {
             return isEmptyType(bi.type);
         }));
     }
@@ -1683,7 +1683,7 @@ bool CheckUnusedVar::isFunctionWithoutSideEffects(const Function& func, const To
         // check nested function
         const Function* bodyFunction = bodyToken->function();
         if (bodyFunction) {
-            if (std::find(checkedFuncs.begin(), checkedFuncs.end(), bodyFunction) != checkedFuncs.end()) { // recursion found
+            if (std::find(checkedFuncs.cbegin(), checkedFuncs.cend(), bodyFunction) != checkedFuncs.cend()) { // recursion found
                 continue;
             }
             checkedFuncs.push_back(bodyFunction);

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -1328,7 +1328,7 @@ void clangimport::AstNode::createTokensFunctionDecl(TokenList *tokenList)
     Scope *nestedIn = const_cast<Scope *>(nameToken->scope());
 
     if (prev) {
-        const std::string addr = *(std::find(mExtTokens.begin(), mExtTokens.end(), "prev") + 1);
+        const std::string addr = *(std::find(mExtTokens.cbegin(), mExtTokens.cend(), "prev") + 1);
         mData->ref(addr, nameToken);
     }
     if (!nameToken->function()) {
@@ -1448,7 +1448,7 @@ void clangimport::AstNode::createTokensForCXXRecord(TokenList *tokenList)
     // definition
     if (isDefinition()) {
         std::vector<AstNodePtr> children2;
-        std::copy_if(children.begin(), children.end(), std::back_inserter(children2), [](const AstNodePtr& child) {
+        std::copy_if(children.cbegin(), children.cend(), std::back_inserter(children2), [](const AstNodePtr& child) {
             return child->nodeType == CXXConstructorDecl ||
             child->nodeType == CXXDestructorDecl ||
             child->nodeType == CXXMethodDecl ||
@@ -1531,7 +1531,7 @@ static void setValues(Tokenizer *tokenizer, SymbolDatabase *symbolDatabase)
 
         int typeSize = 0;
         for (const Variable &var: scope.varlist) {
-            const int mul = std::accumulate(var.dimensions().begin(), var.dimensions().end(), 1, [](int v, const Dimension& dim) {
+            const int mul = std::accumulate(var.dimensions().cbegin(), var.dimensions().cend(), 1, [](int v, const Dimension& dim) {
                 return v * dim.num;
             });
             if (var.valueType())

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -821,7 +821,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 mCurrentConfig = mSettings.userDefines;
                 const std::vector<std::string> v1(split(mSettings.userDefines, ";"));
                 for (const std::string &cfg: split(currCfg, ";")) {
-                    if (std::find(v1.begin(), v1.end(), cfg) == v1.end()) {
+                    if (std::find(v1.cbegin(), v1.cend(), cfg) == v1.cend()) {
                         mCurrentConfig += ";" + cfg;
                     }
                 }
@@ -1573,7 +1573,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
         return;
 
     // Alert only about unique errors
-    if (std::find(mErrorList.begin(), mErrorList.end(), errmsg) != mErrorList.end())
+    if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) != mErrorList.cend())
         return;
 
     if (!mSettings.buildDir.empty())
@@ -1733,8 +1733,8 @@ bool CppCheck::analyseWholeProgram()
     for (const Check::FileInfo *fi : mFileInfo) {
         const CTU::FileInfo *fi2 = dynamic_cast<const CTU::FileInfo *>(fi);
         if (fi2) {
-            ctu.functionCalls.insert(ctu.functionCalls.end(), fi2->functionCalls.begin(), fi2->functionCalls.end());
-            ctu.nestedCalls.insert(ctu.nestedCalls.end(), fi2->nestedCalls.begin(), fi2->nestedCalls.end());
+            ctu.functionCalls.insert(ctu.functionCalls.end(), fi2->functionCalls.cbegin(), fi2->functionCalls.cend());
+            ctu.nestedCalls.insert(ctu.nestedCalls.end(), fi2->nestedCalls.cbegin(), fi2->nestedCalls.cend());
         }
     }
     for (Check *check : Check::instances())

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -670,7 +670,7 @@ std::string ErrorLogger::callStackToString(const std::list<ErrorMessage::FileLoc
 {
     std::string str;
     for (std::list<ErrorMessage::FileLocation>::const_iterator tok = callStack.cbegin(); tok != callStack.cend(); ++tok) {
-        str += (tok == callStack.begin() ? "" : " -> ");
+        str += (tok == callStack.cbegin() ? "" : " -> ");
         str += tok->stringify();
     }
     return str;
@@ -816,7 +816,7 @@ std::string ErrorLogger::plistData(const ErrorMessage &msg)
 
         std::list<ErrorMessage::FileLocation>::const_iterator next = it;
         ++next;
-        const std::string message = (it->getinfo().empty() && next == msg.callStack.end() ? msg.shortMessage() : it->getinfo());
+        const std::string message = (it->getinfo().empty() && next == msg.callStack.cend() ? msg.shortMessage() : it->getinfo());
 
         plist << "    <dict>\r\n"
               << "     <key>kind</key><string>event</string>\r\n"

--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -102,10 +102,10 @@ struct ForwardTraversal {
             return std::make_pair(false, false);
         std::vector<MathLib::bigint> result = analyzer->evaluate(tok, ctx);
         // TODO: We should convert to bool
-        const bool checkThen = std::any_of(result.begin(), result.end(), [](int x) {
+        const bool checkThen = std::any_of(result.cbegin(), result.cend(), [](int x) {
             return x != 0;
         });
-        const bool checkElse = std::any_of(result.begin(), result.end(), [](int x) {
+        const bool checkElse = std::any_of(result.cbegin(), result.cend(), [](int x) {
             return x == 0;
         });
         return std::make_pair(checkThen, checkElse);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -311,7 +311,7 @@ void ImportProject::FileSettings::parseCommand(std::string command)
             std::string i = fval;
             if (i.size() > 1 && i[0] == '\"' && i.back() == '\"')
                 i = unescape(i.substr(1, i.size() - 2));
-            if (std::find(includePaths.begin(), includePaths.end(), i) == includePaths.end())
+            if (std::find(includePaths.cbegin(), includePaths.cend(), i) == includePaths.cend())
                 includePaths.push_back(std::move(i));
         } else if (F=='s' && fval.compare(0,2,"td") == 0) {
             ++pos;
@@ -762,7 +762,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
         for (const ProjectConfiguration &p : projectConfigurationList) {
 
             if (!guiProject.checkVsConfigs.empty()) {
-                const bool doChecking = std::any_of(guiProject.checkVsConfigs.begin(), guiProject.checkVsConfigs.end(), [&](const std::string& c) {
+                const bool doChecking = std::any_of(guiProject.checkVsConfigs.cbegin(), guiProject.checkVsConfigs.cend(), [&](const std::string& c) {
                     return c == p.configuration;
                 });
                 if (!doChecking)
@@ -1297,7 +1297,7 @@ void ImportProject::selectOneVsConfig(Settings::PlatformType platform)
 
 std::list<std::string> ImportProject::getVSConfigs()
 {
-    return std::list<std::string>(mAllVSConfigs.begin(), mAllVSConfigs.end());
+    return std::list<std::string>(mAllVSConfigs.cbegin(), mAllVSConfigs.cend());
 }
 
 void ImportProject::setRelativePaths(const std::string &filename)

--- a/lib/infer.cpp
+++ b/lib/infer.cpp
@@ -184,7 +184,7 @@ struct Interval {
     static std::vector<const ValueFlow::Value*> merge(std::vector<const ValueFlow::Value*> x,
                                                       const std::vector<const ValueFlow::Value*>& y)
     {
-        x.insert(x.end(), y.begin(), y.end());
+        x.insert(x.end(), y.cbegin(), y.cend());
         return x;
     }
 
@@ -245,7 +245,7 @@ struct Interval {
         if (r.empty())
             return {};
         bool b = calculate(op, r.front(), 0);
-        if (std::all_of(r.begin() + 1, r.end(), [&](int i) {
+        if (std::all_of(r.cbegin() + 1, r.cend(), [&](int i) {
             return b == calculate(op, i, 0);
         }))
             return {b};
@@ -263,8 +263,8 @@ static void addToErrorPath(ValueFlow::Value& value, const std::vector<const Valu
     for (const ValueFlow::Value* ref : refs) {
         if (ref->condition && !value.condition)
             value.condition = ref->condition;
-        std::copy_if(ref->errorPath.begin(),
-                     ref->errorPath.end(),
+        std::copy_if(ref->errorPath.cbegin(),
+                     ref->errorPath.cend(),
                      std::back_inserter(value.errorPath),
                      [&](const ErrorPathItem& e) {
             return locations.insert(e.first).second;
@@ -292,7 +292,7 @@ static void setValueKind(ValueFlow::Value& value, const std::vector<const ValueF
 
 static bool inferNotEqual(const std::list<ValueFlow::Value>& values, MathLib::bigint x)
 {
-    return std::any_of(values.begin(), values.end(), [&](const ValueFlow::Value& value) {
+    return std::any_of(values.cbegin(), values.cend(), [&](const ValueFlow::Value& value) {
         return value.isImpossible() && value.intvalue == x;
     });
 }

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1313,10 +1313,10 @@ bool Library::formatstr_function(const Token* ftok) const
 int Library::formatstr_argno(const Token* ftok) const
 {
     const std::map<int, Library::ArgumentChecks>& argumentChecksFunc = functions.at(getFunctionName(ftok)).argumentChecks;
-    auto it = std::find_if(argumentChecksFunc.begin(), argumentChecksFunc.end(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
+    auto it = std::find_if(argumentChecksFunc.cbegin(), argumentChecksFunc.cend(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
         return a.second.formatstr;
     });
-    return it == argumentChecksFunc.end() ? -1 : it->first - 1;
+    return it == argumentChecksFunc.cend() ? -1 : it->first - 1;
 }
 
 bool Library::formatstr_scan(const Token* ftok) const
@@ -1352,7 +1352,7 @@ const std::string& Library::returnValue(const Token *ftok) const
     if (isNotLibraryFunction(ftok))
         return emptyString;
     const std::map<std::string, std::string>::const_iterator it = mReturnValue.find(getFunctionName(ftok));
-    return it != mReturnValue.end() ? it->second : emptyString;
+    return it != mReturnValue.cend() ? it->second : emptyString;
 }
 
 const std::string& Library::returnValueType(const Token *ftok) const
@@ -1360,7 +1360,7 @@ const std::string& Library::returnValueType(const Token *ftok) const
     if (isNotLibraryFunction(ftok))
         return emptyString;
     const std::map<std::string, std::string>::const_iterator it = mReturnValueType.find(getFunctionName(ftok));
-    return it != mReturnValueType.end() ? it->second : emptyString;
+    return it != mReturnValueType.cend() ? it->second : emptyString;
 }
 
 int Library::returnValueContainer(const Token *ftok) const
@@ -1368,7 +1368,7 @@ int Library::returnValueContainer(const Token *ftok) const
     if (isNotLibraryFunction(ftok))
         return -1;
     const std::map<std::string, int>::const_iterator it = mReturnValueContainer.find(getFunctionName(ftok));
-    return it != mReturnValueContainer.end() ? it->second : -1;
+    return it != mReturnValueContainer.cend() ? it->second : -1;
 }
 
 std::vector<MathLib::bigint> Library::unknownReturnValues(const Token *ftok) const
@@ -1376,7 +1376,7 @@ std::vector<MathLib::bigint> Library::unknownReturnValues(const Token *ftok) con
     if (isNotLibraryFunction(ftok))
         return std::vector<MathLib::bigint>();
     const std::map<std::string, std::vector<MathLib::bigint>>::const_iterator it = mUnknownReturnValues.find(getFunctionName(ftok));
-    return (it == mUnknownReturnValues.end()) ? std::vector<MathLib::bigint>() : it->second;
+    return (it == mUnknownReturnValues.cend()) ? std::vector<MathLib::bigint>() : it->second;
 }
 
 const Library::Function *Library::getFunction(const Token *ftok) const
@@ -1397,7 +1397,7 @@ bool Library::hasminsize(const Token *ftok) const
     const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
     if (it == functions.cend())
         return false;
-    return std::any_of(it->second.argumentChecks.begin(), it->second.argumentChecks.end(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
+    return std::any_of(it->second.argumentChecks.cbegin(), it->second.argumentChecks.cend(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
         return !a.second.minsizes.empty();
     });
 }
@@ -1454,7 +1454,7 @@ bool Library::isFunctionConst(const Token *ftok) const
     if (isNotLibraryFunction(ftok))
         return false;
     const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
-    return (it != functions.end() && it->second.isconst);
+    return (it != functions.cend() && it->second.isconst);
 }
 
 bool Library::isnoreturn(const Token *ftok) const
@@ -1493,19 +1493,19 @@ bool Library::markupFile(const std::string &path) const
 bool Library::processMarkupAfterCode(const std::string &path) const
 {
     const std::map<std::string, bool>::const_iterator it = mProcessAfterCode.find(Path::getFilenameExtensionInLowerCase(path));
-    return (it == mProcessAfterCode.end() || it->second);
+    return (it == mProcessAfterCode.cend() || it->second);
 }
 
 bool Library::reportErrors(const std::string &path) const
 {
     const std::map<std::string, bool>::const_iterator it = mReportErrors.find(Path::getFilenameExtensionInLowerCase(path));
-    return (it == mReportErrors.end() || it->second);
+    return (it == mReportErrors.cend() || it->second);
 }
 
 bool Library::isexecutableblock(const std::string &file, const std::string &token) const
 {
     const std::unordered_map<std::string, CodeBlock>::const_iterator it = mExecutableBlocks.find(Path::getFilenameExtensionInLowerCase(file));
-    return (it != mExecutableBlocks.end() && it->second.isBlock(token));
+    return (it != mExecutableBlocks.cend() && it->second.isBlock(token));
 }
 
 int Library::blockstartoffset(const std::string &file) const

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -359,7 +359,7 @@ MathLib::biguint MathLib::toULongNumber(const std::string & str)
 
 unsigned int MathLib::encodeMultiChar(const std::string& str)
 {
-    return std::accumulate(str.begin(), str.end(), uint32_t(), [](uint32_t v, char c) {
+    return std::accumulate(str.cbegin(), str.cend(), uint32_t(), [](uint32_t v, char c) {
         return (v << 8) | c;
     });
 }
@@ -479,9 +479,9 @@ static double myStod(const std::string& str, std::string::const_iterator from, s
 static double floatHexToDoubleNumber(const std::string& str)
 {
     const std::size_t p = str.find_first_of("pP",3);
-    const double factor1 = myStod(str, str.begin() + 2, str.begin()+p, 16);
+    const double factor1 = myStod(str, str.cbegin() + 2, str.cbegin()+p, 16);
     const bool suffix = (str.back() == 'f') || (str.back() == 'F') || (str.back() == 'l') || (str.back() == 'L');
-    const double exponent = myStod(str, str.begin() + p + 1, suffix ? str.end()-1:str.end(), 10);
+    const double exponent = myStod(str, str.cbegin() + p + 1, suffix ? str.cend()-1:str.cend(), 10);
     const double factor2 = std::pow(2, exponent);
     return factor1 * factor2;
 }
@@ -727,7 +727,7 @@ static bool isValidIntegerSuffixIt(std::string::const_iterator it, std::string::
 // cppcheck-suppress unusedFunction
 bool MathLib::isValidIntegerSuffix(const std::string& str, bool supportMicrosoftExtensions)
 {
-    return isValidIntegerSuffixIt(str.begin(), str.end(), supportMicrosoftExtensions);
+    return isValidIntegerSuffixIt(str.cbegin(), str.cend(), supportMicrosoftExtensions);
 }
 
 

--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -54,11 +54,11 @@ std::pair<bool, bool> PathAnalysis::checkCond(const Token * tok, bool& known)
         known = true;
         return std::make_pair(tok->values().front().intvalue, !tok->values().front().intvalue);
     }
-    auto it = std::find_if(tok->values().begin(), tok->values().end(), [](const ValueFlow::Value& v) {
+    auto it = std::find_if(tok->values().cbegin(), tok->values().cend(), [](const ValueFlow::Value& v) {
         return v.isIntValue();
     });
     // If all possible values are the same, then assume all paths have the same value
-    if (it != tok->values().end() && std::all_of(it, tok->values().end(), [&](const ValueFlow::Value& v) {
+    if (it != tok->values().cend() && std::all_of(it, tok->values().cend(), [&](const ValueFlow::Value& v) {
         if (v.isIntValue())
             return v.intvalue == it->intvalue;
         return true;
@@ -191,6 +191,6 @@ bool reaches(const Token * start, const Token * dest, const Library& library, Er
     if (!info.tok)
         return false;
     if (errorPath)
-        errorPath->insert(errorPath->end(), info.errorPath.begin(), info.errorPath.end());
+        errorPath->insert(errorPath->end(), info.errorPath.cbegin(), info.errorPath.cend());
     return true;
 }

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -112,7 +112,7 @@ static bool parseInlineSuppressionCommentToken(const simplecpp::Token *tok, std:
         if (!errmsg.empty())
             bad->emplace_back(tok->location, std::move(errmsg));
 
-        std::copy_if(suppressions.begin(), suppressions.end(), std::back_inserter(inlineSuppressions), [](const Suppressions::Suppression& s) {
+        std::copy_if(suppressions.cbegin(), suppressions.cend(), std::back_inserter(inlineSuppressions), [](const Suppressions::Suppression& s) {
             return !s.errorId.empty();
         });
     } else {
@@ -327,7 +327,7 @@ static bool hasDefine(const std::string &userDefines, const std::string &cfg)
 
 static std::string cfg(const std::vector<std::string> &configs, const std::string &userDefines)
 {
-    std::set<std::string> configs2(configs.begin(), configs.end());
+    std::set<std::string> configs2(configs.cbegin(), configs.cend());
     std::string ret;
     for (const std::string &c : configs2) {
         if (c.empty())

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -69,7 +69,7 @@ void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value) {
 const ValueFlow::Value* ProgramMemory::getValue(nonneg int exprid, bool impossible) const
 {
     const ProgramMemory::Map::const_iterator it = mValues.find(exprid);
-    const bool found = it != mValues.end() && (impossible || !it->second.isImpossible());
+    const bool found = it != mValues.cend() && (impossible || !it->second.isImpossible());
     if (found)
         return &it->second;
     else
@@ -542,7 +542,7 @@ static double asFloat(const ValueFlow::Value& value)
 }
 
 static std::string removeAssign(const std::string& assign) {
-    return std::string{assign.begin(), assign.end() - 1};
+    return std::string{assign.cbegin(), assign.cend() - 1};
 }
 
 struct assign {
@@ -713,7 +713,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["atan2"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -725,7 +725,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["remainder"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -737,7 +737,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["nextafter"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -749,7 +749,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["nexttoward"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -761,7 +761,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["hypot"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -773,7 +773,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["fdim"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -785,7 +785,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["fmax"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -797,7 +797,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["fmin"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -809,7 +809,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["fmod"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -821,7 +821,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["pow"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -833,7 +833,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["scalbln"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -845,7 +845,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         return v;
     };
     functions["ldexp"] = [](const std::vector<ValueFlow::Value>& args) {
-        if (args.size() != 2 || !std::all_of(args.begin(), args.end(), [](const ValueFlow::Value& v) {
+        if (args.size() != 2 || !std::all_of(args.cbegin(), args.cend(), [](const ValueFlow::Value& v) {
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
@@ -1246,10 +1246,10 @@ static ValueFlow::Value executeImpl(const Token* expr, ProgramMemory& pm, const 
     } else if (expr->str() == "[" && expr->astOperand1() && expr->astOperand2()) {
         const Token *tokvalue = nullptr;
         if (!pm.getTokValue(expr->astOperand1()->exprId(), &tokvalue)) {
-            auto tokvalue_it = std::find_if(expr->astOperand1()->values().begin(),
-                                            expr->astOperand1()->values().end(),
+            auto tokvalue_it = std::find_if(expr->astOperand1()->values().cbegin(),
+                                            expr->astOperand1()->values().cend(),
                                             std::mem_fn(&ValueFlow::Value::isTokValue));
-            if (tokvalue_it == expr->astOperand1()->values().end() || !tokvalue_it->isKnown()) {
+            if (tokvalue_it == expr->astOperand1()->values().cend() || !tokvalue_it->isKnown()) {
                 return unknown;
             }
             tokvalue = tokvalue_it->tokvalue;
@@ -1328,7 +1328,7 @@ static ValueFlow::Value executeImpl(const Token* expr, ProgramMemory& pm, const 
         if (!f && settings && expr->str() == "(") {
             std::vector<const Token*> tokArgs = getArguments(expr);
             std::vector<ValueFlow::Value> args(tokArgs.size());
-            std::transform(tokArgs.begin(), tokArgs.end(), args.begin(), [&](const Token* tok) {
+            std::transform(tokArgs.cbegin(), tokArgs.cend(), args.begin(), [&](const Token* tok) {
                 return execute(tok, pm, settings);
             });
             BuiltinLibraryFunction lf = getBuiltinLibraryFunction(ftok->str());

--- a/lib/reverseanalyzer.cpp
+++ b/lib/reverseanalyzer.cpp
@@ -45,10 +45,10 @@ struct ReverseTraversal {
     std::pair<bool, bool> evalCond(const Token* tok) {
         std::vector<MathLib::bigint> result = analyzer->evaluate(tok);
         // TODO: We should convert to bool
-        const bool checkThen = std::any_of(result.begin(), result.end(), [](int x) {
+        const bool checkThen = std::any_of(result.cbegin(), result.cend(), [](int x) {
             return x == 1;
         });
-        const bool checkElse = std::any_of(result.begin(), result.end(), [](int x) {
+        const bool checkElse = std::any_of(result.cbegin(), result.cend(), [](int x) {
             return x == 0;
         });
         return std::make_pair(checkThen, checkElse);

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -392,7 +392,7 @@ public:
 
     /** Is posix library specified? */
     bool posix() const {
-        return std::find(libraries.begin(), libraries.end(), "posix") != libraries.end();
+        return std::find(libraries.cbegin(), libraries.cend(), "posix") != libraries.cend();
     }
 
     /** @brief Request termination of checking */

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1046,7 +1046,7 @@ void SymbolDatabase::createSymbolDatabaseSetScopePointers()
                 bool isEndOfScope = false;
                 for (Scope* innerScope: scope.nestedList) {
                     const auto &list = innerScope->bodyStartList;
-                    if (std::find(list.begin(), list.end(), tok) != list.end()) {     // Is begin of inner scope
+                    if (std::find(list.cbegin(), list.cend(), tok) != list.cend()) {     // Is begin of inner scope
                         tok = tok->link();
                         if (tok->next() == bodyEnd || !tok->next()) {
                             isEndOfScope = true;
@@ -1983,7 +1983,7 @@ void SymbolDatabase::debugSymbolDatabase() const
             ErrorPath errorPath;
             if (tok->valueType()) {
                 msg += tok->valueType()->str();
-                errorPath.insert(errorPath.end(), tok->valueType()->debugPath.begin(), tok->valueType()->debugPath.end());
+                errorPath.insert(errorPath.end(), tok->valueType()->debugPath.cbegin(), tok->valueType()->debugPath.cend());
 
             } else {
                 msg += "missing";
@@ -3434,7 +3434,7 @@ bool Type::hasCircularDependencies(std::set<BaseInfo>* ancestors) const
 
 bool Type::findDependency(const Type* ancestor) const
 {
-    return this == ancestor || std::any_of(derivedFrom.begin(), derivedFrom.end(), [&](const BaseInfo& d) {
+    return this == ancestor || std::any_of(derivedFrom.cbegin(), derivedFrom.cend(), [&](const BaseInfo& d) {
         return d.type && (d.type == this || d.type->findDependency(ancestor));
     });
 }
@@ -4073,7 +4073,7 @@ static const Token* findLambdaEndTokenWithoutAST(const Token* tok) {
     if (!(Token::simpleMatch(tok, "{") && tok->link()))
         return nullptr;
     return tok->link()->next();
-};
+}
 
 void Function::addArguments(const SymbolDatabase *symbolDatabase, const Scope *scope)
 {
@@ -5146,7 +5146,7 @@ std::vector<const Scope*> Scope::findAssociatedScopes() const
                 if (contains(result, base->classScope))
                     continue;
                 std::vector<const Scope*> baseScopes = base->classScope->findAssociatedScopes();
-                result.insert(result.end(), baseScopes.begin(), baseScopes.end());
+                result.insert(result.end(), baseScopes.cbegin(), baseScopes.cend());
             }
         }
     }
@@ -5587,7 +5587,7 @@ const Function* SymbolDatabase::findFunction(const Token *tok) const
 
 const Scope *SymbolDatabase::findScopeByName(const std::string& name) const
 {
-    auto it = std::find_if(scopeList.begin(), scopeList.end(), [&](const Scope& s) {
+    auto it = std::find_if(scopeList.cbegin(), scopeList.cend(), [&](const Scope& s) {
         return s.className == name;
     });
     return it == scopeList.end() ? nullptr : &*it;
@@ -5650,7 +5650,7 @@ const Type* Scope::findType(const std::string & name) const
 
 Scope *Scope::findInNestedListRecursive(const std::string & name)
 {
-    auto it = std::find_if(nestedList.begin(), nestedList.end(), [&](const Scope* s) {
+    auto it = std::find_if(nestedList.cbegin(), nestedList.cend(), [&](const Scope* s) {
         return s->className == name;
     });
     if (it != nestedList.end())
@@ -5668,7 +5668,7 @@ Scope *Scope::findInNestedListRecursive(const std::string & name)
 
 const Function *Scope::getDestructor() const
 {
-    auto it = std::find_if(functionList.begin(), functionList.end(), [](const Function& f) {
+    auto it = std::find_if(functionList.cbegin(), functionList.cend(), [](const Function& f) {
         return f.type == Function::eDestructor;
     });
     return it == functionList.end() ? nullptr : &*it;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1079,7 +1079,7 @@ public:
     }
 
     const Enumerator * findEnumerator(const std::string & name) const {
-        auto it = std::find_if(enumeratorList.begin(), enumeratorList.end(), [&](const Enumerator& i) {
+        auto it = std::find_if(enumeratorList.cbegin(), enumeratorList.cend(), [&](const Enumerator& i) {
             return i.name->str() == name;
         });
         return it == enumeratorList.end() ? nullptr : &*it;

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -699,11 +699,11 @@ void TemplateSimplifier::addInstantiation(Token *token, const std::string &scope
     TokenAndName instantiation(token, scope);
 
     // check if instantiation already exists before adding it
-    const std::list<TokenAndName>::iterator it = std::find(mTemplateInstantiations.begin(),
-                                                           mTemplateInstantiations.end(),
-                                                           instantiation);
+    const std::list<TokenAndName>::const_iterator it = std::find(mTemplateInstantiations.cbegin(),
+                                                                 mTemplateInstantiations.cend(),
+                                                                 instantiation);
 
-    if (it == mTemplateInstantiations.end())
+    if (it == mTemplateInstantiations.cend())
         mTemplateInstantiations.emplace_back(std::move(instantiation));
 }
 
@@ -736,7 +736,7 @@ static bool areAllParamsTypes(const std::vector<const Token *> &params)
     if (params.empty())
         return false;
 
-    return std::all_of(params.begin(), params.end(), [](const Token* param) {
+    return std::all_of(params.cbegin(), params.cend(), [](const Token* param) {
         return Token::Match(param->previous(), "typename|class %name% ,|>");
     });
 }
@@ -949,7 +949,7 @@ void TemplateSimplifier::getTemplateInstantiations()
                 while (true) {
                     const std::string fullName = scopeName + (scopeName.empty()?"":" :: ") +
                                                  qualification + (qualification.empty()?"":" :: ") + tok->str();
-                    const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateDeclarations.begin(), mTemplateDeclarations.end(), FindFullName(fullName));
+                    const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateDeclarations.cbegin(), mTemplateDeclarations.cend(), FindFullName(fullName));
                     if (it != mTemplateDeclarations.end()) {
                         // full name matches
                         addInstantiation(tok, it->scope());
@@ -961,7 +961,7 @@ void TemplateSimplifier::getTemplateInstantiations()
                             std::string fullNameSpace = scopeName + (scopeName.empty()?"":" :: ") +
                                                         nameSpace + (qualification.empty()?"":" :: ") + qualification;
                             std::string newFullName = fullNameSpace + " :: " + tok->str();
-                            const std::list<TokenAndName>::const_iterator it1 = std::find_if(mTemplateDeclarations.begin(), mTemplateDeclarations.end(), FindFullName(newFullName));
+                            const std::list<TokenAndName>::const_iterator it1 = std::find_if(mTemplateDeclarations.cbegin(), mTemplateDeclarations.cend(), FindFullName(newFullName));
                             if (it1 != mTemplateDeclarations.end()) {
                                 // insert using namespace into token stream
                                 std::string::size_type offset = 0;
@@ -1131,11 +1131,11 @@ void TemplateSimplifier::useDefaultArgumentValues(TokenAndName &declaration)
 
         if (tok && tok->str() == ">") {
             tok = tok->previous();
-            std::list<Default>::const_iterator it = eq.begin();
-            for (std::size_t i = (templatepar - eq.size()); it != eq.end() && i < usedpar; ++i)
+            std::list<Default>::const_iterator it = eq.cbegin();
+            for (std::size_t i = (templatepar - eq.size()); it != eq.cend() && i < usedpar; ++i)
                 ++it;
             int count = 0;
-            while (it != eq.end()) {
+            while (it != eq.cend()) {
                 // check for end
                 if (!it->end) {
                     if (mSettings->debugwarnings) {
@@ -1328,10 +1328,10 @@ void TemplateSimplifier::simplifyTemplateAliases()
                 if (aliasParameterNames.find(tok2->str()) == aliasParameterNames.end()) {
                     // Create template instance..
                     if (Token::Match(tok1, "%name% <")) {
-                        const std::list<TokenAndName>::iterator it = std::find_if(mTemplateInstantiations.begin(),
-                                                                                  mTemplateInstantiations.end(),
-                                                                                  FindToken(tok1));
-                        if (it != mTemplateInstantiations.end())
+                        const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateInstantiations.cbegin(),
+                                                                                        mTemplateInstantiations.cend(),
+                                                                                        FindToken(tok1));
+                        if (it != mTemplateInstantiations.cend())
                             addInstantiation(tok2, it->scope());
                     }
                 }
@@ -1624,10 +1624,10 @@ void TemplateSimplifier::expandTemplate(
             end = temp2->linkAt(1)->next();
         } else {
             if (it != mTemplateForwardDeclarationsMap.end()) {
-                const std::list<TokenAndName>::iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
-                                                                           mTemplateForwardDeclarations.end(),
-                                                                           FindToken(it->second));
-                if (it1 != mTemplateForwardDeclarations.end())
+                const std::list<TokenAndName>::const_iterator it1 = std::find_if(mTemplateForwardDeclarations.cbegin(),
+                                                                                 mTemplateForwardDeclarations.cend(),
+                                                                                 FindToken(it->second));
+                if (it1 != mTemplateForwardDeclarations.cend())
                     mMemberFunctionsToDelete.push_back(*it1);
             }
 
@@ -1777,7 +1777,7 @@ void TemplateSimplifier::expandTemplate(
                                 type = type->next();
                             }
                             // check if type is instantiated
-                            if (std::any_of(mTemplateInstantiations.begin(), mTemplateInstantiations.end(), [&](const TokenAndName& inst) {
+                            if (std::any_of(mTemplateInstantiations.cbegin(), mTemplateInstantiations.cend(), [&](const TokenAndName& inst) {
                                 return Token::simpleMatch(inst.token(), name.c_str(), name.size());
                             })) {
                                 // use the instantiated name
@@ -2011,10 +2011,10 @@ void TemplateSimplifier::expandTemplate(
             while (tok3 && tok3->str() != "::")
                 tok3 = tok3->next();
 
-            const std::list<TokenAndName>::iterator it = std::find_if(mTemplateDeclarations.begin(),
-                                                                      mTemplateDeclarations.end(),
-                                                                      FindToken(startOfTemplateDeclaration));
-            if (it != mTemplateDeclarations.end())
+            const std::list<TokenAndName>::const_iterator it = std::find_if(mTemplateDeclarations.cbegin(),
+                                                                            mTemplateDeclarations.cend(),
+                                                                            FindToken(startOfTemplateDeclaration));
+            if (it != mTemplateDeclarations.cend())
                 mMemberFunctionsToDelete.push_back(*it);
         }
 
@@ -3382,16 +3382,16 @@ void TemplateSimplifier::getSpecializations()
     // try to locate a matching declaration for each user defined specialization
     for (const auto& spec : mTemplateDeclarations) {
         if (spec.isSpecialization()) {
-            auto it = std::find_if(mTemplateDeclarations.begin(), mTemplateDeclarations.end(), [&](const TokenAndName& decl) {
+            auto it = std::find_if(mTemplateDeclarations.cbegin(), mTemplateDeclarations.cend(), [&](const TokenAndName& decl) {
                 return specMatch(spec, decl);
             });
-            if (it != mTemplateDeclarations.end())
+            if (it != mTemplateDeclarations.cend())
                 mTemplateSpecializationMap[spec.token()] = it->token();
             else {
-                it = std::find_if(mTemplateForwardDeclarations.begin(), mTemplateForwardDeclarations.end(), [&](const TokenAndName& decl) {
+                it = std::find_if(mTemplateForwardDeclarations.cbegin(), mTemplateForwardDeclarations.cend(), [&](const TokenAndName& decl) {
                     return specMatch(spec, decl);
                 });
-                if (it != mTemplateForwardDeclarations.end())
+                if (it != mTemplateForwardDeclarations.cend())
                     mTemplateSpecializationMap[spec.token()] = it->token();
             }
         }
@@ -3403,16 +3403,16 @@ void TemplateSimplifier::getPartialSpecializations()
     // try to locate a matching declaration for each user defined partial specialization
     for (const auto& spec : mTemplateDeclarations) {
         if (spec.isPartialSpecialization()) {
-            auto it = std::find_if(mTemplateDeclarations.begin(), mTemplateDeclarations.end(), [&](const TokenAndName& decl) {
+            auto it = std::find_if(mTemplateDeclarations.cbegin(), mTemplateDeclarations.cend(), [&](const TokenAndName& decl) {
                 return specMatch(spec, decl);
             });
-            if (it != mTemplateDeclarations.end())
+            if (it != mTemplateDeclarations.cend())
                 mTemplatePartialSpecializationMap[spec.token()] = it->token();
             else {
-                it = std::find_if(mTemplateForwardDeclarations.begin(), mTemplateForwardDeclarations.end(), [&](const TokenAndName& decl) {
+                it = std::find_if(mTemplateForwardDeclarations.cbegin(), mTemplateForwardDeclarations.cend(), [&](const TokenAndName& decl) {
                     return specMatch(spec, decl);
                 });
-                if (it != mTemplateForwardDeclarations.end())
+                if (it != mTemplateForwardDeclarations.cend())
                     mTemplatePartialSpecializationMap[spec.token()] = it->token();
             }
         }
@@ -3768,7 +3768,7 @@ void TemplateSimplifier::simplifyTemplates(
 
         std::set<std::string> expandedtemplates;
 
-        for (std::list<TokenAndName>::reverse_iterator iter1 = mTemplateDeclarations.rbegin(); iter1 != mTemplateDeclarations.rend(); ++iter1) {
+        for (std::list<TokenAndName>::const_reverse_iterator iter1 = mTemplateDeclarations.crbegin(); iter1 != mTemplateDeclarations.crend(); ++iter1) {
             if (iter1->isAlias() || iter1->isFriend())
                 continue;
 
@@ -3820,7 +3820,7 @@ void TemplateSimplifier::simplifyTemplates(
         while (!mMemberFunctionsToDelete.empty()) {
             const std::list<TokenAndName>::iterator it = std::find_if(mTemplateDeclarations.begin(),
                                                                       mTemplateDeclarations.end(),
-                                                                      FindToken(mMemberFunctionsToDelete.begin()->token()));
+                                                                      FindToken(mMemberFunctionsToDelete.cbegin()->token()));
             // multiple functions can share the same declaration so make sure it hasn't already been deleted
             if (it != mTemplateDeclarations.end()) {
                 removeTemplate(it->token());
@@ -3828,7 +3828,7 @@ void TemplateSimplifier::simplifyTemplates(
             } else {
                 const std::list<TokenAndName>::iterator it1 = std::find_if(mTemplateForwardDeclarations.begin(),
                                                                            mTemplateForwardDeclarations.end(),
-                                                                           FindToken(mMemberFunctionsToDelete.begin()->token()));
+                                                                           FindToken(mMemberFunctionsToDelete.cbegin()->token()));
                 // multiple functions can share the same declaration so make sure it hasn't already been deleted
                 if (it1 != mTemplateForwardDeclarations.end()) {
                     removeTemplate(it1->token());

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -51,7 +51,7 @@ void TimerResults::showResults(SHOWTIME_MODES mode) const
     data.reserve(mResults.size());
     {
         std::lock_guard<std::mutex> l(mResultsSync);
-        data.insert(data.begin(), mResults.begin(), mResults.end());
+        data.insert(data.begin(), mResults.cbegin(), mResults.cend());
     }
     std::sort(data.begin(), data.end(), more_second_sec);
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2236,7 +2236,7 @@ const ::Type* Token::typeOf(const Token* tok, const Token** typeTok)
         if (vars.empty())
             return nullptr;
         if (std::all_of(
-                vars.begin(), vars.end(), [&](const Variable* var) {
+                vars.cbegin(), vars.cend(), [&](const Variable* var) {
             return var->type() == vars.front()->type();
         }))
             return vars.front()->type();

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1879,7 +1879,7 @@ namespace {
         }
 
         bool hasChild(const std::string &childName) const {
-            return std::any_of(children.begin(), children.end(), [&](const ScopeInfo3& child) {
+            return std::any_of(children.cbegin(), children.cend(), [&](const ScopeInfo3& child) {
                 return child.name == childName;
             });
         }
@@ -1901,7 +1901,7 @@ namespace {
             const ScopeInfo3 * tempScope = this;
             while (tempScope) {
                 // check children
-                auto it = std::find_if(tempScope->children.begin(), tempScope->children.end(), [&](const ScopeInfo3& child) {
+                auto it = std::find_if(tempScope->children.cbegin(), tempScope->children.cend(), [&](const ScopeInfo3& child) {
                     return &child != this && child.type == Record && (child.name == scope || child.fullName == scope);
                 });
                 if (it != tempScope->children.end())
@@ -2189,7 +2189,7 @@ namespace {
                         return true;
                 } else {
                     const std::string suffix = " :: " + qualification;
-                    if (std::any_of(usingNS.begin(), usingNS.end(), [&](const std::string& ns) {
+                    if (std::any_of(usingNS.cbegin(), usingNS.cend(), [&](const std::string& ns) {
                         return scope == ns + suffix;
                     }))
                         return true;
@@ -4450,7 +4450,7 @@ void Tokenizer::setVarIdPass2()
                     scopeName3.erase(pos + 4);
                 }
                 const std::map<std::string, nonneg int>& baseClassVars = varsByClass[baseClassName];
-                thisClassVars.insert(baseClassVars.begin(), baseClassVars.end());
+                thisClassVars.insert(baseClassVars.cbegin(), baseClassVars.cend());
             }
             tokStart = tokStart->next();
         }
@@ -4458,7 +4458,7 @@ void Tokenizer::setVarIdPass2()
             continue;
 
         // What member variables are there in this class?
-        std::transform(classnameTokens.begin(), classnameTokens.end(), std::back_inserter(scopeInfo), [&](const Token* tok) {
+        std::transform(classnameTokens.cbegin(), classnameTokens.cend(), std::back_inserter(scopeInfo), [&](const Token* tok) {
             return ScopeInfo2(tok->str(), tokStart->link());
         });
 
@@ -9551,7 +9551,7 @@ void Tokenizer::printUnknownTypes() const
         std::string last;
         int count = 0;
 
-        for (auto it = unknowns.begin(); it != unknowns.end(); ++it) {
+        for (auto it = unknowns.cbegin(); it != unknowns.cend(); ++it) {
             // skip types is std namespace because they are not interesting
             if (it->first.find("std::") != 0) {
                 if (it->first != last) {
@@ -9850,7 +9850,7 @@ bool Tokenizer::hasIfdef(const Token *start, const Token *end) const
 {
     if (!mPreprocessor)
         return false;
-    return std::any_of(mPreprocessor->getDirectives().begin(), mPreprocessor->getDirectives().end(), [&](const Directive& d) {
+    return std::any_of(mPreprocessor->getDirectives().cbegin(), mPreprocessor->getDirectives().cend(), [&](const Directive& d) {
         return d.str.compare(0, 3, "#if") == 0 &&
         d.linenr >= start->linenr() &&
         d.linenr <= end->linenr() &&

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1748,7 +1748,7 @@ void TokenList::validateAst() const
                     throw InternalError(tok, "AST broken: endless recursion from '" + tok->str() + "'", InternalError::AST);
                 astTokens.insert(parent);
             } while ((parent = parent->astParent()) != nullptr);
-            safeAstTokens.insert(astTokens.begin(), astTokens.end());
+            safeAstTokens.insert(astTokens.cbegin(), astTokens.cend());
         } else if (tok->str() == ";") {
             safeAstTokens.clear();
         } else {

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -44,7 +44,7 @@ bool isValidGlobPattern(const std::string& pattern)
     for (std::string::const_iterator i = pattern.cbegin(); i != pattern.cend(); ++i) {
         if (*i == '*' || *i == '?') {
             const std::string::const_iterator j = i + 1;
-            if (j != pattern.end() && (*j == '*' || *j == '?')) {
+            if (j != pattern.cend() && (*j == '*' || *j == '?')) {
                 return false;
             }
         }
@@ -126,7 +126,7 @@ void strTolower(std::string& str)
 {
     // This wrapper exists because Sun's CC does not allow a static_cast
     // from extern "C" int(*)(int) to int(*)(int).
-    std::transform(str.begin(), str.end(), str.begin(), [](int c) {
+    std::transform(str.cbegin(), str.cend(), str.begin(), [](int c) {
         return std::tolower(c);
     });
 }

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -47,7 +47,7 @@ struct SelectMapValues {
 template<class Range, class T>
 bool contains(const Range& r, const T& x)
 {
-    return std::find(r.begin(), r.end(), x) != r.end();
+    return std::find(r.cbegin(), r.cend(), x) != r.cend();
 }
 
 template<class T>
@@ -121,7 +121,7 @@ inline static bool isStringCharLiteral(const std::string &str, char q)
         return false;
 
     static const std::array<std::string, 5> suffixes{"", "u8", "u", "U", "L"};
-    return std::any_of(suffixes.begin(), suffixes.end(), [&](const std::string& p) {
+    return std::any_of(suffixes.cbegin(), suffixes.cend(), [&](const std::string& p) {
         return isPrefixStringCharLiteral(str, q, p);
     });
 }

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -81,10 +81,10 @@ private:
 
         // Check if there are duplicate error ids in errorLogger.id
         std::string duplicate;
-        for (std::list<std::string>::iterator it = errorLogger.id.begin();
-             it != errorLogger.id.end();
+        for (std::list<std::string>::const_iterator it = errorLogger.id.cbegin();
+             it != errorLogger.id.cend();
              ++it) {
-            if (std::find(errorLogger.id.begin(), it, *it) != it) {
+            if (std::find(errorLogger.id.cbegin(), it, *it) != it) {
                 duplicate = "Duplicate ID: " + *it;
                 break;
             }

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -121,7 +121,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("TEST1=1;TEST2=2", importer.fileSettings.begin()->defines);
+        ASSERT_EQUALS("TEST1=1;TEST2=2", importer.fileSettings.cbegin()->defines);
     }
 
     void importCompileCommands2() const {
@@ -136,7 +136,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("C:/bar.c", importer.fileSettings.begin()->filename);
+        ASSERT_EQUALS("C:/bar.c", importer.fileSettings.cbegin()->filename);
 #else
         const char json[] = R"([{
                                    "directory": "/foo",
@@ -147,7 +147,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("/bar.c", importer.fileSettings.begin()->filename);
+        ASSERT_EQUALS("/bar.c", importer.fileSettings.cbegin()->filename);
 #endif
     }
 
@@ -161,7 +161,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
+        ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.cbegin()->filename);
     }
 
     void importCompileCommands4() const {
@@ -192,7 +192,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(2, importer.fileSettings.size());
-        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.begin()->includePaths.front());
+        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.cbegin()->includePaths.front());
     }
 
     void importCompileCommands6() const {
@@ -211,8 +211,8 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(2, importer.fileSettings.size());
-        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.begin()->includePaths.front());
-        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/second src/", importer.fileSettings.begin()->includePaths.back());
+        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.cbegin()->includePaths.front());
+        ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/second src/", importer.fileSettings.cbegin()->includePaths.back());
     }
 
 
@@ -228,12 +228,12 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("FILESDIR=\"/some/path\"", importer.fileSettings.begin()->defines);
-        ASSERT_EQUALS(1, importer.fileSettings.begin()->includePaths.size());
-        ASSERT_EQUALS("/home/danielm/cppcheck 2/b/lib/", importer.fileSettings.begin()->includePaths.front());
+        ASSERT_EQUALS("FILESDIR=\"/some/path\"", importer.fileSettings.cbegin()->defines);
+        ASSERT_EQUALS(1, importer.fileSettings.cbegin()->includePaths.size());
+        ASSERT_EQUALS("/home/danielm/cppcheck 2/b/lib/", importer.fileSettings.cbegin()->includePaths.front());
         TODO_ASSERT_EQUALS("/home/danielm/cppcheck 2/externals/",
                            "/home/danielm/cppcheck 2/b/lib/",
-                           importer.fileSettings.begin()->includePaths.back());
+                           importer.fileSettings.cbegin()->includePaths.back());
     }
 
     void importCompileCommands8() const {
@@ -314,7 +314,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(1, importer.fileSettings.size());
-        ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.begin()->filename);
+        ASSERT_EQUALS("/tmp/src.c", importer.fileSettings.cbegin()->filename);
     }
 
     void importCompileCommandsNoCommandSection() const {

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -195,7 +195,7 @@ private:
             EXPECT_EQ("", r);
         }
 
-        unsigned int exitCode = std::accumulate(files.begin(), files.end(), 0U, [&](unsigned int v, const std::pair<std::string, std::string>& f) {
+        unsigned int exitCode = std::accumulate(files.cbegin(), files.cend(), 0U, [&](unsigned int v, const std::pair<std::string, std::string>& f) {
             return v | cppCheck.check(f.first, f.second);
         });
 

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -90,7 +90,7 @@ private:
     static const Scope *findFunctionScopeByToken(const SymbolDatabase * db, const Token *tok) {
         std::list<Scope>::const_iterator scope;
 
-        for (scope = db->scopeList.begin(); scope != db->scopeList.end(); ++scope) {
+        for (scope = db->scopeList.cbegin(); scope != db->scopeList.cend(); ++scope) {
             if (scope->type == Scope::eFunction) {
                 if (scope->classDef == tok)
                     return &(*scope);
@@ -108,7 +108,7 @@ private:
                 currScope = currScope->nestedIn;
         }
         while (currScope) {
-            auto it = std::find_if(currScope->functionList.begin(), currScope->functionList.end(), [&](const Function& f) {
+            auto it = std::find_if(currScope->functionList.cbegin(), currScope->functionList.cend(), [&](const Function& f) {
                 return f.tokenDef->str() == str;
             });
             if (it != currScope->functionList.end())
@@ -2159,9 +2159,9 @@ private:
 
         ASSERT(db && db->scopeList.size() == 1);
 
-        const std::list<Scope>::const_iterator it = db->scopeList.begin();
+        const std::list<Scope>::const_iterator it = db->scopeList.cbegin();
         ASSERT(it->varlist.size() == 1);
-        const std::list<Variable>::const_iterator var = it->varlist.begin();
+        const std::list<Variable>::const_iterator var = it->varlist.cbegin();
         ASSERT(var->name() == "i");
         ASSERT(var->typeStartToken()->str() == "int");
     }
@@ -2171,10 +2171,10 @@ private:
 
         ASSERT(db && db->scopeList.size() == 1);
 
-        const std::list<Scope>::const_iterator it = db->scopeList.begin();
+        const std::list<Scope>::const_iterator it = db->scopeList.cbegin();
         ASSERT(it->varlist.size() == 1);
 
-        const std::list<Variable>::const_iterator var = it->varlist.begin();
+        const std::list<Variable>::const_iterator var = it->varlist.cbegin();
         ASSERT(var->name() == "array");
         ASSERT(var->typeStartToken()->str() == "int");
     }
@@ -2184,10 +2184,10 @@ private:
 
         ASSERT(db && db->scopeList.size() == 1);
 
-        const std::list<Scope>::const_iterator it = db->scopeList.begin();
+        const std::list<Scope>::const_iterator it = db->scopeList.cbegin();
         ASSERT(it->varlist.size() == 1);
 
-        const std::list<Variable>::const_iterator var = it->varlist.begin();
+        const std::list<Variable>::const_iterator var = it->varlist.cbegin();
         ASSERT(var->name() == "array");
         ASSERT(var->typeStartToken()->str() == "int");
     }
@@ -2476,8 +2476,8 @@ private:
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
         ASSERT_EQUALS(1, scope->functionList.size());
-        ASSERT(scope->functionList.begin()->functionScope != nullptr);
-        const Scope * functionScope = scope->functionList.begin()->functionScope;
+        ASSERT(scope->functionList.cbegin()->functionScope != nullptr);
+        const Scope * functionScope = scope->functionList.cbegin()->functionScope;
         ++scope;
         ASSERT(functionScope == &*scope);
     }
@@ -2494,8 +2494,8 @@ private:
         ++scope;
         ASSERT_EQUALS((unsigned int)Scope::eClass, (unsigned int)scope->type);
         ASSERT_EQUALS(1, scope->functionList.size());
-        ASSERT(scope->functionList.begin()->functionScope != nullptr);
-        const Scope * functionScope = scope->functionList.begin()->functionScope;
+        ASSERT(scope->functionList.cbegin()->functionScope != nullptr);
+        const Scope * functionScope = scope->functionList.cbegin()->functionScope;
         ++scope;
         ASSERT(functionScope == &*scope);
     }
@@ -2642,7 +2642,7 @@ private:
     void functionReturnsReference() {
         GET_SYMBOL_DB("Fred::Reference foo();");
         ASSERT_EQUALS(1, db->scopeList.back().functionList.size());
-        const Function &func = *db->scopeList.back().functionList.begin();
+        const Function &func = *db->scopeList.back().functionList.cbegin();
         ASSERT(!Function::returnsReference(&func, false));
         ASSERT(Function::returnsReference(&func, true));
     }
@@ -2656,7 +2656,7 @@ private:
                       "namespace barney { X::X(int) { } }");
 
         // Locate the scope for the class..
-        auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [](const Scope& s) {
+        auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [](const Scope& s) {
             return s.isClassOrStruct();
         });
         const Scope *scope = (it == db->scopeList.end()) ? nullptr : &*it;
@@ -2687,7 +2687,7 @@ private:
                       "}");
 
         // Locate the scope for the class..
-        auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [](const Scope& s) {
+        auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [](const Scope& s) {
             return s.isClassOrStruct();
         });
         const Scope* scope = (it == db->scopeList.end()) ? nullptr : &*it;
@@ -2973,7 +2973,7 @@ private:
         ASSERT_EQUALS(4U, db->scopeList.size());
 
         // Find the scope for the Fred struct..
-        auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [&](const Scope& scope) {
+        auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [&](const Scope& scope) {
             return scope.isClassOrStruct() && scope.className == "Fred";
         });
         const Scope* fredScope = (it == db->scopeList.end()) ? nullptr : &*it;
@@ -3428,7 +3428,7 @@ private:
 
             ASSERT(db != nullptr);
             ASSERT_EQUALS(2U, db->scopeList.size());
-            ASSERT_EQUALS(2U, db->scopeList.begin()->functionList.size());
+            ASSERT_EQUALS(2U, db->scopeList.cbegin()->functionList.size());
         }
     }
 
@@ -4985,7 +4985,7 @@ private:
                           "}\n");
             ASSERT(db);
             ASSERT_EQUALS(1, db->functionScopes.size());
-            auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [](const Scope& s) {
+            auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [](const Scope& s) {
                 return s.className == "T";
             });
             ASSERT(it != db->scopeList.end());
@@ -5007,7 +5007,7 @@ private:
                           "}\n");
             ASSERT(db);
             ASSERT_EQUALS(1, db->functionScopes.size());
-            auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [](const Scope& s) {
+            auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [](const Scope& s) {
                 return s.className == "A";
             });
             ASSERT(it != db->scopeList.end());
@@ -5030,7 +5030,7 @@ private:
                           "void A::f(N::O::B*) {}\n");
             ASSERT(db);
             ASSERT_EQUALS(1, db->functionScopes.size());
-            auto it = std::find_if(db->scopeList.begin(), db->scopeList.end(), [](const Scope& s) {
+            auto it = std::find_if(db->scopeList.cbegin(), db->scopeList.cend(), [](const Scope& s) {
                 return s.className == "A";
             });
             ASSERT(it != db->scopeList.end());
@@ -5111,7 +5111,7 @@ private:
         ASSERT_EQUALS(1, db->scopeList.front().varlist.size());
         auto list = db->scopeList;
         list.pop_front();
-        ASSERT_EQUALS(true, std::all_of(list.begin(), list.end(), [](const Scope& scope) {
+        ASSERT_EQUALS(true, std::all_of(list.cbegin(), list.cend(), [](const Scope& scope) {
             return scope.varlist.empty();
         }));
     }
@@ -7452,8 +7452,8 @@ private:
         const Scope * class_scope = &*scope;
         ++scope;
         ASSERT(class_scope->functionList.size() == 1);
-        ASSERT(class_scope->functionList.begin()->hasBody());
-        ASSERT(class_scope->functionList.begin()->functionScope == &*scope);
+        ASSERT(class_scope->functionList.cbegin()->hasBody());
+        ASSERT(class_scope->functionList.cbegin()->functionScope == &*scope);
     }
 
 #define typeOf(...) typeOf_(__FILE__, __LINE__, __VA_ARGS__)

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -730,7 +730,7 @@ private:
     }
 
     static void append_vector(std::vector<std::string> &dest, const std::vector<std::string> &src) {
-        dest.insert(dest.end(), src.begin(), src.end());
+        dest.insert(dest.end(), src.cbegin(), src.cend());
     }
 
     void matchOp() {
@@ -741,7 +741,7 @@ private:
         append_vector(test_ops, logicalOps);
         append_vector(test_ops, assignmentOps);
 
-        ASSERT_EQUALS(true, std::all_of(test_ops.begin(), test_ops.end(), [&](const std::string& s) {
+        ASSERT_EQUALS(true, std::all_of(test_ops.cbegin(), test_ops.cend(), [&](const std::string& s) {
             return MatchCheck(s, "%op%");
         }));
 
@@ -749,8 +749,8 @@ private:
         std::vector<std::string> other_ops;
         append_vector(other_ops, extendedOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             ASSERT_EQUALS_MSG(false, MatchCheck(*other_op, "%op%"), "Failing other operator: " + *other_op);
         }
     }
@@ -762,7 +762,7 @@ private:
         append_vector(test_ops, comparisonOps);
         append_vector(test_ops, logicalOps);
 
-        ASSERT_EQUALS(true, std::all_of(test_ops.begin(), test_ops.end(), [&](const std::string& s) {
+        ASSERT_EQUALS(true, std::all_of(test_ops.cbegin(), test_ops.cend(), [&](const std::string& s) {
             return MatchCheck(s, "%cop%");
         }));
 
@@ -771,16 +771,16 @@ private:
         append_vector(other_ops, extendedOps);
         append_vector(other_ops, assignmentOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             ASSERT_EQUALS_MSG(false, MatchCheck(*other_op, "%cop%"), "Failing other operator: " + *other_op);
         }
     }
 
 
     void isArithmeticalOp() const {
-        std::vector<std::string>::const_iterator test_op, test_ops_end = arithmeticalOps.end();
-        for (test_op = arithmeticalOps.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = arithmeticalOps.cend();
+        for (test_op = arithmeticalOps.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(true, tok.isArithmeticalOp());
@@ -794,8 +794,8 @@ private:
         append_vector(other_ops, extendedOps);
         append_vector(other_ops, assignmentOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             Token tok;
             tok.str(*other_op);
             ASSERT_EQUALS_MSG(false, tok.isArithmeticalOp(), "Failing arithmetical operator: " + *other_op);
@@ -810,8 +810,8 @@ private:
         append_vector(test_ops, logicalOps);
         append_vector(test_ops, assignmentOps);
 
-        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.end();
-        for (test_op = test_ops.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.cend();
+        for (test_op = test_ops.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(true, tok.isOp());
@@ -821,8 +821,8 @@ private:
         std::vector<std::string> other_ops;
         append_vector(other_ops, extendedOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             Token tok;
             tok.str(*other_op);
             ASSERT_EQUALS_MSG(false, tok.isOp(), "Failing normal operator: " + *other_op);
@@ -836,8 +836,8 @@ private:
         append_vector(test_ops, comparisonOps);
         append_vector(test_ops, logicalOps);
 
-        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.end();
-        for (test_op = test_ops.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.cend();
+        for (test_op = test_ops.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(true, tok.isConstOp());
@@ -848,8 +848,8 @@ private:
         append_vector(other_ops, extendedOps);
         append_vector(other_ops, assignmentOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             Token tok;
             tok.str(*other_op);
             ASSERT_EQUALS_MSG(false, tok.isConstOp(), "Failing normal operator: " + *other_op);
@@ -864,16 +864,16 @@ private:
         append_vector(test_ops, logicalOps);
         append_vector(test_ops, extendedOps);
 
-        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.end();
-        for (test_op = test_ops.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = test_ops.cend();
+        for (test_op = test_ops.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(true, tok.isExtendedOp());
         }
 
         // Negative test against assignment operators
-        std::vector<std::string>::const_iterator other_op, other_ops_end = assignmentOps.end();
-        for (other_op = assignmentOps.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = assignmentOps.cend();
+        for (other_op = assignmentOps.cbegin(); other_op != other_ops_end; ++other_op) {
             Token tok;
             tok.str(*other_op);
             ASSERT_EQUALS_MSG(false, tok.isExtendedOp(), "Failing assignment operator: " + *other_op);
@@ -881,8 +881,8 @@ private:
     }
 
     void isAssignmentOp() const {
-        std::vector<std::string>::const_iterator test_op, test_ops_end = assignmentOps.end();
-        for (test_op = assignmentOps.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = assignmentOps.cend();
+        for (test_op = assignmentOps.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(true, tok.isAssignmentOp());
@@ -896,8 +896,8 @@ private:
         append_vector(other_ops, logicalOps);
         append_vector(other_ops, extendedOps);
 
-        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.end();
-        for (other_op = other_ops.begin(); other_op != other_ops_end; ++other_op) {
+        std::vector<std::string>::const_iterator other_op, other_ops_end = other_ops.cend();
+        for (other_op = other_ops.cbegin(); other_op != other_ops_end; ++other_op) {
             Token tok;
             tok.str(*other_op);
             ASSERT_EQUALS_MSG(false, tok.isAssignmentOp(), "Failing assignment operator: " + *other_op);
@@ -906,22 +906,22 @@ private:
 
     void operators() const {
         std::vector<std::string>::const_iterator test_op;
-        for (test_op = extendedOps.begin(); test_op != extendedOps.end(); ++test_op) {
+        for (test_op = extendedOps.cbegin(); test_op != extendedOps.cend(); ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eExtendedOp, tok.tokType());
         }
-        for (test_op = logicalOps.begin(); test_op != logicalOps.end(); ++test_op) {
+        for (test_op = logicalOps.cbegin(); test_op != logicalOps.cend(); ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eLogicalOp, tok.tokType());
         }
-        for (test_op = bitOps.begin(); test_op != bitOps.end(); ++test_op) {
+        for (test_op = bitOps.cbegin(); test_op != bitOps.cend(); ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eBitOp, tok.tokType());
         }
-        for (test_op = comparisonOps.begin(); test_op != comparisonOps.end(); ++test_op) {
+        for (test_op = comparisonOps.cbegin(); test_op != comparisonOps.cend(); ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS(Token::eComparisonOp, tok.tokType());
@@ -963,8 +963,8 @@ private:
         standard_types.emplace_back("double");
         standard_types.emplace_back("size_t");
 
-        std::vector<std::string>::const_iterator test_op, test_ops_end = standard_types.end();
-        for (test_op = standard_types.begin(); test_op != test_ops_end; ++test_op) {
+        std::vector<std::string>::const_iterator test_op, test_ops_end = standard_types.cend();
+        for (test_op = standard_types.cbegin(); test_op != test_ops_end; ++test_op) {
             Token tok;
             tok.str(*test_op);
             ASSERT_EQUALS_MSG(true, tok.isStandardType(), "Failing standard type: " + *test_op);

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -107,7 +107,7 @@ private:
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));
 
         const SymbolDatabase* sd = tokenizer.getSymbolDatabase();
-        const Scope& scope = *std::next(sd->scopeList.begin(), 3); //The scope of the if block
+        const Scope& scope = *std::next(sd->scopeList.cbegin(), 3); //The scope of the if block
 
         std::ostringstream contents;
         for (const Token* t : ConstTokenRange{ scope.bodyStart->next(), scope.bodyEnd }) {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -306,7 +306,7 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isIntValue() && !v.isImpossible() && v.intvalue == value;
                 }))
                     return true;
@@ -325,7 +325,7 @@ private:
 
         for (const Token* tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isSymbolicValue() && !v.isImpossible() && v.intvalue == value && v.tokvalue->expressionString() == expr;
                 }))
                     return true;
@@ -343,7 +343,7 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isFloatValue() && !v.isImpossible() && v.floatValue >= value - diff && v.floatValue <= value + diff;
                 }))
                     return true;
@@ -387,7 +387,7 @@ private:
         const std::size_t len = strlen(value);
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.valueType == type && Token::simpleMatch(v.tokvalue, value, len);
                 }))
                     return true;
@@ -407,7 +407,7 @@ private:
         const std::size_t len = strlen(value);
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isLifetimeValue() && v.lifetimeScope == lifetimeScope && Token::simpleMatch(v.tokvalue, value, len);
                 }))
                     return true;
@@ -425,7 +425,7 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.valueType == type && v.intvalue == value;
                 }))
                     return true;
@@ -443,7 +443,7 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isMovedValue() && v.moveKind == moveKind;
                 }))
                     return true;
@@ -462,7 +462,7 @@ private:
 
         for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
             if (tok->str() == "x" && tok->linenr() == linenr) {
-                if (std::any_of(tok->values().begin(), tok->values().end(), [&](const ValueFlow::Value& v) {
+                if (std::any_of(tok->values().cbegin(), tok->values().cend(), [&](const ValueFlow::Value& v) {
                     return v.isIntValue() && v.intvalue == value && v.condition;
                 }))
                     return true;
@@ -4307,7 +4307,7 @@ private:
                "        x;\n"
                "}";
         std::list<ValueFlow::Value> values = tokenValues(code, "x <");
-        ASSERT(std::none_of(values.begin(), values.end(), std::mem_fn(&ValueFlow::Value::isUninitValue)));
+        ASSERT(std::none_of(values.cbegin(), values.cend(), std::mem_fn(&ValueFlow::Value::isUninitValue)));
 
         // #9637
         code = "void f() {\n"
@@ -4618,7 +4618,7 @@ private:
 
     bool isNotKnownValues(const char code[], const char str[]) {
         const auto& values = tokenValues(code, str);
-        return std::none_of(values.begin(), values.end(), [](const ValueFlow::Value& v) {
+        return std::none_of(values.cbegin(), values.cend(), [](const ValueFlow::Value& v) {
             return v.isKnown();
         });
     }

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -60,7 +60,7 @@ static void getDeps(const std::string &filename, std::vector<std::string> &depfi
     static const std::array<std::string, 3> externalfolders{"externals/picojson", "externals/simplecpp", "externals/tinyxml2"};
 
     // Is the dependency already included?
-    if (std::find(depfiles.begin(), depfiles.end(), filename) != depfiles.end())
+    if (std::find(depfiles.cbegin(), depfiles.cend(), filename) != depfiles.cend())
         return;
 
     std::ifstream f(filename.c_str());


### PR DESCRIPTION
Turns out there's not much which cannot be done with a `const_iterator` so it can be used in most cases.

We cannot use it with all calls though since the STL debug containers in GCC 4.8 are not supporting it completely.