### PR TITLE
Add ignoring of .cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ stage
 
 # clang tooling temporary files
 .clangd/
+.cache/
 compile_commands.json
 
 # qmake


### PR DESCRIPTION
clangd currently uses .cache/clangd/index directory to store its files: https://reviews.llvm.org/D83099