### PR TITLE
cli: correct typo in help message

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1104,7 +1104,7 @@ void CmdLineParser::printHelp()
         "                         A file that contains a list of config-excludes\n"
         "    --disable=<id>       Disable individual checks.\n"
         "                         Please refer to the documentation of --enable=<id>\n"
-        "                         for futher details.\n"
+        "                         for further details.\n"
         "    --dump               Dump xml data for each translation unit. The dump\n"
         "                         files have the extension .dump and contain ast,\n"
         "                         tokenlist, symboldatabase, valueflow.\n"

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -280,7 +280,7 @@ Example: '-UDEBUG'</para>
           <option>--disable=&lt;id&gt;</option>
         </term>
         <listitem>
-          <para>Disable individual checks. Please refer to the documentation of --enable=&lt;id&gt; for futher details.
+          <para>Disable individual checks. Please refer to the documentation of --enable=&lt;id&gt; for further details.
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
`for futher details` -> `for further details`