### PR TITLE
qt: fix Q_UNUSED macro defintion

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5170,7 +5170,7 @@
   <define name="Q_Q(Class)" value="Class * const q = q_func()"/>
   <define name="Q_RETURN_ARG(type, data)" value="QReturnArgument&lt;type &gt;(#type, data)"/>
   <define name="Q_UNLIKELY(expr)" value="expr"/>
-  <define name="Q_UNUSED(X)" value="(void)(X)"/>
+  <define name="Q_UNUSED(X)" value="(void)(X);"/>
   <define name="QT_BEGIN_NAMESPACE" value=""/>
   <define name="QT_END_NAMESPACE" value=""/>
   <define name="QT_TR_NOOP(x)" value="x"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -420,8 +420,9 @@ void MacroTest3()
     QVERIFY2(2 >= 0, message.constData());
 }
 
-void validCode(int * pIntPtr, QString & qstrArg)
+void validCode(int * pIntPtr, QString & qstrArg, double d)
 {
+    Q_UNUSED(d)
     if (QFile::exists("test")) {}
 
     if (pIntPtr != Q_NULLPTR) {


### PR DESCRIPTION
cf https://codebrowser.dev/qt5/qtbase/src/corelib/global/qglobal.h.html#_M/Q_UNUSED