### PR TITLE
Fix #11577 FN unusedStructMember when casting address (regression, reverts #10684)

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1466,20 +1466,6 @@ void CheckUnusedVar::checkStructMemberUsage()
                 bailout = true;
                 break;
             }
-            if (var && (var->typeStartToken()->str() == scope.className || var->typeEndToken()->str() == scope.className)) {
-                const std::string addressPattern("!!" + scope.className + " & " + var->name()); // cast from struct
-                const Token* addrTok = scope.bodyEnd;
-                do {
-                    addrTok = Token::findmatch(addrTok, addressPattern.c_str());
-                    if ((addrTok && addrTok->str() == ")" && addrTok->link()->isCast()) || isCPPCast(addrTok)) {
-                        bailout = true;
-                        break;
-                    }
-                    if (addrTok)
-                        addrTok = addrTok->next();
-                } while (addrTok);
-            }
-
             if (bailout)
                 break;
         }

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -1651,7 +1651,7 @@ private:
                                "    uint8_t* p = (uint8_t*)&s;\n"
                                "    return p[10];\n"
                                "};\n");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:1]: (style) struct member 'S::padding' is never used.\n", errout.str());
 
         checkStructMemberUsage("struct S { uint8_t padding[500]; };\n"
                                "uint8_t f(const S& s) {\n"
@@ -1659,7 +1659,14 @@ private:
                                "    auto p = reinterpret_cast<const uint8_t*>(&s);\n"
                                "    return p[10];\n"
                                "};\n");
-        ASSERT_EQUALS("", errout.str());
+        ASSERT_EQUALS("[test.cpp:1]: (style) struct member 'S::padding' is never used.\n", errout.str());
+
+        checkStructMemberUsage("struct S { int i, j; };\n" // #11577
+                               "void f(S s) {\n"
+                               "  void* p = (void*)&s;\n"
+                               "  if (s.i) {}\n"
+                               "}\n");
+        ASSERT_EQUALS("[test.cpp:1]: (style) struct member 'S::j' is never used.\n", errout.str());
     }
 
     void structmember19() {


### PR DESCRIPTION
I think showing a warning for the code from #10684 is reasonable.