### PR TITLE
CppCheck: removed changing of `debugwarnings` for non-accepted files

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -625,10 +625,6 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
 {
     mExitCode = 0;
 
-    // only show debug warnings for accepted C/C++ source files
-    if (!Path::acceptFile(filename))
-        mSettings.debugwarnings = false;
-
     if (Settings::terminated())
         return mExitCode;
 


### PR DESCRIPTION
This was introduced in 9a102702cbf5d643dee70abc03e0af51008be8b8 and it doesn't really make sense IMO.

It will also be the last write usage of the settings after #4964 is done and allows us to make the settings const and eliminate a copy which is a minor hot spot when using `ThreadExecutor` and will enable us to use the shared Executor code in all cases without performance regressions.