### PR TITLE
testrunner: even more `SettingsBuilder` usage and `const` cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,7 +667,7 @@ cli/stacktrace.o: cli/stacktrace.cpp cli/stacktrace.h lib/config.h lib/utils.h
 cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/threadexecutor.cpp
 
-test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
+test/fixture.o: test/fixture.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
 test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -30,6 +30,8 @@
 #include <sstream>
 #include <string>
 
+#include <tinyxml2.h>
+
 std::ostringstream errout;
 std::ostringstream output;
 
@@ -419,5 +421,15 @@ TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::platform(cppcheck::P
     // TODO: exename is not yet set
     if (!settings.platform.set(platformStr, errstr, {fixture.exename}))
         throw std::runtime_error("platform '" + platformStr + "' not found");
+    return *this;
+}
+
+TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::libraryxml(const char xmldata[], std::size_t len)
+{
+    tinyxml2::XMLDocument doc;
+    if (tinyxml2::XML_SUCCESS != doc.Parse(xmldata, len))
+        throw std::runtime_error("loading XML data failed");
+    if (settings.library.load(doc).errorcode != Library::ErrorCode::OK)
+        throw std::runtime_error("loading library XML failed");
     return *this;
 }

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -176,6 +176,8 @@ protected:
 
         SettingsBuilder& library(const char lib[]);
 
+        SettingsBuilder& libraryxml(const char xmldata[], std::size_t len);
+
         SettingsBuilder& platform(cppcheck::Platform::Type type);
 
         SettingsBuilder& checkConfiguration() {

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3532,7 +3532,6 @@ private:
     }
 
     void buffer_overrun_readSizeFromCfg() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <podtype name=\"u8\" sign=\"u\" size=\"1\"/>\n"
@@ -3544,7 +3543,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         // Attempt to get size from Cfg files, no false positives if size is not specified
         check("void f() {\n"
@@ -4085,7 +4084,6 @@ private:
     // extracttests.disable
 
     void minsize_argvalue() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mymemset\">\n"
@@ -4097,8 +4095,7 @@ private:
                                "    <arg nr=\"3\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
-        settings.severity.enable(Severity::warning);
+        Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).severity(Severity::warning).build();
         settings.platform.sizeof_wchar_t = 4;
 
         check("void f() {\n"
@@ -4224,7 +4221,6 @@ private:
     }
 
     void minsize_sizeof() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mystrncpy\">\n"
@@ -4237,7 +4233,7 @@ private:
                                "    <arg nr=\"3\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         check("void f() {\n"
               "    char c[7];\n"
@@ -4285,7 +4281,6 @@ private:
     }
 
     void minsize_strlen() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mysprintf\">\n"
@@ -4299,7 +4294,7 @@ private:
                                "    </arg>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         // formatstr..
         check("void f() {\n"
@@ -4399,7 +4394,6 @@ private:
     }
 
     void minsize_mul() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"myfread\">\n"
