### PR TITLE
added `Path::identify()`/`Path::isHeader2()` and deprecated flawed `Path::isCPP()`, `Path::isC()` and `Path::isHeader()`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,7 @@ $(libcppdir)/tokenize.o: lib/tokenize.cpp externals/simplecpp/simplecpp.h lib/ad
 $(libcppdir)/symboldatabase.o: lib/symboldatabase.cpp lib/addoninfo.h lib/astutils.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/keywords.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h lib/vfvalue.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/symboldatabase.cpp
 
-$(libcppdir)/addoninfo.o: lib/addoninfo.cpp externals/picojson/picojson.h lib/addoninfo.h lib/config.h lib/json.h lib/path.h lib/utils.h
+$(libcppdir)/addoninfo.o: lib/addoninfo.cpp externals/picojson/picojson.h lib/addoninfo.h lib/config.h lib/json.h lib/path.h lib/standards.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/addoninfo.cpp
 
 $(libcppdir)/analyzerinfo.o: lib/analyzerinfo.cpp externals/tinyxml2/tinyxml2.h lib/analyzerinfo.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/filesettings.h lib/path.h lib/platform.h lib/standards.h lib/utils.h lib/xml.h
@@ -599,13 +599,13 @@ $(libcppdir)/library.o: lib/library.cpp externals/tinyxml2/tinyxml2.h lib/astuti
 $(libcppdir)/mathlib.o: lib/mathlib.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/mathlib.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/mathlib.cpp
 
-$(libcppdir)/path.o: lib/path.cpp externals/simplecpp/simplecpp.h lib/config.h lib/path.h lib/utils.h
+$(libcppdir)/path.o: lib/path.cpp externals/simplecpp/simplecpp.h lib/config.h lib/path.h lib/standards.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/path.cpp
 
 $(libcppdir)/pathanalysis.o: lib/pathanalysis.cpp lib/astutils.h lib/config.h lib/errortypes.h lib/library.h lib/mathlib.h lib/pathanalysis.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/utils.h lib/vfvalue.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/pathanalysis.cpp
 
-$(libcppdir)/pathmatch.o: lib/pathmatch.cpp lib/config.h lib/path.h lib/pathmatch.h lib/utils.h
+$(libcppdir)/pathmatch.o: lib/pathmatch.cpp lib/config.h lib/path.h lib/pathmatch.h lib/standards.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/pathmatch.cpp
 
 $(libcppdir)/platform.o: lib/platform.cpp externals/tinyxml2/tinyxml2.h lib/config.h lib/path.h lib/platform.h lib/standards.h lib/utils.h lib/xml.h
@@ -662,7 +662,7 @@ cli/cppcheckexecutorsig.o: cli/cppcheckexecutorsig.cpp cli/cppcheckexecutor.h cl
 cli/executor.o: cli/executor.cpp cli/executor.h lib/addoninfo.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/executor.cpp
 
