### PR TITLE
simplified `ThreadExecutor` class by moving some code out of it / fixed some thread safety issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,7 +643,7 @@ cli/cppcheckexecutorseh.o: cli/cppcheckexecutorseh.cpp cli/cppcheckexecutor.h cl
 cli/cppcheckexecutorsig.o: cli/cppcheckexecutorsig.cpp cli/cppcheckexecutor.h cli/cppcheckexecutorsig.h cli/stacktrace.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/cppcheckexecutorsig.cpp
 
-cli/executor.o: cli/executor.cpp cli/executor.h
+cli/executor.o: cli/executor.cpp cli/executor.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/executor.cpp
 
 cli/filelister.o: cli/filelister.cpp cli/filelister.h lib/config.h lib/path.h lib/pathmatch.h lib/utils.h

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -348,6 +348,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
             }
         }
 
+        // TODO: not performed when multiple jobs are being used
         // second loop to parse all markup files which may not work until all
         // c/cpp files have been parsed and checked
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i) {
@@ -488,6 +489,7 @@ void CppCheckExecutor::reportStatus(std::size_t fileindex, std::size_t filecount
         oss << fileindex << '/' << filecount
             << " files checked " << percentDone
             << "% done";
+        // TODO: do not unconditionally print in color
         std::cout << Color::FgBlue << oss.str() << Color::Reset << std::endl;
     }
 }

--- a/cli/executor.h
+++ b/cli/executor.h
@@ -22,10 +22,12 @@
 #include <cstddef>
 #include <list>
 #include <map>
+#include <mutex>
 #include <string>
 
 class Settings;
 class ErrorLogger;
+class ErrorMessage;
 
 /// @addtogroup CLI
 /// @{
@@ -45,9 +47,19 @@ public:
     virtual unsigned int check() = 0;
 
 protected:
+    /**
+     * @brief Check if message is being suppressed and unique.
+     * @param msg the message to check
+     * @return true if message is not suppressed and unique
+     */
+    bool hasToLog(const ErrorMessage &msg);
+
     const std::map<std::string, std::size_t> &mFiles;
     Settings &mSettings;
     ErrorLogger &mErrorLogger;
+
+private:
+    std::mutex mErrorListSync;
     std::list<std::string> mErrorList;
 };
 

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -169,16 +169,11 @@ int ProcessExecutor::handleRead(int rpipe, unsigned int &result)
             std::exit(EXIT_FAILURE);
         }
 
