### PR TITLE
donate-cpu-server.py: only use more precise timestamp for logging - will unbreak "Time" columns and stale report

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.37"
+SERVER_VERSION = "1.3.38"
 
 OLD_VERSION = '2.10'
 
@@ -49,7 +49,8 @@ logger.addHandler(handler_file)
 
 
 def print_ts(msg) -> None:
-    print('[{}] {}'.format(strDateTime(), msg))
+    dt = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+    print('[{}] {}'.format(dt, msg))
 
 
 # Set up an exception hook for all uncaught exceptions so they can be logged
@@ -65,7 +66,7 @@ sys.excepthook = handle_uncaught_exception
 
 
 def strDateTime() -> str:
-    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
+    return datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
 
 
 def dateTimeFromStr(datestr: str) -> datetime.datetime:


### PR DESCRIPTION
The reports have broken "Time" columns:
```
Package                                  Date        Time    2.10    Head     Diff
openexr                                  2023-03-22 64437    1312    1691   -2+381
openfortivpn                             2023-03-22 27706      10      10
```

The stale report is currently broken:
```
Traceback (most recent call last):
  File "/var/daca@home/donate-cpu-server.py", line 1024, in run
    html = staleReport(self.resultPath)
  File "/var/daca@home/donate-cpu-server.py", line 350, in staleReport
    dt = dateTimeFromStr(datestr)
  File "/var/daca@home/donate-cpu-server.py", line 72, in dateTimeFromStr
    return datetime.datetime.strptime(datestr, '%Y-%m-%d %H:%M')
  File "/usr/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/lib/python3.9/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains: :11.297607
```

I accidentally broke this in 1a464ec5abee5905168c8b2c54d63bebc6c29cdc. Actually supporting the more precise datestamps is possible but I can't be bothered right now.