### PR TITLE
moved test-only `Preprocessor::getcode()` out of `lib`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -670,7 +670,7 @@ cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor
 test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
-test/helpers.o: test/helpers.cpp lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
+test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
 
 test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/preprocessor.h lib/suppressions.h test/fixture.h test/options.h
@@ -838,7 +838,7 @@ test/testtimer.o: test/testtimer.cpp lib/check.h lib/color.h lib/config.h lib/er
 test/testtoken.o: test/testtoken.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testtoken.cpp
 
-test/testtokenize.o: test/testtokenize.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
+test/testtokenize.o: test/testtokenize.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testtokenize.cpp
 
 test/testtokenlist.o: test/testtokenlist.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -627,7 +627,7 @@ static simplecpp::DUI createDUI(const Settings &mSettings, const std::string &cf
     return dui;
 }
 
-static bool hasErrors(const simplecpp::OutputList &outputList)
+bool Preprocessor::hasErrors(const simplecpp::OutputList &outputList)
 {
     for (simplecpp::OutputList::const_iterator it = outputList.cbegin(); it != outputList.cend(); ++it) {
         switch (it->type) {
@@ -750,36 +750,6 @@ std::string Preprocessor::getcode(const simplecpp::TokenList &tokens1, const std
     }
 
     return ret.str();
-}
-
-std::string Preprocessor::getcode(const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression)
-{
-    simplecpp::OutputList outputList;
-    std::vector<std::string> files;
-
-    std::istringstream istr(filedata);
-    simplecpp::TokenList tokens1(istr, files, Path::simplifyPath(filename), &outputList);
-    if (inlineSuppression)
-        inlineSuppressions(tokens1, *inlineSuppression);
-    tokens1.removeComments();
-    removeComments();
-    setDirectives(tokens1);
-
-    reportOutput(outputList, true);
-
-    if (hasErrors(outputList))
-        return "";
-
-    std::string ret;
-    try {
-        ret = getcode(tokens1, cfg, files, filedata.find("#file") != std::string::npos);
-        // Since "files" is a local variable the tracking info must be cleared..
-        mMacroUsage.clear();
-        mIfCond.clear();
-    } catch (const simplecpp::Output &) {
-        ret.clear();
-    }
-    return ret;
 }
 
 void Preprocessor::reportOutput(const simplecpp::OutputList &outputList, bool showerror)

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -72,6 +72,7 @@ public:
 class CPPCHECKLIB Preprocessor {
     // TODO: get rid of this
     friend class PreprocessorHelper;
+    friend class TestPreprocessor;
 
 public:
 

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -70,6 +70,9 @@ public:
  * configurations that exist in a source file.
  */
 class CPPCHECKLIB Preprocessor {
+    // TODO: get rid of this
+    friend class PreprocessorHelper;
+
 public:
 
     /**
@@ -146,18 +149,6 @@ public:
     std::string getcode(const simplecpp::TokenList &tokens1, const std::string &cfg, std::vector<std::string> &files, const bool writeLocations);
 
     /**
-     * Get preprocessed code for a given configuration
-     *
-     * Note: for testing only.
-     *
-     * @param filedata file data including preprocessing 'if', 'define', etc
-     * @param cfg configuration to read out
-     * @param filename name of source file
-     * @param inlineSuppression the inline suppressions
-     */
-    std::string getcode(const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression = nullptr);
-
-    /**
      * Calculate HASH. Using toolinfo, tokens1, filedata.
      *
      * @param tokens1    Sourcefile tokens
@@ -191,6 +182,8 @@ public:
 private:
     void missingInclude(const std::string &filename, unsigned int linenr, const std::string &header, HeaderTypes headerType);
     void error(const std::string &filename, unsigned int linenr, const std::string &msg);
+
+    static bool hasErrors(const simplecpp::OutputList &outputList);
 
     const Settings& mSettings;
     ErrorLogger *mErrorLogger;

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -66,6 +66,7 @@ ScopedFile::~ScopedFile() {
     }
 }
 
+// TODO: we should be using the actual Preprocessor implementation
 std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression)
 {
     simplecpp::OutputList outputList;
@@ -76,6 +77,7 @@ std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::s
     if (inlineSuppression)
         preprocessor.inlineSuppressions(tokens1, *inlineSuppression);
     tokens1.removeComments();
+    preprocessor.simplifyPragmaAsm(&tokens1);
     preprocessor.removeComments();
     preprocessor.setDirectives(tokens1);
 
@@ -87,11 +89,13 @@ std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::s
     std::string ret;
     try {
         ret = preprocessor.getcode(tokens1, cfg, files, filedata.find("#file") != std::string::npos);
-        // Since "files" is a local variable the tracking info must be cleared..
-        preprocessor.mMacroUsage.clear();
-        preprocessor.mIfCond.clear();
     } catch (const simplecpp::Output &) {
         ret.clear();
     }
+
+    // Since "files" is a local variable the tracking info must be cleared..
+    preprocessor.mMacroUsage.clear();
+    preprocessor.mIfCond.clear();
+
     return ret;
 }

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -19,6 +19,7 @@
 #include "helpers.h"
 
 #include "path.h"
+#include "preprocessor.h"
 
 #include <cstdio>
 #include <stdexcept>
@@ -30,6 +31,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
+
+#include <simplecpp.h>
 
 ScopedFile::ScopedFile(std::string name, const std::string &content, std::string path)
     : mName(std::move(name))
@@ -61,4 +64,34 @@ ScopedFile::~ScopedFile() {
         rmdir(mPath.c_str());
 #endif
     }
+}
+
+std::string PreprocessorHelper::getcode(Preprocessor &preprocessor, const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression)
+{
+    simplecpp::OutputList outputList;
+    std::vector<std::string> files;
+
+    std::istringstream istr(filedata);
+    simplecpp::TokenList tokens1(istr, files, Path::simplifyPath(filename), &outputList);
+    if (inlineSuppression)
+        preprocessor.inlineSuppressions(tokens1, *inlineSuppression);
+    tokens1.removeComments();
+    preprocessor.removeComments();
+    preprocessor.setDirectives(tokens1);
+
+    preprocessor.reportOutput(outputList, true);
+
+    if (Preprocessor::hasErrors(outputList))
+        return "";
+
+    std::string ret;
+    try {
+        ret = preprocessor.getcode(tokens1, cfg, files, filedata.find("#file") != std::string::npos);
+        // Since "files" is a local variable the tracking info must be cleared..
+        preprocessor.mMacroUsage.clear();
+        preprocessor.mIfCond.clear();
+    } catch (const simplecpp::Output &) {
+        ret.clear();
+    }
+    return ret;
 }

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -31,8 +31,8 @@
 #include <sstream> // IWYU pragma: keep
 #include <string>
 
-
 class Token;
+class Processor;
 
 class givenACodeSampleToTokenize {
 private:
@@ -90,6 +90,22 @@ private:
     const std::string mName;
     const std::string mPath;
     const std::string mFullPath;
+};
+
+class PreprocessorHelper
+{
+public:
+    /**
+     * Get preprocessed code for a given configuration
+     *
+     * Note: for testing only.
+     *
+     * @param filedata file data including preprocessing 'if', 'define', etc
+     * @param cfg configuration to read out
+     * @param filename name of source file
+     * @param inlineSuppression the inline suppressions
+     */
+    static std::string getcode(Preprocessor &preprocessor, const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression = nullptr);
 };
 
 #endif // helpersH

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -363,7 +363,7 @@ private:
         settings.userDefines = "__cplusplus";
         Preprocessor preprocessor(settings, this);
         const std::string code("#error hello world!\n");
-        preprocessor.getcode(code, "X", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "X", "test.c");
         ASSERT_EQUALS("[test.c:1]: (error) #error hello world!\n", errout.str());
     }
 
@@ -376,7 +376,7 @@ private:
             settings.userDefines = "TEST";
             Preprocessor preprocessor(settings, this);
             const std::string code("#file \"ab.h\"\n#error hello world!\n#endfile");
-            preprocessor.getcode(code, "TEST", "test.c");
+            PreprocessorHelper::getcode(preprocessor, code, "TEST", "test.c");
             ASSERT_EQUALS("[ab.h:1]: (error) #error hello world!\n", errout.str());
         }
 
@@ -387,7 +387,7 @@ private:
             settings.userDefines = "TEST";
             Preprocessor preprocessor(settings, this);
             const std::string code("#file \"ab.h\"\n\n#endfile\n#error aaa");
-            preprocessor.getcode(code, "TEST", "test.c");
+            PreprocessorHelper::getcode(preprocessor, code, "TEST", "test.c");
             ASSERT_EQUALS("[test.c:2]: (error) #error aaa\n", errout.str());
         }
     }