@@ -4411,7 +4405,7 @@ private:
                                "    <arg nr=\"4\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         check("void f() {\n"
               "    char c[5];\n"

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -3397,13 +3397,12 @@ private:
     }
 
     void memsetOnStdPodType() { // Ticket #5901
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <podtype name=\"std::uint8_t\" sign=\"u\" size=\"1\"/>\n"
                                "  <podtype name=\"std::atomic_bool\"/>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         checkNoMemset("class A {\n"
                       "    std::array<int, 10> ints;\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -32,7 +32,7 @@ public:
     TestConstructors() : TestFixture("TestConstructors") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
+    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = false) {
@@ -1493,29 +1493,31 @@ private:
     }
 
     void initvar_private_constructor() {
-        const Settings settingsOld = settings;
-        settings.standards.cpp = Standards::CPP11;
-        check("class Fred\n"
-              "{\n"
-              "private:\n"
-              "    int var;\n"
-              "    Fred();\n"
-              "};\n"
-              "Fred::Fred()\n"
-              "{ }");
-        ASSERT_EQUALS("[test.cpp:7]: (warning) Member variable 'Fred::var' is not initialized in the constructor.\n", errout.str());
+        {
+            const Settings s = settingsBuilder(settings).cpp( Standards::CPP11).build();
+            check("class Fred\n"
+                  "{\n"
+                  "private:\n"
+                  "    int var;\n"
+                  "    Fred();\n"
+                  "};\n"
+                  "Fred::Fred()\n"
+                  "{ }", s);
+            ASSERT_EQUALS("[test.cpp:7]: (warning) Member variable 'Fred::var' is not initialized in the constructor.\n", errout.str());
+        }
 
-        settings.standards.cpp = Standards::CPP03;
-        check("class Fred\n"
-              "{\n"
-              "private:\n"
-              "    int var;\n"
-              "    Fred();\n"
-              "};\n"
-              "Fred::Fred()\n"
-              "{ }");
-        ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
+        {
+            const Settings s = settingsBuilder(settings).cpp(Standards::CPP03).build();
+            check("class Fred\n"
+                  "{\n"
+                  "private:\n"
+                  "    int var;\n"
+                  "    Fred();\n"
+                  "};\n"
+                  "Fred::Fred()\n"
+                  "{ }", s);
+            ASSERT_EQUALS("", errout.str());
+        }
     }
 
     void initvar_copy_constructor() { // ticket #1611
@@ -3540,19 +3542,23 @@ private:
     }
 
     void privateCtor1() {
-        settings.standards.cpp = Standards::CPP03;
-        check("class Foo {\n"
-              "    int foo;\n"
-              "    Foo() { }\n"
-              "};");
-        ASSERT_EQUALS("", errout.str());
+        {
+            const Settings s = settingsBuilder(settings).cpp(Standards::CPP03).build();
+            check("class Foo {\n"
+                  "    int foo;\n"
+                  "    Foo() { }\n"
+                  "};", s);
+            ASSERT_EQUALS("", errout.str());
+        }
 
-        settings.standards.cpp = Standards::CPP11;
-        check("class Foo {\n"
-              "    int foo;\n"
-              "    Foo() { }\n"
-              "};");
-        ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Foo::foo' is not initialized in the constructor.\n", errout.str());
+        {
+            const Settings s = settingsBuilder(settings).cpp(Standards::CPP11).build();
+            check("class Foo {\n"
+                  "    int foo;\n"
+                  "    Foo() { }\n"
+                  "};", s);
+            ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Foo::foo' is not initialized in the constructor.\n", errout.str());
+        }
     }
 
     void privateCtor2() {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -33,8 +33,8 @@ public:
     TestFunctions() : TestFixture("TestFunctions") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).severity(Severity::performance).severity(Severity::portability).
-                        certainty(Certainty::inconclusive).c(Standards::C11).cpp(Standards::CPP11).library("std.cfg").library("posix.cfg").build();
+    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).severity(Severity::performance).severity(Severity::portability).
+                              certainty(Certainty::inconclusive).c(Standards::C11).cpp(Standards::CPP11).library("std.cfg").library("posix.cfg").build();
 
     void run() override {
         // Prohibited functions
@@ -262,27 +262,24 @@ private:
               "}", "test.c");
         ASSERT_EQUALS("[test.c:3]: (warning) Obsolete function 'alloca' called. In C99 and later it is recommended to use a variable length array instead.\n", errout.str());
 
-        const Settings settingsOld = settings;
-        settings.standards.c = Standards::C89;
-        settings.standards.cpp = Standards::CPP03;
+        const Settings s = settingsBuilder(settings).c(Standards::C89).cpp(Standards::CPP03).build();
         check("void f()\n"
               "{\n"
               "    char *x = alloca(10);\n"
-              "}", "test.cpp");  // #4382 - there are no VLAs in C++
+              "}", "test.cpp", &s);  // #4382 - there are no VLAs in C++
         ASSERT_EQUALS("", errout.str());
 
         check("void f()\n"
               "{\n"
               "    char *x = alloca(10);\n"
-              "}", "test.c"); // #7558 - no alternative to alloca in C89
+              "}", "test.c", &s); // #7558 - no alternative to alloca in C89
         ASSERT_EQUALS("", errout.str());
 
         check("void f()\n"
               "{\n"
               "    char *x = alloca(10);\n"
-              "}", "test.c");
+              "}", "test.c", &s);
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
     }
 
     // ticket #3121
@@ -1810,18 +1807,17 @@ private:
     }
 
     void checkLibraryMatchFunctions() {
-        const auto settings_old = settings;
-        settings.checkLibrary = true;
-        settings.daca = true;
+        Settings s = settingsBuilder(settings).checkLibrary().build();
+        s.daca = true;
 
         check("void f() {\n"
               "    lib_func();"
-              "}");
+              "}", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(void* v) {\n"
               "    lib_func(v);"
-              "}");
+              "}", "test.cpp", &s);
         ASSERT_EQUALS("[test.cpp:2]: (information) --check-library: There is no matching configuration for function lib_func()\n", errout.str());
 
         // #10105
