### PR TITLE
Fix 11438 and 10807: categorize user defined literal as literal instead of number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -606,7 +606,7 @@ $(libcppdir)/templatesimplifier.o: lib/templatesimplifier.cpp lib/color.h lib/co
 $(libcppdir)/timer.o: lib/timer.cpp lib/config.h lib/timer.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/timer.cpp
 
-$(libcppdir)/token.o: lib/token.cpp lib/astutils.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenlist.h lib/tokenrange.h lib/utils.h lib/valueflow.h
+$(libcppdir)/token.o: lib/token.cpp externals/simplecpp/simplecpp.h lib/astutils.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenlist.h lib/tokenrange.h lib/utils.h lib/valueflow.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/token.cpp
 
 $(libcppdir)/tokenize.o: lib/tokenize.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/summaries.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h

--- a/externals/simplecpp/simplecpp.h
+++ b/externals/simplecpp/simplecpp.h
@@ -113,7 +113,7 @@ namespace simplecpp {
             name = (std::isalpha(static_cast<unsigned char>(string[0])) || string[0] == '_' || string[0] == '$')
                    && (std::memchr(string.c_str(), '\'', string.size()) == nullptr);
             comment = string.size() > 1U && string[0] == '/' && (string[1] == '/' || string[1] == '*');
-            number = std::isdigit(static_cast<unsigned char>(string[0])) || (string.size() > 1U && string[0] == '-' && std::isdigit(static_cast<unsigned char>(string[1])));
+            number = isNumberLike(string);
             op = (string.size() == 1U) ? string[0] : '\0';
         }
 
@@ -162,6 +162,11 @@ namespace simplecpp {
 
         void printAll() const;
         void printOut() const;
+
+        static bool isNumberLike(const TokenString &string) {
+            return std::isdigit(static_cast<unsigned char>(string[0])) || (string.size() > 1U && string[0] == '-' && std::isdigit(static_cast<unsigned char>(string[1])));
+        }
+
     private:
         TokenString string;
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -22,6 +22,7 @@
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"
+#include "simplecpp.h"
 #include "symboldatabase.h"
 #include "tokenlist.h"
 #include "utils.h"
@@ -139,7 +140,7 @@ void Token::update_property_info()
             else if (mTokType != eVariable && mTokType != eFunction && mTokType != eType && mTokType != eKeyword)
                 tokType(eName);
         }
-        else if (std::isdigit((unsigned char)mStr[0]) || (mStr.length() > 1 && mStr[0] == '-' && std::isdigit((unsigned char)mStr[1]))) {
+        else if (simplecpp::Token::isNumberLike(mStr)) {
             if (MathLib::isInt(mStr) || MathLib::isFloat(mStr))
                 tokType(eNumber);
             else

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -138,8 +138,13 @@ void Token::update_property_info()
                 tokType(eKeyword);
             else if (mTokType != eVariable && mTokType != eFunction && mTokType != eType && mTokType != eKeyword)
                 tokType(eName);
-        } else if (std::isdigit((unsigned char)mStr[0]) || (mStr.length() > 1 && mStr[0] == '-' && std::isdigit((unsigned char)mStr[1])))
-            tokType(eNumber);
+        }
+        else if (std::isdigit((unsigned char)mStr[0]) || (mStr.length() > 1 && mStr[0] == '-' && std::isdigit((unsigned char)mStr[1]))) {
+            if (MathLib::isInt(mStr) || MathLib::isFloat(mStr))
+                tokType(eNumber);
+            else
+                tokType(eLiteral); // assume it is a user defined literal
+        }
         else if (mStr == "=" || mStr == "<<=" || mStr == ">>=" ||
                  (mStr.size() == 2U && mStr[1] == '=' && std::strchr("+-*/%&^|", mStr[0])))
             tokType(eAssignmentOp);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8609,7 +8609,7 @@ void Tokenizer::simplifyAsm()
             Token *endasm = tok->next();
             const Token *firstSemiColon = nullptr;
             int comment = 0;
-            while (Token::Match(endasm, "%num%|%name%|,|:|;") || (endasm && endasm->linenr() == comment)) {
+            while (Token::Match(endasm, "%num%|%name%|,|:|;") || (endasm && endasm->isLiteral()) || (endasm && endasm->linenr() == comment)) {
                 if (Token::Match(endasm, "_asm|__asm|__endasm"))
                     break;
                 if (endasm->str() == ";") {

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -267,6 +267,7 @@ private:
         TEST_CASE(enumTrailingComma);
 
         TEST_CASE(nonGarbageCode1); // #8346
+        TEST_CASE(userDefinedLiterals); // #11438, #10807
     }
 
 #define checkCodeInternal(code, filename) checkCodeInternal_(code, filename, __FILE__, __LINE__)
@@ -1822,6 +1823,22 @@ private:
             "void f() {\n"
             "    auto fn = []() -> foo* { return new foo(); };\n"
             "}");
+    }
+
+    void userDefinedLiterals() {
+        // #11438
+        ASSERT_NO_THROW(checkCode("bool f () { return 3ms < 3s; }"));
+        ASSERT_EQUALS("", errout.str());
+
+        // #10807
+        ASSERT_NO_THROW(checkCode("struct S {\n"
+                                  "    template <typename T>\n"
+                                  "    constexpr explicit S(const T& t) {}\n"
+                                  "    static S zero() {\n"
+                                  "        return S(0_s);\n"
+                                  "    }\n"
+                                  "};\n"));
+        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -267,7 +267,6 @@ private:
         TEST_CASE(enumTrailingComma);
 
         TEST_CASE(nonGarbageCode1); // #8346
-        TEST_CASE(userDefinedLiterals); // #11438, #10807
     }
 
 #define checkCodeInternal(code, filename) checkCodeInternal_(code, filename, __FILE__, __LINE__)