@@ -399,7 +399,7 @@ private:
         settings.force = true; // No message if --force is given
         Preprocessor preprocessor(settings, this);
         const std::string code("#error hello world!\n");
-        preprocessor.getcode(code, "X", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "X", "test.c");
         ASSERT_EQUALS("", errout.str());
     }
 
@@ -1212,7 +1212,7 @@ private:
                                     "#undef z\n"
                                     "int z;\n"
                                     "z = 0;\n";
-            ASSERT_EQUALS("\n\nint z ;\nz = 0 ;", preprocessor0.getcode(filedata, "", ""));
+            ASSERT_EQUALS("\n\nint z ;\nz = 0 ;", PreprocessorHelper::getcode(preprocessor0, filedata, "", ""));
         }
     }
 
@@ -1651,14 +1651,14 @@ private:
                                     "#if A\n"
                                     "FOO\n"
                                     "#endif";
-            ASSERT_EQUALS("", preprocessor0.getcode(filedata,"",""));
+            ASSERT_EQUALS("", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
         }
         {
             const char filedata[] = "#define A 1\n"
                                     "#if A==1\n"
                                     "FOO\n"
                                     "#endif";
-            ASSERT_EQUALS("\n\nFOO", preprocessor0.getcode(filedata,"",""));
+            ASSERT_EQUALS("\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
         }
     }
 
