### PR TITLE
Don't ignore build*, accidently it ignored all files starts with buil…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ htmlreport/MANIFEST
 # kdevelop 4.x
 *.kdev4
 
+# Common cmake build directories
+build**/
+
 # Temporal files
 *.swp
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,9 +94,6 @@ htmlreport/MANIFEST
 # kdevelop 4.x
 *.kdev4
 
-# Common cmake build directories
-build*
-
 # Temporal files
 *.swp
 


### PR DESCRIPTION
Pattern build* ignores all files in the repo that starts with build... If developer wants to create a new repository from sources .tar.gz, .zip etc. then ignore doesn't track few files. File `cmake/buildFiles.cmake` is obligatory to proper building
`git status --ignored`
![image](https://github.com/danmar/cppcheck/assets/15615364/171930e6-76ba-4acf-8005-58ba00065f46)

Cmake directories are ignored by pattern build/
