### PR TITLE
donate-cpu-server.py: fixed factor calculation when base time is 0.0

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.34"
+SERVER_VERSION = "1.3.35"
 
 OLD_VERSION = '2.9'
 
@@ -750,7 +750,9 @@ def timeReport(resultPath: str, show_gt: bool, query_params: dict) -> str:
             if time_base > 0.0 and time_head > 0.0:
                 time_factor = time_head / time_base
             elif time_base == 0.0:
-                time_factor = time_head
+                # the smallest possible value is 0.1 so treat that as an increase of 100%
+                # on top of the existing 100% (treating the base 0.0 as such).
+                time_factor = 1.0 + (time_head * 10)
             else:
                 time_factor = 0.0
             suspicious_time_difference = False


### PR DESCRIPTION
I made a mistake in the calculation when `time_base` is `0.0` which leads to faulty entries this in the "improved" time report:

```
Package                                  Date             Time        2.9       Head     Factor
proftpd-mod-autohost                     2022-12-25      53859        0.0        0.1       0.10
```

This also causes these entries to be missing from the "regressed" report.

Treating a change from `0.0` to `0.1` as an increase in 100% (as `0.1` is the lowest possible value) that should result in an factor of `2.0` (`0.0` being the initial 100% with additional one added on top).

`0.0 0.1 2.00` - additional 100% with a total of 200%
`0.0 0.2 3.00` - additional 200% with a total of 300%
`0.0 0.4 5.00` - additional 400% with a total of 500%

In comparison with a non-`0.0` base value:

`0.2 0.4 2.00` - additional 100% with a total of 200%
`0.2 0.6 3.00` - additional 200% with a total of 300%
`0.2 1.0 5.00` - additional 400% with a total of 500%

Note: I am aware the time stamp is wrong. I will address that in a later PR.