@@ -1823,22 +1822,6 @@ private:
             "void f() {\n"
             "    auto fn = []() -> foo* { return new foo(); };\n"
             "}");
-    }
-
-    void userDefinedLiterals() {
-        // #11438
-        ASSERT_NO_THROW(checkCode("bool f () { return 3ms < 3s; }"));
-        ASSERT_EQUALS("", errout.str());
-
-        // #10807
-        ASSERT_NO_THROW(checkCode("struct S {\n"
-                                  "    template <typename T>\n"
-                                  "    constexpr explicit S(const T& t) {}\n"
-                                  "    static S zero() {\n"
-                                  "        return S(0_s);\n"
-                                  "    }\n"
-                                  "};\n"));
-        ASSERT_EQUALS("", errout.str());
     }
 };
 

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -638,7 +638,7 @@ private:
         givenACodeSampleToTokenize nonNumeric("abc", true);
         ASSERT_EQUALS(false, Token::Match(nonNumeric.tokens(), "%num%"));
 
-        givenACodeSampleToTokenize binary("101010b", true);
+        givenACodeSampleToTokenize binary("0b101010", true);
         ASSERT_EQUALS(true, Token::Match(binary.tokens(), "%num%"));
 
         givenACodeSampleToTokenize octal("0123", true);
@@ -653,7 +653,7 @@ private:
         givenACodeSampleToTokenize floatingPoint("0.0f", true);
         ASSERT_EQUALS(true, Token::Match(floatingPoint.tokens(), "%num%"));
 
-        givenACodeSampleToTokenize doublePrecision("0.0d", true);
+        givenACodeSampleToTokenize doublePrecision("0.0", true);
         ASSERT_EQUALS(true, Token::Match(doublePrecision.tokens(), "%num%"));
 
         givenACodeSampleToTokenize signedLong("0L", true);
@@ -685,6 +685,12 @@ private:
 
         givenACodeSampleToTokenize positiveNull("+.0", true);
         ASSERT_EQUALS(true, Token::Match(positiveNull.tokens(), "+ %num%"));
+
+        givenACodeSampleToTokenize decimalSeparated("123'456'678", true);
+        ASSERT_EQUALS(true, Token::Match(decimalSeparated.tokens(), "%num%"));
+
+        givenACodeSampleToTokenize userDefinedLiteral("123_udl", true);
+        ASSERT_EQUALS(false, Token::Match(userDefinedLiteral.tokens(), "%num%"));
     }
 
 
@@ -950,6 +956,12 @@ private:
         ASSERT(tok.tokType() == Token::eBoolean);
         tok.str("false");
         ASSERT(tok.tokType() == Token::eBoolean);
+        tok.str("\"foo\"_userDefinedLiteral");
+        ASSERT(tok.tokType() == Token::eOther); // should be eLiteral
+        tok.str("123_userDefinedLiteral");
+        ASSERT(tok.tokType() == Token::eLiteral);
+        tok.str("0x123._userDefinedLiteral");
+        ASSERT(tok.tokType() == Token::eLiteral);
     }
 
     void isStandardType() const {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -995,6 +995,7 @@ private:
         ASSERT_EQUALS("asm ( \"mov ax , bx\" ) ;", tokenizeAndStringify("__asm { mov ax,bx };"));
         ASSERT_EQUALS("asm ( \"\"mov ax,bx\"\" ) ;", tokenizeAndStringify("__asm__ __volatile__ ( \"mov ax,bx\" );"));
         ASSERT_EQUALS("asm ( \"_emit 12h\" ) ;", tokenizeAndStringify("__asm _emit 12h ;"));
+        ASSERT_EQUALS("asm ( \"_emit 101010b\" ) ;", tokenizeAndStringify("__asm _emit 101010b ;"));
         ASSERT_EQUALS("asm ( \"mov a , b\" ) ;", tokenizeAndStringify("__asm mov a, b ;"));
         ASSERT_EQUALS("asm ( \"\"fnstcw %0\" : \"= m\" ( old_cw )\" ) ;", tokenizeAndStringify("asm volatile (\"fnstcw %0\" : \"= m\" (old_cw));"));
         ASSERT_EQUALS("asm ( \"\"fnstcw %0\" : \"= m\" ( old_cw )\" ) ;", tokenizeAndStringify(" __asm__ (\"fnstcw %0\" : \"= m\" (old_cw));"));


### PR DESCRIPTION
There's a big assumption, that if a token starts with a digit but isn't properly parsed as int/float, that it shall be a user defined literal.
So the code is not actually matching existing user defined literals, just "if it starts int/float-like, but isn't an actual int/float, assume it is a user defined literal"

Fixes https://trac.cppcheck.net/ticket/11438 and https://trac.cppcheck.net/ticket/10807