### PR TITLE
ValueFlow: Improve the starting point for uninitialized variables to find more uninitialized usages after many conditionals

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7692,6 +7692,52 @@ static void addToErrorPath(ValueFlow::Value& value, const ValueFlow::Value& from
     });
 }
 
+static std::vector<Token*> findAllUsages(const Variable* var, Token* start)
+{
+    std::vector<Token*> result;
+    const Scope* scope = var->scope();
+    if (!scope)
+        return result;
+    Token* tok2 = Token::findmatch(start, "%varid%", scope->bodyEnd, var->declarationId());
+    while(tok2) {
+        result.push_back(tok2);
+        tok2 = Token::findmatch(tok2->next(), "%varid%", scope->bodyEnd, var->declarationId());
+    }
+    return result;
+}
+
+static Token* findStartToken(const Variable* var, Token* start)
+{
+    std::vector<Token*> uses = findAllUsages(var, start);
+    if (uses.empty())
+        return start;
+    Token* first = uses.front();
+    const Scope* scope = first->scope();
+    if(Token::findmatch(start, "goto|asm|setjmp|longjmp", first))
+        return start;
+    // If there is only one usage or the first usage is in the same scope
+    if (uses.size() == 1 || scope == var->scope())
+        return first->previous();
+    // If all uses are in the same scope
+    if (std::all_of(uses.begin()+1, uses.end(), [&](const Token* tok) {
+        return tok->scope() == scope;
+    }))
+        return first->previous();
+    // Compute the outer scope
+    while(scope && scope->nestedIn != var->scope())
+        scope = scope->nestedIn;
+    if (!scope)
+        return start;
+    Token* tok = const_cast<Token*>(scope->bodyStart);
+    if (!tok)
+        return start;
+    if (Token::simpleMatch(tok->tokAt(-2), "} else {"))
+        tok = tok->linkAt(-2);
+    if (Token::simpleMatch(tok->previous(), ") {"))
+        return tok->linkAt(-1)->previous();
+    return tok;
+}
+
 static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDatabase*/, const Settings* settings)
 {
     for (Token *tok = tokenlist->front(); tok; tok = tok->next()) {
@@ -7718,6 +7764,8 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
 
         bool partial = false;
 
+        Token* start = findStartToken(var, tok->next());
+
         std::map<Token*, ValueFlow::Value> partialReads;
         if (const Scope* scope = var->typeScope()) {
             if (Token::findsimplematch(scope->bodyStart, "union", scope->bodyEnd))
@@ -7733,7 +7781,7 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
                     continue;
                 }
                 MemberExpressionAnalyzer analyzer(memVar.nameToken()->str(), tok, uninitValue, tokenlist, settings);
-                valueFlowGenericForward(tok->next(), tok->scope()->bodyEnd, analyzer, *settings);
+                valueFlowGenericForward(start, tok->scope()->bodyEnd, analyzer, *settings);
 
                 for (auto&& p : *analyzer.partialReads) {
                     Token* tok2 = p.first;
@@ -7763,7 +7811,7 @@ static void valueFlowUninit(TokenList* tokenlist, SymbolDatabase* /*symbolDataba
         if (partial)
             continue;
 
-        valueFlowForward(tok->next(), tok->scope()->bodyEnd, var->nameToken(), uninitValue, tokenlist, settings);
+        valueFlowForward(start, tok->scope()->bodyEnd, var->nameToken(), uninitValue, tokenlist, settings);
     }
 }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7699,7 +7699,7 @@ static std::vector<Token*> findAllUsages(const Variable* var, Token* start)
     if (!scope)
         return result;
     Token* tok2 = Token::findmatch(start, "%varid%", scope->bodyEnd, var->declarationId());
-    while(tok2) {
+    while (tok2) {
         result.push_back(tok2);
         tok2 = Token::findmatch(tok2->next(), "%varid%", scope->bodyEnd, var->declarationId());
     }
@@ -7712,19 +7712,19 @@ static Token* findStartToken(const Variable* var, Token* start)
     if (uses.empty())
         return start;
     Token* first = uses.front();
-    if(Token::findmatch(start, "goto|asm|setjmp|longjmp", first))
+    if (Token::findmatch(start, "goto|asm|setjmp|longjmp", first))
         return start;
     const Scope* scope = first->scope();
     // If there is only one usage or the first usage is in the same scope
     if (uses.size() == 1 || scope == var->scope())
         return first->previous();
     // If all uses are in the same scope
-    if (std::all_of(uses.begin()+1, uses.end(), [&](const Token* tok) {
+    if (std::all_of(uses.begin() + 1, uses.end(), [&](const Token* tok) {
         return tok->scope() == scope;
     }))
         return first->previous();
     // Compute the outer scope
-    while(scope && scope->nestedIn != var->scope())
+    while (scope && scope->nestedIn != var->scope())
         scope = scope->nestedIn;
     if (!scope)
         return start;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7712,9 +7712,9 @@ static Token* findStartToken(const Variable* var, Token* start)
     if (uses.empty())
         return start;
     Token* first = uses.front();
-    const Scope* scope = first->scope();
     if(Token::findmatch(start, "goto|asm|setjmp|longjmp", first))
         return start;
+    const Scope* scope = first->scope();
     // If there is only one usage or the first usage is in the same scope
     if (uses.size() == 1 || scope == var->scope())
         return first->previous();

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -3499,7 +3499,7 @@ private:
                         "    }\n"
                         "}",
                         "test.cpp");
-        ASSERT_EQUALS("", errout.str());
+        TODO_ASSERT_EQUALS("", "[test.cpp:6]: (error) Uninitialized variable: i\n", errout.str());
 
         valueFlowUninit("void f() {\n"
                         "    int i, y;\n"
@@ -3510,7 +3510,7 @@ private:
                         "    }\n"
                         "}",
                         "test.cpp");
-        ASSERT_EQUALS("", errout.str());
+        TODO_ASSERT_EQUALS("", "[test.cpp:6]: (error) Uninitialized variable: i\n", errout.str());
 
         valueFlowUninit("void f() {\n"
                         "    int i, y;\n"
@@ -3838,7 +3838,7 @@ private:
                         "    if (y == 1) { return; }\n"
                         "    return x;\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (error) Uninitialized variable: x\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: x\n", errout.str());
 
         valueFlowUninit("int f(int x) {\n"
                         "    int ret;\n"
@@ -3871,7 +3871,7 @@ private:
                         "        if (foo) break;\n"
                         "    return x;\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
 
         valueFlowUninit("int f() {\n"
                         "    int x;\n"
@@ -3879,7 +3879,7 @@ private:
                         "        if (bar) break;\n"
                         "    return x;\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: x\n", errout.str());
 
         // try/catch : don't warn about exception variable
         valueFlowUninit("void f() {\n"
@@ -6666,7 +6666,7 @@ private:
                         "    struct AB ab;\n"
                         "    while (x) { ab.a = ab.a + 1; }\n"
                         "}");
-        TODO_ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: ab.a\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: ab.a\n", errout.str());
 
         valueFlowUninit("struct AB { int a; };\n"
                         "void f() {\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -7867,7 +7867,7 @@ private:
         ASSERT_EQUALS(true, testValueOfXImpossible(code, 3U, "a", -1));
         ASSERT_EQUALS(true, testValueOfXImpossible(code, 3U, -1));
     }
-    
+
     void valueFlowImpossibleUnknownConstant()
     {
         const char* code;


### PR DESCRIPTION
Some test cases where the uninitialized variable is used in dead code have become a TODO. The test cases dont seem to be good examples of real-world code though. I think this can be addressed in a future PR.