### PR TITLE
reduced usage of mutable `Settings` objects in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor
 test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
-test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/mathlib.h lib/path.h lib/preprocessor.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
+test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
 
 test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h

--- a/Makefile
+++ b/Makefile
@@ -667,13 +667,13 @@ cli/stacktrace.o: cli/stacktrace.cpp cli/stacktrace.h lib/config.h lib/utils.h
 cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/threadexecutor.cpp
 
-test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h test/redirect.h
+test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
 test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/mathlib.h lib/path.h lib/preprocessor.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
 
-test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h
+test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/main.cpp
 
 test/options.o: test/options.cpp test/options.h
@@ -682,7 +682,7 @@ test/options.o: test/options.cpp test/options.h
 test/test64bit.o: test/test64bit.cpp lib/check.h lib/check64bit.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/test64bit.cpp
 
-test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testanalyzerinformation.cpp
 
 test/testassert.o: test/testassert.cpp lib/check.h lib/checkassert.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -715,7 +715,7 @@ test/testclass.o: test/testclass.cpp externals/simplecpp/simplecpp.h lib/check.h
 test/testcmdlineparser.o: test/testcmdlineparser.cpp cli/cmdlineparser.h cli/cppcheckexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcmdlineparser.cpp
 
-test/testcolor.o: test/testcolor.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h
+test/testcolor.o: test/testcolor.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcolor.cpp
 
 test/testcondition.o: test/testcondition.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkcondition.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -733,7 +733,7 @@ test/testerrorlogger.o: test/testerrorlogger.cpp externals/tinyxml2/tinyxml2.h l
 test/testexceptionsafety.o: test/testexceptionsafety.cpp lib/check.h lib/checkexceptionsafety.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testexceptionsafety.cpp
 
-test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testfilelister.cpp
 
 test/testfunctions.o: test/testfunctions.cpp lib/check.h lib/checkfunctions.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -760,7 +760,7 @@ test/testleakautovar.o: test/testleakautovar.cpp externals/simplecpp/simplecpp.h
 test/testlibrary.o: test/testlibrary.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testlibrary.cpp
 
-test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testmathlib.cpp
 
 test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -769,19 +769,19 @@ test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/c
 test/testnullpointer.o: test/testnullpointer.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checknullpointer.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testnullpointer.cpp
 
-test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h
+test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testoptions.cpp
 
 test/testother.o: test/testother.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkother.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testother.cpp
 
-test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpath.cpp
 
-test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpathmatch.cpp
 
-test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testplatform.cpp
 
 test/testpostfixoperator.o: test/testpostfixoperator.cpp lib/check.h lib/checkpostfixoperator.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h

--- a/Makefile
+++ b/Makefile
@@ -667,13 +667,13 @@ cli/stacktrace.o: cli/stacktrace.cpp cli/stacktrace.h lib/config.h lib/utils.h
 cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/threadexecutor.cpp
 
-test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h test/redirect.h
+test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
 test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/mathlib.h lib/path.h lib/preprocessor.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
 
-test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/preprocessor.h lib/suppressions.h test/fixture.h test/options.h
+test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/main.cpp
 
 test/options.o: test/options.cpp test/options.h
@@ -682,7 +682,7 @@ test/options.o: test/options.cpp test/options.h
 test/test64bit.o: test/test64bit.cpp lib/check.h lib/check64bit.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/test64bit.cpp
 
-test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/platform.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testanalyzerinformation.cpp
 
 test/testassert.o: test/testassert.cpp lib/check.h lib/checkassert.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -733,7 +733,7 @@ test/testerrorlogger.o: test/testerrorlogger.cpp externals/tinyxml2/tinyxml2.h l
 test/testexceptionsafety.o: test/testexceptionsafety.cpp lib/check.h lib/checkexceptionsafety.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testexceptionsafety.cpp
 
-test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/pathmatch.h lib/suppressions.h test/fixture.h
+test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testfilelister.cpp
 
 test/testfunctions.o: test/testfunctions.cpp lib/check.h lib/checkfunctions.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -760,7 +760,7 @@ test/testleakautovar.o: test/testleakautovar.cpp externals/simplecpp/simplecpp.h
 test/testlibrary.o: test/testlibrary.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testlibrary.cpp
 
-test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/mathlib.h lib/suppressions.h test/fixture.h
+test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testmathlib.cpp
 
 test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -769,19 +769,19 @@ test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/c
 test/testnullpointer.o: test/testnullpointer.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checknullpointer.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testnullpointer.cpp
 
-test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h
+test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testoptions.cpp
 
 test/testother.o: test/testother.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkother.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testother.cpp
 
-test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/path.h lib/suppressions.h test/fixture.h
+test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpath.cpp
 
-test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/pathmatch.h lib/suppressions.h test/fixture.h
+test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpathmatch.cpp
 
-test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/platform.h lib/suppressions.h test/fixture.h
+test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testplatform.cpp
 
 test/testpostfixoperator.o: test/testpostfixoperator.cpp lib/check.h lib/checkpostfixoperator.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -832,7 +832,7 @@ test/testsymboldatabase.o: test/testsymboldatabase.cpp lib/check.h lib/color.h l
 test/testthreadexecutor.o: test/testthreadexecutor.cpp cli/executor.h cli/threadexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testthreadexecutor.cpp
 
-test/testtimer.o: test/testtimer.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h lib/timer.h test/fixture.h
+test/testtimer.o: test/testtimer.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testtimer.cpp
 
 test/testtoken.o: test/testtoken.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -400,6 +400,7 @@ void TestFixture::setTemplateFormat(const std::string &templateFormat)
 }
 
 TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::library(const char lib[]) {
+    // TODO: exename is not yet set
     LOAD_LIB_2_EXE(settings.library, lib, fixture.exename.c_str());
     // strip extension
     std::string lib_s(lib);

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -74,7 +74,6 @@ unsigned int TestFixture::countTests;
 std::size_t TestFixture::fails_counter = 0;
 std::size_t TestFixture::todos_counter = 0;
 std::size_t TestFixture::succeeded_todos_counter = 0;
-std::set<std::string> TestFixture::missingLibs;
 
 TestFixture::TestFixture(const char * const _name)
     : mVerbose(false),
@@ -284,11 +283,6 @@ void TestFixture::assertNoThrowFail(const char * const filename, const unsigned 
 
 }
 
-void TestFixture::complainMissingLib(const char * const libname)
-{
-    missingLibs.insert(libname);
-}
-
 void TestFixture::printHelp()
 {
     std::cout << "Testrunner - run Cppcheck tests\n"
@@ -372,12 +366,6 @@ std::size_t TestFixture::runTests(const options& args)
     std::cerr << "Tests failed: " << fails_counter << std::endl << std::endl;
     std::cerr << errmsg.str();
 
-    if (!missingLibs.empty()) {
-        std::cerr << "Missing libraries: ";
-        for (const std::string & missingLib : missingLibs)
-            std::cerr << missingLib << "  ";
-        std::cerr << std::endl << std::endl;
-    }
     std::cerr.flush();
     return fails_counter + succeeded_todos_counter;
 }

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -20,6 +20,7 @@
 
 #include "errortypes.h"
 #include "options.h"
+#include "path.h"
 #include "redirect.h"
 
 #include <cstdio>
@@ -396,4 +397,16 @@ void TestFixture::setTemplateFormat(const std::string &templateFormat)
         mTemplateFormat = templateFormat;
         mTemplateLocation = "";
     }
+}
+
+TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::library(const char lib[]) {
+    LOAD_LIB_2_EXE(settings.library, lib, fixture.exename.c_str());
+    // strip extension
+    std::string lib_s(lib);
+    const std::string ext(".cfg");
+    const auto pos = lib_s.find(ext);
+    if (pos != std::string::npos)
+        lib_s.erase(pos, ext.size());
+    settings.libraries.emplace_back(lib_s);
+    return *this;
 }

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -43,7 +43,6 @@ private:
     static std::size_t fails_counter;
     static std::size_t todos_counter;
     static std::size_t succeeded_todos_counter;
-    static std::set<std::string> missingLibs;
     bool mVerbose;
     std::string mTemplateFormat;
     std::string mTemplateLocation;
@@ -95,7 +94,6 @@ protected:
     void assertThrow(const char * const filename, const unsigned int linenr) const;
     void assertThrowFail(const char * const filename, const unsigned int linenr) const;
     void assertNoThrowFail(const char * const filename, const unsigned int linenr) const;
-    static void complainMissingLib(const char * const libname);
     static std::string deleteLineNumber(const std::string &message);
 
     void setVerbose(bool v) {
@@ -165,13 +163,7 @@ extern std::ostringstream output;
 #define EXPECT_EQ( EXPECTED, ACTUAL ) assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL)
 #define REGISTER_TEST( CLASSNAME ) namespace { CLASSNAME instance_ ## CLASSNAME; }
 
-#define LOAD_LIB_2(LIB, NAME)                                                                                          \
-    do {                                                                                                               \
-        if (((LIB).load(exename.c_str(), NAME).errorcode != Library::ErrorCode::OK)) {                                 \
-            complainMissingLib(NAME);                                                                                  \
-            abort();                                                                                                   \
-        }                                                                                                              \
-    } while (false)
+#define LOAD_LIB_2( LIB, NAME ) do { if (((LIB).load(exename.c_str(), NAME).errorcode != Library::ErrorCode::OK)) throw std::runtime_error("library '" + std::string(NAME) + "' not found"); } while (false)
 
 #define PLATFORM( P, T ) do { std::string errstr; assertEquals(__FILE__, __LINE__, true, P.set(cppcheck::Platform::toString(T), errstr, {exename}), errstr); } while (false)
 

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -103,3 +103,5 @@ std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::s
 
     return ret;
 }
