### PR TITLE
improved testing of missing includes / made it possible to clear the include cache in simplecpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ CLIOBJ =      cli/cmdlineparser.o \
               cli/threadexecutor.o
 
 TESTOBJ =     test/fixture.o \
+              test/helpers.o \
               test/main.o \
               test/options.o \
               test/test64bit.o \
@@ -659,6 +660,9 @@ cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor
 test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
+test/helpers.o: test/helpers.cpp lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
+	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
+
 test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/preprocessor.h lib/suppressions.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/main.cpp
 
@@ -770,7 +774,7 @@ test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/che
 test/testpostfixoperator.o: test/testpostfixoperator.cpp lib/check.h lib/checkpostfixoperator.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpostfixoperator.cpp
 
-test/testpreprocessor.o: test/testpreprocessor.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
+test/testpreprocessor.o: test/testpreprocessor.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpreprocessor.cpp
 
 test/testprocessexecutor.o: test/testprocessexecutor.cpp cli/executor.h cli/processexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h test/redirect.h

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -626,6 +626,7 @@ static simplecpp::DUI createDUI(const Settings &mSettings, const std::string &cf
         dui.std = mSettings.standards.getCPP();
     else
         dui.std = mSettings.standards.getC();
+    dui.clearIncludeCache = mSettings.clearIncludeCache;
     return dui;
 }
 

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -44,6 +44,7 @@ Settings::Settings()
     clang(false),
     clangExecutable("clang"),
     clangTidy(false),
+    clearIncludeCache(false),
     daca(false),
     debugnormal(false),
     debugSimplified(false),

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -150,6 +150,9 @@ public:
     /** Use clang-tidy */
     bool clangTidy;
 
+    /** Internal: Clear the simplecpp non-existing include cache */
+    bool clearIncludeCache;
+
     /** @brief include paths excluded from checking the configuration */
     std::set<std::string> configExcludePaths;
 

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -1,0 +1,61 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2022 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "helpers.h"
+
+#include "path.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+ScopedFile::ScopedFile(std::string name, const std::string &content, std::string path)
+    : mName(std::move(name))
+    , mPath(Path::toNativeSeparators(std::move(path)))
+    , mFullPath(Path::join(mPath, mName))
+{
+    if (!mPath.empty() && mPath != Path::getCurrentPath()) {
+#ifdef _WIN32
+        if (!CreateDirectoryA(mPath.c_str(), nullptr))
+            throw std::runtime_error("ScopedFile(" + mFullPath + ") - could not create directory");
+#else
+        if (mkdir(mPath.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) != 0)
+            throw std::runtime_error("ScopedFile(" + mFullPath + ") - could not create directory");
+#endif
+    }
+
+    std::ofstream of(mFullPath);
+    if (!of.is_open())
+        throw std::runtime_error("ScopedFile(" + mFullPath + ") - could not open file");
+    of << content;
+}
+
+ScopedFile::~ScopedFile() {
+    std::remove(mFullPath.c_str());
+    if (!mPath.empty() && mPath != Path::getCurrentPath()) {
+#ifdef _WIN32
+        RemoveDirectoryA(mPath.c_str());
+#else
+        rmdir(mPath.c_str());
+#endif
+    }
+}

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -74,16 +74,17 @@ private:
 
 class ScopedFile {
 public:
-    ScopedFile(std::string name, const std::string &content) : mName(std::move(name)) {
-        std::ofstream of(mName);
-        of << content;
-    }
+    ScopedFile(std::string name, const std::string &content, std::string path = "");
+    ~ScopedFile();
 
-    ~ScopedFile() {
-        remove(mName.c_str());
+    const std::string& path() const
+    {
+        return mFullPath;
     }
 private:
-    std::string mName;
+    const std::string mName;
+    const std::string mPath;
+    const std::string mFullPath;
 };
 
 #endif // helpersH

--- a/test/testrunner.vcxproj
+++ b/test/testrunner.vcxproj
@@ -39,6 +39,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="helpers.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="options.cpp" />
     <ClCompile Include="test64bit.cpp" />


### PR DESCRIPTION
This is necessary for the missing include tests to work.

This is not working properly if Cppcheck is being used to scan multiple projects within the same execution (e.g. when using it as a library).

This requires https://github.com/danmar/simplecpp/pull/282 and https://github.com/danmar/simplecpp/pull/287 merged first.