@@ -1668,7 +1668,7 @@ private:
                                 "#if (B==A) || (B==C)\n"
                                 "FOO\n"
                                 "#endif";
-        ASSERT_EQUALS("\n\n\nFOO", preprocessor0.getcode(filedata,"",""));
+        ASSERT_EQUALS("\n\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
     }
 
     void define_if3() {
@@ -1676,7 +1676,7 @@ private:
                                 "#if (A==0)\n"
                                 "FOO\n"
                                 "#endif";
-        ASSERT_EQUALS("\n\nFOO", preprocessor0.getcode(filedata,"",""));
+        ASSERT_EQUALS("\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
     }
 
     void define_if4() {
@@ -1684,7 +1684,7 @@ private:
                                 "#if X==123\n"
                                 "FOO\n"
                                 "#endif";
-        ASSERT_EQUALS("\n\nFOO", preprocessor0.getcode(filedata,"",""));
+        ASSERT_EQUALS("\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
     }
 
     void define_if5() { // #4516 - #define B (A & 0x00f0)
@@ -1694,7 +1694,7 @@ private:
                                     "#if B==0x0010\n"
                                     "FOO\n"
                                     "#endif";
-            ASSERT_EQUALS("\n\n\nFOO", preprocessor0.getcode(filedata,"",""));
+            ASSERT_EQUALS("\n\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
         }
         {
             const char filedata[] = "#define A 0x00f0\n"
@@ -1703,14 +1703,14 @@ private:
                                     "#if C==0x0010\n"
                                     "FOO\n"
                                     "#endif";
-            ASSERT_EQUALS("\n\n\n\nFOO", preprocessor0.getcode(filedata,"",""));
+            ASSERT_EQUALS("\n\n\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
         }
         {
             const char filedata[] = "#define A (1+A)\n" // don't hang for recursive macros
                                     "#if A==1\n"
                                     "FOO\n"
                                     "#endif";
-            ASSERT_EQUALS("\n\nFOO", preprocessor0.getcode(filedata,"",""));
+            ASSERT_EQUALS("\n\nFOO", PreprocessorHelper::getcode(preprocessor0, filedata,"",""));
         }
     }
 
@@ -1726,10 +1726,10 @@ private:
                                 "#if B >= 0\n"
                                 "456\n"
                                 "#endif\n";
-        const std::string actualA0 = preprocessor0.getcode(filedata, "A=0", "test.c");
+        const std::string actualA0 = PreprocessorHelper::getcode(preprocessor0, filedata, "A=0", "test.c");
         ASSERT_EQUALS(true,  actualA0.find("123") != std::string::npos);
         ASSERT_EQUALS(false, actualA0.find("456") != std::string::npos);
-        const std::string actualA1 = preprocessor0.getcode(filedata, "A=1", "test.c");
+        const std::string actualA1 = PreprocessorHelper::getcode(preprocessor0, filedata, "A=1", "test.c");
         ASSERT_EQUALS(false, actualA1.find("123") != std::string::npos);
         ASSERT_EQUALS(true,  actualA1.find("456") != std::string::npos);
     }
@@ -1839,8 +1839,8 @@ private:
                                 "B me;\n";
 
         // Preprocess => actual result..
-        ASSERT_EQUALS("\n\n\n\n\n\n$int me ;", preprocessor0.getcode(filedata, "", "a.cpp"));
-        ASSERT_EQUALS("\n\n\n\n\n\n$char me ;", preprocessor0.getcode(filedata, "A", "a.cpp"));
+        ASSERT_EQUALS("\n\n\n\n\n\n$int me ;", PreprocessorHelper::getcode(preprocessor0, filedata, "", "a.cpp"));
+        ASSERT_EQUALS("\n\n\n\n\n\n$char me ;", PreprocessorHelper::getcode(preprocessor0, filedata, "A", "a.cpp"));
     }
 
     void ifndef_define() {
@@ -1864,8 +1864,8 @@ private:
                                 "#endif\n";
 
         // Preprocess => actual result..
-        ASSERT_EQUALS("", preprocessor0.getcode(filedata, "", "a.cpp"));
-        ASSERT_EQUALS("", preprocessor0.getcode(filedata, "A", "a.cpp"));
+        ASSERT_EQUALS("", PreprocessorHelper::getcode(preprocessor0, filedata, "", "a.cpp"));
+        ASSERT_EQUALS("", PreprocessorHelper::getcode(preprocessor0, filedata, "A", "a.cpp"));
     }
 
     void redundant_config() {
@@ -1958,7 +1958,7 @@ private:
                                "// cppcheck-suppress missingIncludeSystem\n"
                                "#include <missing2.h>\n");
         Suppressions inlineSuppr;
-        preprocessor.getcode(code, "", "test.c", &inlineSuppr);
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c", &inlineSuppr);
 
         auto suppressions = inlineSuppr.getSuppressions();
         ASSERT_EQUALS(2, suppressions.size());
@@ -1984,7 +1984,7 @@ private:
         const std::string src("#if defined X || Y\n"
                               "Fred & Wilma\n"
                               "#endif\n");
-        std::string actual = preprocessor0.getcode(src, "X=1", "test.c");
+        std::string actual = PreprocessorHelper::getcode(preprocessor0, src, "X=1", "test.c");
 
         ASSERT_EQUALS("\nFred & Wilma", actual);
     }
