### PR TITLE
Improve `isDeadScope` to handle var inside if constexpr block

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -412,6 +412,15 @@ static bool isDeadScope(const Token * tok, const Scope * scope)
     const Variable * var = tok->variable();
     if (var && (!var->isLocal() || var->isStatic() || var->isExtern()))
         return false;
+    const Scope* curScope = tok->scope();
+    while (curScope && (curScope != scope->nestedIn)) {
+        if (curScope->type == Scope::eIf && curScope->classDef && !curScope->classDef->isConstexpr()) {
+            if (curScope->bodyEnd != scope->bodyEnd && precedes(curScope->bodyEnd, scope->bodyEnd))
+                return true;
+        }
+        curScope = curScope->nestedIn;
+    }
+
     if (tok->scope()->type == Scope::eIf && tok->scope()->classDef->isConstexpr()) {
         return false;
     }

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -412,6 +412,9 @@ static bool isDeadScope(const Token * tok, const Scope * scope)
     const Variable * var = tok->variable();
     if (var && (!var->isLocal() || var->isStatic() || var->isExtern()))
         return false;
+    if (tok->scope()->type == Scope::eIf && tok->scope()->classDef->isConstexpr()) {
+        return false;
+    }
     if (tok->scope() && tok->scope()->bodyEnd != scope->bodyEnd && precedes(tok->scope()->bodyEnd, scope->bodyEnd))
         return true;
     return false;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -4066,14 +4066,35 @@ private:
               "        int count; \n"
               "        const int* pData; \n"
               "    } dataHolder = {}; \n"
+              "    bool yes = true; \n"
+              "    if (yes) { \n"
               "    if constexpr (HAS_DATA) { \n"
               "        int data = 20; \n "
               "        dataHolder.count = 1;\n"
               "        dataHolder.pData = &data;\n"
               "    }\n"
+              "    }"
               "    if(dataHolder.count) \n"
               "        printf(\"Data=%d\", *dataHolder.pData); \n"
               "}\n");
+        ASSERT_EQUALS("[test.cpp:11] -> [test.cpp:9] -> [test.cpp:13]: (error) Using object that points to local variable 'data' that is out of scope.\n"\
+                      "[test.cpp:11] -> [test.cpp:9] -> [test.cpp:14]: (error) Using object that points to local variable 'data' that is out of scope.\n"\
+                      "[test.cpp:11] -> [test.cpp:9] -> [test.cpp:14]: (error) Using pointer to local variable 'data' that is out of scope.\n", errout.str());
+
+        check("void createPipelineLayout() { \n"
+            "    constexpr bool HAS_DATA = true;"
+            "    struct DataHolder { \n"
+            "        int count; \n"
+            "        const int* pData; \n"
+            "    } dataHolder = {}; \n"
+            "    if constexpr (HAS_DATA) { \n"
+            "        int data = 20; \n "
+            "        dataHolder.count = 1;\n"
+            "        dataHolder.pData = &data;\n"
+            "    }\n"
+            "    if(dataHolder.count) \n"
+            "        printf(\"Data=%d\", *dataHolder.pData); \n"
+            "}\n");
         ASSERT_EQUALS("", errout.str());
 
         check("void foo(int a) {\n"

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -4060,6 +4060,22 @@ private:
     }
 
     void invalidLifetime() {
+        check("void createPipelineLayout() { \n"
+              "    constexpr bool HAS_DATA = true;"
+              "    struct DataHolder { \n"
+              "        int count; \n"
+              "        const int* pData; \n"
+              "    } dataHolder = {}; \n"
+              "    if constexpr (HAS_DATA) { \n"
+              "        int data = 20; \n "
+              "        dataHolder.count = 1;\n"
+              "        dataHolder.pData = &data;\n"
+              "    }\n"
+              "    if(dataHolder.count) \n"
+              "        printf(\"Data=%d\", *dataHolder.pData); \n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
+
         check("void foo(int a) {\n"
               "    std::function<void()> f;\n"
               "    if (a > 0) {\n"


### PR DESCRIPTION
Improve `isDeadScope` check to not report false positive if variable resides in constexpr block. 