### PR TITLE
misra: fix misra-3_1 false positive for URIs in block comments

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -1545,7 +1545,8 @@ class MisraChecker:
             starts_with_double_slash = token.str.startswith('//')
             if token.str.startswith('/*') or starts_with_double_slash:
                 s = token.str.lstrip('/')
-                if ((not starts_with_double_slash) and '//' in s) or '/*' in s:
+                double_backslash_not_uri = not all(regex.match("\w+://$", part) for part in s.split("//"))
+                if ((not starts_with_double_slash) and double_backslash_not_uri) or '/*' in s:
                     self.reportError(token, 3, 1)
 
     def misra_3_2(self, rawTokens):


### PR DESCRIPTION
Having a URI in a block comment (example below) would result in a misra 3.1 violation.
This lead to issues in our project, where URLs were embedded block comments, referring to documentation. 
```c
/*
 * https://cppcheck.net
 * /
``` 