+
+const Settings givenACodeSampleToTokenize::settings;

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -103,5 +103,3 @@ std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::s
 
     return ret;
 }
-
-const Settings givenACodeSampleToTokenize::settings;

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -33,7 +33,7 @@ class Suppressions;
 class givenACodeSampleToTokenize {
 private:
     Tokenizer tokenizer;
-    static const Settings settings;
+    const Settings settings;
 
 public:
     explicit givenACodeSampleToTokenize(const char sample[], bool createOnly = false, bool cpp = true)

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -19,6 +19,7 @@
 #ifndef helpersH
 #define helpersH
 
+#include "settings.h"
 #include "tokenize.h"
 #include "tokenlist.h"
 
@@ -27,7 +28,6 @@
 
 class Token;
 class Preprocessor;
-class Settings;
 class Suppressions;
 
 class givenACodeSampleToTokenize {

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -30,11 +30,9 @@ public:
     Test64BitPortability() : TestFixture("Test64BitPortability") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::portability).library("std.cfg").build();
 
     void run() override {
-        settings.severity.enable(Severity::portability);
-
         TEST_CASE(novardecl);
         TEST_CASE(functionpar);
         TEST_CASE(structmember);
@@ -51,7 +49,6 @@ private:
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
-        LOAD_LIB_2(settings.library, "std.cfg");
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -32,7 +32,7 @@ public:
     TestAssert() : TestFixture("TestAssert") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], const char *filename = "test.cpp") {
@@ -49,8 +49,6 @@ private:
     }
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-
         TEST_CASE(assignmentInAssert);
         TEST_CASE(functionCallInAssert);
         TEST_CASE(memberFunctionCallInAssert);

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -50,7 +50,7 @@ private:
 
 #define findLambdaEndToken(code) findLambdaEndToken_(code, __FILE__, __LINE__)
     bool findLambdaEndToken_(const char code[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -84,7 +84,7 @@ private:
 
 #define findLambdaStartToken(code) findLambdaStartToken_(code, __FILE__, __LINE__)
     bool findLambdaStartToken_(const char code[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -117,7 +117,7 @@ private:
 
 #define isNullOperand(code) isNullOperand_(code, __FILE__, __LINE__)
     bool isNullOperand_(const char code[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -139,7 +139,7 @@ private:
 
 #define isReturnScope(code, offset) isReturnScope_(code, offset, __FILE__, __LINE__)
     bool isReturnScope_(const char code[], int offset, const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -170,7 +170,7 @@ private:
 
 #define isSameExpression(code, tokStr1, tokStr2) isSameExpression_(code, tokStr1, tokStr2, __FILE__, __LINE__)
     bool isSameExpression_(const char code[], const char tokStr1[], const char tokStr2[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Library library;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -210,7 +210,7 @@ private:
 
 #define isVariableChanged(code, startPattern, endPattern) isVariableChanged_(code, startPattern, endPattern, __FILE__, __LINE__)
     bool isVariableChanged_(const char code[], const char startPattern[], const char endPattern[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -240,7 +240,7 @@ private:
 
 #define isVariableChangedByFunctionCall(code, pattern, inconclusive) isVariableChangedByFunctionCall_(code, pattern, inconclusive, __FILE__, __LINE__)
     bool isVariableChangedByFunctionCall_(const char code[], const char pattern[], bool *inconclusive, const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -416,7 +416,7 @@ private:
 
 #define nextAfterAstRightmostLeaf(code, parentPattern, rightPattern) nextAfterAstRightmostLeaf_(code, parentPattern, rightPattern, __FILE__, __LINE__)
     bool nextAfterAstRightmostLeaf_(const char code[], const char parentPattern[], const char rightPattern[], const char* file, int line) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -441,7 +441,7 @@ private:
     enum class Result {False, True, Fail};
 
     Result isUsedAsBool(const char code[], const char pattern[]) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         if (!tokenizer.tokenize(istr, "test.cpp"))

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -50,7 +50,7 @@ private:
 
 #define findLambdaEndToken(code) findLambdaEndToken_(code, __FILE__, __LINE__)
     bool findLambdaEndToken_(const char code[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -84,7 +84,7 @@ private:
 
 #define findLambdaStartToken(code) findLambdaStartToken_(code, __FILE__, __LINE__)
     bool findLambdaStartToken_(const char code[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -117,7 +117,7 @@ private:
 
 #define isNullOperand(code) isNullOperand_(code, __FILE__, __LINE__)
     bool isNullOperand_(const char code[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -139,7 +139,7 @@ private:
 
 #define isReturnScope(code, offset) isReturnScope_(code, offset, __FILE__, __LINE__)
     bool isReturnScope_(const char code[], int offset, const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -170,7 +170,7 @@ private:
 
 #define isSameExpression(code, tokStr1, tokStr2) isSameExpression_(code, tokStr1, tokStr2, __FILE__, __LINE__)
     bool isSameExpression_(const char code[], const char tokStr1[], const char tokStr2[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Library library;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -210,7 +210,7 @@ private:
 
 #define isVariableChanged(code, startPattern, endPattern) isVariableChanged_(code, startPattern, endPattern, __FILE__, __LINE__)
     bool isVariableChanged_(const char code[], const char startPattern[], const char endPattern[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -240,7 +240,7 @@ private:
 
 #define isVariableChangedByFunctionCall(code, pattern, inconclusive) isVariableChangedByFunctionCall_(code, pattern, inconclusive, __FILE__, __LINE__)
     bool isVariableChangedByFunctionCall_(const char code[], const char pattern[], bool *inconclusive, const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -416,7 +416,7 @@ private:
 
 #define nextAfterAstRightmostLeaf(code, parentPattern, rightPattern) nextAfterAstRightmostLeaf_(code, parentPattern, rightPattern, __FILE__, __LINE__)
     bool nextAfterAstRightmostLeaf_(const char code[], const char parentPattern[], const char rightPattern[], const char* file, int line) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -441,7 +441,7 @@ private:
     enum class Result {False, True, Fail};
 
     Result isUsedAsBool(const char code[], const char pattern[]) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         if (!tokenizer.tokenize(istr, "test.cpp"))

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -50,7 +50,7 @@ private:
 
 #define findLambdaEndToken(code) findLambdaEndToken_(code, __FILE__, __LINE__)
     bool findLambdaEndToken_(const char code[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -84,7 +84,7 @@ private:
 
 #define findLambdaStartToken(code) findLambdaStartToken_(code, __FILE__, __LINE__)
     bool findLambdaStartToken_(const char code[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -117,7 +117,7 @@ private:
 
 #define isNullOperand(code) isNullOperand_(code, __FILE__, __LINE__)
     bool isNullOperand_(const char code[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -139,7 +139,7 @@ private:
 
 #define isReturnScope(code, offset) isReturnScope_(code, offset, __FILE__, __LINE__)
     bool isReturnScope_(const char code[], int offset, const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -170,7 +170,7 @@ private:
 
 #define isSameExpression(code, tokStr1, tokStr2) isSameExpression_(code, tokStr1, tokStr2, __FILE__, __LINE__)
     bool isSameExpression_(const char code[], const char tokStr1[], const char tokStr2[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Library library;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -210,7 +210,7 @@ private:
 
 #define isVariableChanged(code, startPattern, endPattern) isVariableChanged_(code, startPattern, endPattern, __FILE__, __LINE__)
     bool isVariableChanged_(const char code[], const char startPattern[], const char endPattern[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -240,7 +240,7 @@ private:
 
 #define isVariableChangedByFunctionCall(code, pattern, inconclusive) isVariableChangedByFunctionCall_(code, pattern, inconclusive, __FILE__, __LINE__)
     bool isVariableChangedByFunctionCall_(const char code[], const char pattern[], bool *inconclusive, const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -416,7 +416,7 @@ private:
 
 #define nextAfterAstRightmostLeaf(code, parentPattern, rightPattern) nextAfterAstRightmostLeaf_(code, parentPattern, rightPattern, __FILE__, __LINE__)
     bool nextAfterAstRightmostLeaf_(const char code[], const char parentPattern[], const char rightPattern[], const char* file, int line) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -441,7 +441,7 @@ private:
     enum class Result {False, True, Fail};
 
     Result isUsedAsBool(const char code[], const char pattern[]) {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         if (!tokenizer.tokenize(istr, "test.cpp"))

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -32,30 +32,24 @@ public:
     TestAutoVariables() : TestFixture("TestAutoVariables") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).library("std.cfg").library("qt.cfg").build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = true, const char* filename = "test.cpp") {
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
-        runChecks<CheckAutoVariables>(&tokenizer, &settings, this);
+        runChecks<CheckAutoVariables>(&tokenizer, &settings1, this);
     }
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::style);
-        LOAD_LIB_2(settings.library, "std.cfg");
-        LOAD_LIB_2(settings.library, "qt.cfg");
-        settings.libraries.emplace_back("qt");
-
         TEST_CASE(testautovar1);
         TEST_CASE(testautovar2);
         TEST_CASE(testautovar3); // ticket #2925

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -31,13 +31,9 @@ public:
     TestBool() : TestFixture("TestBool") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).certainty(Certainty::inconclusive).build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::warning);
-        settings.certainty.enable(Certainty::inconclusive);
-
         TEST_CASE(bitwiseOnBoolean);      // if (bool & bool)
         TEST_CASE(incrementBoolean);
         TEST_CASE(assignBoolToPointer);

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -31,12 +31,9 @@ public:
     TestBoost() : TestFixture("TestBoost") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::performance).build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::performance);
-
         TEST_CASE(BoostForeachContainerModification);
     }
 

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -42,22 +42,22 @@ public:
     TestBufferOverrun() : TestFixture("TestBufferOverrun") {}
 
 private:
-    Settings settings0;
+    Settings settings0 = settingsBuilder().library("std.cfg").severity(Severity::warning).severity(Severity::style).severity(Severity::portability).build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
         // Clear the error buffer..
         errout.str("");
 
-        settings0.certainty.enable(Certainty::inconclusive);
+        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check for buffer overruns..
-        runChecks<CheckBufferOverrun>(&tokenizer, &settings0, this);
+        runChecks<CheckBufferOverrun>(&tokenizer, &settings, this);
     }
 
     void check_(const char* file, int line, const char code[], const Settings &settings, const char filename[] = "test.cpp") {
@@ -77,14 +77,14 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        Settings* settings = &settings0;
-        settings->severity.enable(Severity::style);
-        settings->severity.enable(Severity::warning);
-        settings->severity.enable(Severity::portability);
-        settings->severity.enable(Severity::performance);
-        settings->standards.c = Standards::CLatest;
-        settings->standards.cpp = Standards::CPPLatest;
-        settings->certainty.enable(Certainty::inconclusive);
+        Settings settings = settings0;
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::portability);
+        settings.severity.enable(Severity::performance);
+        settings.standards.c = Standards::CLatest;
+        settings.standards.cpp = Standards::CPPLatest;
+        settings.certainty.enable(Certainty::inconclusive);
 
         // Raw tokens..
         std::vector<std::string> files(1, filename);
@@ -97,21 +97,15 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenizer..
-        Tokenizer tokenizer(settings, this);
+        Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for buffer overruns..
-        runChecks<CheckBufferOverrun>(&tokenizer, settings, this);
+        runChecks<CheckBufferOverrun>(&tokenizer, &settings, this);
     }
 
     void run() override {
-        LOAD_LIB_2(settings0.library, "std.cfg");
-
-        settings0.severity.enable(Severity::warning);
-        settings0.severity.enable(Severity::style);
-        settings0.severity.enable(Severity::portability);
-
         TEST_CASE(noerr1);
         TEST_CASE(noerr2);
         TEST_CASE(noerr3);
@@ -5526,9 +5520,7 @@ private:
 
     void checkPipeParameterSize() { // #3521
 
-        Settings settings;
-        LOAD_LIB_2(settings.library, "posix.cfg");
-        settings.libraries.emplace_back("posix");
+        const Settings settings = settingsBuilder().library("posix.cfg").build();
 
         check("void f(){\n"
               "int pipefd[1];\n" // <--  array of two integers is needed

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3350,6 +3350,7 @@ private:
 
     void buffer_overrun_errorpath() {
         setMultiline();
+        const Settings settingsOld = settings0;
         settings0.templateLocation = "{file}:{line}:note:{info}";
 
         check("void f() {\n"
@@ -3359,6 +3360,10 @@ private:
         ASSERT_EQUALS("test.cpp:3:error:Buffer is accessed out of bounds: p\n"
                       "test.cpp:2:note:Assign p, buffer with size 10\n"
                       "test.cpp:3:note:Buffer overrun\n", errout.str());
+
+        // TODO: need to reset this but it breaks other tests
+        (void)settingsOld;
+        //settings0 = settingsOld;
     }
 
     void buffer_overrun_bailoutIfSwitch() {

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -5520,7 +5520,7 @@ private:
 
     void checkPipeParameterSize() { // #3521
 
-        const Settings settings = settingsBuilder().library("posix.cfg").build();
+        static const Settings settings = settingsBuilder().library("posix.cfg").build();
 
         check("void f(){\n"
               "int pipefd[1];\n" // <--  array of two integers is needed

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -5525,7 +5525,7 @@ private:
 
     void checkPipeParameterSize() { // #3521
 
-        static const Settings settings = settingsBuilder().library("posix.cfg").build();
+        const Settings settings = settingsBuilder().library("posix.cfg").build();
 
         check("void f(){\n"
               "int pipefd[1];\n" // <--  array of two integers is needed

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -31,12 +31,10 @@ public:
     TestCharVar() : TestFixture("TestCharVar") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
 
     void run() override {
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unspecified);
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::portability);
 
         TEST_CASE(array_index_1);
         TEST_CASE(array_index_2);

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -137,7 +137,7 @@ private:
     }
 
     std::string parse(const char clang[]) {
-        const Settings settings = settingsBuilder().clang().build();
+        static const Settings settings = settingsBuilder().clang().build();
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(&tokenizer, istr);

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -137,7 +137,7 @@ private:
     }
 
     std::string parse(const char clang[]) {
-        static const Settings settings = settingsBuilder().clang().build();
+        const Settings settings = settingsBuilder().clang().build();
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(&tokenizer, istr);

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -137,8 +137,7 @@ private:
     }
 
     std::string parse(const char clang[]) {
-        Settings settings;
-        settings.clang = true;
+        const Settings settings = settingsBuilder().clang().build();
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(&tokenizer, istr);
@@ -1049,8 +1048,7 @@ private:
 
 
 #define GET_SYMBOL_DB(AST) \
-    Settings settings; \
-    settings.clang = true; \
+    Settings settings = settingsBuilder().clang().build(); \
     { \
         std::string errstr; \
         ASSERT_EQUALS_MSG(true, settings.platform.set("unix64", errstr, {exename.c_str()}), errstr); \

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -259,7 +259,7 @@ private:
     void checkCopyCtorAndEqOperator_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        const Settings settings = settingsBuilder().severity(Severity::warning).build();
+        static const Settings settings = settingsBuilder().severity(Severity::warning).build();
 
         Preprocessor preprocessor(settings);
 
@@ -2886,7 +2886,7 @@ private:
 
 #define checkNoMemset(...) checkNoMemset_(__FILE__, __LINE__, __VA_ARGS__)
     void checkNoMemset_(const char* file, int line, const char code[]) {
-        const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
+        static const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
         checkNoMemset_(file, line, code, settings);
     }
 
@@ -3150,7 +3150,7 @@ private:
                       errout.str());
 
         // #1655
-        const Settings s = settingsBuilder().library("std.cfg").build();
+        static const Settings s = settingsBuilder().library("std.cfg").build();
         checkNoMemset("void f() {\n"
                       "    char c[] = \"abc\";\n"
                       "    std::string s;\n"
@@ -7279,7 +7279,7 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder().severity(Severity::performance).build();
+        static const Settings settings = settingsBuilder().severity(Severity::performance).build();
 
         Preprocessor preprocessor(settings);
 
@@ -7960,7 +7960,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        const Settings settings = settingsBuilder().severity(Severity::style).build();
+        static const Settings settings = settingsBuilder().severity(Severity::style).build();
 
         Preprocessor preprocessor(settings);
 
@@ -8317,7 +8317,7 @@ private:
 
 
     void ctu(const std::vector<std::string> &code) {
-        const Settings settings;
+        static const Settings settings;
         auto &check = getCheck<CheckClass>();
 
         // getFileInfo

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -8317,7 +8317,7 @@ private:
 
 
     void ctu(const std::vector<std::string> &code) {
-        static const Settings settings;
+        const Settings settings;
         auto &check = getCheck<CheckClass>();
 
         // getFileInfo

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -259,7 +259,7 @@ private:
     void checkCopyCtorAndEqOperator_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        static const Settings settings = settingsBuilder().severity(Severity::warning).build();
+        Settings settings = settingsBuilder().severity(Severity::warning).build();
 
         Preprocessor preprocessor(settings);
 
@@ -2886,7 +2886,7 @@ private:
 
 #define checkNoMemset(...) checkNoMemset_(__FILE__, __LINE__, __VA_ARGS__)
     void checkNoMemset_(const char* file, int line, const char code[]) {
-        static const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
+        Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
         checkNoMemset_(file, line, code, settings);
     }
 
@@ -3150,7 +3150,7 @@ private:
                       errout.str());
 
         // #1655
-        static const Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s = settingsBuilder().library("std.cfg").build();
         checkNoMemset("void f() {\n"
                       "    char c[] = \"abc\";\n"
                       "    std::string s;\n"
@@ -7279,7 +7279,7 @@ private:
         errout.str("");
 
         // Check..
-        static const Settings settings = settingsBuilder().severity(Severity::performance).build();
+        Settings settings = settingsBuilder().severity(Severity::performance).build();
 
         Preprocessor preprocessor(settings);
 
@@ -7960,7 +7960,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        static const Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings = settingsBuilder().severity(Severity::style).build();
 
         Preprocessor preprocessor(settings);
 

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -36,13 +36,10 @@ public:
     TestClass() : TestFixture("TestClass") {}
 
 private:
-    Settings settings0;
-    Settings settings1;
+    Settings settings0 = settingsBuilder().severity(Severity::style).build();
+    Settings settings1 = settingsBuilder().severity(Severity::warning).build();
 
     void run() override {
-        settings0.severity.enable(Severity::style);
-        settings1.severity.enable(Severity::warning);
-
         // Load std.cfg configuration
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"
@@ -262,8 +259,7 @@ private:
     void checkCopyCtorAndEqOperator_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        Settings settings;
-        settings.severity.enable(Severity::warning);
+        const Settings settings = settingsBuilder().severity(Severity::warning).build();
 
         Preprocessor preprocessor(settings);
 
@@ -2890,9 +2886,7 @@ private:
 
 #define checkNoMemset(...) checkNoMemset_(__FILE__, __LINE__, __VA_ARGS__)
     void checkNoMemset_(const char* file, int line, const char code[]) {
-        Settings settings;
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::portability);
+        const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
         checkNoMemset_(file, line, code, settings);
     }
 
@@ -3156,8 +3150,7 @@ private:
                       errout.str());
 
         // #1655
-        Settings s;
-        LOAD_LIB_2(s.library, "std.cfg");
+        const Settings s = settingsBuilder().library("std.cfg").build();
         checkNoMemset("void f() {\n"
                       "    char c[] = \"abc\";\n"
                       "    std::string s;\n"
@@ -7231,10 +7224,7 @@ private:
     }
 
     void qualifiedNameMember() { // #10872
-        Settings s;
-        s.severity.enable(Severity::style);
-        s.debugwarnings = true;
-        LOAD_LIB_2(s.library, "std.cfg");
+        Settings s = settingsBuilder().severity(Severity::style).debugwarnings().library("std.cfg").build();
         checkConst("struct data {};\n"
                    "    struct S {\n"
                    "    std::vector<data> std;\n"
@@ -7289,8 +7279,7 @@ private:
         errout.str("");
 
         // Check..
-        Settings settings;
-        settings.severity.enable(Severity::performance);
+        const Settings settings = settingsBuilder().severity(Severity::performance).build();
 
         Preprocessor preprocessor(settings);
 
@@ -7970,8 +7959,8 @@ private:
     void checkOverride_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        Settings settings;
-        settings.severity.enable(Severity::style);
+
+        const Settings settings = settingsBuilder().severity(Severity::style).build();
 
         Preprocessor preprocessor(settings);
 
@@ -8147,9 +8136,9 @@ private:
     void checkUnsafeClassRefMember_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        Settings settings;
+
+        Settings settings = settingsBuilder().severity(Severity::warning).build();
         settings.safeChecks.classes = true;
-        settings.severity.enable(Severity::warning);
 
         Preprocessor preprocessor(settings);
 
@@ -8328,7 +8317,7 @@ private:
 
 
     void ctu(const std::vector<std::string> &code) {
-        Settings settings;
+        const Settings settings;
         auto &check = getCheck<CheckClass>();
 
         // getFileInfo

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -37,9 +37,8 @@
 
 class TestCmdlineParser : public TestFixture {
 public:
-    TestCmdlineParser()
-        : TestFixture("TestCmdlineParser")
-        , defParser(settings, settings.nomsg, settings.nofail) {
+    TestCmdlineParser() : TestFixture("TestCmdlineParser")
+    {
 #if defined(_WIN64) || defined(_WIN32)
         CmdLineParser::SHOW_DEF_PLATFORM_MSG = false;
 #endif
@@ -53,7 +52,7 @@ public:
 
 private:
     Settings settings; // TODO: reset after each test
-    CmdLineParser defParser; // TODO: reset after each test
+    CmdLineParser defParser{settings, settings.nomsg, settings.nofail}; // TODO: reset after each test
 
     void run() override {
         TEST_CASE(nooptions);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -39,28 +39,19 @@ public:
     TestCondition() : TestFixture("TestCondition") {}
 
 private:
-    Settings settings0;
-    Settings settings1;
+    Settings settings0 = settingsBuilder().library("qt.cfg").library("std.cfg").severity(Severity::style).severity(Severity::warning).build();
+    Settings settings1 = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
 
     void run() override {
         // known platform..
         PLATFORM(settings0.platform, cppcheck::Platform::Type::Native);
         PLATFORM(settings1.platform, cppcheck::Platform::Type::Native);
 
-        LOAD_LIB_2(settings0.library, "qt.cfg");
-        settings0.libraries.emplace_back("qt");
-        LOAD_LIB_2(settings0.library, "std.cfg");
-
-        settings0.severity.enable(Severity::style);
-        settings0.severity.enable(Severity::warning);
-
         const char cfg[] = "<?xml version=\"1.0\"?>\n"
                            "<def>\n"
                            "  <function name=\"bar\"> <pure/> </function>\n"
                            "</def>";
         ASSERT(settings1.library.loadxmldata(cfg, sizeof(cfg)));
-        settings1.severity.enable(Severity::style);
-        settings1.severity.enable(Severity::warning);
 
         TEST_CASE(assignAndCompare);   // assignment and comparison don't match
         TEST_CASE(mismatchingBitAnd);  // overlapping bitmasks
@@ -5644,8 +5635,7 @@ private:
     }
 
     void compareOutOfTypeRange() {
-        Settings settingsUnix64;
-        settingsUnix64.severity.enable(Severity::style);
+        Settings settingsUnix64 = settingsBuilder().severity(Severity::style).build();
         PLATFORM(settingsUnix64.platform, cppcheck::Platform::Type::Unix64);
 
         check("void f(unsigned char c) {\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -32,22 +32,22 @@ public:
     TestConstructors() : TestFixture("TestConstructors") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check class constructors..
-        CheckClass checkClass(&tokenizer, &settings, this);
+        CheckClass checkClass(&tokenizer, &settings1, this);
         checkClass.constructors();
     }
 
@@ -66,9 +66,6 @@ private:
     }
 
     void run() override {
-        settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::warning);
-
         TEST_CASE(simple1);
         TEST_CASE(simple2);
         TEST_CASE(simple3);
@@ -1950,9 +1947,8 @@ private:
     }
 
     void initvar_smartptr() { // #10237
-        Settings s;
         // TODO: test shuld probably not pass without library
-        //LOAD_LIB_2(s.library, "std.cfg");
+        const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
         check("struct S {\n"
               "    explicit S(const std::shared_ptr<S>& sp) {\n"
               "        set(*sp);\n"
@@ -1994,11 +1990,7 @@ private:
               "{ }", true);
         ASSERT_EQUALS("[test.cpp:13]: (warning, inconclusive) Member variable 'Fred::ints' is not assigned a value in 'Fred::operator='.\n", errout.str());
 
-        Settings s;
-        s.certainty.setEnabled(Certainty::inconclusive, true);
-        s.severity.enable(Severity::style);
-        s.severity.enable(Severity::warning);
-        LOAD_LIB_2(s.library, "std.cfg");
+        const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
         check("struct S {\n"
               "    S& operator=(const S& s) { return *this; }\n"
               "    std::mutex m;\n"
@@ -3610,10 +3602,8 @@ private:
     }
 
     void uninitVarInheritClassInit() {
-        Settings s;
         // TODO: test should probably not pass without library
-        //LOAD_LIB_2(s.library, "vcl.cfg");
-        //s.libraries.emplace_back("vcl");
+        const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
 
         check("class Fred: public TObject\n"
               "{\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1948,7 +1948,7 @@ private:
 
     void initvar_smartptr() { // #10237
         // TODO: test should probably not pass without library
-        static const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
+        const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
         check("struct S {\n"
               "    explicit S(const std::shared_ptr<S>& sp) {\n"
               "        set(*sp);\n"
@@ -1990,7 +1990,7 @@ private:
               "{ }", true);
         ASSERT_EQUALS("[test.cpp:13]: (warning, inconclusive) Member variable 'Fred::ints' is not assigned a value in 'Fred::operator='.\n", errout.str());
 
-        static const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
+        const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
         check("struct S {\n"
               "    S& operator=(const S& s) { return *this; }\n"
               "    std::mutex m;\n"
@@ -3603,7 +3603,7 @@ private:
 
     void uninitVarInheritClassInit() {
         // TODO: test should probably not pass without library
-        static const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
+        const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
 
         check("class Fred: public TObject\n"
               "{\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1947,8 +1947,8 @@ private:
     }
 
     void initvar_smartptr() { // #10237
-        // TODO: test shuld probably not pass without library
-        const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
+        // TODO: test should probably not pass without library
+        static const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
         check("struct S {\n"
               "    explicit S(const std::shared_ptr<S>& sp) {\n"
               "        set(*sp);\n"
@@ -1990,7 +1990,7 @@ private:
               "{ }", true);
         ASSERT_EQUALS("[test.cpp:13]: (warning, inconclusive) Member variable 'Fred::ints' is not assigned a value in 'Fred::operator='.\n", errout.str());
 
-        const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
+        static const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
         check("struct S {\n"
               "    S& operator=(const S& s) { return *this; }\n"
               "    std::mutex m;\n"
@@ -3603,7 +3603,7 @@ private:
 
     void uninitVarInheritClassInit() {
         // TODO: test should probably not pass without library
-        const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
+        static const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
 
         check("class Fred: public TObject\n"
               "{\n"

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -31,11 +31,11 @@
 
 class TestErrorLogger : public TestFixture {
 public:
-    TestErrorLogger() : TestFixture("TestErrorLogger"), fooCpp5("foo.cpp", 5, 1), barCpp8("bar.cpp", 8, 1) {}
+    TestErrorLogger() : TestFixture("TestErrorLogger") {}
 
 private:
-    const ErrorMessage::FileLocation fooCpp5;
-    const ErrorMessage::FileLocation barCpp8;
+    const ErrorMessage::FileLocation fooCpp5{"foo.cpp", 5, 1};
+    const ErrorMessage::FileLocation barCpp8{"bar.cpp", 8, 1};
 
     void run() override {
         TEST_CASE(PatternSearchReplace);

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -29,8 +29,7 @@
 
 class TestFileLister : public TestFixture {
 public:
-    TestFileLister()
-        : TestFixture("TestFileLister") {}
+    TestFileLister() : TestFixture("TestFileLister") {}
 
 private:
     void run() override {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -33,20 +33,10 @@ public:
     TestFunctions() : TestFixture("TestFunctions") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).severity(Severity::performance).severity(Severity::portability).
+                        certainty(Certainty::inconclusive).c(Standards::C11).cpp(Standards::CPP11).library("std.cfg").library("posix.cfg").build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::performance);
-        settings.severity.enable(Severity::portability);
-        settings.certainty.enable(Certainty::inconclusive);
-        settings.standards.c = Standards::C11;
-        settings.standards.cpp = Standards::CPP11;
-        LOAD_LIB_2(settings.library, "std.cfg");
-        LOAD_LIB_2(settings.library, "posix.cfg");
-        settings.libraries.emplace_back("posix");
-
         // Prohibited functions
         TEST_CASE(prohibitedFunctions_posix);
         TEST_CASE(prohibitedFunctions_index);

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -35,13 +35,13 @@ public:
     TestIncompleteStatement() : TestFixture("TestIncompleteStatement") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).build();
 
     void check(const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -54,18 +54,16 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for incomplete statements..
-        CheckOther checkOther(&tokenizer, &settings, this);
+        CheckOther checkOther(&tokenizer, &settings1, this);
         checkOther.checkIncompleteStatement();
     }
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-
         TEST_CASE(test1);
         TEST_CASE(test2);
         TEST_CASE(test3);

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -35,14 +35,9 @@ public:
     TestIO() : TestFixture("TestIO") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").library("windows.cfg").library("qt.cfg").build();
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-        LOAD_LIB_2(settings.library, "windows.cfg");
-        LOAD_LIB_2(settings.library, "qt.cfg");
-        settings.libraries.emplace_back("qt");
-
         TEST_CASE(coutCerrMisusage);
 
         TEST_CASE(wrongMode_simple);
@@ -91,22 +86,23 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        settings.severity.clear();
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::style);
+        Settings settings1 = settings;
+        settings1.severity.clear();
+        settings1.severity.enable(Severity::warning);
+        settings1.severity.enable(Severity::style);
         if (portability)
-            settings.severity.enable(Severity::portability);
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
-        PLATFORM(settings.platform, platform);
+            settings1.severity.enable(Severity::portability);
+        settings1.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        PLATFORM(settings1.platform, platform);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         const std::string file_in = cpp ? "test.cpp" : "test.c";
         ASSERT_LOC(tokenizer.tokenize(istr, file_in.c_str()), file, line);
 
         // Check..
-        CheckIO checkIO(&tokenizer, &settings, this);
+        CheckIO checkIO(&tokenizer, &settings1, this);
         checkIO.checkWrongPrintfScanfArguments();
         if (!onlyFormatStr) {
             checkIO.checkCoutCerrMisusage();

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -36,6 +36,7 @@ public:
 
 private:
     const Settings settings = settingsBuilder().library("std.cfg").library("windows.cfg").library("qt.cfg").build();
+    Settings settings1 = settingsBuilder().library("std.cfg").library("windows.cfg").library("qt.cfg").build();
 
     void run() override {
         TEST_CASE(coutCerrMisusage);
@@ -86,7 +87,6 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        Settings settings1 = settings;
         settings1.severity.clear();
         settings1.severity.enable(Severity::warning);
         settings1.severity.enable(Severity::style);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -2654,7 +2654,7 @@ public:
     TestLeakAutoVarRecursiveCountLimit() : TestFixture("TestLeakAutoVarRecursiveCountLimit") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").checkLibrary().build();
 
     void checkP(const char code[], bool cpp = false) {
         // Clear the error buffer..
@@ -2675,15 +2675,11 @@ private:
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
-        settings.checkLibrary = true;
-
         // Check for leaks..
         runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
     }
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(recursiveCountLimit); // #5872 #6157 #9097
     }
 
@@ -2714,7 +2710,7 @@ public:
     TestLeakAutoVarStrcpy() : TestFixture("TestLeakAutoVarStrcpy") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").checkLibrary().build();
 
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
@@ -2725,15 +2721,11 @@ private:
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        settings.checkLibrary = true;
-
         // Check for leaks..
         runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
     }
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(returnedValue); // #9298
         TEST_CASE(deallocuse2);
         TEST_CASE(fclose_false_positive); // #9575
@@ -2778,7 +2770,7 @@ public:
     TestLeakAutoVarWindows() : TestFixture("TestLeakAutoVarWindows") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("windows.cfg").build();
 
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
@@ -2794,8 +2786,6 @@ private:
     }
 
     void run() override {
-        LOAD_LIB_2(settings.library, "windows.cfg");
-
         TEST_CASE(heapDoubleFree);
     }
 

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -41,7 +41,7 @@ public:
     TestLibrary() : TestFixture("TestLibrary") {}
 
 private:
-    Settings settings;
+    const Settings settings;
 
     void run() override {
         TEST_CASE(isCompliantValidationExpression);

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -38,7 +38,7 @@ public:
     TestMemleak() : TestFixture("TestMemleak") {}
 
 private:
-    Settings settings;
+    const Settings settings;
 
     void run() override {
         TEST_CASE(testFunctionReturnType);
@@ -125,34 +125,25 @@ public:
     TestMemleakInFunction() : TestFixture("TestMemleakInFunction") {}
 
 private:
-    Settings settings0;
-    Settings settings1;
-    Settings settings2;
+    const Settings settings = settingsBuilder().library("std.cfg").library("posix.cfg").build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
         errout.str("");
 
-        Settings *settings = &settings1;
-
         // Tokenize..
-        Tokenizer tokenizer(settings, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check for memory leaks..
-        CheckMemoryLeakInFunction checkMemoryLeak(&tokenizer, settings, this);
+        CheckMemoryLeakInFunction checkMemoryLeak(&tokenizer, &settings, this);
         checkMemoryLeak.checkReallocUsage();
     }
 
 
     void run() override {
-        LOAD_LIB_2(settings1.library, "std.cfg");
-        LOAD_LIB_2(settings1.library, "posix.cfg");
-        settings1.libraries.emplace_back("posix");
-        LOAD_LIB_2(settings2.library, "std.cfg");
-
         TEST_CASE(realloc1);
         TEST_CASE(realloc2);
         TEST_CASE(realloc3);
@@ -470,7 +461,7 @@ public:
     TestMemleakInClass() : TestFixture("TestMemleakInClass") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).library("std.cfg").build();
 
     /**
      * Tokenize and execute leak check for given code
@@ -491,11 +482,6 @@ private:
     }
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::style);
-
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(class1);
         TEST_CASE(class2);
         TEST_CASE(class3);
@@ -1686,7 +1672,7 @@ public:
     TestMemleakStructMember() : TestFixture("TestMemleakStructMember") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").library("posix.cfg").build();
 
     void check_(const char* file, int line, const char code[], bool isCPP = true) {
         // Clear the error buffer..
@@ -1703,10 +1689,6 @@ private:
     }
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-        LOAD_LIB_2(settings.library, "posix.cfg");
-        settings.libraries.emplace_back("posix");
-
         // testing that errors are detected
         TEST_CASE(err);
 
@@ -2274,7 +2256,7 @@ public:
     TestMemleakNoVar() : TestFixture("TestMemleakNoVar") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::warning).library("std.cfg").library("posix.cfg").build();
 
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
@@ -2291,13 +2273,6 @@ private:
     }
 
     void run() override {
-        settings.certainty.setEnabled(Certainty::inconclusive, true);
-        settings.severity.enable(Severity::warning);
-
-        LOAD_LIB_2(settings.library, "std.cfg");
-        LOAD_LIB_2(settings.library, "posix.cfg");
-        settings.libraries.emplace_back("posix");
-
         // pass allocated memory to function..
         TEST_CASE(functionParameter);
 

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -41,12 +41,9 @@ public:
     TestNullPointer() : TestFixture("TestNullPointer") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").severity(Severity::warning).build();
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-        settings.severity.enable(Severity::warning);
-
         TEST_CASE(nullpointerAfterLoop);
         TEST_CASE(nullpointer1);
         TEST_CASE(nullpointer2);
@@ -183,22 +180,22 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings, this);
+        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
     }
 
     void checkP(const char code[]) {
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, false);
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -211,12 +208,12 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenizer..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings, this);
+        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
     }
 
 
@@ -4052,7 +4049,7 @@ private:
     }
 
     void functioncalllibrary() {
-        Settings settings1;
+        const Settings settings1;
         Tokenizer tokenizer(&settings1,this);
         std::istringstream code("void f() { int a,b,c; x(a,b,c); }");
         ASSERT_EQUALS(true, tokenizer.tokenize(code, "test.c"));

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -195,7 +195,7 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        static const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -195,7 +195,7 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
+        static const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -25,18 +25,13 @@
 
 class TestPathMatch : public TestFixture {
 public:
-    TestPathMatch()
-        : TestFixture("TestPathMatch")
-        , emptyMatcher(std::vector<std::string>())
-        , srcMatcher(std::vector<std::string>(1, "src/"))
-        , fooCppMatcher(std::vector<std::string>(1, "foo.cpp"))
-        , srcFooCppMatcher(std::vector<std::string>(1, "src/foo.cpp")) {}
+    TestPathMatch() : TestFixture("TestPathMatch") {}
 
 private:
-    const PathMatch emptyMatcher;
-    const PathMatch srcMatcher;
-    const PathMatch fooCppMatcher;
-    const PathMatch srcFooCppMatcher;
+    const PathMatch emptyMatcher{std::vector<std::string>()};
+    const PathMatch srcMatcher{std::vector<std::string>(1, "src/")};
+    const PathMatch fooCppMatcher{std::vector<std::string>(1, "foo.cpp")};
+    const PathMatch srcFooCppMatcher{std::vector<std::string>(1, "src/foo.cpp")};
 
     void run() override {
         TEST_CASE(emptymaskemptyfile);

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -30,7 +30,7 @@ public:
     TestPostfixOperator() : TestFixture("TestPostfixOperator") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::performance).build();
 
 #define check(code) check_(code, __FILE__, __LINE__)
     void check_(const char code[], const char* file, int line) {
@@ -48,8 +48,6 @@ private:
     }
 
     void run() override {
-        settings.severity.enable(Severity::performance);
-
         TEST_CASE(testsimple);
         TEST_CASE(testfor);
         TEST_CASE(testvolatile);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -43,9 +43,7 @@ class ErrorLogger;
 
 class TestPreprocessor : public TestFixture {
 public:
-    TestPreprocessor()
-        : TestFixture("TestPreprocessor")
-        , preprocessor0(settings0, this) {}
+    TestPreprocessor() : TestFixture("TestPreprocessor") {}
 
     class OurPreprocessor : public Preprocessor {
     public:
@@ -71,7 +69,7 @@ public:
 
 private:
     Settings settings0 = settingsBuilder().severity(Severity::information).build();
-    Preprocessor preprocessor0;
+    Preprocessor preprocessor0{settings0, this};
 
     void run() override {
 

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -45,9 +45,7 @@ class TestPreprocessor : public TestFixture {
 public:
     TestPreprocessor()
         : TestFixture("TestPreprocessor")
-        , preprocessor0(settings0, this) {
-        settings0.severity.enable(Severity::information);
-    }
+        , preprocessor0(settings0, this) {}
 
     class OurPreprocessor : public Preprocessor {
     public:
@@ -72,7 +70,7 @@ public:
     };
 
 private:
-    Settings settings0;
+    Settings settings0 = settingsBuilder().severity(Severity::information).build();
     Preprocessor preprocessor0;
 
     void run() override {

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -37,14 +37,10 @@ public:
     TestSimplifyTemplate() : TestFixture("TestSimplifyTemplate") {}
 
 private:
-    Settings settings;
+    // If there are unused templates, keep those
+    const Settings settings = settingsBuilder().severity(Severity::portability).checkUnusedTemplates().build();
 
     void run() override {
-        settings.severity.enable(Severity::portability);
-
-        // If there are unused templates, keep those
-        settings.checkUnusedTemplates = true;
-
         TEST_CASE(template1);
         TEST_CASE(template2);
         TEST_CASE(template3);
@@ -313,9 +309,9 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool debugwarnings = false, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        settings.debugwarnings = debugwarnings;
-        PLATFORM(settings.platform, type);
-        Tokenizer tokenizer(&settings, this);
+        Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
+        PLATFORM(settings1.platform, type);
+        Tokenizer tokenizer(&settings1, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -34,24 +34,13 @@ public:
 
 
 private:
-    Settings settings0;
-    Settings settings1;
-    Settings settings_std;
-    Settings settings_windows;
+    // If there are unused templates, keep those
+    const Settings settings0 = settingsBuilder().severity(Severity::portability).checkUnusedTemplates().build();
+    const Settings settings1 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
+    const Settings settings_std = settingsBuilder().library("std.cfg").checkUnusedTemplates().build();
+    const Settings settings_windows = settingsBuilder().library("windows.cfg").severity(Severity::portability).checkUnusedTemplates().build();
 
     void run() override {
-        LOAD_LIB_2(settings_std.library, "std.cfg");
-        LOAD_LIB_2(settings_windows.library, "windows.cfg");
-        settings0.severity.enable(Severity::portability);
-        settings1.severity.enable(Severity::style);
-        settings_windows.severity.enable(Severity::portability);
-
-        // If there are unused templates, keep those
-        settings0.checkUnusedTemplates = true;
-        settings1.checkUnusedTemplates = true;
-        settings_std.checkUnusedTemplates = true;
-        settings_windows.checkUnusedTemplates = true;
-
         TEST_CASE(combine_strings);
         TEST_CASE(combine_wstrings);
         TEST_CASE(combine_ustrings);
@@ -178,13 +167,12 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool simplify = true, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        PLATFORM(settings0.platform, type);
-        Tokenizer tokenizer(&settings0, this);
+        Settings settings = settings0;
+        PLATFORM(settings.platform, type);
+        Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
-
-        (void)simplify;
 
         return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
@@ -206,12 +194,12 @@ private:
     std::string tokenizeAndStringify_(const char* file, int linenr, const char code[], bool simplify = false, bool expand = true, cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const char* filename = "test.cpp", bool cpp11 = true) {
         errout.str("");
 
-        settings1.debugwarnings = true;
-        PLATFORM(settings1.platform, platform);
-        settings1.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
+        Settings settings = settingsBuilder(settings1).debugwarnings().build();
+        PLATFORM(settings.platform, platform);
+        settings.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
 
         // tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -40,19 +40,12 @@ public:
 
 
 private:
-    Settings settings0;
-    Settings settings1;
-    Settings settings2;
+    // If there are unused templates, keep those
+    const Settings settings0 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
+    const Settings settings1 = settingsBuilder().checkUnusedTemplates().build();
+    const Settings settings2 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
 
     void run() override {
-        settings0.severity.enable(Severity::style);
-        settings2.severity.enable(Severity::style);
-
-        // If there are unused templates, keep those
-        settings0.checkUnusedTemplates = true;
-        settings1.checkUnusedTemplates = true;
-        settings2.checkUnusedTemplates = true;
-
         TEST_CASE(c1);
         TEST_CASE(c2);
         TEST_CASE(canreplace1);
@@ -234,10 +227,10 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool simplify = true, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native, bool debugwarnings = true) {
         errout.str("");
 
-        settings0.certainty.enable(Certainty::inconclusive);
-        settings0.debugwarnings = debugwarnings;   // show warnings about unhandled typedef
-        PLATFORM(settings0.platform, type);
-        Tokenizer tokenizer(&settings0, this);
+        // show warnings about unhandled typedef
+        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
+        PLATFORM(settings.platform, type);
+        Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -286,9 +279,9 @@ private:
     void checkSimplifyTypedef_(const char code[], const char* file, int line) {
         errout.str("");
         // Tokenize..
-        settings2.certainty.enable(Certainty::inconclusive);
-        settings2.debugwarnings = true;   // show warnings about unhandled typedef
-        Tokenizer tokenizer(&settings2, this);
+        // show warnings about unhandled typedef
+        const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
     }

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -280,7 +280,7 @@ private:
         errout.str("");
         // Tokenize..
         // show warnings about unhandled typedef
-        const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
+        static const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -280,7 +280,7 @@ private:
         errout.str("");
         // Tokenize..
         // show warnings about unhandled typedef
-        static const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
+        const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -39,19 +39,12 @@ public:
 
 
 private:
-    Settings settings0;
-    Settings settings1;
-    Settings settings2;
+    // If there are unused templates, keep those
+    const Settings settings0 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
+    const Settings settings1 = settingsBuilder().checkUnusedTemplates().build();
+    const Settings settings2 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
 
     void run() override {
-        settings0.severity.enable(Severity::style);
-        settings2.severity.enable(Severity::style);
-
-        // If there are unused templates, keep those
-        settings0.checkUnusedTemplates = true;
-        settings1.checkUnusedTemplates = true;
-        settings2.checkUnusedTemplates = true;
-
         TEST_CASE(simplifyUsing1);
         TEST_CASE(simplifyUsing2);
         TEST_CASE(simplifyUsing3);
@@ -107,10 +100,9 @@ private:
     std::string tok_(const char* file, int line, const char code[], cppcheck::Platform::Type type = cppcheck::Platform::Type::Native, bool debugwarnings = true, bool preprocess = false) {
         errout.str("");
 
-        settings0.certainty.enable(Certainty::inconclusive);
-        settings0.debugwarnings = debugwarnings;
-        PLATFORM(settings0.platform, type);
-        Tokenizer tokenizer(&settings0, this);
+        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
+        PLATFORM(settings.platform, type);
+        Tokenizer tokenizer(&settings, this);
 
         if (preprocess) {
             std::vector<std::string> files{ "test.cpp" };

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -36,13 +36,9 @@ public:
     TestSizeof() : TestFixture("TestSizeof") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).certainty(Certainty::inconclusive).build();
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::portability);
-        settings.certainty.enable(Certainty::inconclusive);
-
         TEST_CASE(sizeofsizeof);
         TEST_CASE(sizeofCalculation);
         TEST_CASE(sizeofFunction);

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -35,14 +35,9 @@ public:
     TestStl() : TestFixture("TestStl") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).severity(Severity::performance).library("std.cfg").build();
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::style);
-        settings.severity.enable(Severity::performance);
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(outOfBounds);
         TEST_CASE(outOfBoundsSymbolic);
         TEST_CASE(outOfBoundsIndexExpression);
@@ -185,17 +180,15 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
-        settings.standards.cpp = cppstandard;
-
+        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).cpp(cppstandard).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
 
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        runChecks<CheckStl>(&tokenizer, &settings, this);
+        runChecks<CheckStl>(&tokenizer, &settings1, this);
     }
 
     void check_(const char* file, int line, const std::string& code, const bool inconclusive = false) {

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -35,7 +35,7 @@ public:
     TestStl() : TestFixture("TestStl") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).severity(Severity::performance).library("std.cfg").build();
+    Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).severity(Severity::performance).library("std.cfg").build();
 
     void run() override {
         TEST_CASE(outOfBounds);

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -32,12 +32,9 @@ public:
     TestString() : TestFixture("TestString") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).build();
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-        settings.severity.enable(Severity::style);
-
         TEST_CASE(stringLiteralWrite);
 
         TEST_CASE(alwaysTrueFalseStringCompare);

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -44,7 +44,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -44,7 +44,7 @@ private:
         errout.str("");
 
         // tokenize..
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -44,7 +44,7 @@ private:
         errout.str("");
 
         // tokenize..
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -63,14 +63,11 @@ class TestSymbolDatabase;
 
 class TestSymbolDatabase : public TestFixture {
 public:
-    TestSymbolDatabase()
-        : TestFixture("TestSymbolDatabase")
-        ,vartok(nullptr)
-        ,typetok(nullptr) {}
+    TestSymbolDatabase() : TestFixture("TestSymbolDatabase") {}
 
 private:
-    const Token* vartok;
-    const Token* typetok;
+    const Token* vartok{nullptr};
+    const Token* typetok{nullptr};
     // If there are unused templates, keep those
     Settings settings1 = settingsBuilder().library("std.cfg").checkUnusedTemplates().build();
     Settings settings2 = settingsBuilder().checkUnusedTemplates().build();

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -71,8 +71,9 @@ public:
 private:
     const Token* vartok;
     const Token* typetok;
-    Settings settings1;
-    Settings settings2;
+    // If there are unused templates, keep those
+    Settings settings1 = settingsBuilder().library("std.cfg").checkUnusedTemplates().build();
+    Settings settings2 = settingsBuilder().checkUnusedTemplates().build();
 
     void reset() {
         vartok = nullptr;
@@ -117,12 +118,7 @@ private:
     }
 
     void run() override {
-        LOAD_LIB_2(settings1.library, "std.cfg");
         PLATFORM(settings2.platform, cppcheck::Platform::Type::Unspecified);
-
-        // If there are unused templates, keep those
-        settings1.checkUnusedTemplates = true;
-        settings2.checkUnusedTemplates = true;
 
         TEST_CASE(array);
         TEST_CASE(array_ptr);
@@ -2311,17 +2307,15 @@ private:
         errout.str("");
 
         // Check..
-        settings1.debugwarnings = debug;
+        const Settings settings = settingsBuilder(settings1).debugwarnings(debug).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // force symbol database creation
         tokenizer.createSymbolDatabase();
-
-        settings1.debugwarnings = false;
     }
 
     void functionArgs1() {

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -39,7 +39,7 @@ public:
     TestThreadExecutor() : TestFixture("TestThreadExecutor") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().library("std.cfg").build();
 
     /**
      * Execute check using n jobs for y files which are have
@@ -64,12 +64,13 @@ private:
             }
         }
 
-        settings.jobs = jobs;
-        settings.showtime = showtime;
+        Settings settings1 = settings;
+        settings1.jobs = jobs;
+        settings1.showtime = showtime;
         if (plistOutput)
-            settings.plistOutput = plistOutput;
+            settings1.plistOutput = plistOutput;
         // TODO: test with settings.project.fileSettings;
-        ThreadExecutor executor(filemap, settings, *this);
+        ThreadExecutor executor(filemap, settings1, *this);
         std::vector<std::unique_ptr<ScopedFile>> scopedfiles;
         scopedfiles.reserve(filemap.size());
         for (std::map<std::string, std::size_t>::const_iterator i = filemap.cbegin(); i != filemap.cend(); ++i)
@@ -79,8 +80,6 @@ private:
     }
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(deadlock_with_many_errors);
         TEST_CASE(many_threads);
         TEST_CASE(many_threads_showtime);

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -39,7 +39,7 @@ public:
     TestThreadExecutor() : TestFixture("TestThreadExecutor") {}
 
 private:
-    const Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings = settingsBuilder().library("std.cfg").build();
 
     /**
      * Execute check using n jobs for y files which are have

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -135,7 +135,7 @@ private:
 
 #define MatchCheck(...) MatchCheck_(__FILE__, __LINE__, __VA_ARGS__)
     bool MatchCheck_(const char* file, int line, const std::string& code, const std::string& pattern, unsigned int varid = 0) {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(";" + code + ";");
         try {
@@ -395,7 +395,7 @@ private:
 
     void getStrSize() const {
         Token tok;
-        static const Settings settings;
+        const Settings settings;
 
         tok.str("\"\"");
         ASSERT_EQUALS(sizeof(""), Token::getStrSize(&tok, &settings));

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -395,7 +395,7 @@ private:
 
     void getStrSize() const {
         Token tok;
-        const Settings settings;
+        static const Settings settings;
 
         tok.str("\"\"");
         ASSERT_EQUALS(sizeof(""), Token::getStrSize(&tok, &settings));

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -395,7 +395,7 @@ private:
 
     void getStrSize() const {
         Token tok;
-        Settings settings;
+        const Settings settings;
 
         tok.str("\"\"");
         ASSERT_EQUALS(sizeof(""), Token::getStrSize(&tok, &settings));

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -524,7 +524,7 @@ private:
     std::string tokenizeDebugListing_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
         errout.str("");
 
-        const Settings settings = settingsBuilder(settings2).c(Standards::C89).cpp(Standards::CPP03).build();
+        static const Settings settings = settingsBuilder(settings2).c(Standards::C89).cpp(Standards::CPP03).build();
 
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -44,28 +44,13 @@ public:
     TestTokenizer() : TestFixture("TestTokenizer") {}
 
 private:
-    Settings settings0;
-    Settings settings1;
-    Settings settings2;
-    Settings settings_windows;
+    // If there are unused templates, keep those
+    Settings settings0 = settingsBuilder().library("qt.cfg").checkUnusedTemplates().build();
+    const Settings settings1 = settingsBuilder().library("qt.cfg").checkUnusedTemplates().build();
+    const Settings settings2 = settingsBuilder().library("qt.cfg").checkUnusedTemplates().build();
+    const Settings settings_windows = settingsBuilder().library("windows.cfg").checkUnusedTemplates().build();
 
     void run() override {
-        LOAD_LIB_2(settings_windows.library, "windows.cfg");
-
-        // If there are unused templates, keep those
-        settings0.checkUnusedTemplates = true;
-        settings1.checkUnusedTemplates = true;
-        settings2.checkUnusedTemplates = true;
-        settings_windows.checkUnusedTemplates = true;
-
-        // library=qt
-        LOAD_LIB_2(settings0.library, "qt.cfg");
-        settings0.libraries.emplace_back("qt");
-        LOAD_LIB_2(settings1.library, "qt.cfg");
-        settings1.libraries.emplace_back("qt");
-        LOAD_LIB_2(settings2.library, "qt.cfg");
-        settings2.libraries.emplace_back("qt");
-
         TEST_CASE(tokenize1);
         TEST_CASE(tokenize2);
         TEST_CASE(tokenize4);
@@ -471,12 +456,11 @@ private:
     std::string tokenizeAndStringify_(const char* file, int linenr, const char code[], bool expand = true, cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const char* filename = "test.cpp", Standards::cppstd_t std = Standards::CPP11) {
         errout.str("");
 
-        settings1.debugwarnings = true;
-        PLATFORM(settings1.platform, platform);
-        settings1.standards.cpp = std;
+        Settings settings = settingsBuilder(settings1).debugwarnings().cpp(std).build();
+        PLATFORM(settings.platform, platform);
 
         // tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 
@@ -500,12 +484,11 @@ private:
     std::string tokenizeAndStringifyWindows_(const char* file, int linenr, const char code[], bool expand = true, cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const char* filename = "test.cpp", bool cpp11 = true) {
         errout.str("");
 
-        settings_windows.debugwarnings = true;
-        PLATFORM(settings_windows.platform, platform);
-        settings_windows.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
+        Settings settings = settingsBuilder(settings_windows).debugwarnings().cpp(cpp11 ? Standards::CPP11 : Standards::CPP03).build();
+        PLATFORM(settings.platform, platform);
 
         // tokenize..
-        Tokenizer tokenizer(&settings_windows, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 
@@ -541,10 +524,9 @@ private:
     std::string tokenizeDebugListing_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
         errout.str("");
 
-        settings2.standards.c = Standards::C89;
-        settings2.standards.cpp = Standards::CPP03;
+        const Settings settings = settingsBuilder(settings2).c(Standards::C89).cpp(Standards::CPP03).build();
 
-        Tokenizer tokenizer(&settings2, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -524,7 +524,7 @@ private:
     std::string tokenizeDebugListing_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
         errout.str("");
 
-        static const Settings settings = settingsBuilder(settings2).c(Standards::C89).cpp(Standards::CPP03).build();
+        const Settings settings = settingsBuilder(settings2).c(Standards::C89).cpp(Standards::CPP03).build();
 
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -40,7 +40,7 @@ private:
     }
 
     // inspired by #5895
-    void testaddtoken1() {
+    void testaddtoken1() const {
         const std::string code = "0x89504e470d0a1a0a";
         TokenList tokenlist(&settings);
         tokenlist.addtoken(code, 1, 1, false);
@@ -69,7 +69,7 @@ private:
         ASSERT(Token::simpleMatch(tokenlist.front(), "a + + 1 ; 1 + + b ;"));
     }
 
-    void isKeyword() {
+    void isKeyword() const {
 
         const char code[] = "for a int delete true";
 

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -30,7 +30,7 @@ public:
     TestTokenList() : TestFixture("TestTokenList") {}
 
 private:
-    Settings settings;
+    const Settings settings;
 
     void run() override {
         TEST_CASE(testaddtoken1);
@@ -49,8 +49,9 @@ private:
 
     void testaddtoken2() {
         const std::string code = "0xF0000000";
-        settings.platform.int_bit = 32;
-        TokenList tokenlist(&settings);
+        Settings settings1;
+        settings1.platform.int_bit = 32;
+        TokenList tokenlist(&settings1);
         tokenlist.addtoken(code, 1, 1, false);
         ASSERT_EQUALS("0xF0000000", tokenlist.front()->str());
     }

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -47,7 +47,7 @@ private:
         ASSERT_EQUALS("0x89504e470d0a1a0a", tokenlist.front()->str());
     }
 
-    void testaddtoken2() {
+    void testaddtoken2() const {
         const std::string code = "0xF0000000";
         Settings settings1;
         settings1.platform.int_bit = 32;

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -101,7 +101,7 @@ private:
     }
 
     void scopeExample() const {
-        Settings settings;
+        const Settings settings;
         Tokenizer tokenizer{ &settings, nullptr };
         std::istringstream sample("void a(){} void main(){ if(true){a();} }");
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -101,7 +101,7 @@ private:
     }
 
     void scopeExample() const {
-        static const Settings settings;
+        const Settings settings;
         Tokenizer tokenizer{ &settings, nullptr };
         std::istringstream sample("void a(){} void main(){ if(true){a();} }");
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -101,7 +101,7 @@ private:
     }
 
     void scopeExample() const {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer{ &settings, nullptr };
         std::istringstream sample("void a(){} void main(){ if(true){a();} }");
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -238,9 +238,8 @@ private:
     }
 
     void checkIntegerOverflow() {
-        Settings settings;
+        Settings settings = settingsBuilder().severity(Severity::warning).build();
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unix32);
-        settings.severity.enable(Severity::warning);
 
         check("x = (int)0x10000 * (int)0x10000;", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Signed integer overflow for expression '(int)0x10000*(int)0x10000'.\n", errout.str());
@@ -331,8 +330,7 @@ private:
     }
 
     void longCastAssign() {
-        Settings settings;
-        settings.severity.enable(Severity::style);
+        Settings settings = settingsBuilder().severity(Severity::style).build();
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
 
         check("long f(int x, int y) {\n"
@@ -363,8 +361,7 @@ private:
     }
 
     void longCastReturn() {
-        Settings settings;
-        settings.severity.enable(Severity::style);
+        Settings settings = settingsBuilder().severity(Severity::style).build();
 
         check("long f(int x, int y) {\n"
               "  return x * y;\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -35,11 +35,9 @@ public:
     TestUninitVar() : TestFixture("TestUninitVar") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().library("std.cfg").build();
 
     void run() override {
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(uninitvar1);
         TEST_CASE(uninitvar_warn_once); // only write 1 warning at a time
         TEST_CASE(uninitvar_decl);      // handling various types in C and C++ files
@@ -111,14 +109,15 @@ private:
         // Clear the error buffer..
         errout.str("");
 
+        const Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
+
         // Tokenize..
-        settings.debugwarnings = debugwarnings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, fname), file, line);
 
         // Check for redundant code..
-        CheckUninitVar checkuninitvar(&tokenizer, &settings, this);
+        CheckUninitVar checkuninitvar(&tokenizer, &settings1, this);
         checkuninitvar.check();
 
         settings.debugwarnings = false;

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -31,11 +31,9 @@ public:
     TestUnusedFunctions() : TestFixture("TestUnusedFunctions") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::style).build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-
         TEST_CASE(incondition);
         TEST_CASE(return1);
         TEST_CASE(return2);

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -36,11 +36,9 @@ public:
     TestUnusedPrivateFunction() : TestFixture("TestUnusedPrivateFunction") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::style).build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-
         TEST_CASE(test1);
         TEST_CASE(test2);
         TEST_CASE(test3);

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -37,13 +37,9 @@ public:
     TestUnusedVar() : TestFixture("TestUnusedVar") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().severity(Severity::style).checkLibrary().library("std.cfg").build();
 
     void run() override {
-        settings.severity.enable(Severity::style);
-        settings.checkLibrary = true;
-        LOAD_LIB_2(settings.library, "std.cfg");
-
         TEST_CASE(isRecordTypeWithoutSideEffects);
         TEST_CASE(cleanFunction);
 

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -26,8 +26,6 @@
 #include <limits>
 #include <string>
 
-const Settings givenACodeSampleToTokenize::settings;
-
 class TestUtils : public TestFixture {
 public:
     TestUtils() : TestFixture("TestUtils") {}

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -31,7 +31,7 @@ public:
     TestVaarg() : TestFixture("TestVaarg") {}
 
 private:
-    Settings settings;
+    const Settings settings = settingsBuilder().severity(Severity::warning).build();
 
 #define check(code) check_(code, __FILE__, __LINE__)
     void check_(const char code[], const char* file, int line) {
@@ -48,8 +48,6 @@ private:
     }
 
     void run() override {
-        settings.severity.enable(Severity::warning);
-
         TEST_CASE(wrongParameterTo_va_start);
         TEST_CASE(referenceAs_va_start);
         TEST_CASE(va_end_missing);

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -46,7 +46,7 @@ public:
     TestValueFlow() : TestFixture("TestValueFlow") {}
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().library("std.cfg").build();
 
     void run() override {
         // strcpy, abort cfg
@@ -56,7 +56,6 @@ private:
                            "  <function name=\"abort\"> <noreturn>true</noreturn> </function>\n" // abort is a noreturn function
                            "</def>";
         ASSERT_EQUALS(true, settings.library.loadxmldata(cfg, sizeof(cfg)));
-        LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(valueFlowNumber);
         TEST_CASE(valueFlowString);
@@ -6572,8 +6571,7 @@ private:
     void valueFlowSafeFunctionParameterValues() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s;
-        LOAD_LIB_2(s.library, "std.cfg");
+        Settings s = settingsBuilder().library("std.cfg").build();
         s.safeChecks.classes = s.safeChecks.externalFunctions = s.safeChecks.internalFunctions = true;
 
         code = "short f(short x) {\n"
@@ -6624,8 +6622,7 @@ private:
     void valueFlowUnknownFunctionReturn() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s;
-        LOAD_LIB_2(s.library, "std.cfg");
+        Settings s = settingsBuilder().library("std.cfg").build();
         s.checkUnknownFunctionReturn.insert("rand");
 
         code = "x = rand();";

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -33,13 +33,10 @@ class TestVarID : public TestFixture {
 public:
     TestVarID() : TestFixture("TestVarID") {
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
-        settings.standards.c = Standards::C89;
-        settings.standards.cpp = Standards::CPPLatest;
-        settings.checkUnusedTemplates = true;
     }
 
 private:
-    Settings settings;
+    Settings settings = settingsBuilder().c(Standards::C89).cpp(Standards::CPPLatest).checkUnusedTemplates().build();
     void run() override {
         TEST_CASE(varid1);
         TEST_CASE(varid2);

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -31,13 +31,13 @@
 
 class TestVarID : public TestFixture {
 public:
-    TestVarID() : TestFixture("TestVarID") {
-        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
-    }
+    TestVarID() : TestFixture("TestVarID") {}
 
 private:
     Settings settings = settingsBuilder().c(Standards::C89).cpp(Standards::CPPLatest).checkUnusedTemplates().build();
     void run() override {
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
+
         TEST_CASE(varid1);
         TEST_CASE(varid2);
         TEST_CASE(varid3);


### PR DESCRIPTION
Currently the `Settings` objects in the tests are all mutable. This might cause some tests to modify the settings as they also contain run-time information which will be used by subsequent tests using the same object.

We should make sure that they are `const` if possible. Otherwise we need to make sure the tests will always be run on a a fixed configuration.