### PR TITLE
Preprocessor: relaxed dependency on `Suppressions`

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -662,7 +662,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
     CheckUnusedFunctions checkUnusedFunctions(nullptr, nullptr, nullptr);
 
     try {
-        Preprocessor preprocessor(mSettings, mSettings.nomsg, this);
+        Preprocessor preprocessor(mSettings, this);
         std::set<std::string> configurations;
 
         simplecpp::OutputList outputList;
@@ -739,7 +739,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         }
 
         // Parse comments and then remove them
-        preprocessor.inlineSuppressions(tokens1);
+        preprocessor.inlineSuppressions(tokens1, mSettings.nomsg);
         if (mSettings.dump || !mSettings.addons.empty()) {
             mSettings.nomsg.dump(dumpProlog);
         }

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -84,10 +84,10 @@ public:
     /** character that is inserted in expanded macros */
     static char macroChar;
 
-    explicit Preprocessor(const Settings& settings, Suppressions &suppressions, ErrorLogger *errorLogger = nullptr);
+    explicit Preprocessor(const Settings& settings, ErrorLogger *errorLogger = nullptr);
     virtual ~Preprocessor();
 
-    void inlineSuppressions(const simplecpp::TokenList &tokens);
+    void inlineSuppressions(const simplecpp::TokenList &tokens, Suppressions &suppressions);
 
     void setDirectives(const simplecpp::TokenList &tokens);
     void setDirectives(const std::list<Directive> &directives) {
@@ -147,11 +147,15 @@ public:
 
     /**
      * Get preprocessed code for a given configuration
+     *
+     * Note: for testing only.
+     *
      * @param filedata file data including preprocessing 'if', 'define', etc
      * @param cfg configuration to read out
      * @param filename name of source file
+     * @param inlineSuppression the inline suppressions
      */
-    std::string getcode(const std::string &filedata, const std::string &cfg, const std::string &filename);
+    std::string getcode(const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression = nullptr);
 
     /**
      * Calculate HASH. Using toolinfo, tokens1, filedata.
@@ -189,7 +193,6 @@ private:
     void error(const std::string &filename, unsigned int linenr, const std::string &msg);
 
     const Settings& mSettings;
-    Suppressions &mSuppressions;
     ErrorLogger *mErrorLogger;
 
     /** list of all directives met while preprocessing file */

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -46,3 +46,18 @@ def test_missing_include_check_config(tmpdir):
 
 def test_missing_include_check_config_j(tmpdir):
     __test_missing_include_check_config(tmpdir, True)
+
+def test_missing_include_inline_suppr(tmpdir):
+    test_file = os.path.join(tmpdir, 'test.c')
+    with open(test_file, 'wt') as f:
+        f.write("""
+                // cppcheck-suppress missingInclude
+                #include "missing.h"
+                // cppcheck-suppress missingIncludeSystem
+                #include <missing2.h>
+                """)
+
+    args = ['--enable=missingInclude', '--inline-suppr', test_file]
+
+    _, _, stderr = cppcheck(args)
+    assert stderr == ''

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -265,7 +265,7 @@ private:
         Settings settings;
         settings.severity.enable(Severity::warning);
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -371,7 +371,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -525,7 +525,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings1, settings1.nomsg, nullptr);
+        Preprocessor preprocessor(settings1);
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this, &preprocessor);
@@ -688,7 +688,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -1137,7 +1137,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -1613,7 +1613,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings1, settings1.nomsg, nullptr);
+        Preprocessor preprocessor(settings1);
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this, &preprocessor);
@@ -2577,7 +2577,7 @@ private:
         settings0.certainty.setEnabled(Certainty::inconclusive, inconclusive);
         settings0.severity.enable(Severity::warning);
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -2900,7 +2900,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -3533,7 +3533,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings1, settings1.nomsg, nullptr);
+        Preprocessor preprocessor(settings1);
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this, &preprocessor);
@@ -3573,7 +3573,7 @@ private:
             s = &settings0;
         s->certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
-        Preprocessor preprocessor(*s, s->nomsg, nullptr);
+        Preprocessor preprocessor(*s);
 
         // Tokenize..
         Tokenizer tokenizer(s, this, &preprocessor);
