### PR TITLE
Fix #11486 FN unusedFunction when enum value with same name exists

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -214,7 +214,7 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const char Fi
             funcname = tok->next();
             while (Token::Match(funcname, "%name% :: %name%"))
                 funcname = funcname->tokAt(2);
-        } else if (Token::Match(tok, "[;{}.,()[=+-/|!?:]")) {
+        } else if (tok->scope()->type != Scope::ScopeType::eEnum && Token::Match(tok, "[;{}.,()[=+-/|!?:]")) {
             funcname = tok->next();
             if (funcname && funcname->str() == "&")
                 funcname = funcname->next();

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -311,8 +311,7 @@ bool CheckUnusedFunctions::check(ErrorLogger * const errorLogger, const Settings
         if (func.usedOtherFile || func.filename.empty())
             continue;
         if (it->first == "main" ||
-            (settings.isWindowsPlatform() && (it->first == "WinMain" || it->first == "_tmain")) ||
-            it->first == "if")
+            (settings.isWindowsPlatform() && (it->first == "WinMain" || it->first == "_tmain")))
             continue;
         if (!func.usedSameFile) {
             if (isOperatorFunction(it->first))

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -61,6 +61,7 @@ private:
         TEST_CASE(initializer_list);
         TEST_CASE(member_function_ternary);
         TEST_CASE(boost);
+        TEST_CASE(enumValues);
 
         TEST_CASE(multipleFiles);   // same function name in multiple files
 
@@ -440,6 +441,18 @@ private:
               "{}\n"
               "parse(line, blanks_p >> ident[&_xy] >> blanks_p >> eol_p).full");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void enumValues() { // #11486
+        check("enum E1 { Break1 };\n"
+              "struct S {\n"
+              "    enum class E { Break };\n"
+              "    void Break() {}\n"
+              "    void Break1() {}\n"
+              "};\n");
+        ASSERT_EQUALS("[test.cpp:4]: (style) The function 'Break' is never used.\n"
+                      "[test.cpp:5]: (style) The function 'Break1' is never used.\n",
+                      errout.str());
     }
 
     void multipleFiles() {


### PR DESCRIPTION
The issue with the undefined order of the error messages could also be avoid by splitting the test into two.