### PR TITLE
Add missing rebinding trait to TaggedAllocator

### DIFF
--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -41,6 +41,15 @@ struct TaggedAllocator : std::allocator<T>
     TaggedAllocator(Ts&&... ts)
         : std::allocator<T>(std::forward<Ts>(ts)...)
     {}
+
+    template<class U>
+    TaggedAllocator(const TaggedAllocator<U, N>);
+
+    template<class U>
+    struct rebind
+    {
+        using other = TaggedAllocator<U, N>;
+    };
 };
 
 template<typename T, std::size_t N = DefaultSmallVectorSize>


### PR DESCRIPTION
GCC 13 checks for this trait, and Cppcheck cannot be compiled without it. See: https://gcc.gnu.org/gcc-13/porting_to.html#alloc-rebind