### PR TITLE
disabled codecov comments and actions for now

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+comment: false
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
In the past few days we have suddenly gotten feedback from codecov via actions and comments. These have been dormant since it seems our credentials were outdated and that's why we didn't get this before. Because of the currently incomplete coverage data in the backend we are getting pointless comments in the PRs and the actions are also failing in some cases. See https://community.codecov.com/t/codecov-actions-and-comments-suddenly-appeared-in-prs-ci/4202 for more details.

There's also some changes we need to do the configuration as well as some other things which need to be cleared up so for the time being we will disable these feedback mechanisms.