@@ -1994,12 +1994,12 @@ private:
                               "Fred & Wilma\n"
                               "#endif\n");
         {
-            std::string actual = preprocessor0.getcode(src, "X=1", "test.c");
+            std::string actual = PreprocessorHelper::getcode(preprocessor0, src, "X=1", "test.c");
             ASSERT_EQUALS("", actual);
         }
 
         {
-            std::string actual = preprocessor0.getcode(src, "X=1;Y=2", "test.c");
+            std::string actual = PreprocessorHelper::getcode(preprocessor0, src, "X=1;Y=2", "test.c");
             ASSERT_EQUALS("\nFred & Wilma", actual);
         }
     }
@@ -2011,34 +2011,34 @@ private:
                             "#if (X == Y)\n"
                             "Fred & Wilma\n"
                             "#endif\n";
-        const std::string actual = preprocessor0.getcode(code, "TEST", "test.c");
+        const std::string actual = PreprocessorHelper::getcode(preprocessor0, code, "TEST", "test.c");
         ASSERT_EQUALS("\n\n\nFred & Wilma", actual);
     }
 
     void predefine4() {
         // #3577
         const char code[] = "char buf[X];\n";
-        const std::string actual = preprocessor0.getcode(code, "X=123", "test.c");
+        const std::string actual = PreprocessorHelper::getcode(preprocessor0, code, "X=123", "test.c");
         ASSERT_EQUALS("char buf [ $123 ] ;", actual);
     }
 
     void predefine5() {  // #3737, #5119 - automatically define __cplusplus
         // #3737...
         const char code[] = "#ifdef __cplusplus\n123\n#endif";
-        ASSERT_EQUALS("",      preprocessor0.getcode(code, "", "test.c"));
-        ASSERT_EQUALS("\n123", preprocessor0.getcode(code, "", "test.cpp"));
+        ASSERT_EQUALS("",      PreprocessorHelper::getcode(preprocessor0, code, "", "test.c"));
+        ASSERT_EQUALS("\n123", PreprocessorHelper::getcode(preprocessor0, code, "", "test.cpp"));
     }
 
     void predefine6() { // automatically define __STDC_VERSION__
         const char code[] = "#ifdef __STDC_VERSION__\n123\n#endif";
-        ASSERT_EQUALS("\n123", preprocessor0.getcode(code, "", "test.c"));
-        ASSERT_EQUALS("",      preprocessor0.getcode(code, "", "test.cpp"));
+        ASSERT_EQUALS("\n123", PreprocessorHelper::getcode(preprocessor0, code, "", "test.c"));
+        ASSERT_EQUALS("",      PreprocessorHelper::getcode(preprocessor0, code, "", "test.cpp"));
     }
 
     void invalidElIf() {
         // #2942 - segfault
         const char code[] = "#elif (){\n";
-        const std::string actual = preprocessor0.getcode(code, "TEST", "test.c");
+        const std::string actual = PreprocessorHelper::getcode(preprocessor0, code, "TEST", "test.c");
         ASSERT_EQUALS("", actual);
     }
 
