### PR TITLE
Fix #10946 Debug warning: autoNoType with lambda

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7148,8 +7148,13 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
 
     if (reportDebugWarnings && mSettings->debugwarnings) {
         for (Token *tok = tokens; tok; tok = tok->next()) {
-            if (tok->str() == "auto" && !tok->valueType())
+            if (tok->str() == "auto" && !tok->valueType()) {
+                //if (Token::Match(tok->next(), "%name% ; %name% = [") && isLambdaCaptureList(tok->tokAt(5)))
+                //    continue;
+                //if (Token::Match(tok->next(), "%name% { [") && isLambdaCaptureList(tok->tokAt(3)))
+                //    continue;
                 debugMessage(tok, "autoNoType", "auto token with no type.");
+            }
         }
     }
 

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7149,10 +7149,10 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
     if (reportDebugWarnings && mSettings->debugwarnings) {
         for (Token *tok = tokens; tok; tok = tok->next()) {
             if (tok->str() == "auto" && !tok->valueType()) {
-                //if (Token::Match(tok->next(), "%name% ; %name% = [") && isLambdaCaptureList(tok->tokAt(5)))
-                //    continue;
-                //if (Token::Match(tok->next(), "%name% { [") && isLambdaCaptureList(tok->tokAt(3)))
-                //    continue;
+                if (Token::Match(tok->next(), "%name% ; %name% = [") && isLambdaCaptureList(tok->tokAt(5)))
+                    continue;
+                if (Token::Match(tok->next(), "%name% { [") && isLambdaCaptureList(tok->tokAt(3)))
+                    continue;
                 debugMessage(tok, "autoNoType", "auto token with no type.");
             }
         }


### PR DESCRIPTION
It seems we cannot trigger this warning in any test, since `setValueTypeInTokenList()` is only called with `reportDebugWarnings == true` by `simplifyTokens1()`.