@@ -1837,7 +1833,7 @@ private:
               "\n"
               "        void testFunctionReturnType() {\n"
               "        }\n"
-              "};");
+              "};", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         // #11183
@@ -1847,7 +1843,7 @@ private:
               "\n"
               "void f() {\n"
               "    cb(std::string(\"\"));\n"
-              "}");
+              "}", "test.cpp", &s);
         TODO_ASSERT_EQUALS("", "[test.cpp:6]: (information) --check-library: There is no matching configuration for function cb()\n", errout.str());
 
         // #7375
@@ -1855,38 +1851,38 @@ private:
               "    struct S { int i; char c; };\n"
               "    size_t s = sizeof(S);\n"
               "    static_assert(s == 9);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(char) {}\n"
               "void g() {\n"
               "    f(int8_t(1));\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(std::uint64_t& u) {\n"
               "    u = std::uint32_t(u) * std::uint64_t(100);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
-        check("void f() { throw(1); }\n"); // #8958
+        check("void f() { throw(1); }\n", "test.cpp", &s); // #8958
         ASSERT_EQUALS("", errout.str());
 
         check("using namespace std;\n"
-              "void f() { throw range_error(\"abc\"); }\n");
+              "void f() { throw range_error(\"abc\"); }\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("class C {\n" // #9002
               "public:\n"
               "    static int f() { return 1; }\n"
               "};\n"
-              "void g() { C::f(); }\n");
+              "void g() { C::f(); }\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(const std::vector<std::string>& v) {\n" // #11223
               "    for (const auto& s : v)\n"
               "        s.find(\"\");\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("[test.cpp:3]: (warning) Return value of function s.find() is not used.\n", errout.str());
 
         check("void f() {\n"
@@ -1896,19 +1892,19 @@ private:
               "    q->push_back(1);\n"
               "    auto* r = new std::vector<int>;\n"
               "    r->push_back(1);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "    auto p = std::make_shared<std::vector<int>>();\n"
               "    p->push_back(1);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(std::vector<std::vector<int>>& v) {\n"
               "    auto it = v.begin();\n"
               "    it->push_back(1);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
@@ -1918,7 +1914,7 @@ private:
               "    w.push_back(1);\n"
               "    auto x = std::vector<int>(1);\n"
               "    x.push_back(1);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         TODO_ASSERT_EQUALS("",
                            "[test.cpp:7]: (information) --check-library: There is no matching configuration for function auto::push_back()\n",
                            errout.str());
@@ -1928,7 +1924,7 @@ private:
               "    p->push_back(1);\n"
               "    auto q{ std::make_shared<std::vector<int>>{} };\n"
               "    q->push_back(1);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         TODO_ASSERT_EQUALS("",
                            "[test.cpp:3]: (information) --check-library: There is no matching configuration for function auto::push_back()\n"
                            "[test.cpp:5]: (information) --check-library: There is no matching configuration for function auto::push_back()\n",
