### PR TITLE
CI-windows.yml: removed Qt 6.3 from build matrix

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        qt_ver: [5.15.2, 6.2.4, 6.3.2, 6.4.2]
+        qt_ver: [5.15.2, 6.2.4, 6.4.2]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Non-LTS Qt releases are only being patched for six months and are immediately superseded by the next feature release. So Qt 6.3 essentially became EOL four months ago and there's no point in keeping it in the CI.

See https://endoflife.date/qt.