-        if (!mSettings.nomsg.isSuppressed(msg)) {
-            // Alert only about unique errors
-            std::string errmsg = msg.toString(mSettings.verbose);
-            if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) == mErrorList.cend()) {
-                mErrorList.emplace_back(std::move(errmsg));
-                if (type == PipeWriter::REPORT_ERROR)
-                    mErrorLogger.reportErr(msg);
-                else
-                    mErrorLogger.reportInfo(msg);
-            }
+        if (hasToLog(msg)) {
+            if (type == PipeWriter::REPORT_ERROR)
+                mErrorLogger.reportErr(msg);
+            else
+                mErrorLogger.reportInfo(msg);
         }
     } else if (type == PipeWriter::CHILD_END) {
         std::istringstream iss(buf);

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -48,12 +48,12 @@ ThreadExecutor::~ThreadExecutor()
 class ThreadExecutor::Data
 {
 public:
-    Data(const ThreadExecutor &threadExecutor) : mFiles(threadExecutor.mFiles), mProcessedFiles(0), mTotalFiles(0), mProcessedSize(0)
+    Data(const ThreadExecutor &threadExecutor) : mFiles(threadExecutor.mFiles), mFileSettings(threadExecutor.mSettings.project.fileSettings), mProcessedFiles(0), mTotalFiles(0), mProcessedSize(0)
     {
         mItNextFile = mFiles.begin();
-        mItNextFileSettings = threadExecutor.mSettings.project.fileSettings.begin();
+        mItNextFileSettings = mFileSettings.begin();
 
-        mTotalFiles = mFiles.size() + threadExecutor.mSettings.project.fileSettings.size();
+        mTotalFiles = mFiles.size() + mFileSettings.size();
         mTotalFileSize = std::accumulate(mFiles.cbegin(), mFiles.cend(), std::size_t(0), [](std::size_t v, const std::pair<std::string, std::size_t>& p) {
             return v + p.second;
         });
@@ -61,6 +61,7 @@ public:
 
     const std::map<std::string, std::size_t> &mFiles;
     std::map<std::string, std::size_t>::const_iterator mItNextFile;
+    const std::list<ImportProject::FileSettings> &mFileSettings;
     std::list<ImportProject::FileSettings>::const_iterator mItNextFileSettings;
 
     std::size_t mProcessedFiles;
@@ -167,7 +168,7 @@ unsigned int STDCALL ThreadExecutor::threadProc(Data *data, SyncLogForwarder* lo
     data->mFileSync.lock();
 
     for (;;) {
-        if (itFile == data->mFiles.cend() && itFileSettings == logForwarder->mThreadExecutor.mSettings.project.fileSettings.cend()) {
+        if (itFile == data->mFiles.cend() && itFileSettings == data->mFileSettings.cend()) {
             data->mFileSync.unlock();
             break;
         }

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -48,7 +48,7 @@ ThreadExecutor::~ThreadExecutor()
 class ThreadExecutor::Data
 {
 public:
-    Data(const ThreadExecutor &threadExecutor) : mFiles(threadExecutor.mFiles), mFileSettings(threadExecutor.mSettings.project.fileSettings), mProcessedFiles(0), mTotalFiles(0), mProcessedSize(0)
+    Data(const ThreadExecutor &threadExecutor) : mFiles(threadExecutor.mFiles), mFileSettings(threadExecutor.mSettings.project.fileSettings), mProcessedFiles(0), mProcessedSize(0)
     {
         mItNextFile = mFiles.begin();
         mItNextFileSettings = mFileSettings.begin();

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -93,8 +93,6 @@ public:
         report(msg, MessageType::REPORT_INFO);
     }
 
-    ThreadExecutor &mThreadExecutor;
-
     std::mutex mErrorSync;
     std::mutex mReportSync;
 
@@ -132,6 +130,8 @@ private:
             }
         }
     }
+
+    ThreadExecutor &mThreadExecutor;
 };
 
 unsigned int ThreadExecutor::check()

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -47,8 +47,9 @@ public:
     unsigned int check() override;
 
 private:
+    class Data;
     class SyncLogForwarder;
-    static unsigned int STDCALL threadProc(SyncLogForwarder *logForwarder);
+    static unsigned int STDCALL threadProc(Data *data, SyncLogForwarder *logForwarder);
 };
 
 /// @}

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -19,8 +19,6 @@
 #ifndef THREADEXECUTOR_H
 #define THREADEXECUTOR_H
 
-#include "config.h"
-
 #include "executor.h"
 
 #include <cstddef>
@@ -46,10 +44,7 @@ public:
 
     unsigned int check() override;
 
-private:
-    class Data;
-    class SyncLogForwarder;
-    static unsigned int STDCALL threadProc(Data *data, SyncLogForwarder *logForwarder, const Settings &settings);
+    friend class SyncLogForwarder;
 };
 
 /// @}

--- a/cli/threadexecutor.h
+++ b/cli/threadexecutor.h
@@ -49,7 +49,7 @@ public:
 private:
     class Data;
     class SyncLogForwarder;
-    static unsigned int STDCALL threadProc(Data *data, SyncLogForwarder *logForwarder);
+    static unsigned int STDCALL threadProc(Data *data, SyncLogForwarder *logForwarder, const Settings &settings);
 };
 
 /// @}

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -25,7 +25,6 @@
 /*
     TODO:
     - rename "file" to "single"
-    - synchronise map access in multithreaded mode or disable timing
     - add unit tests
         - for --showtime (needs input file)
         - for Timer* classes
@@ -48,9 +47,9 @@ void TimerResults::showResults(SHOWTIME_MODES mode) const
     TimerResultsData overallData;
 
     std::vector<dataElementType> data;
-    data.reserve(mResults.size());
     {
         std::lock_guard<std::mutex> l(mResultsSync);
+        data.reserve(mResults.size());
         data.insert(data.begin(), mResults.cbegin(), mResults.cend());
     }
     std::sort(data.begin(), data.end(), more_second_sec);

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -316,7 +316,7 @@ void TestFixture::run(const std::string &str)
     try {
         if (quiet_tests) {
             std::cout << '\n' << classname << ':';
-            REDIRECT;
+            SUPPRESS;
             run();
         }
         else

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -102,7 +102,7 @@ bool TestFixture::prepareTest(const char testname[])
             std::putchar('.'); // Use putchar to write through redirection of std::cout/cerr
             std::fflush(stdout);
         } else {
-            std::cout << classname << "::" << testname << std::endl;
+            std::cout << classname << "::" << mTestname << std::endl;
         }
         return true;
     }
@@ -324,15 +324,15 @@ void TestFixture::run(const std::string &str)
     }
     catch (const InternalError& e) {
         ++fails_counter;
-        errmsg << "InternalError: " << e.errorMessage << std::endl;
+        errmsg << classname << "::" << mTestname << " - InternalError: " << e.errorMessage << std::endl;
     }
     catch (const std::exception& error) {
         ++fails_counter;
-        errmsg << "exception: " << error.what() << std::endl;
+        errmsg << classname << "::" << mTestname << " - Exception: " << error.what() << std::endl;
     }
     catch (...) {
         ++fails_counter;
-        errmsg << "Unknown exception" << std::endl;
+        errmsg << classname << "::" << mTestname << " - Unknown exception" << std::endl;
     }
 }
 

--- a/test/redirect.h
+++ b/test/redirect.h
@@ -29,6 +29,7 @@ extern std::ostringstream output;
  * @brief Utility class for capturing cout and cerr to ostringstream buffers
  * for later use. Uses RAII to stop redirection when the object goes out of
  * scope.
+ * NOTE: This is *not* thread-safe.
  */
 class RedirectOutputError {
 public:
@@ -83,10 +84,38 @@ private:
     std::streambuf *_oldCerr;
 };
 
