### PR TITLE
removed `CppCheck` dependency from `CppCheckExecutor::parseFromArgs()`

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -78,9 +78,8 @@ CppCheckExecutor::~CppCheckExecutor()
     delete mErrorOutput;
 }
 
-bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* const argv[])
+bool CppCheckExecutor::parseFromArgs(Settings &settings, int argc, const char* const argv[])
 {
-    Settings& settings = cppcheck->settings();
     CmdLineParser parser(settings);
     const bool success = parser.parseFromArgs(argc, argv);
 
@@ -199,23 +198,20 @@ int CppCheckExecutor::check(int argc, const char* const argv[])
 {
     CheckUnusedFunctions::clear();
 
-    CppCheck cppCheck(*this, true, executeCommand);
-
-    const Settings& settings = cppCheck.settings();
-    mSettings = &settings;
-
-    if (!parseFromArgs(&cppCheck, argc, argv)) {
-        mSettings = nullptr;
+    Settings settings;
+    if (!parseFromArgs(settings, argc, argv)) {
         return EXIT_FAILURE;
     }
     if (Settings::terminated()) {
-        mSettings = nullptr;
         return EXIT_SUCCESS;
     }
 
-    int ret;
+    CppCheck cppCheck(*this, true, executeCommand);
+    cppCheck.settings() = settings;
+    mSettings = &settings;
 
-    if (cppCheck.settings().exceptionHandling)
+    int ret;
+    if (settings.exceptionHandling)
         ret = check_wrapper(cppCheck);
     else
         ret = check_internal(cppCheck);

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -101,7 +101,7 @@ bool CppCheckExecutor::parseFromArgs(CppCheck *cppcheck, int argc, const char* c
         if (parser.getShowErrorMessages()) {
             mShowAllErrors = true;
             std::cout << ErrorMessage::getXMLHeader(settings.cppcheckCfgProductName);
-            cppcheck->getErrorMessages();
+            CppCheck::getErrorMessages(*this);
             std::cout << ErrorMessage::getXMLFooter() << std::endl;
         }
 

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -115,12 +115,12 @@ protected:
      * @brief Parse command line args and get settings and file lists
      * from there.
      *
-     * @param cppcheck cppcheck instance
+     * @param settings the settings to store into
      * @param argc argc from main()
      * @param argv argv from main()
      * @return false when errors are found in the input
      */
-    bool parseFromArgs(CppCheck *cppcheck, int argc, const char* const argv[]);
+    bool parseFromArgs(Settings &settings, int argc, const char* const argv[]);
 
 private:
 

--- a/gui/newsuppressiondialog.cpp
+++ b/gui/newsuppressiondialog.cpp
@@ -50,8 +50,7 @@ NewSuppressionDialog::NewSuppressionDialog(QWidget *parent) :
     };
 
     QErrorLogger errorLogger;
-    CppCheck cppcheck(errorLogger, false, nullptr);
-    cppcheck.getErrorMessages();
+    CppCheck::getErrorMessages(errorLogger);
     errorLogger.errorIds.sort();
 
     mUI->mComboErrorId->addItems(errorLogger.errorIds);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1649,25 +1649,26 @@ void CppCheck::reportProgress(const std::string &filename, const char stage[], c
     mErrorLogger.reportProgress(filename, stage, value);
 }
 
-void CppCheck::getErrorMessages()
+void CppCheck::getErrorMessages(ErrorLogger &errorlogger)
 {
-    Settings s(mSettings);
+    Settings s;
     s.severity.enable(Severity::warning);
     s.severity.enable(Severity::style);
     s.severity.enable(Severity::portability);
     s.severity.enable(Severity::performance);
     s.severity.enable(Severity::information);
 
-    purgedConfigurationMessage(emptyString,emptyString);
-
-    mTooManyConfigs = true;
-    tooManyConfigsError(emptyString,0U);
+    CppCheck cppcheck(errorlogger, true, nullptr);
+    cppcheck.purgedConfigurationMessage(emptyString,emptyString);
+    cppcheck.mTooManyConfigs = true;
+    cppcheck.tooManyConfigsError(emptyString,0U);
+    // TODO: add functions to get remaining error messages
 
     // call all "getErrorMessages" in all registered Check classes
     for (std::list<Check *>::const_iterator it = Check::instances().cbegin(); it != Check::instances().cend(); ++it)
-        (*it)->getErrorMessages(this, &s);
+        (*it)->getErrorMessages(&errorlogger, &s);
 
-    Preprocessor::getErrorMessages(this, &s);
+    Preprocessor::getErrorMessages(&errorlogger, &s);
 }
 
 void CppCheck::analyseClangTidy(const ImportProject::FileSettings &fileSettings)

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -116,7 +116,7 @@ public:
      * @brief Call all "getErrorMessages" in all registered Check classes.
      * Also print out XML header and footer.
      */
-    void getErrorMessages();
+    static void getErrorMessages(ErrorLogger &errorlogger);
 
     void tooManyConfigsError(const std::string &file, const int numberOfConfigurations);
     void purgedConfigurationMessage(const std::string &file, const std::string& configuration);

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -75,8 +75,7 @@ private:
 
     void getErrorMessages() const {
         ErrorLogger2 errorLogger;
-        CppCheck cppCheck(errorLogger, true, nullptr);
-        cppCheck.getErrorMessages();
+        CppCheck::getErrorMessages(errorLogger);
         ASSERT(!errorLogger.id.empty());
 
         // Check if there are duplicate error ids in errorLogger.id


### PR DESCRIPTION
That function is basically just parsing the command-line options into the settings so no need for a `CppCheck` object yet. Also moved the object down to the actual usage.

Preparation for moving the `Settings` ownership out of `CppCheck` in #4964.