### PR TITLE
compilerDefinitions.cmake: specify proper define for "safe libc++"

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -16,7 +16,8 @@ endif()
 if (CPPCHK_GLIBCXX_DEBUG AND UNIX AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         if (USE_LIBCXX)
-            add_definitions(-DLIBCXX_ENABLE_DEBUG_MODE)
+            add_definitions(-D_LIBCPP_ENABLE_ASSERTIONS=1)
+            # TODO: also add _LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS?
         endif()
     else()
         # TODO: check if this can be enabled again for Clang - also done in Makefile


### PR DESCRIPTION
I followed the documentation from https://libcxx.llvm.org/DesignDocs/DebugMode.html#using-the-debug-mode which refers to `LIBCXX_ENABLE_DEBUG_MODE`. But that is a CMake define you are supposed to pass when building `libc++`. Also the debug mode needs the library to be built with it which is not something we do. So as suggested we should enable the assertions via `_LIBCPP_ENABLE_ASSERTIONS=1` instead - see https://libcxx.llvm.org/UsingLibcxx.html#assertions-mode.