### PR TITLE
valgrind.yml: use `debuginfod-find` instead of manually installing debug symbols

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -20,24 +20,13 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 
-      - name: Prepare
-        run: |
-          sudo apt-get update
-          sudo apt-get install debian-goodies ubuntu-dbgsym-keyring
-
-      - name: Add debug repos on ubuntu
-        run:  |
-           echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ddebs.list
-           echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ddebs.list
-           echo "deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/ddebs.list
-
       - name: Install missing software
         run: |
           sudo apt-get update
           sudo apt-get install libxml2-utils
           sudo apt-get install valgrind
-          sudo apt-get install libc6-dbg-amd64-cross
           sudo apt-get install libboost-container-dev
+          sudo apt-get install debuginfod
 
       - name: Build cppcheck
         run: |
@@ -53,6 +42,8 @@ jobs:
         run: |
           valgrind --error-limit=yes --leak-check=full --num-callers=50 --show-reachable=yes --track-origins=yes --suppressions=valgrind/testrunner.supp --gen-suppressions=all --log-fd=9 --error-exitcode=42 ./testrunner TestGarbage TestOther TestSimplifyTemplate 9>memcheck.log
           cat memcheck.log
+        env:
+          DEBUGINFOD_URLS: https://debuginfod.ubuntu.com
           
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This will fetch all the necessary debuginfo and will also avoid CI failures caused by invalid keys used for the ddebs packages:
```
W: GPG error: http://ddebs.ubuntu.com/ jammy-proposed Release: The following signatures were invalid: BADSIG C8CAB6595FDFF622 Ubuntu Debug Symbol Archive Automatic Signing Key (2016) <ubuntu-archive@lists.ubuntu.com>
E: The repository 'http://ddebs.ubuntu.com/ jammy-proposed Release' is not signed.
```