### PR TITLE
Preprocessor: removed unreachable `ConfigurationNotChecked` finding

### DIFF
--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -157,15 +157,6 @@ public:
     std::string getcode(const std::string &filedata, const std::string &cfg, const std::string &filename);
 
     /**
-     * make sure empty configuration macros are not used in code. the given code must be a single configuration
-     * @param cfg configuration
-     * @param macroUsageList macro usage list
-     * @return true => configuration is valid
-     */
-    bool validateCfg(const std::string &cfg, const std::list<simplecpp::MacroUsage> &macroUsageList);
-    void validateCfgError(const std::string &file, const unsigned int line, const std::string &cfg, const std::string &macro);
-
-    /**
      * Calculate HASH. Using toolinfo, tokens1, filedata.
      *
      * @param tokens1    Sourcefile tokens

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -244,9 +244,6 @@ private:
         TEST_CASE(getConfigsU6);
         TEST_CASE(getConfigsU7);
 
-        TEST_CASE(validateCfg1);
-        TEST_CASE(validateCfg2);
-
         TEST_CASE(if_sizeof);
 
         TEST_CASE(invalid_ifs); // #5909
@@ -274,6 +271,7 @@ private:
         TEST_CASE(testMissingIncludeCheckConfig);
     }
 
+    // TODO: we should be calling the actual Preprocessor::preprocess() implementation
     void preprocess(const char* code, std::map<std::string, std::string>& actual, const char filename[] = "file.c") {
         errout.str("");
         std::istringstream istr(code);
@@ -2279,37 +2277,6 @@ private:
                             "#else\n"
                             "#endif\n";
         ASSERT_EQUALS("\nY\n", getConfigsStr(code, "-DX"));
-    }
-
-
-    void validateCfg1() {
-        Preprocessor preprocessor(settings0, this);
-
-        std::vector<std::string> files(1, "test.c");
-        simplecpp::MacroUsage macroUsage(files, false);
-        macroUsage.useLocation.fileIndex = 0;
-        macroUsage.useLocation.line = 1;
-        macroUsage.macroName = "X";
-        std::list<simplecpp::MacroUsage> macroUsageList(1, macroUsage);
-
-        ASSERT_EQUALS(true, preprocessor.validateCfg("", macroUsageList));
-        ASSERT_EQUALS(false, preprocessor.validateCfg("X",macroUsageList));
-        ASSERT_EQUALS(false, preprocessor.validateCfg("A=42;X", macroUsageList));
-        ASSERT_EQUALS(true, preprocessor.validateCfg("X=1", macroUsageList));
-        ASSERT_EQUALS(true, preprocessor.validateCfg("Y", macroUsageList));
-
-        macroUsageList.front().macroValueKnown = true; // #8404
-        ASSERT_EQUALS(true, preprocessor.validateCfg("X", macroUsageList));
-    }
-
-    void validateCfg2() {
-        const char filedata[] = "#ifdef ABC\n"
-                                "#endif\n"
-                                "int i = ABC;";
-
-        std::map<std::string, std::string> actual;
-        preprocess(filedata, actual, "file.cpp");
-        ASSERT_EQUALS("[file.cpp:3]: (information) Skipping configuration 'ABC' since the value of 'ABC' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.\n", errout.str());
     }
 
     void if_sizeof() { // #4071


### PR DESCRIPTION
The finding can never be triggered `Preprocessor::validateCfg()` bails out when the define contains a `=` (e.g. `DEF_1=1`). 

I came across this as I was trying to write a unit test for this and failed to trigger this.

`cfg` is generated by calling `Preprocessor::createDUI()`. That calls `splitcfg(mSettings.userDefines, dui.defines, "1")` to generate that config but as the last parameter shows it will set a default value of `1` if it is not specified. So it is not possible to generate a configuration which contains defines without any values and `Preprocessor::validateCfg()` will not be able to report any warnings.

I assume the configuration string was changed at some point rending that validation void.