-cli/filelister.o: cli/filelister.cpp cli/filelister.h lib/config.h lib/path.h lib/pathmatch.h lib/utils.h
+cli/filelister.o: cli/filelister.cpp cli/filelister.h lib/config.h lib/path.h lib/pathmatch.h lib/standards.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/filelister.cpp
 
 cli/main.o: cli/main.cpp cli/cppcheckexecutor.h lib/config.h lib/errortypes.h lib/filesettings.h lib/platform.h lib/standards.h lib/utils.h

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -185,7 +185,9 @@ bool CmdLineParser::fillSettingsFromArgs(int argc, const char* const argv[])
     // Output a warning for the user if he tries to exclude headers
     const std::vector<std::string>& ignored = getIgnoredPaths();
     const bool warn = std::any_of(ignored.cbegin(), ignored.cend(), [](const std::string& i) {
-        return Path::isHeader(i);
+        bool header;
+        Path::identify(i, &header);
+        return header;
     });
     if (warn) {
         mLogger.printMessage("filename exclusion does not apply to header (.h and .hpp) files.");

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -185,9 +185,7 @@ bool CmdLineParser::fillSettingsFromArgs(int argc, const char* const argv[])
     // Output a warning for the user if he tries to exclude headers
     const std::vector<std::string>& ignored = getIgnoredPaths();
     const bool warn = std::any_of(ignored.cbegin(), ignored.cend(), [](const std::string& i) {
-        bool header;
-        Path::identify(i, &header);
-        return header;
+        return Path::isHeader2(i);
     });
     if (warn) {
         mLogger.printMessage("filename exclusion does not apply to header (.h and .hpp) files.");

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -962,7 +962,9 @@ void ResultsTree::recheckSelectedFiles()
                 askFileDir(currentFile);
                 return;
             }
-            if (Path::isHeader(currentFile.toStdString())) {
+            bool header = false;
+            Path::identify(currentFile.toStdString(), &header);
+            if (header) {
                 if (!data[FILE0].toString().isEmpty() && !selectedItems.contains(data[FILE0].toString())) {
                     selectedItems<<((!mCheckPath.isEmpty() && (data[FILE0].toString().indexOf(mCheckPath) != 0)) ? (mCheckPath + "/" + data[FILE0].toString()) : data[FILE0].toString());
                     if (!selectedItems.contains(fileNameWithCheckPath))

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -962,9 +962,7 @@ void ResultsTree::recheckSelectedFiles()
                 askFileDir(currentFile);
                 return;
             }
-            bool header = false;
-            Path::identify(currentFile.toStdString(), &header);
-            if (header) {
+            if (Path::isHeader2(currentFile.toStdString())) {
                 if (!data[FILE0].toString().isEmpty() && !selectedItems.contains(data[FILE0].toString())) {
                     selectedItems<<((!mCheckPath.isEmpty() && (data[FILE0].toString().indexOf(mCheckPath) != 0)) ? (mCheckPath + "/" + data[FILE0].toString()) : data[FILE0].toString());
                     if (!selectedItems.contains(fileNameWithCheckPath))

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -462,8 +462,12 @@ void ResultsView::updateDetails(const QModelIndex &index)
     QString formattedMsg = message;
 
     const QString file0 = data["file0"].toString();
-    if (!file0.isEmpty() && Path::isHeader(data["file"].toString().toStdString()))
-        formattedMsg += QString("\n\n%1: %2").arg(tr("First included by"), QDir::toNativeSeparators(file0));
+    if (!file0.isEmpty()) {
+        bool header = false;
+        Path::identify(data["file"].toString().toStdString(), &header);
+        if (header)
+            formattedMsg += QString("\n\n%1: %2").arg(tr("First included by"), QDir::toNativeSeparators(file0));
+    }
 
     if (data["cwe"].toInt() > 0)
         formattedMsg.prepend("CWE: " + QString::number(data["cwe"].toInt()) + "\n");

--- a/gui/resultsview.cpp
+++ b/gui/resultsview.cpp
@@ -462,12 +462,8 @@ void ResultsView::updateDetails(const QModelIndex &index)
     QString formattedMsg = message;
 
     const QString file0 = data["file0"].toString();
-    if (!file0.isEmpty()) {
-        bool header = false;
-        Path::identify(data["file"].toString().toStdString(), &header);
-        if (header)
-            formattedMsg += QString("\n\n%1: %2").arg(tr("First included by"), QDir::toNativeSeparators(file0));
-    }
+    if (!file0.isEmpty() && Path::isHeader2(data["file"].toString().toStdString()))
+        formattedMsg += QString("\n\n%1: %2").arg(tr("First included by"), QDir::toNativeSeparators(file0));
 
     if (data["cwe"].toInt() > 0)
         formattedMsg.prepend("CWE: " + QString::number(data["cwe"].toInt()) + "\n");

--- a/lib/config.h
+++ b/lib/config.h
@@ -110,6 +110,17 @@
 #  define WARN_UNUSED
 #endif
 
+// deprecated
+#if defined(__GNUC__) \
+    || defined(__clang__) \
+    || defined(__CPPCHECK__)
+#  define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#  define DEPRECATED __declspec(deprecated)
+#else
+#  define DEPRECATED
+#endif
+
 #define REQUIRES(msg, ...) class=typename std::enable_if<__VA_ARGS__::value>::type
 
 #include <string>

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -246,6 +246,7 @@ bool Path::isHeader(const std::string &path)
 
 Standards::Language Path::identify(const std::string &path, bool *header)
 {
+    // cppcheck-suppress uninitvar - TODO: FP
     if (header)
         *header = false;
 

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -270,6 +270,13 @@ Standards::Language Path::identify(const std::string &path, bool *header)
     return Standards::Language::None;
 }
 
+bool Path::isHeader2(const std::string &path)
+{
+    bool header;
+    (void)Path::identify(path, &header);
+    return header;
+}
+
 std::string Path::getAbsoluteFilePath(const std::string& filePath)
 {
     std::string absolute_path;

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -237,6 +237,7 @@ bool Path::acceptFile(const std::string &path, const std::set<std::string> &extr
     return (identify(path, &header) != Standards::Language::None && !header) || extra.find(getFilenameExtension(path)) != extra.end();
 }
 
+// cppcheck-suppress unusedFunction
 bool Path::isHeader(const std::string &path)
 {
     const std::string extension = getFilenameExtensionInLowerCase(path);

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -253,6 +253,7 @@ Standards::Language Path::identify(const std::string &path, bool *header)
         return Standards::Language::CPP;
     if (c_src_exts.find(ext) != c_src_exts.end())
         return Standards::Language::C;
+    // cppcheck-suppress knownConditionTrueFalse - TODO: FP
     if (!caseInsensitiveFilesystem())
         strTolower(ext);
     if (ext == ".h") {

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <sys/stat.h>
+#include <unordered_set>
 #include <utility>
 
 #include <simplecpp.h>
@@ -193,6 +194,18 @@ std::string Path::getRelativePath(const std::string& absolutePath, const std::ve
     return absolutePath;
 }
 
+static const std::unordered_set<std::string> cpp_src_exts = {
+    ".cpp", ".cxx", ".cc", ".c++", ".tpp", ".txx", ".ipp", ".ixx"
+};
+
+static const std::unordered_set<std::string> c_src_exts = {
+    ".c", ".cl"
+};
+
+static const std::unordered_set<std::string> header_exts = {
+    ".h", ".hpp", ".h++", ".hxx", ".hh"
+};
+
 bool Path::isC(const std::string &path)
 {
     // In unix, ".C" is considered C++ file
@@ -220,13 +233,41 @@ bool Path::isCPP(const std::string &path)
 
 bool Path::acceptFile(const std::string &path, const std::set<std::string> &extra)
 {
-    return !Path::isHeader(path) && (Path::isCPP(path) || Path::isC(path) || extra.find(getFilenameExtension(path)) != extra.end());
+    bool header = false;
+    return (identify(path, &header) != Standards::Language::None && !header) || extra.find(getFilenameExtension(path)) != extra.end();
 }
 
 bool Path::isHeader(const std::string &path)
 {
     const std::string extension = getFilenameExtensionInLowerCase(path);
     return startsWith(extension, ".h");
+}
+
+Standards::Language Path::identify(const std::string &path, bool *header)
+{
+    if (header)
+        *header = false;
+
+    std::string ext = getFilenameExtension(path);
+    if (ext == ".C")
+        return Standards::Language::CPP;
+    if (c_src_exts.find(ext) != c_src_exts.end())
+        return Standards::Language::C;
+    if (!caseInsensitiveFilesystem())
+        strTolower(ext);
+    if (ext == ".h") {
+        if (header)
+            *header = true;
+        return Standards::Language::C; // treat as C for now
+    }
+    if (cpp_src_exts.find(ext) != cpp_src_exts.end())
+        return Standards::Language::CPP;
+    if (header_exts.find(ext) != header_exts.end()) {
+        if (header)
+            *header = true;
+        return Standards::Language::CPP;
+    }
+    return Standards::Language::None;
 }
 
 std::string Path::getAbsoluteFilePath(const std::string& filePath)

--- a/lib/path.h
+++ b/lib/path.h
@@ -173,9 +173,16 @@ public:
      * @brief Is filename a header based on file extension
      * @param path filename to check. path info is optional
      * @return true if filename extension is meant for headers
-     * @deprecated returns only heuristic result - use @identify() instead
+     * @deprecated returns only heuristic result - use @identify() or @isHeader2() instead
      */
     static DEPRECATED bool isHeader(const std::string &path);
+
+    /**
+     * @brief Is filename a header based on file extension
+     * @param path filename to check. path info is optional
+     * @return true if filename extension is meant for headers
+     */
+    static bool isHeader2(const std::string &path);
 
     /**
      * @brief Identify the language based on the file extension

--- a/lib/path.h
+++ b/lib/path.h
@@ -22,6 +22,7 @@
 //---------------------------------------------------------------------------
 
 #include "config.h"
+#include "standards.h"
 
 #include <set>
 #include <string>
@@ -156,22 +157,33 @@ public:
      * @brief Identify language based on file extension.
      * @param path filename to check. path info is optional
      * @return true if extension is meant for C files
+     * @deprecated does not account for headers - use @identify() instead
      */
-    static bool isC(const std::string &path);
+    static DEPRECATED bool isC(const std::string &path);
 
     /**
      * @brief Identify language based on file extension.
      * @param path filename to check. path info is optional
      * @return true if extension is meant for C++ files
+     * @deprecated returns true for some header extensions - use @identify() instead
      */
-    static bool isCPP(const std::string &path);
+    static DEPRECATED bool isCPP(const std::string &path);
 
     /**
      * @brief Is filename a header based on file extension
      * @param path filename to check. path info is optional
      * @return true if filename extension is meant for headers
+     * @deprecated returns only heuristic result - use @identify() instead
      */
-    static bool isHeader(const std::string &path);
+    static DEPRECATED bool isHeader(const std::string &path);
+
+    /**
+     * @brief Identify the language based on the file extension
+     * @param path filename to check. path info is optional
+     * @param header if provided indicates if the file is a header
+     * @return the language type
+     */
+    static Standards::Language identify(const std::string &path, bool *header = nullptr);
 
     /**
      * @brief Get filename without a directory path part.

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -730,11 +730,13 @@ static simplecpp::DUI createDUI(const Settings &mSettings, const std::string &cf
     dui.includePaths = mSettings.includePaths; // -I
     dui.includes = mSettings.userIncludes;  // --include
     // TODO: use mSettings.standards.stdValue instead
-    if (Path::isCPP(filename)) {
+    // TODO: error out on unknown language?
+    const Standards::Language lang = Path::identify(filename);
+    if (lang == Standards::Language::CPP) {
         dui.std = mSettings.standards.getCPP();
         splitcfg(mSettings.platform.getLimitsDefines(Standards::getCPP(dui.std)), dui.defines, "");
     }
-    else {
+    else if (lang == Standards::Language::C) {
         dui.std = mSettings.standards.getC();
         splitcfg(mSettings.platform.getLimitsDefines(Standards::getC(dui.std)), dui.defines, "");
     }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -85,10 +85,7 @@ void TokenList::determineCppC()
 {
     // only try to determine it if it wasn't enforced
     if (mLang == Standards::Language::None) {
-        if (Path::isC(getSourceFilePath()))
-            mLang = Standards::Language::C;
-        else if (Path::isCPP(getSourceFilePath()))
-            mLang = Standards::Language::CPP;
+        mLang = Path::identify(getSourceFilePath());
     }
 }
 

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -38,12 +38,14 @@ private:
         TEST_CASE(getRelative);
         TEST_CASE(is_c);
         TEST_CASE(is_cpp);
+        TEST_CASE(is_header);
         TEST_CASE(get_path_from_filename);
         TEST_CASE(join);
         TEST_CASE(isDirectory);
         TEST_CASE(isFile);
         TEST_CASE(sameFileName);
         TEST_CASE(getFilenameExtension);
+        TEST_CASE(identify);
     }
 
     void removeQuotationMarks() const {
@@ -59,6 +61,7 @@ private:
     }
 
     void acceptFile() const {
+        ASSERT(Path::acceptFile("index.c"));
         ASSERT(Path::acceptFile("index.cpp"));
         ASSERT(Path::acceptFile("index.invalid.cpp"));
         ASSERT(Path::acceptFile("index.invalid.Cpp"));
@@ -72,6 +75,14 @@ private:
         // don't accept any headers
         ASSERT_EQUALS(false, Path::acceptFile("index.h"));
         ASSERT_EQUALS(false, Path::acceptFile("index.hpp"));
+
+        const std::set<std::string> extra = { ".extra", ".header" };
+        ASSERT(Path::acceptFile("index.c", extra));
+        ASSERT(Path::acceptFile("index.cpp", extra));
+        ASSERT(Path::acceptFile("index.extra", extra));
+        ASSERT(Path::acceptFile("index.header", extra));
+        ASSERT(Path::acceptFile("index.h", extra)==false);
+        ASSERT(Path::acceptFile("index.hpp", extra)==false);
     }
 
     void getCurrentPath() const {
@@ -117,12 +128,16 @@ private:
         ASSERT_EQUALS("C:/foobar/test.cpp", Path::getRelativePath("C:/foobar/test.cpp", basePaths));
     }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     void is_c() const {
-        ASSERT(Path::isC("index.cpp")==false);
-        ASSERT(Path::isC("")==false);
-        ASSERT(Path::isC("c")==false);
         ASSERT(Path::isC("index.c"));
+        ASSERT(Path::isC("index.cl"));
         ASSERT(Path::isC("C:\\foo\\index.c"));
+        ASSERT(Path::isC("/mnt/c/foo/index.c"));
 
         // In unix .C is considered C++
 #if defined(_WIN32) || (defined(__APPLE__) && defined(__MACH__))
@@ -130,10 +145,28 @@ private:
 #else
         ASSERT_EQUALS(false, Path::isC("C:\\foo\\index.C"));
 #endif
+
+        ASSERT(Path::isC("index.cpp")==false);
+        ASSERT(Path::isC("")==false);
+        ASSERT(Path::isC("c")==false);
+
+        // unlike isCPP() it does not account for headers
+        ASSERT(Path::isC(".h")==false);
     }
 
     void is_cpp() const {
-        ASSERT(Path::isCPP("index.c")==false);
+        ASSERT(Path::isCPP("index.cpp"));
+        ASSERT(Path::isCPP("index.cxx"));
+        ASSERT(Path::isCPP("index.cc"));
+        ASSERT(Path::isCPP("index.c++"));
+        ASSERT(Path::isCPP("index.tpp"));
+        ASSERT(Path::isCPP("index.txx"));
+        ASSERT(Path::isCPP("index.ipp"));
+        ASSERT(Path::isCPP("index.ixx"));
+        ASSERT(Path::isCPP("C:\\foo\\index.cpp"));
+        ASSERT(Path::isCPP("C:\\foo\\index.Cpp"));
+        ASSERT(Path::isCPP("/mnt/c/foo/index.cpp"));
+        ASSERT(Path::isCPP("/mnt/c/foo/index.Cpp"));
 
         // In unix .C is considered C++
 #if defined(_WIN32) || (defined(__APPLE__) && defined(__MACH__))
@@ -141,10 +174,35 @@ private:
 #else
         ASSERT_EQUALS(true, Path::isCPP("index.C"));
 #endif
-        ASSERT(Path::isCPP("index.cpp"));
-        ASSERT(Path::isCPP("C:\\foo\\index.cpp"));
-        ASSERT(Path::isCPP("C:\\foo\\index.Cpp"));
+
+        ASSERT(Path::isCPP("index.c")==false);
+
+        // C++ headers are also considered C++
+        ASSERT(Path::isCPP("index.hpp"));
+        // .h++ is missing in the list of C++ headers
+        ASSERT(Path::isCPP("index.h++")==false);
     }
+
+    void is_header() const {
+        ASSERT(Path::isHeader("index.h"));
+        ASSERT(Path::isHeader("index.hpp"));
+        ASSERT(Path::isHeader("index.hxx"));
+        ASSERT(Path::isHeader("index.h++"));
+        ASSERT(Path::isHeader("index.hh"));
+
+        ASSERT(Path::isHeader("index.c")==false);
+        ASSERT(Path::isHeader("index.cpp")==false);
+
+        // function uses heuristic approach which causes these false positives
+        // no need to fix - function is deprecated and was replaced by identify()
+        TODO_ASSERT(Path::isHeader("index.header")==false);
+        TODO_ASSERT(Path::isHeader("index.htm")==false);
+        TODO_ASSERT(Path::isHeader("index.html")==false);
+    }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
     void get_path_from_filename() const {
         ASSERT_EQUALS("", Path::getPathFromFilename("index.h"));
@@ -224,6 +282,87 @@ private:
         ASSERT_EQUALS(".hh", Path::getFilenameExtension("test.Hh", true));
         ASSERT_EQUALS(".hh", Path::getFilenameExtension("test.hH", true));
 #endif
+    }
+
+
+    void identify() const {
+        Standards::Language lang;
+        bool header;
+
+        ASSERT_EQUALS(Standards::Language::None, Path::identify(""));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("c"));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("cpp"));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("h"));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("hpp"));
+
+        // TODO: what about files starting with a "."?
+        //ASSERT_EQUALS(Standards::Language::None, Path::identify(".c"));
+        //ASSERT_EQUALS(Standards::Language::None, Path::identify(".cpp"));
+        //ASSERT_EQUALS(Standards::Language::None, Path::identify(".h"));
+        //ASSERT_EQUALS(Standards::Language::None, Path::identify(".hpp"));
+
+        // C
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("index.c"));
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("index.cl"));
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("C:\\foo\\index.c"));
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("/mnt/c/foo/index.c"));
+
+        // In unix .C is considered C++
+#ifdef _WIN32
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("C:\\foo\\index.C"));
+#endif
+
+        lang = Path::identify("index.c", &header);
+        ASSERT_EQUALS(Standards::Language::C, lang);
+        ASSERT_EQUALS(false, header);
+
+        // C++
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.cpp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.cxx"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.cc"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.c++"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.tpp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.txx"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.ipp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.ixx"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("C:\\foo\\index.cpp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("C:\\foo\\index.Cpp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("/mnt/c/foo/index.cpp"));
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("/mnt/c/foo/index.Cpp"));
+
+        // TODO: check for case-insenstive filesystem instead
+        // In unix .C is considered C++
+#if !defined(_WIN32) && !(defined(__APPLE__) && defined(__MACH__))
+        ASSERT_EQUALS(Standards::Language::CPP, Path::identify("index.C"));
+#else
+        ASSERT_EQUALS(Standards::Language::C, Path::identify("index.C"));
+#endif
+
+        lang = Path::identify("index.cpp", &header);
+        ASSERT_EQUALS(Standards::Language::CPP, lang);
+        ASSERT_EQUALS(false, header);
+
+        // headers
+        lang = Path::identify("index.h", &header);
+        ASSERT_EQUALS(Standards::Language::C, lang);
+        ASSERT_EQUALS(true, header);
+
+        lang = Path::identify("index.hpp", &header);
+        ASSERT_EQUALS(Standards::Language::CPP, lang);
+        ASSERT_EQUALS(true, header);
+        lang = Path::identify("index.hxx", &header);
+        ASSERT_EQUALS(Standards::Language::CPP, lang);
+        ASSERT_EQUALS(true, header);
+        lang = Path::identify("index.h++", &header);
+        ASSERT_EQUALS(Standards::Language::CPP, lang);
+        ASSERT_EQUALS(true, header);
+        lang = Path::identify("index.hh", &header);
+        ASSERT_EQUALS(Standards::Language::CPP, lang);
+        ASSERT_EQUALS(true, header);
+
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("index.header"));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("index.htm"));
+        ASSERT_EQUALS(Standards::Language::None, Path::identify("index.html"));
     }
 };
 

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -46,6 +46,7 @@ private:
         TEST_CASE(sameFileName);
         TEST_CASE(getFilenameExtension);
         TEST_CASE(identify);
+        TEST_CASE(is_header_2);
     }
 
     void removeQuotationMarks() const {
@@ -363,6 +364,20 @@ private:
         ASSERT_EQUALS(Standards::Language::None, Path::identify("index.header"));
         ASSERT_EQUALS(Standards::Language::None, Path::identify("index.htm"));
         ASSERT_EQUALS(Standards::Language::None, Path::identify("index.html"));
+    }
+
+    void is_header_2() const {
+        ASSERT(Path::isHeader2("index.h"));
+        ASSERT(Path::isHeader2("index.hpp"));
+        ASSERT(Path::isHeader2("index.hxx"));
+        ASSERT(Path::isHeader2("index.h++"));
+        ASSERT(Path::isHeader2("index.hh"));
+
+        ASSERT(Path::isHeader2("index.c")==false);
+        ASSERT(Path::isHeader2("index.cpp")==false);
+        ASSERT(Path::isHeader2("index.header")==false);
+        ASSERT(Path::isHeader2("index.htm")==false);
+        ASSERT(Path::isHeader2("index.html")==false);
     }
 };
 

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -2812,6 +2812,14 @@ private:
     }
 
     void varid_header() {
+        ASSERT_EQUALS("1: class A@1 ;\n"
+                      "2: struct B {\n"
+                      "3: void setData ( const A@1 & a ) ;\n"
+                      "4: } ;\n",
+                      tokenize("class A;\n"
+                               "struct B {\n"
+                               "    void setData(const A & a);\n"
+                               "}; ", "test.h"));
         ASSERT_EQUALS("1: class A ;\n"
                       "2: struct B {\n"
                       "3: void setData ( const A & a@1 ) ;\n"
@@ -2819,7 +2827,15 @@ private:
                       tokenize("class A;\n"
                                "struct B {\n"
                                "    void setData(const A & a);\n"
-                               "}; ", "test.h"));
+                               "}; ", "test.hpp"));
+        ASSERT_EQUALS("1: void f ( )\n"
+                      "2: {\n"
+                      "3: int class@1 ;\n"
+                      "4: }\n",
+                      tokenize("void f()\n"
+                               "{\n"
+                               "    int class;\n"
+                               "}", "test.h"));
     }
 
     void varid_rangeBasedFor() {


### PR DESCRIPTION
None of the `Path::is*()` function is working as expected or consistent (detailed via additional unit tests and deprecation comments).
I tried to fix them but that would have made made cases with headers quite awkward to implement so I opted to generate a new function. This also optimized `Path::acceptFile()` a file.

I am not 100% happy with including `settings.h` but I didn't see a place to move this to. If #3774 gets merged we might be able to move the `enum` into `keywords.h` (that could also be renamed).

I kept the old function in case somebody else is using these (they are in the API after all) and will remove them after the next release.