@@ -2307,7 +2307,7 @@ private:
         settings.userDefines = "foo";
         Preprocessor preprocessor(settings, this);
         const std::string code("#error hello world!\n");
-        preprocessor.getcode(code, "X", "./././test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "X", "./././test.c");
         ASSERT_EQUALS("[test.c:1]: (error) #error hello world!\n", errout.str());
     }
 
@@ -2344,7 +2344,7 @@ private:
 
         std::ostringstream ostr;
         Preprocessor preprocessor(settings0, this);
-        preprocessor.getcode(filedata, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, filedata, "", "test.c");
         preprocessor.dump(ostr);
         ASSERT_EQUALS(dumpdata, ostr.str());
     }
@@ -2371,7 +2371,7 @@ private:
 
         std::ostringstream ostr;
         Preprocessor preprocessor(settings0, this);
-        preprocessor.getcode(filedata, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, filedata, "", "test.c");
         preprocessor.dump(ostr);
         ASSERT_EQUALS(dumpdata, ostr.str());
     }
@@ -2388,7 +2388,7 @@ private:
 
         std::ostringstream ostr;
         Preprocessor preprocessor(settings0, this);
-        preprocessor.getcode(filedata, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, filedata, "", "test.c");
         preprocessor.dump(ostr);
         ASSERT_EQUALS(dumpdata, ostr.str());
     }
