### PR TITLE
deprecate non-`native` platform being used by default in Windows builds

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -128,10 +128,18 @@ void CmdLineParser::printError(const std::string &message)
     printMessage("error: " + message);
 }
 
+#if defined(_WIN64) || defined(_WIN32)
+bool CmdLineParser::SHOW_DEF_PLATFORM_MSG = true;
+#endif
+
 // TODO: normalize/simplify/native all path parameters
 // TODO: error out on all missing given files/paths
 bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 {
+#if defined(_WIN64) || defined(_WIN32)
+    bool default_platform = true;
+#endif
+
     bool def = false;
     bool maxconfigs = false;
 
@@ -617,6 +625,10 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     return false;
                 }
 
+#if defined(_WIN64) || defined(_WIN32)
+                default_platform = false;
+#endif
+
                 // TODO: remove
                 // these are loaded via external files and thus have Settings::PlatformFile set instead.
                 // override the type so they behave like the regular platforms.
@@ -1038,6 +1050,14 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
         printHelp();
         return true;
     }
+
+#if defined(_WIN64)
+    if (SHOW_DEF_PLATFORM_MSG && default_platform)
+        printMessage("Windows 64-bit binaries currently default to the 'win64' platform. Starting with Cppcheck 2.13 they will default to 'native' instead. Please specify '--platform=win64' explicitly if you rely on this.");
+#elif defined(_WIN32)
+    if (SHOW_DEF_PLATFORM_MSG && default_platform)
+        printMessage("Windows 32-bit binaries currently default to the 'win32A' platform. Starting with Cppcheck 2.13 they will default to 'native' instead. Please specify '--platform=win32A' explicitly if you rely on this.");
+#endif
 
     // Print error only if we have "real" command and expect files
     if (!mExitAfterPrint && mPathNames.empty() && mSettings->project.fileSettings.empty()) {

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -93,6 +93,11 @@ public:
         return mIgnoredPaths;
     }
 
+#if defined(_WIN64) || defined(_WIN32)
+    // temporary variable to "un-break" tests
+    static bool SHOW_DEF_PLATFORM_MSG;
+#endif
+
 protected:
 
     /**

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -4,3 +4,4 @@ release notes for cppcheck-2.10
 - if the file provided via "--file-list" cannot be opened it will now error out
 - add command-line option "--disable=<id>" to individually disable checks
 - added CMake option BUILD_CORE_DLL to build lib as cppcheck-core.dll with Visual Studio
+- Windows binaries currently default to the "win32A" and "win64" platform respectively. Starting with Cppcheck 2.13 they will default to 'native' instead. Please specify '--platform=win32A' or '--platform=win64' explicitly if you rely on this.

--- a/test/cli/test-helloworld.py
+++ b/test/cli/test-helloworld.py
@@ -72,7 +72,7 @@ def test_addon_absolute_path():
 
 def test_addon_relative_path():
     prjpath = getRelativeProjectPath()
-    ret, stdout, stderr = cppcheck(['--addon=misra', '--template=cppcheck1', prjpath])
+    ret, stdout, stderr = cppcheck(['--platform=native', '--addon=misra', '--template=cppcheck1', prjpath])
     filename = os.path.join(prjpath, 'main.c')
     assert ret == 0, stdout
     assert stdout == ('Checking %s ...\n'
@@ -83,7 +83,7 @@ def test_addon_relative_path():
 def test_addon_with_gui_project():
     project_file = 'helloworld/test.cppcheck'
     create_gui_project_file(project_file, paths=['.'], addon='misra')
-    ret, stdout, stderr = cppcheck(['--template=cppcheck1', '--project=' + project_file])
+    ret, stdout, stderr = cppcheck(['--platform=native', '--template=cppcheck1', '--project=' + project_file])
     filename = os.path.join('helloworld', 'main.c')
     assert ret == 0, stdout
     assert stdout == 'Checking %s ...\n' % filename

--- a/test/testplatform.cpp
+++ b/test/testplatform.cpp
@@ -37,6 +37,7 @@ private:
         TEST_CASE(valid_config_file_4);
         TEST_CASE(invalid_config_file_1);
         TEST_CASE(empty_elements);
+        TEST_CASE(default_platform);
     }
 
     static bool readPlatform(cppcheck::Platform& platform, const char* xmldata) {
@@ -312,6 +313,17 @@ private:
         ASSERT(!readPlatform(platform, xmldata));
         ASSERT_EQUALS(platform.PlatformFile, platform.platformType);
         ASSERT(!platform.isWindowsPlatform());
+    }
+
+    void default_platform() {
+        cppcheck::Platform platform;
+#if defined(_WIN64)
+        ASSERT_EQUALS(cppcheck::Platform::Win64, platform.platformType);
+#elif defined(_WIN32)
+        ASSERT_EQUALS(cppcheck::Platform::Win32A, platform.platformType);
+#else
+        ASSERT_EQUALS(cppcheck::Platform::Native, platform.platformType);
+#endif
     }
 };
 


### PR DESCRIPTION
This is not documented or easily visible. It is also causing determinism issue when trying to reproduce results across platforms (I encountered this various times).

The awkward added code and tests is only temporary until this can be removed.