### PR TITLE
std.cfg: added support for more container methods

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6653,8 +6653,9 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- For std::string::insert see http://en.cppreference.com/w/cpp/string/basic_string/insert -->
   <!-- For std::vector::insert see http://en.cppreference.com/w/cpp/container/vector/insert -->
   <!-- For std::unordered_map::insert see https://en.cppreference.com/w/cpp/container/unordered_map/insert -->
+  <!-- For std::unordered_set::insert see https://en.cppreference.com/w/cpp/container/unordered_set/insert -->
   <!-- Return value type is "iterator" or "void" depending on the overloaded function. -->
-  <function name="std::list::insert,std::multimap::insert,std::map::insert,std::set::insert,std::multiset::insert,std::string::insert,std::vector::insert,std::unordered_map::insert">
+  <function name="std::list::insert,std::multimap::insert,std::map::insert,std::set::insert,std::multiset::insert,std::string::insert,std::vector::insert,std::unordered_map::insert,std::unordered_set::insert">
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6652,8 +6652,9 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- For std::set::insert see http://en.cppreference.com/w/cpp/container/set/insert -->
   <!-- For std::string::insert see http://en.cppreference.com/w/cpp/string/basic_string/insert -->
   <!-- For std::vector::insert see http://en.cppreference.com/w/cpp/container/vector/insert -->
+  <!-- For std::unordered_map::insert see https://en.cppreference.com/w/cpp/container/unordered_map/insert -->
   <!-- Return value type is "iterator" or "void" depending on the overloaded function. -->
-  <function name="std::list::insert,std::multimap::insert,std::map::insert,std::set::insert,std::multiset::insert,std::string::insert,std::vector::insert">
+  <function name="std::list::insert,std::multimap::insert,std::map::insert,std::set::insert,std::multiset::insert,std::string::insert,std::vector::insert,std::unordered_map::insert">
     <noreturn>false</noreturn>
     <arg nr="1">
       <not-uninit/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6690,7 +6690,8 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!-- template< class K > size_type std::map::count( const K& x ) const; // since C++14 -->
   <!--                     size_type std::set::count( const value_type& val) const; -->
   <!--                     size_type std::unordered_set::count( const Key& key ) const; -->
-  <function name="std::map::count,std::set::count,std::unordered_set::count">
+  <!--                     size_type std::unordered_map::count( const Key& key ) const; -->
+  <function name="std::map::count,std::set::count,std::unordered_set::count,std::unordered_map::count">
     <noreturn>false</noreturn>
     <returnValue type="size_t"/>
     <use-retval/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6667,7 +6667,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
     </arg>
   </function>
-  <function name="std::deque::emplace_back,std::deque::emplace_front,std::list::emplace_back,std::list::emplace_front,std::forward_list::emplace_front,std::queue::emplace,std::stack::emplace,std::vector::emplace_back,std::vector::emplace_front">
+  <function name="std::deque::emplace_back,std::deque::emplace_front,std::list::emplace_back,std::list::emplace_front,std::forward_list::emplace_front,std::queue::emplace,std::stack::emplace,std::vector::emplace_back,std::vector::emplace_front,std::unordered_set::emplace">
     <noreturn>false</noreturn>
     <arg nr="variadic">
       <not-uninit/>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6691,7 +6691,8 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <!--                     size_type std::set::count( const value_type& val) const; -->
   <!--                     size_type std::unordered_set::count( const Key& key ) const; -->
   <!--                     size_type std::unordered_map::count( const Key& key ) const; -->
-  <function name="std::map::count,std::set::count,std::unordered_set::count,std::unordered_map::count">
+  <!--                     size_type std::multimap::count( const Key& key ) const; -->
+  <function name="std::map::count,std::set::count,std::unordered_set::count,std::unordered_map::count,std::multimap::count">
     <noreturn>false</noreturn>
     <returnValue type="size_t"/>
     <use-retval/>

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -37,6 +37,7 @@
 #include <iterator>
 #include <numeric>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 #include <version>
@@ -847,6 +848,14 @@ void std_unordered_set_count_ignoredReturnValue(const std::unordered_set<int>& u
     // cppcheck-suppress [uninitvar, ignoredReturnValue]
     u.count(i);
 }
+
+void std_unordered_map_count_ignoredReturnValue(const std::unordered_map<int, int>& u)
+{
+    int i;
+    // cppcheck-suppress [uninitvar, ignoredReturnValue]
+    u.count(i);
+}
+
 
 void valid_code()
 {

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -864,6 +864,13 @@ void std_multimap_count_ignoredReturnValue(const std::multimap<int, int>& m)
     m.count(i);
 }
 
+void std_unordered_map_insert_unnitvar(std::unordered_set<int>& u)
+{
+    int i;
+    // cppcheck-suppress uninitvar
+    u.insert(i);
+}
+
 void valid_code()
 {
     std::vector<int> vecInt{0, 1, 2};

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -871,6 +871,13 @@ void std_unordered_map_insert_unnitvar(std::unordered_set<int>& u)
     u.insert(i);
 }
 
+void std_unordered_map_emplace_unnitvar(std::unordered_set<int>& u)
+{
+    int i;
+    // cppcheck-suppress uninitvar
+    u.emplace(i);
+}
+
 void valid_code()
 {
     std::vector<int> vecInt{0, 1, 2};

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <istream>
 #include <iterator>
+#include <map>
 #include <numeric>
 #include <string_view>
 #include <unordered_map>
@@ -856,6 +857,12 @@ void std_unordered_map_count_ignoredReturnValue(const std::unordered_map<int, in
     u.count(i);
 }
 
+void std_multimap_count_ignoredReturnValue(const std::multimap<int, int>& m)
+{
+    int i;
+    // cppcheck-suppress [uninitvar, ignoredReturnValue]
+    m.count(i);
+}
 
 void valid_code()
 {


### PR DESCRIPTION
Easy fixes for `--check-library` warnings from our selfcheck - see https://trac.cppcheck.net/ticket/11313#comment:12:

`std::unordered_set::emplace()`
`std::unordered_set::insert()`
`std::unordered_map::insert()`
`std::multimap::count()`
`std::unordered_map::count()`