-#define REDIRECT RedirectOutputError redir; do {} while (false)
+class SuppressOutput {
+public:
+    /** Set up suppression, flushing anything in the pipes. */
+    SuppressOutput() {
+        // flush all old output
+        std::cout.flush();
+        std::cerr.flush();
+
+        _oldCout = std::cout.rdbuf(); // back up cout's streambuf
+        _oldCerr = std::cerr.rdbuf(); // back up cerr's streambuf
+
+        std::cout.rdbuf(nullptr); // disable cout
+        std::cerr.rdbuf(nullptr); // disable cerr
+    }
+
+    /** Revert cout and cerr behaviour */
+    ~SuppressOutput() {
+        std::cout.rdbuf(_oldCout); // restore cout's original streambuf
+        std::cerr.rdbuf(_oldCerr); // restore cerrs's original streambuf
+    }
+
+private:
+    std::streambuf *_oldCout;
+    std::streambuf *_oldCerr;
+};
+
+#define REDIRECT RedirectOutputError redir
 #define GET_REDIRECT_OUTPUT redir.getOutput()
 #define CLEAR_REDIRECT_OUTPUT redir.clearOutput()
 #define GET_REDIRECT_ERROUT redir.getErrout()
 #define CLEAR_REDIRECT_ERROUT redir.clearErrout()
