### PR TITLE
made `CmdLineParser::mSettings` a reference

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -113,7 +113,7 @@ static bool addPathsToSet(const std::string& fileName, std::set<std::string>& se
     return true;
 }
 
-CmdLineParser::CmdLineParser(Settings *settings)
+CmdLineParser::CmdLineParser(Settings &settings)
     : mSettings(settings)
     , mShowHelp(false)
     , mShowVersion(false)
@@ -146,13 +146,13 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
     bool def = false;
     bool maxconfigs = false;
 
-    mSettings->exename = argv[0];
+    mSettings.exename = argv[0];
 #ifdef __linux__
     // Executing cppcheck in PATH. argv[0] does not contain the path.
-    if (mSettings->exename.find_first_of("/\\") == std::string::npos) {
+    if (mSettings.exename.find_first_of("/\\") == std::string::npos) {
         char buf[PATH_MAX] = {0};
         if (FileLister::fileExists("/proc/self/exe") && readlink("/proc/self/exe", buf, sizeof(buf)-1) > 0)
-            mSettings->exename = buf;
+            mSettings.exename = buf;
     }
 #endif
 
@@ -181,17 +181,17 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (define.find('=') == std::string::npos)
                     define += "=1";
 
-                if (!mSettings->userDefines.empty())
-                    mSettings->userDefines += ";";
-                mSettings->userDefines += define;
+                if (!mSettings.userDefines.empty())
+                    mSettings.userDefines += ";";
+                mSettings.userDefines += define;
 
                 def = true;
             }
 
             // -E
             else if (std::strcmp(argv[i], "-E") == 0) {
-                mSettings->preprocessOnly = true;
-                mSettings->quiet = true;
+                mSettings.preprocessOnly = true;
+                mSettings.quiet = true;
             }
 
             // Include paths
@@ -219,7 +219,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (!endsWith(path,'/'))
                     path += '/';
 
-                mSettings->includePaths.emplace_back(std::move(path));
+                mSettings.includePaths.emplace_back(std::move(path));
             }
 
             // User undef
@@ -241,75 +241,75 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     undef = 2 + argv[i];
                 }
 
-                mSettings->userUndefs.insert(std::move(undef));
+                mSettings.userUndefs.insert(std::move(undef));
             }
 
             else if (std::strncmp(argv[i], "--addon=", 8) == 0)
-                mSettings->addons.emplace(argv[i]+8);
+                mSettings.addons.emplace(argv[i]+8);
 
             else if (std::strncmp(argv[i],"--addon-python=", 15) == 0)
-                mSettings->addonPython.assign(argv[i]+15);
+                mSettings.addonPython.assign(argv[i]+15);
 
             // Check configuration
             else if (std::strcmp(argv[i], "--check-config") == 0)
