### PR TITLE
optimized suppression lookups a bit when no suppressions exist

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -169,7 +169,7 @@ int ProcessExecutor::handleRead(int rpipe, unsigned int &result)
             std::exit(EXIT_FAILURE);
         }
 
-        if (!mSettings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage())) {
+        if (!mSettings.nomsg.isSuppressed(msg)) {
             // Alert only about unique errors
             std::string errmsg = msg.toString(mSettings.verbose);
             if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) == mErrorList.cend()) {
@@ -376,7 +376,7 @@ void ProcessExecutor::reportInternalChildErr(const std::string &childname, const
                               "cppcheckError",
                               Certainty::normal);
 
-    if (!mSettings.nomsg.isSuppressed(errmsg.toSuppressionsErrorMessage()))
+    if (!mSettings.nomsg.isSuppressed(errmsg))
         mErrorLogger.reportErr(errmsg);
 }
 

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -95,7 +95,7 @@ private:
 
     void report(const ErrorMessage &msg, MessageType msgType)
     {
-        if (mThreadExecutor.mSettings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage()))
+        if (mThreadExecutor.mSettings.nomsg.isSuppressed(msg))
             return;
 
         // Alert only about unique errors

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1615,6 +1615,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (!mSettings.buildDir.empty())
         mAnalyzerInformation.reportErr(msg);
 
+    // TODO: only convert if necessary
     const Suppressions::ErrorMessage errorMessage = msg.toSuppressionsErrorMessage();
 
     if (mUseGlobalSuppressions) {
@@ -1653,8 +1654,7 @@ void CppCheck::reportProgress(const std::string &filename, const char stage[], c
 
 void CppCheck::reportInfo(const ErrorMessage &msg)
 {
-    const Suppressions::ErrorMessage &errorMessage = msg.toSuppressionsErrorMessage();
-    if (!mSettings.nomsg.isSuppressed(errorMessage))
+    if (!mSettings.nomsg.isSuppressed(msg))
         mErrorLogger.reportInfo(msg);
 }
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -379,6 +379,13 @@ bool Suppressions::isSuppressed(const Suppressions::ErrorMessage &errmsg)
     return false;
 }
 
+bool Suppressions::isSuppressed(const ::ErrorMessage &errmsg)
+{
+    if (mSuppressions.empty())
+        return false;
+    return isSuppressed(errmsg.toSuppressionsErrorMessage());
+}
+
 bool Suppressions::isSuppressedLocal(const Suppressions::ErrorMessage &errmsg)
 {
     const bool unmatchedSuppression(errmsg.errorId == "unmatchedSuppression");

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -34,6 +34,7 @@
 /// @{
 
 class Tokenizer;
+class ErrorMessage;
 
 /** @brief class for handling suppressions */
 class CPPCHECKLIB Suppressions {
@@ -177,6 +178,13 @@ public:
      * @return true if this error is suppressed.
      */
     bool isSuppressed(const ErrorMessage &errmsg);
+
+    /**
+     * @brief Returns true if this message should not be shown to the user.
+     * @param errmsg error message
+     * @return true if this error is suppressed.
+     */
+    bool isSuppressed(const ::ErrorMessage &errmsg);
 
     /**
      * @brief Returns true if this message should not be shown to the user, only uses local suppressions.

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -63,7 +63,7 @@ public:
         next->reportOut(outmsg);
     }
     void reportErr(const ErrorMessage &msg) override {
-        if (!msg.callStack.empty() && !settings.nomsg.isSuppressed(msg.toSuppressionsErrorMessage()))
+        if (!msg.callStack.empty() && !settings.nomsg.isSuppressed(msg))
             next->reportErr(msg);
     }
 private:


### PR DESCRIPTION
There is no need to generate a `Suppressions::ErrorMessage` when no suppressions exist.