### PR TITLE
CppcheckExecutor: use dedicated ErrorLogger for printing error messages XML

### DIFF
--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -180,11 +180,6 @@ private:
      * Error output
      */
     std::ofstream* mErrorOutput{};
-
-    /**
-     * Has --errorlist been given?
-     */
-    bool mShowAllErrors{};
 };
 
 #endif // CPPCHECKEXECUTOR_H


### PR DESCRIPTION
This starts to untangle the `ErrorLogger` implementation in `CppcheckExecutor` which handles three different cases and makes things unnecessarily complicated.