### PR TITLE
Remove dead URL

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -329,7 +329,7 @@ void CheckOther::cstyleCastError(const Token *tok)
                 "C-style pointer casting detected. C++ offers four different kinds of casts as replacements: "
                 "static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to "
                 "any of those automatically, thus it is considered safer if the programmer explicitly states "
-                "which kind of cast is expected. See also: https://www.securecoding.cert.org/confluence/display/cplusplus/EXP05-CPP.+Do+not+use+C-style+casts.", CWE398, Certainty::normal);
+                "which kind of cast is expected.", CWE398, Certainty::normal);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This rule seems to have been removed: https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88046335