-                mSettings->checkConfiguration = true;
+                mSettings.checkConfiguration = true;
 
             // Check library definitions
             else if (std::strcmp(argv[i], "--check-library") == 0) {
-                mSettings->checkLibrary = true;
+                mSettings.checkLibrary = true;
             }
 
             else if (std::strncmp(argv[i], "--checks-max-time=", 18) == 0) {
-                mSettings->checksMaxTime = std::atoi(argv[i] + 18);
+                mSettings.checksMaxTime = std::atoi(argv[i] + 18);
             }
 
             else if (std::strcmp(argv[i], "--clang") == 0) {
-                mSettings->clang = true;
+                mSettings.clang = true;
             }
 
             else if (std::strncmp(argv[i], "--clang=", 8) == 0) {
-                mSettings->clang = true;
-                mSettings->clangExecutable = argv[i] + 8;
+                mSettings.clang = true;
+                mSettings.clangExecutable = argv[i] + 8;
             }
 
             else if (std::strncmp(argv[i], "--config-exclude=",17) ==0) {
-                mSettings->configExcludePaths.insert(Path::fromNativeSeparators(argv[i] + 17));
+                mSettings.configExcludePaths.insert(Path::fromNativeSeparators(argv[i] + 17));
             }
 
             else if (std::strncmp(argv[i], "--config-excludes-file=", 23) == 0) {
                 // open this file and read every input file (1 file name per line)
                 const std::string cfgExcludesFile(23 + argv[i]);
-                if (!addPathsToSet(cfgExcludesFile, mSettings->configExcludePaths)) {
+                if (!addPathsToSet(cfgExcludesFile, mSettings.configExcludePaths)) {
                     printError("unable to open config excludes file at '" + cfgExcludesFile + "'");
                     return false;
                 }
             }
 
             else if (std::strncmp(argv[i], "--cppcheck-build-dir=", 21) == 0) {
-                mSettings->buildDir = Path::fromNativeSeparators(argv[i] + 21);
-                if (endsWith(mSettings->buildDir, '/'))
-                    mSettings->buildDir.pop_back();
+                mSettings.buildDir = Path::fromNativeSeparators(argv[i] + 21);
+                if (endsWith(mSettings.buildDir, '/'))
+                    mSettings.buildDir.pop_back();
             }
 
             // Show --debug output after the first simplifications
             else if (std::strcmp(argv[i], "--debug") == 0 ||
                      std::strcmp(argv[i], "--debug-normal") == 0)
-                mSettings->debugnormal = true;
+                mSettings.debugnormal = true;
 
             // Flag used for various purposes during debugging
             else if (std::strcmp(argv[i], "--debug-simplified") == 0)
-                mSettings->debugSimplified = true;
+                mSettings.debugSimplified = true;
 
             // Show template information
             else if (std::strcmp(argv[i], "--debug-template") == 0)
-                mSettings->debugtemplate = true;
+                mSettings.debugtemplate = true;
 
             // Show debug warnings
             else if (std::strcmp(argv[i], "--debug-warnings") == 0)
-                mSettings->debugwarnings = true;
+                mSettings.debugwarnings = true;
 
             else if (std::strncmp(argv[i], "--disable=", 10) == 0) {
-                const std::string errmsg = mSettings->removeEnabled(argv[i] + 10);
+                const std::string errmsg = mSettings.removeEnabled(argv[i] + 10);
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
@@ -335,27 +335,27 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // dump cppcheck data
             else if (std::strcmp(argv[i], "--dump") == 0)
-                mSettings->dump = true;
+                mSettings.dump = true;
 
             else if (std::strncmp(argv[i], "--enable=", 9) == 0) {
                 const std::string enable_arg = argv[i] + 9;
-                const std::string errmsg = mSettings->addEnabled(enable_arg);
+                const std::string errmsg = mSettings.addEnabled(enable_arg);
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
                 }
                 // when "style" is enabled, also enable "warning", "performance" and "portability"
                 if (enable_arg.find("style") != std::string::npos) {
-                    mSettings->addEnabled("warning");
-                    mSettings->addEnabled("performance");
-                    mSettings->addEnabled("portability");
+                    mSettings.addEnabled("warning");
+                    mSettings.addEnabled("performance");
+                    mSettings.addEnabled("portability");
                 }
             }
 
             // print all possible error messages..
             else if (std::strcmp(argv[i], "--errorlist") == 0) {
                 mShowErrorMessages = true;
-                mSettings->xml = true;
+                mSettings.xml = true;
                 mExitAfterPrint = true;
             }
 
@@ -363,7 +363,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             else if (std::strncmp(argv[i], "--error-exitcode=", 17) == 0) {
                 const std::string temp = argv[i]+17;
                 std::istringstream iss(temp);
-                if (!(iss >> mSettings->exitCode)) {
+                if (!(iss >> mSettings.exitCode)) {
                     printError("argument must be an integer. Try something like '--error-exitcode=1'.");
                     return false;
                 }
@@ -371,7 +371,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // Exception handling inside cppcheck client
             else if (std::strcmp(argv[i], "--exception-handling") == 0) {
-                mSettings->exceptionHandling = true;
+                mSettings.exceptionHandling = true;
             }
 
             // Exception handling inside cppcheck client
@@ -381,7 +381,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printError("invalid '--exception-handling' argument");
                     return false;
                 }
-                mSettings->exceptionHandling = true;
+                mSettings.exceptionHandling = true;
                 CppCheckExecutor::setExceptionOutput((exceptionOutfilename == "stderr") ? stderr : stdout);
             }
 
@@ -395,7 +395,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printError("couldn't open the file: \"" + filename + "\".");
                     return false;
                 }
-                const std::string errmsg(mSettings->nofail.parseFile(f));
+                const std::string errmsg(mSettings.nofail.parseFile(f));
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
@@ -404,7 +404,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // use a file filter
             else if (std::strncmp(argv[i], "--file-filter=", 14) == 0)
