### PR TITLE
Fix FP#11508

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -124,6 +124,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <iostream>
 
 static void bailoutInternal(const std::string& type, TokenList *tokenlist, ErrorLogger *errorLogger, const Token *tok, const std::string &what, const std::string &file, int line, std::string function)
 {
@@ -3340,6 +3341,10 @@ static bool derefShared(const Token* tok)
 ValueFlow::Value ValueFlow::getLifetimeObjValue(const Token *tok, bool inconclusive)
 {
     std::vector<ValueFlow::Value> values = ValueFlow::getLifetimeObjValues(tok, inconclusive);
+    if (tok->str() == "svArg")
+    {
+        std::cout <<" LAMA: " << values.size() << '\n';
+    }
     // There should only be one lifetime
     if (values.size() != 1)
         return ValueFlow::Value{};
@@ -4790,7 +4795,14 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase* /*db*/, Erro
 
             ValueFlow::Value master;
             master.valueType = ValueFlow::Value::ValueType::LIFETIME;
-            master.lifetimeScope = ValueFlow::Value::LifetimeScope::Local;
+            if (astIsContainerView(tok) && tok->isVariable() && tok->variable()->isArgument())
+            {
+                master.lifetimeScope = ValueFlow::Value::LifetimeScope::SubFunction;
+            }
+            else
+            {
+                master.lifetimeScope = ValueFlow::Value::LifetimeScope::Local;
+            }
 
             if (astIsIterator(parent->tokAt(2))) {
                 master.errorPath.emplace_back(parent->tokAt(2), "Iterator to container is created here.");

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4820,7 +4820,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase* /*db*/, Erro
                 }
             } else if (astIsContainerView(tok)) {
                 for (const ValueFlow::Value& v : tok->values()) {
-                    if (v.isLifetimeValue())
+                    if (!v.isLocalLifetimeValue())
                         continue;
                     if (!v.tokvalue)
                         continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -4820,7 +4820,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase* /*db*/, Erro
                 }
             } else if (astIsContainerView(tok)) {
                 for (const ValueFlow::Value& v : tok->values()) {
-                    if (!v.isLifetimeValue())
+                    if (v.isLifetimeValue())
                         continue;
                     if (!v.tokvalue)
                         continue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -124,7 +124,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <iostream>
 
 static void bailoutInternal(const std::string& type, TokenList *tokenlist, ErrorLogger *errorLogger, const Token *tok, const std::string &what, const std::string &file, int line, std::string function)
 {
@@ -3341,10 +3340,6 @@ static bool derefShared(const Token* tok)
 ValueFlow::Value ValueFlow::getLifetimeObjValue(const Token *tok, bool inconclusive)
 {
     std::vector<ValueFlow::Value> values = ValueFlow::getLifetimeObjValues(tok, inconclusive);
-    if (tok->str() == "svArg")
-    {
-        std::cout <<" LAMA: " << values.size() << '\n';
-    }
     // There should only be one lifetime
     if (values.size() != 1)
         return ValueFlow::Value{};
@@ -4799,14 +4794,7 @@ static void valueFlowLifetime(TokenList *tokenlist, SymbolDatabase* /*db*/, Erro
 
             ValueFlow::Value master;
             master.valueType = ValueFlow::Value::ValueType::LIFETIME;
-            if (astIsContainerView(tok) && tok->isVariable() && tok->variable()->isArgument())
-            {
-                master.lifetimeScope = ValueFlow::Value::LifetimeScope::SubFunction;
-            }
-            else
-            {
-                master.lifetimeScope = ValueFlow::Value::LifetimeScope::Local;
-            }
+            master.lifetimeScope = ValueFlow::Value::LifetimeScope::Local;
 
             if (astIsIterator(parent->tokAt(2))) {
                 master.errorPath.emplace_back(parent->tokAt(2), "Iterator to container is created here.");

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -4182,6 +4182,27 @@ private:
               "  f(bar);\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:10]: (error) Address of local auto-variable assigned to a function parameter.\n", errout.str());
+
+        check("void f(std::string_view text);\n" // #11508
+              "void g() {\n"
+              "std::string teststr;\n"
+              "f(teststr);"
+              "}\n"
+              "void f(std::string_view text) {"
+              "g(text.data());\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+       check("void f(std::span<int> data);\n" // #11508
+             "void g() {\n"
+             "std::vector<int> v;\n"
+             "f(v);"
+             "}\n"
+             "void f(std::span<int> data) {"
+             "g(data.begin());\n"
+             "}\n");
+        ASSERT_EQUALS("", errout.str());
+
     }
 
     void deadPointer() {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -4185,22 +4185,22 @@ private:
 
         check("void f(std::string_view text);\n" // #11508
               "void g() {\n"
-              "std::string teststr;\n"
-              "f(teststr);"
+              "  std::string teststr;\n"
+              "  f(teststr);"
               "}\n"
               "void f(std::string_view text) {"
-              "g(text.data());\n"
+              "  g(text.data());\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
 
-       check("void f(std::span<int> data);\n" // #11508
-             "void g() {\n"
-             "std::vector<int> v;\n"
-             "f(v);"
-             "}\n"
-             "void f(std::span<int> data) {"
-             "g(data.begin());\n"
-             "}\n");
+        check("void f(std::span<int> data);\n" // #11508
+              "void g() {\n"
+              "  std::vector<int> v;\n"
+              "  f(v);"
+              "}\n"
+              "void f(std::span<int> data) {"
+              "  g(data.begin());\n"
+              "}\n");
         ASSERT_EQUALS("", errout.str());
 
     }


### PR DESCRIPTION
My current understanding is that views are treated as references - there is an issue that for references each of them has its own lifetime but view always uses lifetime of container it is 'viewing'. Lifetime of variable is done by comparing end of scopes where function is declared at and where it is used. Since those are 2 separate functions and not lambda FP is observed