### PR TITLE
posix.cfg: FP with strncasecmp wrong minsize

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -2106,30 +2106,9 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
   </function>
   <!-- https://man7.org/linux/man-pages/man3/strncasecmp.3.html -->
   <!-- int strncasecmp(const char *s1, const char *s2, size_t n); -->
-  <function name="strncasecmp">
-    <pure/>
-    <use-retval/>
-    <noreturn>false</noreturn>
-    <leak-ignore/>
-    <returnValue type="int"/>
-    <arg nr="1" direction="in">
-      <not-null/>
-      <not-uninit/>
-      <minsize type="argvalue" arg="3"/>
-    </arg>
-    <arg nr="2" direction="in">
-      <not-null/>
-      <not-uninit/>
-      <minsize type="argvalue" arg="3"/>
-    </arg>
-    <arg nr="3" direction="in">
-      <not-bool/>
-      <valid>0:</valid>
-    </arg>
-  </function>
   <!-- https://man7.org/linux/man-pages/man3/wcsncasecmp.3.html -->
   <!-- int wcsncasecmp(const wchar_t *s1, const wchar_t *s2, size_t n) -->
-  <function name="wcsncasecmp">
+  <function name="strncasecmp,wcsncasecmp">
     <pure/>
     <use-retval/>
     <noreturn>false</noreturn>
@@ -2138,12 +2117,10 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
     <arg nr="1" direction="in">
       <not-null/>
       <not-uninit/>
-      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="2" direction="in">
       <not-null/>
       <not-uninit/>
-      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="3" direction="in">
       <not-bool/>


### PR DESCRIPTION
See https://sourceforge.net/p/cppcheck/discussion/general/thread/4deedb0e6f/

Also combine with wcsncasecmp because it's identical (like strncmp in std.cfg)