### PR TITLE
testrunner: fail if `TODO_ASSERT_*` succeeds

### DIFF
--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -380,7 +380,7 @@ std::size_t TestFixture::runTests(const options& args)
         std::cerr << std::endl << std::endl;
     }
     std::cerr.flush();
-    return fails_counter;
+    return fails_counter + succeeded_todos_counter;
 }
 
 void TestFixture::reportOut(const std::string & outmsg, Color /*c*/)

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -3740,13 +3740,11 @@ private:
               "        std::cout << abc << p;\n"
               "    }\n"
               "}", false);
-        TODO_ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
-                           "[test.cpp:2] -> [test.cpp:4]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
-                           "[test.cpp:2] -> [test.cpp:5]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
-                           "[test.cpp:2] -> [test.cpp:6]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n",
-                           "[test.cpp:2] -> [test.cpp:3]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
-                           "[test.cpp:2] -> [test.cpp:4]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n",
-                           errout.str());
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
+                      "[test.cpp:2] -> [test.cpp:4]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
+                      "[test.cpp:2] -> [test.cpp:5]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n"
+                      "[test.cpp:2] -> [test.cpp:6]: (warning) Either the condition 'p==0' is redundant or there is possible null pointer dereference: p.\n",
+                      errout.str());
 
         check("void f() {\n"
               "    void* p1 = 0;\n"


### PR DESCRIPTION
Since the `TODO_ASSERT_*` macros are essentially xfail/xpass we also need to fail if those do not return the expected results.