@@ -1939,12 +1935,12 @@ private:
               "    std::list<F>::iterator it;\n"
               "    for (it = l.begin(); it != l.end(); ++it)\n"
               "        it->g(0);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("auto f() {\n"
               "    return std::runtime_error(\"abc\");\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("struct S {\n" // #11543
@@ -1955,7 +1951,7 @@ private:
               "void S::f(int i) const {\n"
               "    for (const std::shared_ptr<S>& c : v)\n"
               "        c->f(i);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("namespace N {\n"
@@ -1964,29 +1960,29 @@ private:
               "void f() {\n"
               "    const auto& t = N::S::s;\n"
               "    if (t.find(\"abc\") != t.end()) {}\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(std::vector<std::unordered_map<int, std::unordered_set<int>>>& v, int i, int j) {\n"
               "    auto& s = v[i][j];\n"
               "    s.insert(0);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("int f(const std::vector<std::string>& v, int i, char c) {\n"
               "    const auto& s = v[i];\n"
               "    return s.find(c);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n" // #11604
               "    int (*g)() = nullptr;\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "    INT (*g)() = nullptr;\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
 
         check("struct T;\n"
@@ -1995,13 +1991,11 @@ private:
               "    auto p = get();\n"
               "    p->h(i);\n"
               "    p.reset(nullptr);\n"
-              "}\n");
+              "}\n", "test.cpp", &s);
         TODO_ASSERT_EQUALS("[test.cpp:5]: (information) --check-library: There is no matching configuration for function T::h()\n",
                            "[test.cpp:5]: (information) --check-library: There is no matching configuration for function T::h()\n"
                            "[test.cpp:6]: (information) --check-library: There is no matching configuration for function std::shared_ptr::reset()\n",
                            errout.str());
-
-        settings = settings_old;
     }
 
     void checkUseStandardLibrary1() {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -1291,7 +1291,6 @@ private:
     }
 
     void checkIgnoredReturnValue() {
-        Settings settings2 = settingsBuilder().severity(Severity::warning).build();
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def version=\"2\">\n"
                                "  <function name=\"mystrcmp,foo::mystrcmp\">\n"
@@ -1300,7 +1299,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings2.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings2 = settingsBuilder().severity(Severity::warning).libraryxml(xmldata, sizeof(xmldata)).build();
 
         check("void foo() {\n"
               "  mystrcmp(a, b);\n"
@@ -1443,7 +1442,6 @@ private:
     }
 
     void checkIgnoredErrorCode() {
-        Settings settings2 = settingsBuilder().severity(Severity::style).build();
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def version=\"2\">\n"
                                "  <function name=\"mystrcmp\">\n"
@@ -1452,7 +1450,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings2.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settings2 = settingsBuilder().severity(Severity::style).libraryxml(xmldata, sizeof(xmldata)).build();
 
         check("void foo() {\n"
               "  mystrcmp(a, b);\n"

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -225,19 +225,19 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], bool cpp = false) {
+    void check_(const char* file, int line, const char code[], bool cpp = false, const Settings *s = nullptr) {
         // Clear the error buffer..
         errout.str("");
 
+        const Settings settings1 = settingsBuilder(s ? *s : settings).checkLibrary().build();
+
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, cpp ? "test.cpp" : "test.c"), file, line);
 
-        settings.checkLibrary = true;
-
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
+        runChecks<CheckLeakAutoVar>(&tokenizer, &settings1, this);
     }
 
     void check_(const char* file, int line, const char code[], const Settings & s) {
@@ -469,9 +469,7 @@ private:
     }
 
     void assign23() {
-        const Settings settingsOld = settings;
-        LOAD_LIB_2(settings.library, "posix.cfg");
-        settings.libraries.emplace_back("posix");
+        const Settings s = settingsBuilder(settings).library("posix.cfg").build();
         check("void f() {\n"
               "    int n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14;\n"
               "    *&n1 = open(\"xx.log\", O_RDONLY);\n"
@@ -488,7 +486,7 @@ private:
               "    ((*&n12)) = open(\"xx.log\", O_RDONLY);\n"
               "    *(&(*&n13)) = open(\"xx.log\", O_RDONLY);\n"
               "    ((*&(*&n14))) = open(\"xx.log\", O_RDONLY);\n"
-              "}\n", true);
+              "}\n", true, &s);
         ASSERT_EQUALS("[test.cpp:17]: (error) Resource leak: n1\n"
                       "[test.cpp:17]: (error) Resource leak: n2\n"
                       "[test.cpp:17]: (error) Resource leak: n3\n"
@@ -504,7 +502,6 @@ private:
                       "[test.cpp:17]: (error) Resource leak: n13\n"
                       "[test.cpp:17]: (error) Resource leak: n14\n",
                       errout.str());
-        settings = settingsOld;
     }
 
     void assign24() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -2625,8 +2625,6 @@ private:
     }
 
     void functionCallLeakIgnoreConfig() { // #7923
-        Settings settingsLeakIgnore = settings;
-
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def format=\"2\">\n"
                                "  <function name=\"SomeClass::someMethod\">\n"
@@ -2635,7 +2633,7 @@ private:
                                "    <arg nr=\"1\" direction=\"in\"/>\n"
                                "  </function>\n"
                                "</def>\n";
-        ASSERT(settingsLeakIgnore.library.loadxmldata(xmldata, sizeof(xmldata)));
+        const Settings settingsLeakIgnore = settingsBuilder(settings).libraryxml(xmldata, sizeof(xmldata)).build();
         check("void f() {\n"
               "    double* a = new double[1024];\n"
               "    SomeClass::someMethod(a);\n"

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -71,6 +71,12 @@ private:
         TEST_CASE(loadLibErrors);
     }
 
+    static bool loadxmldata(Library &lib, const char xmldata[], std::size_t len)
+    {
+        tinyxml2::XMLDocument doc;
+        return (tinyxml2::XML_SUCCESS == doc.Parse(xmldata, len)) && (lib.load(doc).errorcode == Library::ErrorCode::OK);
+    }
+
     void isCompliantValidationExpression() const {
         ASSERT_EQUALS(true, Library::isCompliantValidationExpression("-1"));
         ASSERT_EQUALS(true, Library::isCompliantValidationExpression("1"));
@@ -97,7 +103,7 @@ private:
         // Reading an empty library file is considered to be OK
         const char xmldata[] = "<?xml version=\"1.0\"?>\n<def/>";
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
     }
 
@@ -115,7 +121,7 @@ private:
         tokenList.front()->next()->astOperand1(tokenList.front());
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 1U);
         ASSERT(library.functions.at("foo").argumentChecks.empty());
         ASSERT(library.isnotnoreturn(tokenList.front()));
