### PR TITLE
test-my-pr robustification

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -203,7 +203,7 @@ while True:
         package = package_urls[packages_processed-1]
     else:
         try:
-            package = lib.try_retry(lib.get_package, max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
+            package = lib.get_package()
         except Exception as e:
             print('Error: Failed to get package ({}), retry later'.format(e))
             sys.exit(1)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -253,15 +253,18 @@ def get_cppcheck_versions():
 
 
 def get_packages_count():
-    print('Connecting to server to get count of packages..')
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.connect(__server_address)
-        sock.send(b'getPackagesCount\n')
-        packages = sock.recv(64)
-    # TODO: sock.recv() sometimes hangs and returns b'' afterwards
-    if not packages:
-        raise Exception('received empty response')
-    return int(packages)
+    def __get_packages_count():
+        print('Connecting to server to get count of packages..')
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect(__server_address)
+            sock.send(b'getPackagesCount\n')
+            packages = sock.recv(64)
+        # TODO: sock.recv() sometimes hangs and returns b'' afterwards
+        if not packages:
+            raise Exception('received empty response')
+        return int(packages)
+
+    return try_retry(__get_packages_count)
 
 
 def get_package(package_index=None):

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.42"
+CLIENT_VERSION = "1.3.43"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60
@@ -268,19 +268,22 @@ def get_packages_count():
 
 
 def get_package(package_index=None):
-    print('Connecting to server to get assigned work..')
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.connect(__server_address)
-        if package_index is None:
-            sock.send(b'get\n')
-        else:
-            request = 'getPackageIdx:' + str(package_index) + '\n'
-            sock.send(request.encode())
-        package = sock.recv(256)
-    # TODO: sock.recv() sometimes hangs and returns b'' afterwards
-    if not package:
-        raise Exception('received empty response')
-    return package.decode('utf-8')
+    def __get_package(package_index):
+        print('Connecting to server to get assigned work..')
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect(__server_address)
+            if package_index is None:
+                sock.send(b'get\n')
+            else:
+                request = 'getPackageIdx:' + str(package_index) + '\n'
+                sock.send(request.encode())
+            package = sock.recv(256)
+        # TODO: sock.recv() sometimes hangs and returns b'' afterwards
+        if not package:
+            raise Exception('received empty response')
+        return package.decode('utf-8')
+
+    return try_retry(__get_package, fargs=(package_index,), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
 
 
 def __handle_remove_readonly(func, path, exc):


### PR DESCRIPTION
Make `test-my-pr.py` a little more robust by retrying if `get_package()` or `get_package_count()` fails. For `get_package()`, this meant moving the retry-logic already present in `donate-cpu` to the library (this fixes trac ticket [#11045](https://trac.cppcheck.net/ticket/11405)). For `get_package_count()`, which is only used in `test-my-pr`, this meant adding the retry-logic to the function. 