### PR TITLE
token.cpp: removed unreachable cases from `multiComparePercent()`

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -436,14 +436,6 @@ static int multiComparePercent(const Token *tok, const char*& haystack, nonneg i
     ++haystack;
     // Compare only the first character of the string for optimization reasons
     switch (haystack[0]) {
-    case '\0':
-    case ' ':
-    case '|':
-        //simple '%' character
-        haystack += 1;
-        if (tok->isArithmeticalOp() && tok->str() == "%")
-            return 1;
-        break;
     case 'v':
         if (haystack[3] == '%') { // %var%
             haystack += 4;


### PR DESCRIPTION
The calling function `multiCompare()` already explicitly checks that those characters are not present so we don't need to handle them in the switch.

It also seems to lead to better inlining and improve the performance by a few percent.