@@ -130,7 +136,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         {
             TokenList tokenList(nullptr);
             std::istringstream istr("fred.foo(123);"); // <- wrong scope, not library function
@@ -162,7 +168,7 @@ private:
         tokenList.createAst();
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.isNotLibraryFunction(tokenList.front()));
     }
 
@@ -176,7 +182,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         {
             TokenList tokenList(nullptr);
@@ -231,7 +237,7 @@ private:
         tokenList.front()->next()->varId(1);
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.isNotLibraryFunction(tokenList.front()->next()));
     }
 
@@ -248,7 +254,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[1].notuninit);
         ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[2].notnull);
         ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[3].formatstr);
@@ -267,7 +273,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
     }
 
@@ -281,7 +287,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
 
         TokenList tokenList(nullptr);
@@ -307,7 +313,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d);");
@@ -339,7 +345,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d,e,f,g,h,i,j,k);");
@@ -481,7 +487,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d,e);");
@@ -540,7 +546,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 2U);
         ASSERT(library.functions.at("Foo::foo").argumentChecks.empty());
         ASSERT(library.functions.at("bar").argumentChecks.empty());
@@ -569,7 +575,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 1U);
 
         {
@@ -596,7 +602,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         {
             Tokenizer tokenizer(&settings, nullptr);
@@ -625,7 +631,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("a(); b();");
@@ -659,7 +665,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
@@ -686,8 +692,8 @@ private:
                                 "</def>";
 
         Library library;
-        ASSERT_EQUALS(true, library.loadxmldata(xmldata1, sizeof(xmldata1)));
-        ASSERT_EQUALS(true, library.loadxmldata(xmldata2, sizeof(xmldata2)));
+        ASSERT_EQUALS(true, loadxmldata(library, xmldata1, sizeof(xmldata1)));
+        ASSERT_EQUALS(true, loadxmldata(library, xmldata2, sizeof(xmldata2)));
 
         ASSERT_EQUALS(library.deallocId("free"), library.allocId("malloc"));
         ASSERT_EQUALS(library.deallocId("free"), library.allocId("foo"));
@@ -702,7 +708,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
@@ -721,7 +727,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         ASSERT(Library::isresource(library.allocId("CreateX")));
@@ -738,7 +744,7 @@ private:
                                    "  <podtype name=\"s16\" sign=\"s\" size=\"2\"/>\n"
                                    "</def>";
             Library library;
-            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
             // s8
             {
                 const struct Library::PodType * const type = library.podtype("s8");
@@ -816,7 +822,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         Library::Container& A = library.containers["A"];
         Library::Container& B = library.containers["B"];
@@ -931,14 +937,14 @@ private:
                                    "<def>\n"
                                    "</def>";
             Library library;
-            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         }
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                    "<def format=\"1\">\n"
                                    "</def>";
             Library library;
-            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
+            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
         }
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6110,7 +6110,6 @@ private:
     }
 
     void duplicateExpression3() {
-        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mystrcmp\">\n"
@@ -6119,7 +6118,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
 
         check("void foo() {\n"
               "    if (x() || x()) {}\n"

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7997,14 +7997,13 @@ private:
         ASSERT_EQUALS("unsigned long long", typeOf("enum E : unsigned long long { }; void foo() { E e[3]; bar(e[0]); }", "[ 0"));
 
 #define CHECK_LIBRARY_FUNCTION_RETURN_TYPE(type) do { \
-        Settings sF; \
         const char xmldata[] = "<?xml version=\"1.0\"?>\n" \
                                "<def>\n" \
                                "<function name=\"g\">\n" \
                                "<returnValue type=\"" #type "\"/>\n" \
                                "</function>\n" \
                                "</def>";              \
-        ASSERT(sF.library.loadxmldata(xmldata, sizeof(xmldata))); \
+        const Settings sF = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build(); \
         ASSERT_EQUALS(#type, typeOf("void f() { auto x = g(); }", "x", "test.cpp", &sF)); \
 } while (false)
         // *INDENT-OFF*

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -35,7 +35,7 @@ public:
     TestUninitVar() : TestFixture("TestUninitVar") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    const Settings settings = settingsBuilder().library("std.cfg").build();
 
     void run() override {
         TEST_CASE(uninitvar1);
@@ -105,11 +105,11 @@ private:
     }
 
 #define checkUninitVar(...) checkUninitVar_(__FILE__, __LINE__, __VA_ARGS__)
-    void checkUninitVar_(const char* file, int line, const char code[], const char fname[] = "test.cpp", bool debugwarnings = false) {
+    void checkUninitVar_(const char* file, int line, const char code[], const char fname[] = "test.cpp", bool debugwarnings = false, const Settings *s = nullptr) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
+        const Settings settings1 = settingsBuilder(s ? *s : settings).debugwarnings(debugwarnings).build();
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this);
@@ -830,19 +830,19 @@ private:
                        "}", "test.cpp", false);
         ASSERT_EQUALS("", errout.str());
 
-        const Settings settingsOld = settings;
-        // Ticket #6701 - Variable name is a POD type according to cfg
-        const char xmldata[] = "<?xml version=\"1.0\"?>\n"
-                               "<def format=\"1\">"
-                               "  <podtype name=\"_tm\"/>"
-                               "</def>";
-        ASSERT_EQUALS(true, settings.library.loadxmldata(xmldata, sizeof(xmldata)));
-        checkUninitVar("void f() {\n"
-                       "  Fred _tm;\n"
-                       "  _tm.dostuff();\n"
-                       "}");
-        ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
+        {
+            // Ticket #6701 - Variable name is a POD type according to cfg
+            const char xmldata[] = "<?xml version=\"1.0\"?>\n"
+                                   "<def format=\"1\">"
+                                   "  <podtype name=\"_tm\"/>"
+                                   "</def>";
+            const Settings s = settingsBuilder(settings).libraryxml(xmldata, sizeof(xmldata)).build();
+            checkUninitVar("void f() {\n"
+                           "  Fred _tm;\n"
+                           "  _tm.dostuff();\n"
+                           "}", "test.cpp", false, &s);
+            ASSERT_EQUALS("", errout.str());
+        }
 
         // Ticket #7822 - Array type
         checkUninitVar("A *f() {\n"
@@ -4349,7 +4349,6 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         {
-            const Settings settingsOld = settings;
             const char argDirectionsTestXmlData[] = "<?xml version=\"1.0\"?>\n"
                                                     "<def>\n"
                                                     "  <function name=\"uninitvar_funcArgInTest\">\n"
@@ -4359,15 +4358,14 @@ private:
                                                     "    <arg nr=\"1\" direction=\"out\"/>\n"
                                                     "  </function>\n"
                                                     "</def>";
-
-            ASSERT_EQUALS(true, settings.library.loadxmldata(argDirectionsTestXmlData, sizeof(argDirectionsTestXmlData) / sizeof(argDirectionsTestXmlData[0])));
+            const Settings s = settingsBuilder(settings).libraryxml(argDirectionsTestXmlData, sizeof(argDirectionsTestXmlData)).build();
 
             checkUninitVar("struct AB { int a; };\n"
                            "void f(void) {\n"
                            "    struct AB ab;\n"
                            "    uninitvar_funcArgInTest(&ab);\n"
                            "    x = ab;\n"
-                           "}\n", "test.c");
+                           "}\n", "test.c", false, &s);
             ASSERT_EQUALS("[test.c:5]: (error) Uninitialized struct member: ab.a\n", errout.str());
 
             checkUninitVar("struct AB { int a; };\n"
@@ -4375,9 +4373,8 @@ private:
                            "    struct AB ab;\n"
                            "    uninitvar_funcArgOutTest(&ab);\n"
                            "    x = ab;\n"
-                           "}\n", "test.c");
+                           "}\n", "test.c", false, &s);
             ASSERT_EQUALS("", errout.str());
-            settings = settingsOld;
         }
 
         checkUninitVar("struct AB { int a; int b; };\n"
@@ -5140,8 +5137,7 @@ private:
     }
 
     void uninitvar_configuration() {
-        const auto oldSettings = settings;
-        settings.checkLibrary = true;
+        const Settings s = settingsBuilder(settings).checkLibrary().build();
 
         checkUninitVar("int f() {\n"
                        "    int i, j;\n"
@@ -5149,10 +5145,8 @@ private:
                        "        i = 0;\n"
                        "        return i;\n"
                        "    } while (0);\n"
-                       "}\n");
+                       "}\n", "test.cpp", false, &s);
         ASSERT_EQUALS("", errout.str());