-                mSettings->fileFilters.emplace_back(argv[i] + 14);
+                mSettings.fileFilters.emplace_back(argv[i] + 14);
 
             // file list specified
             else if (std::strncmp(argv[i], "--file-list=", 12) == 0) {
@@ -418,7 +418,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // Force checking of files that have "too many" configurations
             else if (std::strcmp(argv[i], "-f") == 0 || std::strcmp(argv[i], "--force") == 0)
-                mSettings->force = true;
+                mSettings.force = true;
 
             // Print help
             else if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
@@ -462,13 +462,13 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             }
 
             else if (std::strncmp(argv[i], "--include=", 10) == 0) {
-                mSettings->userIncludes.emplace_back(Path::fromNativeSeparators(argv[i] + 10));
+                mSettings.userIncludes.emplace_back(Path::fromNativeSeparators(argv[i] + 10));
             }
 
             else if (std::strncmp(argv[i], "--includes-file=", 16) == 0) {
                 // open this file and read every input file (1 file name per line)
                 const std::string includesFile(16 + argv[i]);
-                if (!addIncludePathsToList(includesFile, mSettings->includePaths)) {
+                if (!addIncludePathsToList(includesFile, mSettings.includePaths)) {
                     printError("unable to open includes file at '" + includesFile + "'");
                     return false;
                 }
@@ -476,11 +476,11 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // Inconclusive checking
             else if (std::strcmp(argv[i], "--inconclusive") == 0)
-                mSettings->certainty.enable(Certainty::inconclusive);
+                mSettings.certainty.enable(Certainty::inconclusive);
 
             // Enables inline suppressions.
             else if (std::strcmp(argv[i], "--inline-suppr") == 0)
-                mSettings->inlineSuppressions = true;
+                mSettings.inlineSuppressions = true;
 
             // Checking threads
             else if (std::strncmp(argv[i], "-j", 2) == 0) {
@@ -502,12 +502,12 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     numberString = argv[i]+2;
 
                 std::istringstream iss(numberString);
-                if (!(iss >> mSettings->jobs)) {
+                if (!(iss >> mSettings.jobs)) {
                     printError("argument to '-j' is not a number.");
                     return false;
                 }
 
-                if (mSettings->jobs > 10000) {
+                if (mSettings.jobs > 10000) {
                     // This limit is here just to catch typos. If someone has
                     // need for more jobs, this value should be increased.
                     printError("argument for '-j' is allowed to be 10000 at max.");
@@ -535,7 +535,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     numberString = argv[i]+2;
 
                 std::istringstream iss(numberString);
-                if (!(iss >> mSettings->loadAverage)) {
+                if (!(iss >> mSettings.loadAverage)) {
                     printError("argument to '-l' is not a number.");
                     return false;
                 }
@@ -557,9 +557,9 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 }
 
                 if (str == "c")
-                    mSettings->enforcedLang = Settings::Language::C;
+                    mSettings.enforcedLang = Settings::Language::C;
                 else if (str == "c++")
-                    mSettings->enforcedLang = Settings::Language::CPP;
+                    mSettings.enforcedLang = Settings::Language::CPP;
                 else {
                     printError("unknown language '" + str + "' enforced.");
                     return false;
@@ -568,20 +568,20 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // --library
             else if (std::strncmp(argv[i], "--library=", 10) == 0) {
-                mSettings->libraries.emplace_back(argv[i] + 10);
+                mSettings.libraries.emplace_back(argv[i] + 10);
             }
 
             // Set maximum number of #ifdef configurations to check
             else if (std::strncmp(argv[i], "--max-configs=", 14) == 0) {
-                mSettings->force = false;
+                mSettings.force = false;
 
                 std::istringstream iss(14+argv[i]);
-                if (!(iss >> mSettings->maxConfigs)) {
+                if (!(iss >> mSettings.maxConfigs)) {
                     printError("argument to '--max-configs=' is not a number.");
                     return false;
                 }
 
-                if (mSettings->maxConfigs < 1) {
+                if (mSettings.maxConfigs < 1) {
                     printError("argument to '--max-configs=' must be greater than 0.");
                     return false;
                 }
@@ -591,16 +591,16 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // max ctu depth
             else if (std::strncmp(argv[i], "--max-ctu-depth=", 16) == 0)
-                mSettings->maxCtuDepth = std::atoi(argv[i] + 16);
+                mSettings.maxCtuDepth = std::atoi(argv[i] + 16);
 
             // Write results in file
             else if (std::strncmp(argv[i], "--output-file=", 14) == 0)
-                mSettings->outputFile = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 14));
+                mSettings.outputFile = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 14));
 
             // Experimental: limit execution time for extended valueflow analysis. basic valueflow analysis
             // is always executed.
             else if (std::strncmp(argv[i], "--performance-valueflow-max-time=", 33) == 0)
-                mSettings->performanceValueFlowMaxTime = std::atoi(argv[i] + 33);
+                mSettings.performanceValueFlowMaxTime = std::atoi(argv[i] + 33);
 
             // Specify platform
             else if (std::strncmp(argv[i], "--platform=", 11) == 0) {
@@ -608,7 +608,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
                 std::string errstr;
                 const std::vector<std::string> paths = {argv[0]};
-                if (!mSettings->platform.set(platform, errstr, paths)) {
+                if (!mSettings.platform.set(platform, errstr, paths)) {
                     printError(errstr);
                     return false;
                 }
@@ -621,20 +621,20 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 // these are loaded via external files and thus have Settings::PlatformFile set instead.
                 // override the type so they behave like the regular platforms.
                 if (platform == "unix32-unsigned")
-                    mSettings->platform.type = cppcheck::Platform::Type::Unix32;
+                    mSettings.platform.type = cppcheck::Platform::Type::Unix32;
                 else if (platform == "unix64-unsigned")
-                    mSettings->platform.type = cppcheck::Platform::Type::Unix64;
+                    mSettings.platform.type = cppcheck::Platform::Type::Unix64;
             }
 
             // Write results in results.plist
             else if (std::strncmp(argv[i], "--plist-output=", 15) == 0) {
-                mSettings->plistOutput = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 15));
-                if (mSettings->plistOutput.empty())
-                    mSettings->plistOutput = "./";
-                else if (!endsWith(mSettings->plistOutput,'/'))
-                    mSettings->plistOutput += '/';
+                mSettings.plistOutput = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 15));
+                if (mSettings.plistOutput.empty())
+                    mSettings.plistOutput = "./";
+                else if (!endsWith(mSettings.plistOutput,'/'))
+                    mSettings.plistOutput += '/';
 
-                const std::string plistOutput = Path::toNativeSeparators(mSettings->plistOutput);
+                const std::string plistOutput = Path::toNativeSeparators(mSettings.plistOutput);
                 if (!FileLister::isDirectory(plistOutput)) {
                     std::string message("plist folder does not exist: \"");
                     message += plistOutput;
@@ -646,29 +646,29 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // Special Cppcheck Premium options
             else if (std::strncmp(argv[i], "--premium=", 10) == 0 && isCppcheckPremium()) {
-                if (!mSettings->premiumArgs.empty())
-                    mSettings->premiumArgs += " ";
+                if (!mSettings.premiumArgs.empty())
+                    mSettings.premiumArgs += " ";
                 const std::string p(argv[i] + 10);
-                mSettings->premiumArgs += "--" + p;
+                mSettings.premiumArgs += "--" + p;
                 if (p == "misra-c-2012")
-                    mSettings->addons.emplace("misra");
+                    mSettings.addons.emplace("misra");
             }
 
             // --project
             else if (std::strncmp(argv[i], "--project=", 10) == 0) {
-                mSettings->checkAllConfigurations = false; // Can be overridden with --max-configs or --force
+                mSettings.checkAllConfigurations = false; // Can be overridden with --max-configs or --force
                 std::string projectFile = argv[i]+10;
-                ImportProject::Type projType = mSettings->project.import(projectFile, mSettings);
-                mSettings->project.projectType = projType;
+                ImportProject::Type projType = mSettings.project.import(projectFile, &mSettings);
+                mSettings.project.projectType = projType;
                 if (projType == ImportProject::Type::CPPCHECK_GUI) {
-                    mPathNames = mSettings->project.guiProject.pathNames;
-                    for (const std::string &lib : mSettings->project.guiProject.libraries)
-                        mSettings->libraries.emplace_back(lib);
+                    mPathNames = mSettings.project.guiProject.pathNames;
+                    for (const std::string &lib : mSettings.project.guiProject.libraries)
+                        mSettings.libraries.emplace_back(lib);
 
-                    const auto& excludedPaths = mSettings->project.guiProject.excludedPaths;
+                    const auto& excludedPaths = mSettings.project.guiProject.excludedPaths;
                     std::copy(excludedPaths.cbegin(), excludedPaths.cend(), std::back_inserter(mIgnoredPaths));
 
-                    std::string platform(mSettings->project.guiProject.platform);
+                    std::string platform(mSettings.project.guiProject.platform);
 
                     // keep existing platform from command-line intact
                     if (!platform.empty()) {
@@ -679,21 +679,21 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
                         std::string errstr;
                         const std::vector<std::string> paths = {projectFile, argv[0]};
-                        if (!mSettings->platform.set(platform, errstr, paths)) {
+                        if (!mSettings.platform.set(platform, errstr, paths)) {
                             printError(errstr);
                             return false;
                         }
                     }
 
-                    if (!mSettings->project.guiProject.projectFile.empty()) {
-                        projectFile = mSettings->project.guiProject.projectFile;
-                        projType = mSettings->project.import(mSettings->project.guiProject.projectFile, mSettings);
+                    if (!mSettings.project.guiProject.projectFile.empty()) {
+                        projectFile = mSettings.project.guiProject.projectFile;
+                        projType = mSettings.project.import(mSettings.project.guiProject.projectFile, &mSettings);
                     }
                 }
                 if (projType == ImportProject::Type::VS_SLN || projType == ImportProject::Type::VS_VCXPROJ) {
-                    if (mSettings->project.guiProject.analyzeAllVsConfigs == "false")
-                        mSettings->project.selectOneVsConfig(mSettings->platform.type);
-                    if (!CppCheckExecutor::tryLoadLibrary(mSettings->library, argv[0], "windows.cfg")) {
+                    if (mSettings.project.guiProject.analyzeAllVsConfigs == "false")
+                        mSettings.project.selectOneVsConfig(mSettings.platform.type);
+                    if (!CppCheckExecutor::tryLoadLibrary(mSettings.library, argv[0], "windows.cfg")) {
                         // This shouldn't happen normally.
                         printError("failed to load 'windows.cfg'. Your Cppcheck installation is broken. Please re-install.");
                         return false;
@@ -716,28 +716,28 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             // --project-configuration
             else if (std::strncmp(argv[i], "--project-configuration=", 24) == 0) {
                 mVSConfig = argv[i] + 24;
-                if (!mVSConfig.empty() && (mSettings->project.projectType == ImportProject::Type::VS_SLN || mSettings->project.projectType == ImportProject::Type::VS_VCXPROJ))
-                    mSettings->project.ignoreOtherConfigs(mVSConfig);
+                if (!mVSConfig.empty() && (mSettings.project.projectType == ImportProject::Type::VS_SLN || mSettings.project.projectType == ImportProject::Type::VS_VCXPROJ))
+                    mSettings.project.ignoreOtherConfigs(mVSConfig);
             }
 
             // Only print something when there are errors
             else if (std::strcmp(argv[i], "-q") == 0 || std::strcmp(argv[i], "--quiet") == 0)
-                mSettings->quiet = true;
+                mSettings.quiet = true;
 
             // Output relative paths
             else if (std::strcmp(argv[i], "-rp") == 0 || std::strcmp(argv[i], "--relative-paths") == 0)
-                mSettings->relativePaths = true;
+                mSettings.relativePaths = true;
             else if (std::strncmp(argv[i], "-rp=", 4) == 0 || std::strncmp(argv[i], "--relative-paths=", 17) == 0) {
-                mSettings->relativePaths = true;
+                mSettings.relativePaths = true;
                 if (argv[i][argv[i][3]=='='?4:17] != 0) {
                     std::string paths = argv[i]+(argv[i][3]=='='?4:17);
                     for (;;) {
                         const std::string::size_type pos = paths.find(';');
                         if (pos == std::string::npos) {
-                            mSettings->basePaths.emplace_back(Path::fromNativeSeparators(paths));
+                            mSettings.basePaths.emplace_back(Path::fromNativeSeparators(paths));
                             break;
                         }
-                        mSettings->basePaths.emplace_back(Path::fromNativeSeparators(paths.substr(0, pos)));
+                        mSettings.basePaths.emplace_back(Path::fromNativeSeparators(paths.substr(0, pos)));
                         paths.erase(0, pos + 1);
                     }
                 } else {
@@ -748,7 +748,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             // Report progress
             else if (std::strcmp(argv[i], "--report-progress") == 0) {
-                mSettings->reportProgress = true;
+                mSettings.reportProgress = true;
             }
 
 #ifdef HAVE_RULES
@@ -756,7 +756,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             else if (std::strncmp(argv[i], "--rule=", 7) == 0) {
                 Settings::Rule rule;
                 rule.pattern = 7 + argv[i];
-                mSettings->rules.emplace_back(std::move(rule));
+                mSettings.rules.emplace_back(std::move(rule));
             }
 
             // Rule file
@@ -794,7 +794,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                         }
 
                         if (!rule.pattern.empty())
-                            mSettings->rules.emplace_back(std::move(rule));
+                            mSettings.rules.emplace_back(std::move(rule));
                     }
                 } else {
                     printError("unable to load rule-file: " + std::string(12+argv[i]));
@@ -807,13 +807,13 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             else if (std::strncmp(argv[i], "--showtime=", 11) == 0) {
                 const std::string showtimeMode = argv[i] + 11;
                 if (showtimeMode == "file")
-                    mSettings->showtime = SHOWTIME_MODES::SHOWTIME_FILE;
+                    mSettings.showtime = SHOWTIME_MODES::SHOWTIME_FILE;
                 else if (showtimeMode == "summary")
-                    mSettings->showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY;
+                    mSettings.showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY;
                 else if (showtimeMode == "top5")
-                    mSettings->showtime = SHOWTIME_MODES::SHOWTIME_TOP5;
+                    mSettings.showtime = SHOWTIME_MODES::SHOWTIME_TOP5;
                 else if (showtimeMode.empty())
-                    mSettings->showtime = SHOWTIME_MODES::SHOWTIME_NONE;
+                    mSettings.showtime = SHOWTIME_MODES::SHOWTIME_NONE;
                 else {
                     printError("unrecognized showtime mode: \"" + showtimeMode + "\". Supported modes: file, summary, top5.");
                     return false;
@@ -825,10 +825,10 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 const std::string std = argv[i] + 6;
                 // TODO: print error when standard is unknown
                 if (std::strncmp(std.c_str(), "c++", 3) == 0) {
-                    mSettings->standards.cpp = Standards::getCPP(std);
+                    mSettings.standards.cpp = Standards::getCPP(std);
                 }
                 else if (std::strncmp(std.c_str(), "c", 1) == 0) {
-                    mSettings->standards.c = Standards::getC(std);
+                    mSettings.standards.c = Standards::getC(std);
                 }
                 else {
                     printError("unknown --std value '" + std + "'");
@@ -838,7 +838,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             else if (std::strncmp(argv[i], "--suppress=", 11) == 0) {
                 const std::string suppression = argv[i]+11;
-                const std::string errmsg(mSettings->nomsg.addSuppressionLine(suppression));
+                const std::string errmsg(mSettings.nomsg.addSuppressionLine(suppression));
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
@@ -865,7 +865,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printError(message);
                     return false;
                 }
-                const std::string errmsg(mSettings->nomsg.parseFile(f));
+                const std::string errmsg(mSettings.nomsg.parseFile(f));
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
@@ -874,7 +874,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 
             else if (std::strncmp(argv[i], "--suppress-xml=", 15) == 0) {
                 const char * filename = argv[i] + 15;
-                const std::string errmsg(mSettings->nomsg.parseXmlFile(filename));
+                const std::string errmsg(mSettings.nomsg.parseXmlFile(filename));
                 if (!errmsg.empty()) {
                     printError(errmsg);
                     return false;
@@ -886,32 +886,32 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                      std::strncmp(argv[i], "--template=", 11) == 0) {
                 // "--template format"
                 if (argv[i][10] == '=')
-                    mSettings->templateFormat = argv[i] + 11;
+                    mSettings.templateFormat = argv[i] + 11;
                 else if ((i+1) < argc && argv[i+1][0] != '-') {
                     ++i;
-                    mSettings->templateFormat = argv[i];
+                    mSettings.templateFormat = argv[i];
                 } else {
                     printError("argument to '--template' is missing.");
                     return false;
                 }
 
-                if (mSettings->templateFormat == "gcc") {
-                    mSettings->templateFormat = "{bold}{file}:{line}:{column}: {magenta}warning:{default} {message} [{id}]{reset}\\n{code}";
-                    mSettings->templateLocation = "{bold}{file}:{line}:{column}: {dim}note:{reset} {info}\\n{code}";
-                } else if (mSettings->templateFormat == "daca2") {
-                    mSettings->daca = true;
-                    mSettings->templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]";
-                    mSettings->templateLocation = "{file}:{line}:{column}: note: {info}";
-                } else if (mSettings->templateFormat == "vs")
-                    mSettings->templateFormat = "{file}({line}): {severity}: {message}";
-                else if (mSettings->templateFormat == "edit")
-                    mSettings->templateFormat = "{file} +{line}: {severity}: {message}";
-                else if (mSettings->templateFormat == "cppcheck1")
-                    mSettings->templateFormat = "{callstack}: ({severity}{inconclusive:, inconclusive}) {message}";
-                else if (mSettings->templateFormat == "selfcheck") {
-                    mSettings->templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}";
-                    mSettings->templateLocation = "{file}:{line}:{column}: note: {info}\\n{code}";
-                    mSettings->daca = true;
+                if (mSettings.templateFormat == "gcc") {
+                    mSettings.templateFormat = "{bold}{file}:{line}:{column}: {magenta}warning:{default} {message} [{id}]{reset}\\n{code}";
+                    mSettings.templateLocation = "{bold}{file}:{line}:{column}: {dim}note:{reset} {info}\\n{code}";
+                } else if (mSettings.templateFormat == "daca2") {
+                    mSettings.daca = true;
+                    mSettings.templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]";
+                    mSettings.templateLocation = "{file}:{line}:{column}: note: {info}";
+                } else if (mSettings.templateFormat == "vs")
+                    mSettings.templateFormat = "{file}({line}): {severity}: {message}";
+                else if (mSettings.templateFormat == "edit")
+                    mSettings.templateFormat = "{file} +{line}: {severity}: {message}";
+                else if (mSettings.templateFormat == "cppcheck1")
+                    mSettings.templateFormat = "{callstack}: ({severity}{inconclusive:, inconclusive}) {message}";
+                else if (mSettings.templateFormat == "selfcheck") {
+                    mSettings.templateFormat = "{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]\\n{code}";
+                    mSettings.templateLocation = "{file}:{line}:{column}: note: {info}\\n{code}";
+                    mSettings.daca = true;
                 }
             }
 
@@ -919,10 +919,10 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                      std::strncmp(argv[i], "--template-location=", 20) == 0) {
                 // "--template-location format"
                 if (argv[i][19] == '=')
-                    mSettings->templateLocation = argv[i] + 20;
+                    mSettings.templateLocation = argv[i] + 20;
                 else if ((i+1) < argc && argv[i+1][0] != '-') {
                     ++i;
-                    mSettings->templateLocation = argv[i];
+                    mSettings.templateLocation = argv[i];
                 } else {
                     printError("argument to '--template' is missing.");
                     return false;
@@ -930,11 +930,11 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             }
 
             else if (std::strncmp(argv[i], "--template-max-time=", 20) == 0) {
-                mSettings->templateMaxTime = std::atoi(argv[i] + 20);
+                mSettings.templateMaxTime = std::atoi(argv[i] + 20);
             }
 
             else if (std::strncmp(argv[i], "--typedef-max-time=", 19) == 0) {
-                mSettings->typedefMaxTime = std::atoi(argv[i] + 19);
+                mSettings.typedefMaxTime = std::atoi(argv[i] + 19);
             }
 
             else if (std::strncmp(argv[i], "--valueflow-max-iterations=", 27) == 0) {
@@ -949,41 +949,41 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     printError("argument to '--valueflow-max-iteration' needs to be at least 0.");
                     return false;
                 }
-                mSettings->valueFlowMaxIterations = static_cast<std::size_t>(tmp);
+                mSettings.valueFlowMaxIterations = static_cast<std::size_t>(tmp);
             }
 
             else if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--verbose") == 0)
-                mSettings->verbose = true;
+                mSettings.verbose = true;
 
             else if (std::strcmp(argv[i], "--version") == 0) {
                 mShowVersion = true;
                 mExitAfterPrint = true;
-                mSettings->loadCppcheckCfg();
+                mSettings.loadCppcheckCfg();
                 return true;
             }
 
             // Write results in results.xml
             else if (std::strcmp(argv[i], "--xml") == 0)
-                mSettings->xml = true;
+                mSettings.xml = true;
 
             // Define the XML file version (and enable XML output)
             else if (std::strncmp(argv[i], "--xml-version=", 14) == 0) {
                 const std::string numberString(argv[i]+14);
 
                 std::istringstream iss(numberString);
-                if (!(iss >> mSettings->xml_version)) {
+                if (!(iss >> mSettings.xml_version)) {
                     printError("argument to '--xml-version' is not a number.");
                     return false;
                 }
 
-                if (mSettings->xml_version != 2) {
+                if (mSettings.xml_version != 2) {
                     // We only have xml version 2
                     printError("'--xml-version' can only be 2.");
                     return false;
                 }
 
                 // Enable also XML if version is set
-                mSettings->xml = true;
+                mSettings.xml = true;
             }
 
             else {
@@ -1000,27 +1000,27 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
         }
     }
 
-    mSettings->loadCppcheckCfg();
+    mSettings.loadCppcheckCfg();
 
     // Default template format..
-    if (mSettings->templateFormat.empty()) {
-        mSettings->templateFormat = "{bold}{file}:{line}:{column}: {red}{inconclusive:{magenta}}{severity}:{inconclusive: inconclusive:}{default} {message} [{id}]{reset}\\n{code}";
-        if (mSettings->templateLocation.empty())
-            mSettings->templateLocation = "{bold}{file}:{line}:{column}: {dim}note:{reset} {info}\\n{code}";
+    if (mSettings.templateFormat.empty()) {
+        mSettings.templateFormat = "{bold}{file}:{line}:{column}: {red}{inconclusive:{magenta}}{severity}:{inconclusive: inconclusive:}{default} {message} [{id}]{reset}\\n{code}";
+        if (mSettings.templateLocation.empty())
+            mSettings.templateLocation = "{bold}{file}:{line}:{column}: {dim}note:{reset} {info}\\n{code}";
     }
 
-    mSettings->project.ignorePaths(mIgnoredPaths);
+    mSettings.project.ignorePaths(mIgnoredPaths);
 
-    if (mSettings->force || maxconfigs)
-        mSettings->checkAllConfigurations = true;
+    if (mSettings.force || maxconfigs)
+        mSettings.checkAllConfigurations = true;
 
-    if (mSettings->force)
-        mSettings->maxConfigs = INT_MAX;
+    if (mSettings.force)
+        mSettings.maxConfigs = INT_MAX;
 
-    else if ((def || mSettings->preprocessOnly) && !maxconfigs)
-        mSettings->maxConfigs = 1U;
+    else if ((def || mSettings.preprocessOnly) && !maxconfigs)
+        mSettings.maxConfigs = 1U;
 
-    if (mSettings->checks.isEnabled(Checks::unusedFunction) && mSettings->jobs > 1) {
+    if (mSettings.checks.isEnabled(Checks::unusedFunction) && mSettings.jobs > 1) {
         printMessage("unusedFunction check can't be used with '-j' option. Disabling unusedFunction check.");
     }
 
@@ -1043,14 +1043,14 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
 #endif
 
     // Print error only if we have "real" command and expect files
-    if (!mExitAfterPrint && mPathNames.empty() && mSettings->project.fileSettings.empty()) {
+    if (!mExitAfterPrint && mPathNames.empty() && mSettings.project.fileSettings.empty()) {
         printError("no C or C++ source files found.");
         return false;
     }
 
     // Use paths _pathnames if no base paths for relative path output are given
-    if (mSettings->basePaths.empty() && mSettings->relativePaths)
-        mSettings->basePaths = mPathNames;
+    if (mSettings.basePaths.empty() && mSettings.relativePaths)
+        mSettings.basePaths = mPathNames;
 
     return true;
 }
@@ -1381,7 +1381,7 @@ void CmdLineParser::printHelp()
 }
 
 bool CmdLineParser::isCppcheckPremium() const {
-    if (mSettings->cppcheckCfgProductName.empty())
-        mSettings->loadCppcheckCfg();
-    return mSettings->cppcheckCfgProductName.compare(0, 16, "Cppcheck Premium") == 0;
+    if (mSettings.cppcheckCfgProductName.empty())
+        mSettings.loadCppcheckCfg();
+    return mSettings.cppcheckCfgProductName.compare(0, 16, "Cppcheck Premium") == 0;
 }

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -43,7 +43,7 @@ public:
      * @param settings Settings instance that will be modified according to
      * options user has given.
      */
-    explicit CmdLineParser(Settings *settings);
+    explicit CmdLineParser(Settings &settings);
 
     /**
      * Parse given command line.
@@ -120,7 +120,7 @@ private:
 
     std::vector<std::string> mPathNames;
     std::vector<std::string> mIgnoredPaths;
-    Settings *mSettings;
+    Settings &mSettings;
     bool mShowHelp;
     bool mShowVersion;
     bool mShowErrorMessages;

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -82,7 +82,7 @@ CppCheckExecutor::~CppCheckExecutor()
 bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* const argv[])
 {
     Settings& settings = cppcheck->settings();
-    CmdLineParser parser(&settings);
+    CmdLineParser parser(settings);
     const bool success = parser.parseFromArgs(argc, argv);
 
     if (success) {

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -38,7 +38,7 @@ class TestCmdlineParser : public TestFixture {
 public:
     TestCmdlineParser()
         : TestFixture("TestCmdlineParser")
-        , defParser(&settings) {
+        , defParser(settings) {
 #if defined(_WIN64) || defined(_WIN32)
         CmdLineParser::SHOW_DEF_PLATFORM_MSG = false;
 #endif
@@ -206,7 +206,7 @@ private:
     void nooptions() {
         REDIRECT;
         const char * const argv[] = {"cppcheck"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(1, argv));
         ASSERT_EQUALS(true, parser.getShowHelp());
         ASSERT(GET_REDIRECT_OUTPUT.find("Cppcheck - A tool for static C/C++ code analysis") == 0);
@@ -215,7 +215,7 @@ private:
     void helpshort() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-h"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(true, parser.getShowHelp());
         ASSERT(GET_REDIRECT_OUTPUT.find("Cppcheck - A tool for static C/C++ code analysis") == 0);
@@ -224,7 +224,7 @@ private:
     void helplong() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--help"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(true, parser.getShowHelp());
         ASSERT(GET_REDIRECT_OUTPUT.find("Cppcheck - A tool for static C/C++ code analysis") == 0);
@@ -233,7 +233,7 @@ private:
     void showversion() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--version"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(true, parser.getShowVersion());
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT); // version is not actually shown
@@ -242,7 +242,7 @@ private:
     void onefile() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(1, (int)parser.getPathNames().size());
         ASSERT_EQUALS("file.cpp", parser.getPathNames().at(0));
@@ -252,7 +252,7 @@ private:
     void onepath() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "src"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(1, (int)parser.getPathNames().size());
         ASSERT_EQUALS("src", parser.getPathNames().at(0));
@@ -262,7 +262,7 @@ private:
     void optionwithoutfile() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-v"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT_EQUALS(false, parser.parseFromArgs(2, argv));
         ASSERT_EQUALS(0, (int)parser.getPathNames().size());
         ASSERT_EQUALS("cppcheck: error: no C or C++ source files found.\n", GET_REDIRECT_OUTPUT);
@@ -1359,7 +1359,7 @@ private:
     void ignorepathsnopath() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-i"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         // Fails since no ignored path given
         ASSERT_EQUALS(false, parser.parseFromArgs(2, argv));
         ASSERT_EQUALS("cppcheck: error: argument to '-i' is missing.\n", GET_REDIRECT_OUTPUT);
@@ -1482,7 +1482,7 @@ private:
     void ignorepaths1() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-isrc", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(3, argv));
         ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src", parser.getIgnoredPaths()[0]);
@@ -1492,7 +1492,7 @@ private:
     void ignorepaths2() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-i", "src", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(4, argv));
         ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src", parser.getIgnoredPaths()[0]);
@@ -1502,7 +1502,7 @@ private:
     void ignorepaths3() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-isrc", "-imodule", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(4, argv));
         ASSERT_EQUALS(2, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src", parser.getIgnoredPaths()[0]);
@@ -1513,7 +1513,7 @@ private:
     void ignorepaths4() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-i", "src", "-i", "module", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(6, argv));
         ASSERT_EQUALS(2, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src", parser.getIgnoredPaths()[0]);
@@ -1524,7 +1524,7 @@ private:
     void ignorefilepaths1() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-ifoo.cpp", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(3, argv));
         ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("foo.cpp", parser.getIgnoredPaths()[0]);
@@ -1534,7 +1534,7 @@ private:
     void ignorefilepaths2() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-isrc/foo.cpp", "file.cpp"};
-        CmdLineParser parser(&settings);
+        CmdLineParser parser(settings);
         ASSERT(parser.parseFromArgs(3, argv));
         ASSERT_EQUALS(1, parser.getIgnoredPaths().size());
         ASSERT_EQUALS("src/foo.cpp", parser.getIgnoredPaths()[0]);


### PR DESCRIPTION
This avoids unchecked pointer dereferences within the class.