### PR TITLE
readme.md: removed defunct (and unnecessary) GitHub Actions badge [skip ci]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # **Cppcheck** 
 
-|GitHub Actions|OSS-Fuzz|Coverity Scan Build Status|License|
-|:-:|:--:|:--:|:--:|
-|[![Github Action Status](https://github.com/danmar/cppcheck/workflows/CI/badge.svg)](https://github.com/danmar/cppcheck/actions?query=workflow%3ACI)|[![OSS-Fuzz](https://oss-fuzz-build-logs.storage.googleapis.com/badges/cppcheck.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:cppcheck)|[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/512.svg)](https://scan.coverity.com/projects/512)|[![License](https://img.shields.io/badge/license-GPL3.0-blue.svg)](https://opensource.org/licenses/GPL-3.0) 
+OSS-Fuzz|Coverity Scan Build Status|License|
+|:--:|:--:|:--:|
+[![OSS-Fuzz](https://oss-fuzz-build-logs.storage.googleapis.com/badges/cppcheck.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:cppcheck)|[![Coverity Scan Build Status](https://img.shields.io/coverity/scan/512.svg)](https://scan.coverity.com/projects/512)|[![License](https://img.shields.io/badge/license-GPL3.0-blue.svg)](https://opensource.org/licenses/GPL-3.0) 
 
 ## About the name
 


### PR DESCRIPTION
As discussed in https://github.com/danmar/cppcheck/pull/4854#issuecomment-1460658523.