-
-        settings = oldSettings;
     }
 
     void checkExpr() {

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -31,7 +31,7 @@ public:
     TestUnusedFunctions() : TestFixture("TestUnusedFunctions") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).build();
+    const Settings settings = settingsBuilder().severity(Severity::style).build();
 
     void run() override {
         TEST_CASE(incondition);
@@ -77,11 +77,11 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native) {
+    void check_(const char* file, int line, const char code[], cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const Settings *s = nullptr) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).platform(platform).build();
+        const Settings settings1 = settingsBuilder(s ? *s : settings).platform(platform).build();
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this);
@@ -612,16 +612,13 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
-        LOAD_LIB_2(settings.library, "windows.cfg");
+        const Settings s = settingsBuilder(settings).library("windows.cfg").build();
 
-        check("int WinMain() { }");
+        check("int WinMain() { }", cppcheck::Platform::Type::Native, &s);
         ASSERT_EQUALS("", errout.str());
 
-        check("int _tmain() { }");
+        check("int _tmain() { }", cppcheck::Platform::Type::Native, &s);
         ASSERT_EQUALS("", errout.str());
-
-        settings = settingsOld;
     }
 
     void entrypointsWinU() {
@@ -631,16 +628,13 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
-        LOAD_LIB_2(settings.library, "windows.cfg");
+        const Settings s = settingsBuilder(settings).library("windows.cfg").build();
 
-        check("int wWinMain() { }");
+        check("int wWinMain() { }", cppcheck::Platform::Type::Native, &s);
         ASSERT_EQUALS("", errout.str());
 
-        check("int _tmain() { }");
+        check("int _tmain() { }", cppcheck::Platform::Type::Native, &s);
         ASSERT_EQUALS("", errout.str());
-
-        settings = settingsOld;
     }
 
     void entrypointsUnix() {
@@ -649,14 +643,11 @@ private:
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_init' is never used.\n"
                       "[test.cpp:2]: (style) The function '_fini' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
-        LOAD_LIB_2(settings.library, "gnu.cfg");
+        const Settings s = settingsBuilder(settings).library("gnu.cfg").build();
 
         check("int _init() { }\n"
-              "int _fini() { }\n");
+              "int _fini() { }\n", cppcheck::Platform::Type::Native, &s);
         ASSERT_EQUALS("", errout.str());
