### PR TITLE
Token: added non-cost overload for `templateSimplifierPointers()`

### DIFF
--- a/lib/token.h
+++ b/lib/token.h
@@ -696,7 +696,10 @@ public:
     unsigned char bits() const {
         return mImpl->mBits;
     }
-    std::set<TemplateSimplifier::TokenAndName*>* templateSimplifierPointers() const {
+    const std::set<TemplateSimplifier::TokenAndName*>* templateSimplifierPointers() const {
+        return mImpl->mTemplateSimplifierPointers;
+    }
+    std::set<TemplateSimplifier::TokenAndName*>* templateSimplifierPointers() {
         return mImpl->mTemplateSimplifierPointers;
     }
     void templateSimplifierPointer(TemplateSimplifier::TokenAndName* tokenAndName) {


### PR DESCRIPTION
I guess this is what the exceptions in `functionConst` are about: https://trac.cppcheck.net/ticket/11500.

This definitely still needs some cleanups. But we cannot get rid of all `const_cast` as VaueFlow is using that by design - see also #4345.

I will split the safe changes into a separate PR though.