### PR TITLE
Fix crash in isTemporary()

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -407,7 +407,7 @@ bool isTemporary(bool cpp, const Token* tok, const Library* library, bool unknow
         return false;
     if (Token::simpleMatch(tok, "?")) {
         const Token* branchTok = tok->astOperand2();
-        if (!branchTok->astOperand1()->valueType())
+        if (!branchTok->astOperand1() || !branchTok->astOperand1()->valueType())
             return false;
         if (!branchTok->astOperand2()->valueType())
             return false;

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -6870,6 +6870,15 @@ private:
                "    g(x < y ? : 1);\n"
                "};\n";
         valueOfTok(code, "?");
+
+        code = "struct C {\n"
+               "    explicit C(bool);\n"
+               "    operator bool();\n"
+               "};\n"
+               "void f(bool b) {\n"
+               "    const C& c = C(b) ? : C(false);\n"
+               "};\n";
+        valueOfTok(code, "?");
     }
 
     void valueFlowHang() {


### PR DESCRIPTION
From `flang-20181226/flang-driver/test/Analysis/lifetime-extension.cpp`