### PR TITLE
CheckExceptionSafety: moved `CWE` objects into source file

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -35,6 +35,9 @@ namespace {
     CheckExceptionSafety instance;
 }
 
+static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
+static const struct CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
+static const struct CWE CWE480(480U);   // Use of Incorrect Operator
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -32,11 +32,6 @@ class Settings;
 class ErrorLogger;
 class Token;
 
-// CWE ID used:
-static const struct CWE CWE398(398U);   // Indicator of Poor Code Quality
-static const struct CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
-static const struct CWE CWE480(480U);   // Use of Incorrect Operator
-
 
 /// @addtogroup Checks
 /// @{


### PR DESCRIPTION
Those were the only global ones.