+
+#define SUPPRESS SuppressOutput supprout
 
 #endif

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -43,7 +43,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE, const char* const plistOutput = nullptr) {
         errout.str("");
         output.str("");
 
@@ -56,6 +56,9 @@ private:
 
         settings.jobs = jobs;
         settings.showtime = showtime;
+        if (plistOutput)
+            settings.plistOutput = plistOutput;
+        // TODO: test with settings.project.fileSettings;
         ProcessExecutor executor(filemap, settings, *this);
         std::vector<std::unique_ptr<ScopedFile>> scopedfiles;
         scopedfiles.reserve(filemap.size());
@@ -72,6 +75,7 @@ private:
         TEST_CASE(deadlock_with_many_errors);
         TEST_CASE(many_threads);
         TEST_CASE(many_threads_showtime);
+        TEST_CASE(many_threads_plist);
         TEST_CASE(no_errors_more_files);
         TEST_CASE(no_errors_less_files);
         TEST_CASE(no_errors_equal_amount_files);
@@ -110,6 +114,19 @@ private:
               "  char *a = malloc(10);\n"
               "  return 0;\n"
               "}", SHOWTIME_MODES::SHOWTIME_SUMMARY);
+    }
+
+    void many_threads_plist() {
+        const char plistOutput[] = "plist";
+        ScopedFile plistFile("dummy", plistOutput);
+
+        REDIRECT;
+        check(16, 100, 100,
+              "int main()\n"
+              "{\n"
+              "  char *a = malloc(10);\n"
+              "  return 0;\n"
+              "}", SHOWTIME_MODES::SHOWTIME_NONE, plistOutput);
     }
 
     void no_errors_more_files() {

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -107,7 +107,7 @@ private:
 
     // #11249 - reports TSAN errors
     void many_threads_showtime() {
-        REDIRECT;
+        SUPPRESS;
         check(16, 100, 100,
               "int main()\n"
               "{\n"
@@ -120,7 +120,7 @@ private:
         const char plistOutput[] = "plist";
         ScopedFile plistFile("dummy", plistOutput);
 
-        REDIRECT;
+        SUPPRESS;
         check(16, 100, 100,
               "int main()\n"
               "{\n"

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -105,7 +105,7 @@ private:
 
     // #11249 - reports TSAN errors - only applies to threads not processes though
     void many_threads_showtime() {
-        REDIRECT;
+        SUPPRESS;
         check(16, 100, 100,
               "int main()\n"
               "{\n"
@@ -118,7 +118,7 @@ private:
         const char plistOutput[] = "plist";
         ScopedFile plistFile("dummy", plistOutput);
 
-        REDIRECT;
+        SUPPRESS;
         check(16, 100, 100,
               "int main()\n"
               "{\n"

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -43,7 +43,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE, const char* const plistOutput = nullptr) {
         errout.str("");
         output.str("");
 
@@ -56,6 +56,9 @@ private:
 
         settings.jobs = jobs;
         settings.showtime = showtime;
+        if (plistOutput)
+            settings.plistOutput = plistOutput;
+        // TODO: test with settings.project.fileSettings;
         ThreadExecutor executor(filemap, settings, *this);
         std::vector<std::unique_ptr<ScopedFile>> scopedfiles;
         scopedfiles.reserve(filemap.size());
@@ -71,6 +74,7 @@ private:
         TEST_CASE(deadlock_with_many_errors);
         TEST_CASE(many_threads);
         TEST_CASE(many_threads_showtime);
+        TEST_CASE(many_threads_plist);
         TEST_CASE(no_errors_more_files);
         TEST_CASE(no_errors_less_files);
         TEST_CASE(no_errors_equal_amount_files);
@@ -108,6 +112,19 @@ private:
               "  char *a = malloc(10);\n"
               "  return 0;\n"
               "}", SHOWTIME_MODES::SHOWTIME_SUMMARY);
+    }
+
+    void many_threads_plist() {
+        const char plistOutput[] = "plist";
+        ScopedFile plistFile("dummy", plistOutput);
+
+        REDIRECT;
+        check(16, 100, 100,
+              "int main()\n"
+              "{\n"
+              "  char *a = malloc(10);\n"
+              "  return 0;\n"
+              "}", SHOWTIME_MODES::SHOWTIME_NONE, plistOutput);
     }
 
     void no_errors_more_files() {


### PR DESCRIPTION
This is a step on the way to hopefully fixing the suppression issues when using multiple threads. It might also allow us to share more code between the thread and process implementations.