-
-        settings = settingsOld;
     }
 };
 

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -37,7 +37,7 @@ public:
     TestUnusedVar() : TestFixture("TestUnusedVar") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).checkLibrary().library("std.cfg").build();
+    const Settings settings = settingsBuilder().severity(Severity::style).checkLibrary().library("std.cfg").build();
 
     void run() override {
         TEST_CASE(isRecordTypeWithoutSideEffects);
@@ -251,7 +251,7 @@ private:
 
 #define functionVariableUsage(...) functionVariableUsage_(__FILE__, __LINE__, __VA_ARGS__)
 #define checkStructMemberUsage(...) checkStructMemberUsage_(__FILE__, __LINE__, __VA_ARGS__)
-    void checkStructMemberUsage_(const char* file, int line, const char code[], const std::list<Directive>* directives = nullptr) {
+    void checkStructMemberUsage_(const char* file, int line, const char code[], const std::list<Directive>* directives = nullptr, const Settings *s = nullptr) {
         // Clear the error buffer..
         errout.str("");
 
@@ -259,13 +259,15 @@ private:
         if (directives)
             preprocessor.setDirectives(*directives);
 
+        const Settings *settings1 = s ? s : &settings;
+
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check for unused variables..
-        CheckUnusedVar checkUnusedVar(&tokenizer, &settings, this);
+        CheckUnusedVar checkUnusedVar(&tokenizer, settings1, this);
         (checkUnusedVar.checkStructMemberUsage)();
     }
 
@@ -1787,8 +1789,8 @@ private:
         ASSERT_EQUALS("[test.cpp:1]: (style) struct member 'A::i' is never used.\n",
                       errout.str());
 
-        const Settings settingsOld = settings;
-        settings.enforcedLang = Settings::C;
+        Settings s = settings;
+        s.enforcedLang = Settings::C;
         checkStructMemberUsage("struct A {\n" // #10852
                                "    struct B {\n"
                                "        int x;\n"
@@ -1797,7 +1799,7 @@ private:
                                "void f() {\n"
                                "    struct B* pb = &a.b;\n"
                                "    pb->x = 1;\n"
-                               "}\n");
+                               "}\n", nullptr, &s);
         ASSERT_EQUALS("", errout.str());
 
         checkStructMemberUsage("union U {\n"
@@ -1815,9 +1817,8 @@ private:
                                "    pb->x = 1;\n"
                                "    struct C* pc = &u.c;\n"
                                "    pc->s[0] = 1;\n"
-                               "}\n");
+                               "}\n", nullptr, &s);
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
     }
 
     void structmember20() { // #10737

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -310,9 +310,11 @@ private:
     }
 
 #define testValueOfX(...) testValueOfX_(__FILE__, __LINE__, __VA_ARGS__)
