### PR TITLE
gnu.cfg: strcasestr wrong return type

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -980,10 +980,10 @@
     <warn severity="style" reason="Obsolescent" alternatives="sprintf"/>
   </function>
   <!-- https://www.gnu.org/software/gnulib/manual/html_node/c_002dstrcasestr.html -->
-  <!-- size_t strcasestr(const char *s1, const char *s2); -->
+  <!-- char* strcasestr(const char *s1, const char *s2); -->
   <function name="strcasestr">
     <use-retval/>
-    <returnValue type="size_t"/>
+    <returnValue type="char *"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <pure/>


### PR DESCRIPTION
See https://www.gnu.org/software/gnulib/manual/html_node/c_002dstrcasestr.html to verify