### PR TITLE
fixed some `-Wdeprecated-copy-dtor` Clang compiler warnings

### DIFF
--- a/lib/analyzer.h
+++ b/lib/analyzer.h
@@ -182,6 +182,9 @@ struct Analyzer {
     /// Return analyzer for expression at token
     virtual ValuePtr<Analyzer> reanalyze(Token* tok, const std::string& msg = emptyString) const = 0;
     virtual ~Analyzer() {}
+    Analyzer(const Analyzer&) = default;
+protected:
+    Analyzer() = default;
 };
 
 #endif

--- a/lib/ctu.h
+++ b/lib/ctu.h
@@ -83,6 +83,7 @@ namespace CTU {
             {}
             CallBase(const Tokenizer *tokenizer, const Token *callToken);
             virtual ~CallBase() {}
+            CallBase(const CallBase&) = default;
             std::string callId;
             int callArgNr{};
             std::string callFunctionName;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -87,6 +87,8 @@ public:
 
     ImportProject();
     virtual ~ImportProject() = default;
+    ImportProject(const ImportProject&) = default;
+    ImportProject& operator=(const ImportProject&) = default;
 
     void selectOneVsConfig(cppcheck::Platform::PlatformType platform);
 

--- a/lib/infer.h
+++ b/lib/infer.h
@@ -34,6 +34,9 @@ struct InferModel {
     virtual bool match(const ValueFlow::Value& value) const = 0;
     virtual ValueFlow::Value yield(MathLib::bigint value) const = 0;
     virtual ~InferModel() {}
+    InferModel(const InferModel&) = default;
+protected:
+    InferModel() = default;
 };
 
 std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6497,6 +6497,9 @@ struct ConditionHandler {
         });
     }
     virtual ~ConditionHandler() {}
+    ConditionHandler(const ConditionHandler&) = default;
+protected:
+    ConditionHandler() = default;
 };
 
 static void valueFlowCondition(const ValuePtr<ConditionHandler>& handler,


### PR DESCRIPTION
The remaining warnings will implicitly be fixed by #4791 and #4723.