@@ -7254,7 +7254,7 @@ private:
         // Check..
         settings0.certainty.setEnabled(Certainty::inconclusive, true);
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -7292,7 +7292,7 @@ private:
         Settings settings;
         settings.severity.enable(Severity::performance);
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -7506,7 +7506,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
 
         // Tokenize..
         Tokenizer tokenizer(&settings0, this, &preprocessor);
@@ -7624,7 +7624,7 @@ private:
         settings.severity.enable(Severity::warning);
         settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -7973,7 +7973,7 @@ private:
         Settings settings;
         settings.severity.enable(Severity::style);
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -8151,7 +8151,7 @@ private:
         settings.safeChecks.classes = true;
         settings.severity.enable(Severity::warning);
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);
@@ -8174,7 +8174,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings1, settings1.nomsg, nullptr);
+        Preprocessor preprocessor(settings1);
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this, &preprocessor);
@@ -8373,7 +8373,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        Preprocessor preprocessor(settings1, settings1.nomsg, nullptr);
+        Preprocessor preprocessor(settings1);
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this, &preprocessor);

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -2896,7 +2896,7 @@ private:
         checkNoMemset_(file, line, code, settings);
     }
 
-    void checkNoMemset_(const char* file, int line, const char code[], Settings &settings) {
+    void checkNoMemset_(const char* file, int line, const char code[], const Settings &settings) {
         // Clear the error log
         errout.str("");
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -155,7 +155,7 @@ private:
         std::map<std::string, simplecpp::TokenList*> filedata;
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
-        Preprocessor preprocessor(*settings, settings->nomsg, nullptr);
+        Preprocessor preprocessor(*settings);
         preprocessor.setDirectives(tokens1);
 
         // Tokenizer..

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -288,7 +288,7 @@ private:
     std::string checkCodeInternal_(const std::string &code, const char* filename, const char* file, int line) {
         errout.str("");
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -307,7 +307,7 @@ private:
         settings->certainty.setEnabled(Certainty::inconclusive, inconclusive);
         settings->verbose = verbose;
 
-        Preprocessor preprocessor(*settings, settings->nomsg, nullptr);
+        Preprocessor preprocessor(*settings);
 
         // Tokenize..
         Tokenizer tokenizer(settings, this, &preprocessor);
@@ -347,7 +347,7 @@ private:
         std::map<std::string, simplecpp::TokenList*> filedata;
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
-        Preprocessor preprocessor(*settings, settings->nomsg, nullptr);
+        Preprocessor preprocessor(*settings);
         preprocessor.setDirectives(tokens1);
 
         // Tokenizer..
@@ -1572,7 +1572,7 @@ private:
         settings.severity.enable(Severity::style);
         settings.standards.cpp = Standards::CPP03; // #5560
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizerCpp(&settings, this, &preprocessor);
@@ -1778,7 +1778,7 @@ private:
         settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
         settings.platform.defaultSign = 's';
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this, &preprocessor);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -6614,7 +6614,7 @@ private:
                                 "int PTR4 q4_var RBR4 = 0;\n";
 
         // Preprocess file..
-        Preprocessor preprocessor(settings0, settings0.nomsg);
+        Preprocessor preprocessor(settings0);
         std::list<std::string> configurations;
         std::string filedata;
         std::istringstream fin(raw_code);
@@ -7362,7 +7362,7 @@ private:
         std::map<std::string, simplecpp::TokenList*> filedata;
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
-        Preprocessor preprocessor(settings0, settings0.nomsg, nullptr);
+        Preprocessor preprocessor(settings0);
         preprocessor.setDirectives(tokens1);
 
         // Tokenizer..

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -259,7 +259,7 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
         if (directives)
             preprocessor.setDirectives(*directives);
 
@@ -284,7 +284,7 @@ private:
         std::map<std::string, simplecpp::TokenList*> filedata;
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
-        Preprocessor preprocessor(settings, settings.nomsg, nullptr);
+        Preprocessor preprocessor(settings);
         preprocessor.setDirectives(tokens1);
 
         // Tokenizer..


### PR DESCRIPTION
`Preprocessor::missingInclude()` was implementing the suppression logic which already exists in the `ErrorLogger`. `TestPreProcessor::inline_suppression_for_missing_include()` was relying on this logic but it was not testing the actual production code but the simplified `Preprocessor::getcode()` which is a testing-only implementation. I added Python tests to test this instead.

On a side note - we have several simplified preprocessing implementations which are only used in tests and do not reflect what the actual production code is doing. We need to get rid of these or at least consolidate them.