### PR TITLE
improved `Path` handling of mixed separators

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -226,15 +226,11 @@ std::string Path::getAbsoluteFilePath(const std::string& filePath)
     return absolute_path;
 }
 
-std::string Path::stripDirectoryPart(const std::string &file)
+std::string Path::stripDirectoryPart(std::string file)
 {
-#if defined(_WIN32) && !defined(__MINGW32__)
-    const char native = '\\';
-#else
-    const char native = '/';
-#endif
+    file = fromNativeSeparators(std::move(file));
 
-    const std::string::size_type p = file.rfind(native);
+    const std::string::size_type p = file.rfind('/');
     if (p != std::string::npos) {
         return file.substr(p + 1);
     }

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -151,9 +151,12 @@ bool Path::isAbsolute(const std::string& path)
     return false;
 }
 
-std::string Path::getRelativePath(const std::string& absolutePath, const std::vector<std::string>& basePaths)
+std::string Path::getRelativePath(std::string absolutePath, const std::vector<std::string>& basePaths)
 {
-    for (const std::string &bp : basePaths) {
+    absolutePath = Path::fromNativeSeparators(std::move(absolutePath));
+
+    for (std::string bp : basePaths) {
+        bp = Path::fromNativeSeparators(std::move(bp));
         if (absolutePath == bp || bp.empty()) // Seems to be a file, or path is empty
             continue;
 
@@ -162,7 +165,7 @@ std::string Path::getRelativePath(const std::string& absolutePath, const std::ve
 
         if (endsWith(bp,'/'))
             return absolutePath.substr(bp.length());
-        else if (absolutePath.size() > bp.size() && absolutePath[bp.length()] == '/')
+        if (absolutePath.size() > bp.size() && absolutePath[bp.length()] == '/')
             return absolutePath.substr(bp.length() + 1);
     }
     return absolutePath;

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -243,6 +243,8 @@ bool Path::fileExists(const std::string &file)
 }
 
 std::string Path::join(std::string path1, std::string path2) {
+    path1 = fromNativeSeparators(std::move(path1));
+    path2 = fromNativeSeparators(std::move(path2));
     if (path1.empty() || path2.empty())
         return path1 + path2;
     if (path2.front() == '/')

--- a/lib/path.h
+++ b/lib/path.h
@@ -117,7 +117,7 @@ public:
      * @param basePaths Paths to which it may be made relative.
      * @return relative path, if possible. Otherwise absolutePath is returned unchanged
      */
-    static std::string getRelativePath(const std::string& absolutePath, const std::vector<std::string>& basePaths);
+    static std::string getRelativePath(std::string absolutePath, const std::vector<std::string>& basePaths);
 
     /**
      * @brief Get an absolute file path from a relative one.

--- a/lib/path.h
+++ b/lib/path.h
@@ -172,7 +172,7 @@ public:
      * @param file filename to be stripped. path info is optional
      * @return filename without directory path part.
      */
-    static std::string stripDirectoryPart(const std::string &file);
+    static std::string stripDirectoryPart(std::string file);
 
     /**
      * @brief Checks if a File exists

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -203,19 +203,19 @@ bool cppcheck::Platform::loadPlatformFile(const char exename[], const std::strin
     std::vector<std::string> filenames;
     filenames.push_back(filename);
     filenames.push_back(filename + ".xml");
-    filenames.push_back("platforms/" + filename);
-    filenames.push_back("platforms/" + filename + ".xml");
+    filenames.push_back(Path::join("platforms", filename));
+    filenames.push_back(Path::join("platforms", filename + ".xml"));
     if (exename && (std::string::npos != Path::fromNativeSeparators(exename).find('/'))) {
         filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + filename);
-        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename);
-        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + "platforms/" + filename + ".xml");
+        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + Path::join("platforms", filename));
+        filenames.push_back(Path::getPathFromFilename(Path::fromNativeSeparators(exename)) + Path::join("platforms", filename + ".xml"));
     }
 #ifdef FILESDIR
     std::string filesdir = FILESDIR;
     if (!filesdir.empty() && filesdir[filesdir.size()-1] != '/')
         filesdir += '/';
-    filenames.push_back(filesdir + ("platforms/" + filename));
-    filenames.push_back(filesdir + ("platforms/" + filename + ".xml"));
+    filenames.push_back(filesdir + Path::join("platforms", filename));
+    filenames.push_back(filesdir + Path::join("platforms", filename + ".xml"));
 #endif
 
     // open file..

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -178,6 +178,8 @@ bool cppcheck::Platform::platform(const std::string& platformstr, std::string& e
         return false;
     }
     else {
+        if (verbose)
+            std::cout << "current working directory '" + Path::getCurrentPath() + "'" << std::endl;
         bool found = false;
         for (const std::string& path : paths) {
             if (verbose)

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7474,7 +7474,7 @@ void ValueType::setDebugPath(const Token* tok, SourceLocation ctx, SourceLocatio
     std::string file = ctx.file_name();
     if (file.empty())
         return;
-    std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
+    std::string s = Path::stripDirectoryPart(std::move(file)) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name();
     debugPath.emplace_back(tok, std::move(s));
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -168,7 +168,7 @@ static void setSourceLocation(ValueFlow::Value& v,
     std::string file = ctx.file_name();
     if (file.empty())
         return;
-    std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
+    std::string s = Path::stripDirectoryPart(std::move(file)) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name() + ": " + debugString(v);
     v.debugPath.emplace_back(tok, std::move(s));
 }

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -39,6 +39,7 @@ private:
         TEST_CASE(get_path_from_filename);
         TEST_CASE(join);
         TEST_CASE(getAbsoluteFilePath);
+        TEST_CASE(stripDirectoryPart);
     }
 
     void removeQuotationMarks() const {
@@ -166,6 +167,18 @@ private:
         ASSERT_EQUALS(Path::join(cwd_down, "inc/a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("../inc/a.h")));
         ASSERT_EQUALS(Path::join(cwd_down, "inc/a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("../inc/../inc/a.h")));
 #endif
+    }
+
+    void stripDirectoryPart() const {
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("a/a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("a/b/a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("/mnt/a/b/a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("a\\a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("a\\b\\a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("S:\\a\\b\\a.h"));
+        ASSERT_EQUALS("a.h", Path::stripDirectoryPart("S:/a/b/a.h"));
+
     }
 };
 

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -173,6 +173,12 @@ private:
         ASSERT_EQUALS("/tmp/", Path::getPathFromFilename("/tmp/index.h"));
         ASSERT_EQUALS("a/b/c/", Path::getPathFromFilename("a/b/c/index.h"));
         ASSERT_EQUALS("a/b/c/", Path::getPathFromFilename("a/b/c/"));
+        ASSERT_EQUALS("S:\\tmp\\", Path::getPathFromFilename("S:\\tmp\\index.h"));
+        ASSERT_EQUALS("a\\b\\c\\", Path::getPathFromFilename("a\\b\\c\\index.h"));
+        ASSERT_EQUALS("a\\b\\c\\", Path::getPathFromFilename("a\\b\\c\\"));
+        ASSERT_EQUALS("S:\\a\\b\\c\\", Path::getPathFromFilename("S:\\a\\b\\c\\"));
+        ASSERT_EQUALS("S:/tmp/", Path::getPathFromFilename("S:/tmp/index.h"));
+        ASSERT_EQUALS("S:/a/b/c/", Path::getPathFromFilename("S:/a/b/c/index.h"));
     }
 
     void join() const {

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -148,7 +148,9 @@ private:
         ASSERT_EQUALS("a", Path::join("", "a"));
         ASSERT_EQUALS("a/b", Path::join("a", "b"));
         ASSERT_EQUALS("a/b", Path::join("a/", "b"));
+        ASSERT_EQUALS("a/b", Path::join("a\\", "b"));
         ASSERT_EQUALS("/b", Path::join("a", "/b"));
+        ASSERT_EQUALS("/b", Path::join("a", "\\b"));
     }
 };
 

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -95,18 +95,48 @@ private:
     }
 
     void getRelative() const {
-        const std::vector<std::string> basePaths = {
-            "", // Don't crash with empty paths
-            "C:/foo",
-            "C:/bar/",
-            "C:/test.cpp"
-        };
+        {
+            const std::vector<std::string> basePaths = {
+                "",     // Don't crash with empty paths
+                "C:/foo",
+                "C:/bar/",
+                "C:/test.cpp"
+            };
 
-        ASSERT_EQUALS("x.c", Path::getRelativePath("C:/foo/x.c", basePaths));
-        ASSERT_EQUALS("y.c", Path::getRelativePath("C:/bar/y.c", basePaths));
-        ASSERT_EQUALS("foo/y.c", Path::getRelativePath("C:/bar/foo/y.c", basePaths));
-        ASSERT_EQUALS("C:/test.cpp", Path::getRelativePath("C:/test.cpp", basePaths));
-        ASSERT_EQUALS("C:/foobar/test.cpp", Path::getRelativePath("C:/foobar/test.cpp", basePaths));
+            ASSERT_EQUALS("x.c", Path::getRelativePath("C:/foo/x.c", basePaths));
+            ASSERT_EQUALS("y.c", Path::getRelativePath("C:/bar/y.c", basePaths));
+            ASSERT_EQUALS("foo/y.c", Path::getRelativePath("C:/bar/foo/y.c", basePaths));
+            ASSERT_EQUALS("C:/test.cpp", Path::getRelativePath("C:/test.cpp", basePaths));
+            ASSERT_EQUALS("C:/foobar/test.cpp", Path::getRelativePath("C:/foobar/test.cpp", basePaths));
+        }
+        {
+            const std::vector<std::string> basePaths = {
+                "",     // Don't crash with empty paths
+                "C:\\foo",
+                "C:\\bar\\",
+                "C:\\test.cpp"
+            };
+
+            ASSERT_EQUALS("x.c", Path::getRelativePath("C:\\foo\\x.c", basePaths));
+            ASSERT_EQUALS("y.c", Path::getRelativePath("C:\\bar\\y.c", basePaths));
+            ASSERT_EQUALS("foo/y.c", Path::getRelativePath("C:\\bar\\foo\\y.c", basePaths));
+            ASSERT_EQUALS("C:/test.cpp", Path::getRelativePath("C:\\test.cpp", basePaths));
+            ASSERT_EQUALS("C:/foobar/test.cpp", Path::getRelativePath("C:\\foobar\\test.cpp", basePaths));
+        }
+        {
+            const std::vector<std::string> basePaths = {
+                "",     // Don't crash with empty paths
+                "/c/foo",
+                "/c/bar/",
+                "/c/test.cpp"
+            };
+
+            ASSERT_EQUALS("x.c", Path::getRelativePath("/c/foo/x.c", basePaths));
+            ASSERT_EQUALS("y.c", Path::getRelativePath("/c/bar/y.c", basePaths));
+            ASSERT_EQUALS("foo/y.c", Path::getRelativePath("/c/bar/foo\\y.c", basePaths));
+            ASSERT_EQUALS("/c/test.cpp", Path::getRelativePath("/c/test.cpp", basePaths));
+            ASSERT_EQUALS("/c/foobar/test.cpp", Path::getRelativePath("/c/foobar/test.cpp", basePaths));
+        }
     }
 
     void is_c() const {

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -38,6 +38,7 @@ private:
         TEST_CASE(is_cpp);
         TEST_CASE(get_path_from_filename);
         TEST_CASE(join);
+        TEST_CASE(getAbsoluteFilePath);
     }
 
     void removeQuotationMarks() const {
@@ -151,6 +152,20 @@ private:
         ASSERT_EQUALS("a/b", Path::join("a\\", "b"));
         ASSERT_EQUALS("/b", Path::join("a", "/b"));
         ASSERT_EQUALS("/b", Path::join("a", "\\b"));
+    }
+
+    // TODO: this is quite messy - should Path::getAbsoluteFilePath() return normalized separators?
+    void getAbsoluteFilePath() const {
+        // Path::getAbsoluteFilePath() only works with existing paths on Linux
+#ifdef _WIN32
+        const std::string cwd = Path::getCurrentPath();
+        ASSERT_EQUALS(Path::join(cwd, "a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("a.h")));
+        ASSERT_EQUALS(Path::join(cwd, "inc/a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("inc/a.h")));
+        const std::string cwd_down = Path::getPathFromFilename(cwd);
+        ASSERT_EQUALS(Path::join(cwd_down, "a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("../a.h")));
+        ASSERT_EQUALS(Path::join(cwd_down, "inc/a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("../inc/a.h")));
+        ASSERT_EQUALS(Path::join(cwd_down, "inc/a.h"), Path::fromNativeSeparators(Path::getAbsoluteFilePath("../inc/../inc/a.h")));
+#endif
     }
 };
 


### PR DESCRIPTION
I ran into issues because some functions returned the native separator and some didn't.