### PR TITLE
Update constVariable IDs for references and pointers

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1630,9 +1630,9 @@ void CheckOther::constVariableError(const Variable *var, const Function *functio
         reportError(nullptr, Severity::style, "constParameter", "Parameter 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constVariable",  "Variable 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constParameterReference", "Parameter 'x' can be declared with const");
-        reportError(nullptr, Severity::style, "constVariableReference",  "Variable 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constVariableReference", "Variable 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constParameterPointer", "Parameter 'x' can be declared with const");
-        reportError(nullptr, Severity::style, "constVariablePointer",  "Variable 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constVariablePointer", "Variable 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constParameterCallback", "Parameter 'x' can be declared with const, however it seems that 'f' is a callback function.");
         return;
     }

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1629,6 +1629,10 @@ void CheckOther::constVariableError(const Variable *var, const Function *functio
     if (!var) {
         reportError(nullptr, Severity::style, "constParameter", "Parameter 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constVariable",  "Variable 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constParameterReference", "Parameter 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constVariableReference",  "Variable 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constParameterPointer", "Parameter 'x' can be declared with const");
+        reportError(nullptr, Severity::style, "constVariablePointer",  "Variable 'x' can be declared with const");
         reportError(nullptr, Severity::style, "constParameterCallback", "Parameter 'x' can be declared with const, however it seems that 'f' is a callback function.");
         return;
     }
@@ -1645,6 +1649,10 @@ void CheckOther::constVariableError(const Variable *var, const Function *functio
         errorPath.emplace_front(function->functionPointerUsage, "You might need to cast the function pointer here");
         id += "Callback";
         message += ". However it seems that '" + function->name() + "' is a callback function, if '$symbol' is declared with const you might also need to cast function pointer(s).";
+    } else if (var->isReference()) {
+        id += "Reference";
+    } else if (var->isPointer() && !var->isArray()) {
+        id += "Pointer";
     }
 
     reportError(errorPath, Severity::style, id.c_str(), message, CWE398, Certainty::normal);

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -5,3 +5,11 @@ release notes for cppcheck-2.11
 - "missingInclude" and "missingIncludeSystem" are reported with "-j" is > 1 and processes are used in the backend (default in non-Windows binaries)
 - "missingInclude" and "missingIncludeSystem" will now cause the "--error-exitcode" to be applied
 - "--enable=information" will no longer implicitly enable "missingInclude" starting with 2.16. Please enable it explicitly if you require it.
+- The `constParameter` and `constVariable` checks have been split into 3 different IDs based on if the variable is a pointer, a reference, or local. The different IDs will allow users to suppress different const warning based on variable type.
+    - `constParameter`
+    - `constParameterReference`
+    - `constParameterPointer`
+    - `constVariable`
+    - `constVariableReference`
+    - `constVariablePointer`
+

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -4236,7 +4236,7 @@ void ignoredReturnValue_string_compare(std::string teststr, std::wstring testwst
     testwstr.compare(L"wtest");
 }
 
-// cppcheck-suppress constParameter
+// cppcheck-suppress constParameterReference
 void ignoredReturnValue_container_access(std::string& s, std::string_view& sv, std::vector<int>& v)
 {
     // cppcheck-suppress ignoredReturnValue

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -114,7 +114,7 @@ protected:
     static T& getCheck()
     {
         for (Check *check : Check::instances()) {
-            //cppcheck-suppress [constVariable, useStlAlgorithm] - TODO: fix constVariable FP
+            //cppcheck-suppress [constVariablePointer, useStlAlgorithm] - TODO: fix constVariable FP
             if (T* c = dynamic_cast<T*>(check))
                 return *c;
         }


### PR DESCRIPTION
Since we warn for local variables as well as references and pointers using a different ID will help users globally suppress the warnings.