### PR TITLE
cmdlineparser.cpp: fixed compilation

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -351,7 +351,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                     mSettings.addEnabled("portability");
                 }
                 if (enable_arg.find("information") != std::string::npos) {
-                    mSettings->addEnabled("missingInclude");
+                    mSettings.addEnabled("missingInclude");
                     printMessage("'--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.");
                 }
             }


### PR DESCRIPTION
The `main` build is broken . This was bound to happen that there's a non-conflicting breakage with all those things I do in parallel.

@danmar Please refrain from merging any more PRs until this has been merged. I will be out for the evening so somebody else has to merge it through.