### PR TITLE
ProcessExecutor: avoid explicit usage of suppressions

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -515,7 +515,7 @@ void ProcessExecutor::reportInternalChildErr(const std::string &childname, const
                               "cppcheckError",
                               Certainty::normal);
 
-    if (!mSuppressions.nomsg.isSuppressed(errmsg, {}))
+    if (hasToLog(errmsg))
         mErrorLogger.reportErr(errmsg);
 }
 


### PR DESCRIPTION
The `hasToLog()` call performs this check.