-    bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, int value) {
+    bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, int value, const Settings *s = nullptr) {
+        const Settings *settings1 = s ? s : &settings;
+
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -3866,22 +3868,22 @@ private:
     void valueFlowRightShift() {
         const char *code;
         /* Set some temporary fixed values to simplify testing */
-        const Settings settingsTmp = settings;
-        settings.platform.int_bit = 32;
-        settings.platform.long_bit = 64;
-        settings.platform.long_long_bit = MathLib::bigint_bits * 2;
+        Settings s = settings;
+        s.platform.int_bit = 32;
+        s.platform.long_bit = 64;
+        s.platform.long_long_bit = MathLib::bigint_bits * 2;
 
         code = "int f(int a) {\n"
                "  int x = (a & 0xff) >> 16;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code,3U,0));
+        ASSERT_EQUALS(true, testValueOfX(code,3U,0,&s));
 
         code = "int f(unsigned int a) {\n"
                "  int x = (a % 123) >> 16;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code,3U,0));
+        ASSERT_EQUALS(true, testValueOfX(code,3U,0,&s));
 
         code = "int f(int y) {\n"
                "  int x = (y & 0xFFFFFFF) >> 31;\n"
@@ -3893,57 +3895,55 @@ private:
                "  int x = (y & 0xFFFFFFF) >> 32;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(short y) {\n"
                "  int x = (y & 0xFFFFFF) >> 31;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(short y) {\n"
                "  int x = (y & 0xFFFFFF) >> 32;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 63;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 64;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 63;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 64;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 121;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 128;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
-
-        settings = settingsTmp;
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
     }
 
     void valueFlowFwdAnalysis() {

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -235,10 +235,12 @@ private:
     }
 
 #define tokenize(...) tokenize_(__FILE__, __LINE__, __VA_ARGS__)
-    std::string tokenize_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
+    std::string tokenize_(const char* file, int line, const char code[], const char filename[] = "test.cpp", const Settings *s = nullptr) {
         errout.str("");
 
-        Tokenizer tokenizer(&settings, this);
+        const Settings *settings1 = s ? s : &settings;
+
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC((tokenizer.tokenize)(istr, filename), file, line);
 
@@ -2020,10 +2022,9 @@ private:
     }
 
     void varid_in_class25() {
-        const char *code{}, *expected{};
-        const Settings oldSettings = settings;
-        LOAD_LIB_2(settings.library, "std.cfg");
+        const Settings s = settingsBuilder(settings).library("std.cfg").build();
 
+        const char *code{}, *expected{};
         code = "struct F {\n" // #11497
                "    int i;\n"
                "    void f(const std::vector<F>&v) {\n"
@@ -2036,7 +2037,7 @@ private:
                    "4: if ( v@2 . front ( ) . i@3 ) { }\n"
                    "5: }\n"
                    "6: } ;\n";
-        ASSERT_EQUALS(expected, tokenize(code, "test.cpp"));
+        ASSERT_EQUALS(expected, tokenize(code, "test.cpp", &s));
 
         code = "struct T { };\n" // 11533
                "struct U { T t; };\n"
@@ -2052,8 +2053,7 @@ private:
                    "5: std :: vector < U * > * p@2 ; p@2 = g ( ) ;\n"
                    "6: auto t@3 ; t@3 = p@2 . front ( ) . t@4 ;\n"
                    "7: }\n";
-        ASSERT_EQUALS(expected, tokenize(code, "test.cpp"));
-        settings = oldSettings;
+        ASSERT_EQUALS(expected, tokenize(code, "test.cpp", &s));
     }
 
     void varid_namespace_1() { // #7272


### PR DESCRIPTION
I will look at deduplicating the check implementations and need to specify default parameters in later PR(s).

`Library::loadxmldata()` has not completely been moved as there are some cases which cannot be changed (yet).