@@ -2407,7 +2407,7 @@ private:
 
         std::string code("#include \"header.h\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("", errout.str());
     }
@@ -2424,7 +2424,7 @@ private:
 
         std::string code("#include \"header.h\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: \"header.h\" not found. [missingInclude]\n", errout.str());
     }
@@ -2443,7 +2443,7 @@ private:
 
         std::string code("#include \"header.h\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: \"header.h\" not found. [missingInclude]\n", errout.str());
     }
@@ -2463,7 +2463,7 @@ private:
 
         std::string code("#include \"inc/header.h\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("", errout.str());
     }
@@ -2483,7 +2483,7 @@ private:
 
         std::string code("#include \"" + header.path() + "\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("", errout.str());
     }
@@ -2502,7 +2502,7 @@ private:
 
         std::string code("#include \"" + header + "\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: \"" + header + "\" not found. [missingInclude]\n", errout.str());
     }
@@ -2521,7 +2521,7 @@ private:
 
         std::string code("#include <header.h>");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: <header.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]\n", errout.str());
     }
@@ -2538,7 +2538,7 @@ private:
 
         std::string code("#include <header.h>");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: <header.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]\n", errout.str());
     }
@@ -2559,7 +2559,7 @@ private:
 
         std::string code("#include <header.h>");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("", errout.str());
     }
@@ -2579,7 +2579,7 @@ private:
 
         std::string code("#include <" + header.path() + ">");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("", errout.str());
     }
@@ -2598,7 +2598,7 @@ private:
 
         std::string code("#include <" + header + ">");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: <" + header + "> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]\n", errout.str());
     }
@@ -2621,7 +2621,7 @@ private:
                          "#include <missing2.h>\n"
                          "#include \"header2.h\"");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: \"missing.h\" not found. [missingInclude]\n"
                       "test.c:2:0: information: Include file: <header.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]\n"
@@ -2661,7 +2661,7 @@ private:
                          "#include <" + header6.path() + ">\n"
                          "#include <" + missing4 + ">\n");
         errout.str("");
-        preprocessor.getcode(code, "", "test.c");
+        PreprocessorHelper::getcode(preprocessor, code, "", "test.c");
 
         ASSERT_EQUALS("test.c:1:0: information: Include file: \"missing.h\" not found. [missingInclude]\n"
                       "test.c:2:0: information: Include file: <header.h> not found. Please note: Cppcheck does not need standard library headers to get proper results. [missingIncludeSystem]\n"

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -18,6 +18,7 @@
 
 #include "config.h"
 #include "errortypes.h"
+#include "helpers.h"
 #include "platform.h"
 #include "preprocessor.h" // usually tests here should not use preprocessor...
 #include "settings.h"
@@ -6652,7 +6653,7 @@ private:
         std::string filedata;
         std::istringstream fin(raw_code);
         preprocessor.preprocess(fin, filedata, configurations, emptyString, settings0.includePaths);
-        const std::string code = preprocessor.getcode(filedata, emptyString, emptyString);
+        const std::string code = PreprocessorHelper::getcode(preprocessor, filedata, emptyString, emptyString);
 
         ASSERT_THROW(tokenizeAndStringify(code.c_str()), InternalError);
     }


### PR DESCRIPTION
I couldn't wrap my head around it while trying to merge those functions. I also had some weird issue I could not resolve.

I also think the `Preprocessor`/`Settings` object in the tests should not be shared between all tests. I think it is not reset properly.