### PR TITLE
parse files with `simplecpp` without providing a stream

### DIFF
--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -159,7 +159,7 @@ private:
      * @param fileStream stream the file content can be read from
      * @return number of errors found
      */
-    unsigned int checkFile(const std::string& filename, const std::string &cfgname, std::istream& fileStream);
+    unsigned int checkFile(const std::string& filename, const std::string &cfgname, std::istream* fileStream = nullptr);
 
     /**
      * @brief Check raw tokens


### PR DESCRIPTION
This leverages the new interface introduced with https://github.com/danmar/simplecpp/pull/244 to avoid usage of C++ `std::ifstream` in favor of the C `FILE` I/O which has less overhead.

This is already used internally for include files opened via simplecpp and this also uses it for the actual input files.