### PR TITLE
TemplateSimplifier: made `mTokenizer` and `mSettings` references

### DIFF
--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -46,7 +46,7 @@ class CPPCHECKLIB TemplateSimplifier {
     friend class TestSimplifyTemplate;
 
 public:
-    explicit TemplateSimplifier(Tokenizer *tokenizer);
+    explicit TemplateSimplifier(Tokenizer &tokenizer);
     ~TemplateSimplifier();
 
     /**
@@ -489,9 +489,9 @@ private:
         const std::string &indent = "    ") const;
     void printOut(const std::string &text = emptyString) const;
 
-    Tokenizer *mTokenizer;
+    Tokenizer &mTokenizer;
     TokenList &mTokenList;
-    const Settings *mSettings;
+    const Settings &mSettings;
     ErrorLogger *mErrorLogger;
     bool mChanged;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -162,7 +162,7 @@ Tokenizer::Tokenizer(const Settings *settings, ErrorLogger *errorLogger, const P
     mSettings(settings),
     mErrorLogger(errorLogger),
     mSymbolDatabase(nullptr),
-    mTemplateSimplifier(new TemplateSimplifier(this)),
+    mTemplateSimplifier(new TemplateSimplifier(*this)),
     mVarId(0),
     mUnnamedCount(0),
     mCodeWithTemplates(false), //is there any templates?


### PR DESCRIPTION
This avoids unchecked pointer dereferences within the class.