### PR TITLE
Revert mutable settings changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -667,13 +667,13 @@ cli/stacktrace.o: cli/stacktrace.cpp cli/stacktrace.h lib/config.h lib/utils.h
 cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/threadexecutor.cpp
 
-test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
+test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
-test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
+test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/mathlib.h lib/path.h lib/preprocessor.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/helpers.cpp
 
-test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h
+test/main.o: test/main.cpp externals/simplecpp/simplecpp.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/preprocessor.h lib/suppressions.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/main.cpp
 
 test/options.o: test/options.cpp test/options.h
@@ -682,7 +682,7 @@ test/options.o: test/options.cpp test/options.h
 test/test64bit.o: test/test64bit.cpp lib/check.h lib/check64bit.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/test64bit.cpp
 
-test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testanalyzerinformation.o: test/testanalyzerinformation.cpp lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/platform.h lib/suppressions.h lib/utils.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testanalyzerinformation.cpp
 
 test/testassert.o: test/testassert.cpp lib/check.h lib/checkassert.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -715,7 +715,7 @@ test/testclass.o: test/testclass.cpp externals/simplecpp/simplecpp.h lib/check.h
 test/testcmdlineparser.o: test/testcmdlineparser.cpp cli/cmdlineparser.h cli/cppcheckexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcmdlineparser.cpp
 
-test/testcolor.o: test/testcolor.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testcolor.o: test/testcolor.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcolor.cpp
 
 test/testcondition.o: test/testcondition.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkcondition.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -733,7 +733,7 @@ test/testerrorlogger.o: test/testerrorlogger.cpp externals/tinyxml2/tinyxml2.h l
 test/testexceptionsafety.o: test/testexceptionsafety.cpp lib/check.h lib/checkexceptionsafety.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testexceptionsafety.cpp
 
-test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testfilelister.o: test/testfilelister.cpp cli/filelister.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/pathmatch.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testfilelister.cpp
 
 test/testfunctions.o: test/testfunctions.cpp lib/check.h lib/checkfunctions.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -760,7 +760,7 @@ test/testleakautovar.o: test/testleakautovar.cpp externals/simplecpp/simplecpp.h
 test/testlibrary.o: test/testlibrary.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testlibrary.cpp
 
-test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testmathlib.o: test/testmathlib.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/mathlib.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testmathlib.cpp
 
 test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -769,19 +769,19 @@ test/testmemleak.o: test/testmemleak.cpp lib/check.h lib/checkmemoryleak.h lib/c
 test/testnullpointer.o: test/testnullpointer.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checknullpointer.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testnullpointer.cpp
 
-test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h
+test/testoptions.o: test/testoptions.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h test/fixture.h test/options.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testoptions.cpp
 
 test/testother.o: test/testother.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkother.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testother.cpp
 
-test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testpath.o: test/testpath.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/path.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpath.cpp
 
-test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testpathmatch.o: test/testpathmatch.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/pathmatch.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testpathmatch.cpp
 
-test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testplatform.o: test/testplatform.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/platform.h lib/suppressions.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testplatform.cpp
 
 test/testpostfixoperator.o: test/testpostfixoperator.cpp lib/check.h lib/checkpostfixoperator.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
@@ -832,7 +832,7 @@ test/testsymboldatabase.o: test/testsymboldatabase.cpp lib/check.h lib/color.h l
 test/testthreadexecutor.o: test/testthreadexecutor.cpp cli/executor.h cli/threadexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testthreadexecutor.cpp
 
-test/testtimer.o: test/testtimer.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h test/fixture.h
+test/testtimer.o: test/testtimer.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/suppressions.h lib/timer.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testtimer.cpp
 
 test/testtoken.o: test/testtoken.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h

--- a/Makefile
+++ b/Makefile
@@ -667,7 +667,7 @@ cli/stacktrace.o: cli/stacktrace.cpp cli/stacktrace.h lib/config.h lib/utils.h
 cli/threadexecutor.o: cli/threadexecutor.cpp cli/cppcheckexecutor.h cli/executor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/threadexecutor.cpp
 
-test/fixture.o: test/fixture.cpp externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
+test/fixture.o: test/fixture.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/fixture.cpp
 
 test/helpers.o: test/helpers.cpp externals/simplecpp/simplecpp.h lib/config.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/preprocessor.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/helpers.h

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -411,13 +411,3 @@ TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::library(const char l
     settings.libraries.emplace_back(lib_s);
     return *this;
 }
-
-TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::platform(cppcheck::Platform::Type type)
-{
-    const std::string platformStr = cppcheck::Platform::toString(type);
-    std::string errstr;
-    // TODO: exename is not yet set
-    if (!settings.platform.set(platformStr, errstr, {fixture.exename}))
-        throw std::runtime_error("platform '" + platformStr + "' not found");
-    return *this;
-}

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -20,7 +20,6 @@
 
 #include "errortypes.h"
 #include "options.h"
-#include "path.h"
 #include "redirect.h"
 
 #include <cstdio>
@@ -75,6 +74,7 @@ unsigned int TestFixture::countTests;
 std::size_t TestFixture::fails_counter = 0;
 std::size_t TestFixture::todos_counter = 0;
 std::size_t TestFixture::succeeded_todos_counter = 0;
+std::set<std::string> TestFixture::missingLibs;
 
 TestFixture::TestFixture(const char * const _name)
     : mVerbose(false),
@@ -284,6 +284,11 @@ void TestFixture::assertNoThrowFail(const char * const filename, const unsigned 
 
 }
 
+void TestFixture::complainMissingLib(const char * const libname)
+{
+    missingLibs.insert(libname);
+}
+
 void TestFixture::printHelp()
 {
     std::cout << "Testrunner - run Cppcheck tests\n"
@@ -367,6 +372,12 @@ std::size_t TestFixture::runTests(const options& args)
     std::cerr << "Tests failed: " << fails_counter << std::endl << std::endl;
     std::cerr << errmsg.str();
 
+    if (!missingLibs.empty()) {
+        std::cerr << "Missing libraries: ";
+        for (const std::string & missingLib : missingLibs)
+            std::cerr << missingLib << "  ";
+        std::cerr << std::endl << std::endl;
+    }
     std::cerr.flush();
     return fails_counter + succeeded_todos_counter;
 }
@@ -397,17 +408,4 @@ void TestFixture::setTemplateFormat(const std::string &templateFormat)
         mTemplateFormat = templateFormat;
         mTemplateLocation = "";
     }
-}
-
-TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::library(const char lib[]) {
-    // TODO: exename is not yet set
-    LOAD_LIB_2_EXE(settings.library, lib, fixture.exename.c_str());
-    // strip extension
-    std::string lib_s(lib);
-    const std::string ext(".cfg");
-    const auto pos = lib_s.find(ext);
-    if (pos != std::string::npos)
-        lib_s.erase(pos, ext.size());
-    settings.libraries.emplace_back(lib_s);
-    return *this;
 }

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -30,8 +30,6 @@
 #include <sstream>
 #include <string>
 
-#include <tinyxml2.h>
-
 std::ostringstream errout;
 std::ostringstream output;
 
@@ -421,15 +419,5 @@ TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::platform(cppcheck::P
     // TODO: exename is not yet set
     if (!settings.platform.set(platformStr, errstr, {fixture.exename}))
         throw std::runtime_error("platform '" + platformStr + "' not found");
-    return *this;
-}
-
-TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::libraryxml(const char xmldata[], std::size_t len)
-{
-    tinyxml2::XMLDocument doc;
-    if (tinyxml2::XML_SUCCESS != doc.Parse(xmldata, len))
-        throw std::runtime_error("loading XML data failed");
-    if (settings.library.load(doc).errorcode != Library::ErrorCode::OK)
-        throw std::runtime_error("loading library XML failed");
     return *this;
 }

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -176,8 +176,6 @@ protected:
 
         SettingsBuilder& library(const char lib[]);
 
-        SettingsBuilder& libraryxml(const char xmldata[], std::size_t len);
-
         SettingsBuilder& platform(cppcheck::Platform::Type type);
 
         SettingsBuilder& checkConfiguration() {

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -24,7 +24,6 @@
 #include "color.h"
 #include "config.h"
 #include "errorlogger.h"
-#include "settings.h"
 
 #include <cstddef>
 #include <list>
@@ -44,6 +43,7 @@ private:
     static std::size_t fails_counter;
     static std::size_t todos_counter;
     static std::size_t succeeded_todos_counter;
+    static std::set<std::string> missingLibs;
     bool mVerbose;
     std::string mTemplateFormat;
     std::string mTemplateLocation;
@@ -95,6 +95,7 @@ protected:
     void assertThrow(const char * const filename, const unsigned int linenr) const;
     void assertThrowFail(const char * const filename, const unsigned int linenr) const;
     void assertNoThrowFail(const char * const filename, const unsigned int linenr) const;
+    static void complainMissingLib(const char * const libname);
     static std::string deleteLineNumber(const std::string &message);
 
     void setVerbose(bool v) {
@@ -126,72 +127,6 @@ protected:
         T& check = getCheck<T>();
         check.runChecks(tokenizer, settings, errorLogger);
     }
-
-    // TODO: bail out on redundant settings
-    class SettingsBuilder
-    {
-    public:
-        explicit SettingsBuilder(const TestFixture &fixture) : fixture(fixture) {}
-        SettingsBuilder(const TestFixture &fixture, Settings settings) : fixture(fixture), settings(std::move(settings)) {}
-
-        SettingsBuilder& severity(Severity::SeverityType sev) {
-            settings.severity.enable(sev);
-            return *this;
-        }
-
-        SettingsBuilder& certainty(Certainty cert, bool b = true) {
-            settings.certainty.setEnabled(cert, b);
-            return *this;
-        }
-
-        SettingsBuilder& clang() {
-            settings.clang = true;
-            return *this;
-        }
-
-        SettingsBuilder& checkLibrary() {
-            settings.checkLibrary = true;
-            return *this;
-        }
-
-        SettingsBuilder& checkUnusedTemplates() {
-            settings.checkUnusedTemplates = true;
-            return *this;
-        }
-
-        SettingsBuilder& debugwarnings(bool b = true) {
-            settings.debugwarnings = b;
-            return *this;
-        }
-
-        SettingsBuilder& c(Standards::cstd_t std) {
-            settings.standards.c = std;
-            return *this;
-        }
-
-        SettingsBuilder& cpp(Standards::cppstd_t std) {
-            settings.standards.cpp = std;
-            return *this;
-        }
-
-        SettingsBuilder& library(const char lib[]);
-
-        Settings build() {
-            return std::move(settings);
-        }
-    private:
-        const TestFixture &fixture;
-        Settings settings;
-    };
-
-    SettingsBuilder settingsBuilder() const {
-        return SettingsBuilder(*this);
-    }
-
-    SettingsBuilder settingsBuilder(Settings settings) const {
-        return SettingsBuilder(*this, std::move(settings));
-    }
-
 public:
     void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
     void reportErr(const ErrorMessage &msg) override;
@@ -230,8 +165,13 @@ extern std::ostringstream output;
 #define EXPECT_EQ( EXPECTED, ACTUAL ) assertEquals(__FILE__, __LINE__, EXPECTED, ACTUAL)
 #define REGISTER_TEST( CLASSNAME ) namespace { CLASSNAME instance_ ## CLASSNAME; }
 
-#define LOAD_LIB_2_EXE( LIB, NAME, EXE ) do { if (((LIB).load((EXE), NAME).errorcode != Library::ErrorCode::OK)) throw std::runtime_error("library '" + std::string(NAME) + "' not found"); } while (false)
-#define LOAD_LIB_2( LIB, NAME ) LOAD_LIB_2_EXE(LIB, NAME, exename.c_str())
+#define LOAD_LIB_2(LIB, NAME)                                                                                          \
+    do {                                                                                                               \
+        if (((LIB).load(exename.c_str(), NAME).errorcode != Library::ErrorCode::OK)) {                                 \
+            complainMissingLib(NAME);                                                                                  \
+            abort();                                                                                                   \
+        }                                                                                                              \
+    } while (false)
 
 #define PLATFORM( P, T ) do { std::string errstr; assertEquals(__FILE__, __LINE__, true, P.set(cppcheck::Platform::toString(T), errstr, {exename}), errstr); } while (false)
 

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -134,8 +134,8 @@ protected:
         explicit SettingsBuilder(const TestFixture &fixture) : fixture(fixture) {}
         SettingsBuilder(const TestFixture &fixture, Settings settings) : fixture(fixture), settings(std::move(settings)) {}
 
-        SettingsBuilder& severity(Severity::SeverityType sev, bool b = true) {
-            settings.severity.setEnabled(sev, b);
+        SettingsBuilder& severity(Severity::SeverityType sev) {
+            settings.severity.enable(sev);
             return *this;
         }
 
@@ -154,8 +154,8 @@ protected:
             return *this;
         }
 
-        SettingsBuilder& checkUnusedTemplates(bool b = true) {
-            settings.checkUnusedTemplates = b;
+        SettingsBuilder& checkUnusedTemplates() {
+            settings.checkUnusedTemplates = true;
             return *this;
         }
 
@@ -175,18 +175,6 @@ protected:
         }
 
         SettingsBuilder& library(const char lib[]);
-
-        SettingsBuilder& platform(cppcheck::Platform::Type type);
-
-        SettingsBuilder& checkConfiguration() {
-            settings.checkConfiguration = true;
-            return *this;
-        }
-
-        SettingsBuilder& checkHeaders(bool b = true) {
-            settings.checkHeaders = b;
-            return *this;
-        }
 
         Settings build() {
             return std::move(settings);

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -19,7 +19,6 @@
 #ifndef helpersH
 #define helpersH
 
-#include "settings.h"
 #include "tokenize.h"
 #include "tokenlist.h"
 
@@ -28,12 +27,13 @@
 
 class Token;
 class Preprocessor;
+class Settings;
 class Suppressions;
 
 class givenACodeSampleToTokenize {
 private:
     Tokenizer tokenizer;
-    const Settings settings;
+    static const Settings settings;
 
 public:
     explicit givenACodeSampleToTokenize(const char sample[], bool createOnly = false, bool cpp = true)

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -30,9 +30,11 @@ public:
     Test64BitPortability() : TestFixture("Test64BitPortability") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::portability).library("std.cfg").build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::portability);
+
         TEST_CASE(novardecl);
         TEST_CASE(functionpar);
         TEST_CASE(structmember);
@@ -49,6 +51,7 @@ private:
 
         // Tokenize..
         Tokenizer tokenizer(&settings, this);
+        LOAD_LIB_2(settings.library, "std.cfg");
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -32,7 +32,7 @@ public:
     TestAssert() : TestFixture("TestAssert") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).build();
+    Settings settings;
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], const char *filename = "test.cpp") {
@@ -49,6 +49,8 @@ private:
     }
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+
         TEST_CASE(assignmentInAssert);
         TEST_CASE(functionCallInAssert);
         TEST_CASE(memberFunctionCallInAssert);

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -50,7 +50,7 @@ private:
 
 #define findLambdaEndToken(code) findLambdaEndToken_(code, __FILE__, __LINE__)
     bool findLambdaEndToken_(const char code[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -84,7 +84,7 @@ private:
 
 #define findLambdaStartToken(code) findLambdaStartToken_(code, __FILE__, __LINE__)
     bool findLambdaStartToken_(const char code[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -117,7 +117,7 @@ private:
 
 #define isNullOperand(code) isNullOperand_(code, __FILE__, __LINE__)
     bool isNullOperand_(const char code[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -139,7 +139,7 @@ private:
 
 #define isReturnScope(code, offset) isReturnScope_(code, offset, __FILE__, __LINE__)
     bool isReturnScope_(const char code[], int offset, const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -170,7 +170,7 @@ private:
 
 #define isSameExpression(code, tokStr1, tokStr2) isSameExpression_(code, tokStr1, tokStr2, __FILE__, __LINE__)
     bool isSameExpression_(const char code[], const char tokStr1[], const char tokStr2[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Library library;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
@@ -210,7 +210,7 @@ private:
 
 #define isVariableChanged(code, startPattern, endPattern) isVariableChanged_(code, startPattern, endPattern, __FILE__, __LINE__)
     bool isVariableChanged_(const char code[], const char startPattern[], const char endPattern[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -240,7 +240,7 @@ private:
 
 #define isVariableChangedByFunctionCall(code, pattern, inconclusive) isVariableChangedByFunctionCall_(code, pattern, inconclusive, __FILE__, __LINE__)
     bool isVariableChangedByFunctionCall_(const char code[], const char pattern[], bool *inconclusive, const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -416,7 +416,7 @@ private:
 
 #define nextAfterAstRightmostLeaf(code, parentPattern, rightPattern) nextAfterAstRightmostLeaf_(code, parentPattern, rightPattern, __FILE__, __LINE__)
     bool nextAfterAstRightmostLeaf_(const char code[], const char parentPattern[], const char rightPattern[], const char* file, int line) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -441,7 +441,7 @@ private:
     enum class Result {False, True, Fail};
 
     Result isUsedAsBool(const char code[], const char pattern[]) {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         if (!tokenizer.tokenize(istr, "test.cpp"))

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -383,7 +383,8 @@ private:
                               const char* file,
                               int line)
     {
-        const Settings settings = settingsBuilder().library("std.cfg").build();
+        Settings settings;
+        LOAD_LIB_2(settings.library, "std.cfg");
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -32,24 +32,30 @@ public:
     TestAutoVariables() : TestFixture("TestAutoVariables") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).library("std.cfg").library("qt.cfg").build();
+    Settings settings;
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = true, const char* filename = "test.cpp") {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
-        runChecks<CheckAutoVariables>(&tokenizer, &settings1, this);
+        runChecks<CheckAutoVariables>(&tokenizer, &settings, this);
     }
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::style);
+        LOAD_LIB_2(settings.library, "std.cfg");
+        LOAD_LIB_2(settings.library, "qt.cfg");
+        settings.libraries.emplace_back("qt");
+
         TEST_CASE(testautovar1);
         TEST_CASE(testautovar2);
         TEST_CASE(testautovar3); // ticket #2925

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -31,9 +31,13 @@ public:
     TestBool() : TestFixture("TestBool") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).certainty(Certainty::inconclusive).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::warning);
+        settings.certainty.enable(Certainty::inconclusive);
+
         TEST_CASE(bitwiseOnBoolean);      // if (bool & bool)
         TEST_CASE(incrementBoolean);
         TEST_CASE(assignBoolToPointer);

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -31,9 +31,12 @@ public:
     TestBoost() : TestFixture("TestBoost") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::performance).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::performance);
+
         TEST_CASE(BoostForeachContainerModification);
     }
 

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -3532,6 +3532,7 @@ private:
     }
 
     void buffer_overrun_readSizeFromCfg() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <podtype name=\"u8\" sign=\"u\" size=\"1\"/>\n"
@@ -3543,7 +3544,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         // Attempt to get size from Cfg files, no false positives if size is not specified
         check("void f() {\n"
@@ -4084,6 +4085,7 @@ private:
     // extracttests.disable
 
     void minsize_argvalue() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mymemset\">\n"
@@ -4095,7 +4097,8 @@ private:
                                "    <arg nr=\"3\"/>\n"
                                "  </function>\n"
                                "</def>";
-        Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).severity(Severity::warning).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
+        settings.severity.enable(Severity::warning);
         settings.platform.sizeof_wchar_t = 4;
 
         check("void f() {\n"
@@ -4221,6 +4224,7 @@ private:
     }
 
     void minsize_sizeof() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mystrncpy\">\n"
@@ -4233,7 +4237,7 @@ private:
                                "    <arg nr=\"3\"/>\n"
                                "  </function>\n"
                                "</def>";
-        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         check("void f() {\n"
               "    char c[7];\n"
@@ -4281,6 +4285,7 @@ private:
     }
 
     void minsize_strlen() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mysprintf\">\n"
@@ -4294,7 +4299,7 @@ private:
                                "    </arg>\n"
                                "  </function>\n"
                                "</def>";
-        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         // formatstr..
         check("void f() {\n"
@@ -4394,6 +4399,7 @@ private:
     }
 
     void minsize_mul() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"myfread\">\n"
@@ -4405,7 +4411,7 @@ private:
                                "    <arg nr=\"4\"/>\n"
                                "  </function>\n"
                                "</def>";
-        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         check("void f() {\n"
               "    char c[5];\n"

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -77,8 +77,14 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings = settingsBuilder(settings0).severity(Severity::style).severity(Severity::warning).severity(Severity::portability).severity(Severity::performance)
-                                  .c(Standards::CLatest).cpp(Standards::CPPLatest).certainty(Certainty::inconclusive).build();
+        Settings settings = settings0;
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::portability);
+        settings.severity.enable(Severity::performance);
+        settings.standards.c = Standards::CLatest;
+        settings.standards.cpp = Standards::CPPLatest;
+        settings.certainty.enable(Certainty::inconclusive);
 
         // Raw tokens..
         std::vector<std::string> files(1, filename);

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -31,9 +31,11 @@ public:
     TestCharVar() : TestFixture("TestCharVar") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).platform(cppcheck::Platform::Type::Unspecified).build();
+    Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
 
     void run() override {
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unspecified);
+
         TEST_CASE(array_index_1);
         TEST_CASE(array_index_2);
         TEST_CASE(bitop);

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -31,10 +31,12 @@ public:
     TestCharVar() : TestFixture("TestCharVar") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
+    Settings settings;
 
     void run() override {
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unspecified);
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::portability);
 
         TEST_CASE(array_index_1);
         TEST_CASE(array_index_2);

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -137,7 +137,8 @@ private:
     }
 
     std::string parse(const char clang[]) {
-        const Settings settings = settingsBuilder().clang().build();
+        Settings settings;
+        settings.clang = true;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(&tokenizer, istr);
@@ -1048,7 +1049,8 @@ private:
 
 
 #define GET_SYMBOL_DB(AST) \
-    Settings settings = settingsBuilder().clang().build(); \
+    Settings settings; \
+    settings.clang = true; \
     { \
         std::string errstr; \
         ASSERT_EQUALS_MSG(true, settings.platform.set("unix64", errstr, {exename.c_str()}), errstr); \

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -1048,7 +1048,11 @@ private:
 
 
 #define GET_SYMBOL_DB(AST) \
-    const Settings settings = settingsBuilder().clang().platform(cppcheck::Platform::Type::Unix64).build(); \
+    Settings settings = settingsBuilder().clang().build(); \
+    { \
+        std::string errstr; \
+        ASSERT_EQUALS_MSG(true, settings.platform.set("unix64", errstr, {exename.c_str()}), errstr); \
+    } \
     Tokenizer tokenizer(&settings, this); \
     { \
         std::istringstream istr(AST); \

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -36,10 +36,13 @@ public:
     TestClass() : TestFixture("TestClass") {}
 
 private:
-    Settings settings0 = settingsBuilder().severity(Severity::style).build();
-    Settings settings1 = settingsBuilder().severity(Severity::warning).build();
+    Settings settings0;
+    Settings settings1;
 
     void run() override {
+        settings0.severity.enable(Severity::style);
+        settings1.severity.enable(Severity::warning);
+
         // Load std.cfg configuration
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"
@@ -259,7 +262,8 @@ private:
     void checkCopyCtorAndEqOperator_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        Settings settings = settingsBuilder().severity(Severity::warning).build();
+        Settings settings;
+        settings.severity.enable(Severity::warning);
 
         Preprocessor preprocessor(settings);
 
@@ -2886,7 +2890,9 @@ private:
 
 #define checkNoMemset(...) checkNoMemset_(__FILE__, __LINE__, __VA_ARGS__)
     void checkNoMemset_(const char* file, int line, const char code[]) {
-        Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
+        Settings settings;
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::portability);
         checkNoMemset_(file, line, code, settings);
     }
 
@@ -3150,7 +3156,8 @@ private:
                       errout.str());
 
         // #1655
-        Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s;
+        LOAD_LIB_2(s.library, "std.cfg");
         checkNoMemset("void f() {\n"
                       "    char c[] = \"abc\";\n"
                       "    std::string s;\n"
@@ -7224,7 +7231,10 @@ private:
     }
 
     void qualifiedNameMember() { // #10872
-        Settings s = settingsBuilder().severity(Severity::style).debugwarnings().library("std.cfg").build();
+        Settings s;
+        s.severity.enable(Severity::style);
+        s.debugwarnings = true;
+        LOAD_LIB_2(s.library, "std.cfg");
         checkConst("struct data {};\n"
                    "    struct S {\n"
                    "    std::vector<data> std;\n"
@@ -7279,7 +7289,8 @@ private:
         errout.str("");
 
         // Check..
-        Settings settings = settingsBuilder().severity(Severity::performance).build();
+        Settings settings;
+        settings.severity.enable(Severity::performance);
 
         Preprocessor preprocessor(settings);
 
@@ -7959,8 +7970,8 @@ private:
     void checkOverride_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-
-        Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings;
+        settings.severity.enable(Severity::style);
 
         Preprocessor preprocessor(settings);
 
@@ -8136,9 +8147,9 @@ private:
     void checkUnsafeClassRefMember_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-
-        Settings settings = settingsBuilder().severity(Severity::warning).build();
+        Settings settings;
         settings.safeChecks.classes = true;
+        settings.severity.enable(Severity::warning);
 
         Preprocessor preprocessor(settings);
 
@@ -8317,7 +8328,7 @@ private:
 
 
     void ctu(const std::vector<std::string> &code) {
-        const Settings settings;
+        Settings settings;
         auto &check = getCheck<CheckClass>();
 
         // getFileInfo

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -3397,12 +3397,13 @@ private:
     }
 
     void memsetOnStdPodType() { // Ticket #5901
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <podtype name=\"std::uint8_t\" sign=\"u\" size=\"1\"/>\n"
                                "  <podtype name=\"std::atomic_bool\"/>\n"
                                "</def>";
-        const Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         checkNoMemset("class A {\n"
                       "    std::array<int, 10> ints;\n"

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -259,7 +259,7 @@ private:
     void checkCopyCtorAndEqOperator_(const char code[], const char* file, int line) {
         // Clear the error log
         errout.str("");
-        const Settings settings = settingsBuilder().severity(Severity::warning).build();
+        Settings settings = settingsBuilder().severity(Severity::warning).build();
 
         Preprocessor preprocessor(settings);
 
@@ -2570,7 +2570,6 @@ private:
         // Clear the error log
         errout.str("");
 
-        // TODO: subsequent tests depend on these changes - should use SettingsBuilder
         settings0.certainty.setEnabled(Certainty::inconclusive, inconclusive);
         settings0.severity.enable(Severity::warning);
 
@@ -2887,7 +2886,7 @@ private:
 
 #define checkNoMemset(...) checkNoMemset_(__FILE__, __LINE__, __VA_ARGS__)
     void checkNoMemset_(const char* file, int line, const char code[]) {
-        const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
+        Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).build();
         checkNoMemset_(file, line, code, settings);
     }
 
@@ -3151,7 +3150,7 @@ private:
                       errout.str());
 
         // #1655
-        const Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s = settingsBuilder().library("std.cfg").build();
         checkNoMemset("void f() {\n"
                       "    char c[] = \"abc\";\n"
                       "    std::string s;\n"
@@ -3558,20 +3557,23 @@ private:
     }
 
 #define checkConst(...) checkConst_(__FILE__, __LINE__, __VA_ARGS__)
-    void checkConst_(const char* file, int line, const char code[], const Settings *s = nullptr, bool inconclusive = true) {
+    void checkConst_(const char* file, int line, const char code[], Settings *s = nullptr, bool inconclusive = true) {
         // Clear the error log
         errout.str("");
 
-        const Settings settings = settingsBuilder(s ? *s : settings0).certainty(Certainty::inconclusive, inconclusive).build();
+        // Check..
+        if (!s)
+            s = &settings0;
+        s->certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
-        Preprocessor preprocessor(settings);
+        Preprocessor preprocessor(*s);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(s, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        CheckClass checkClass(&tokenizer, &settings, this);
+        CheckClass checkClass(&tokenizer, s, this);
         (checkClass.checkConst)();
     }
 
@@ -7222,7 +7224,7 @@ private:
     }
 
     void qualifiedNameMember() { // #10872
-        const Settings s = settingsBuilder().severity(Severity::style).debugwarnings().library("std.cfg").build();
+        Settings s = settingsBuilder().severity(Severity::style).debugwarnings().library("std.cfg").build();
         checkConst("struct data {};\n"
                    "    struct S {\n"
                    "    std::vector<data> std;\n"
@@ -7277,7 +7279,7 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder().severity(Severity::performance).build();
+        Settings settings = settingsBuilder().severity(Severity::performance).build();
 
         Preprocessor preprocessor(settings);
 
@@ -7607,7 +7609,9 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder().severity(Severity::warning).certainty(Certainty::inconclusive, inconclusive).build();
+        Settings settings;
+        settings.severity.enable(Severity::warning);
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         Preprocessor preprocessor(settings);
 
@@ -7956,7 +7960,7 @@ private:
         // Clear the error log
         errout.str("");
 
-        const Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings = settingsBuilder().severity(Severity::style).build();
 
         Preprocessor preprocessor(settings);
 

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -37,8 +37,9 @@
 
 class TestCmdlineParser : public TestFixture {
 public:
-    TestCmdlineParser() : TestFixture("TestCmdlineParser")
-    {
+    TestCmdlineParser()
+        : TestFixture("TestCmdlineParser")
+        , defParser(settings, settings.nomsg, settings.nofail) {
 #if defined(_WIN64) || defined(_WIN32)
         CmdLineParser::SHOW_DEF_PLATFORM_MSG = false;
 #endif
@@ -52,7 +53,7 @@ public:
 
 private:
     Settings settings; // TODO: reset after each test
-    CmdLineParser defParser{settings, settings.nomsg, settings.nofail}; // TODO: reset after each test
+    CmdLineParser defParser; // TODO: reset after each test
 
     void run() override {
         TEST_CASE(nooptions);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -39,19 +39,28 @@ public:
     TestCondition() : TestFixture("TestCondition") {}
 
 private:
-    Settings settings0 = settingsBuilder().library("qt.cfg").library("std.cfg").severity(Severity::style).severity(Severity::warning).build();
-    Settings settings1 = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
+    Settings settings0;
+    Settings settings1;
 
     void run() override {
         // known platform..
         PLATFORM(settings0.platform, cppcheck::Platform::Type::Native);
         PLATFORM(settings1.platform, cppcheck::Platform::Type::Native);
 
+        LOAD_LIB_2(settings0.library, "qt.cfg");
+        settings0.libraries.emplace_back("qt");
+        LOAD_LIB_2(settings0.library, "std.cfg");
+
+        settings0.severity.enable(Severity::style);
+        settings0.severity.enable(Severity::warning);
+
         const char cfg[] = "<?xml version=\"1.0\"?>\n"
                            "<def>\n"
                            "  <function name=\"bar\"> <pure/> </function>\n"
                            "</def>";
         ASSERT(settings1.library.loadxmldata(cfg, sizeof(cfg)));
+        settings1.severity.enable(Severity::style);
+        settings1.severity.enable(Severity::warning);
 
         TEST_CASE(assignAndCompare);   // assignment and comparison don't match
         TEST_CASE(mismatchingBitAnd);  // overlapping bitmasks
@@ -5635,7 +5644,8 @@ private:
     }
 
     void compareOutOfTypeRange() {
-        Settings settingsUnix64 = settingsBuilder().severity(Severity::style).build();
+        Settings settingsUnix64;
+        settingsUnix64.severity.enable(Severity::style);
         PLATFORM(settingsUnix64.platform, cppcheck::Platform::Type::Unix64);
 
         check("void f(unsigned char c) {\n"

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -39,10 +39,14 @@ public:
     TestCondition() : TestFixture("TestCondition") {}
 
 private:
-    const Settings settings0 = settingsBuilder().library("qt.cfg").library("std.cfg").severity(Severity::style).severity(Severity::warning).platform(cppcheck::Platform::Type::Native).build();
-    Settings settings1 = settingsBuilder().severity(Severity::style).severity(Severity::warning).platform(cppcheck::Platform::Type::Native).build();
+    Settings settings0 = settingsBuilder().library("qt.cfg").library("std.cfg").severity(Severity::style).severity(Severity::warning).build();
+    Settings settings1 = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
 
     void run() override {
+        // known platform..
+        PLATFORM(settings0.platform, cppcheck::Platform::Type::Native);
+        PLATFORM(settings1.platform, cppcheck::Platform::Type::Native);
+
         const char cfg[] = "<?xml version=\"1.0\"?>\n"
                            "<def>\n"
                            "  <function name=\"bar\"> <pure/> </function>\n"
@@ -128,7 +132,7 @@ private:
         TEST_CASE(knownConditionIncrementLoop); // #9808
     }
 
-    void check(const char code[], Settings &settings, const char* filename = "test.cpp") {
+    void check(const char code[], Settings *settings, const char* filename = "test.cpp") {
         // Clear the error buffer..
         errout.str("");
 
@@ -142,21 +146,21 @@ private:
         std::map<std::string, simplecpp::TokenList*> filedata;
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
-        Preprocessor preprocessor(settings);
+        Preprocessor preprocessor(*settings);
         preprocessor.setDirectives(tokens1);
 
         // Tokenizer..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Run checks..
-        runChecks<CheckCondition>(&tokenizer, &settings, this);
+        runChecks<CheckCondition>(&tokenizer, settings, this);
     }
 
     void check(const char code[], const char* filename = "test.cpp", bool inconclusive = false) {
-        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive, inconclusive).build();
-        check(code, settings, filename);
+        settings0.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        check(code, &settings0, filename);
     }
 
     void assignAndCompare() {
@@ -5631,69 +5635,70 @@ private:
     }
 
     void compareOutOfTypeRange() {
-        Settings settingsUnix64 = settingsBuilder().severity(Severity::style).platform(cppcheck::Platform::Type::Unix64).build();
+        Settings settingsUnix64 = settingsBuilder().severity(Severity::style).build();
+        PLATFORM(settingsUnix64.platform, cppcheck::Platform::Type::Unix64);
 
         check("void f(unsigned char c) {\n"
               "  if (c == 256) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'unsigned char' against value 256. Condition is always false.\n", errout.str());
 
         check("void f(unsigned char* b, int i) {\n" // #6372
               "  if (b[i] == 256) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'unsigned char' against value 256. Condition is always false.\n", errout.str());
 
         check("void f(unsigned char c) {\n"
               "  if (c == 255) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(bool b) {\n"
               "  if (b == true) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         // #10372
         check("void f(signed char x) {\n"
               "  if (x == 0xff) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'signed char' against value 255. Condition is always false.\n", errout.str());
 
         check("void f(short x) {\n"
               "  if (x == 0xffff) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'signed short' against value 65535. Condition is always false.\n", errout.str());
 
         check("void f(int x) {\n"
               "  if (x == 0xffffffff) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(long x) {\n"
               "  if (x == ~0L) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(long long x) {\n"
               "  if (x == ~0LL) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("int f(int x) {\n"
               "    const int i = 0xFFFFFFFF;\n"
               "    if (x == i) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("void f() {\n"
               "  char c;\n"
               "  if ((c = foo()) != -1) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(int x) {\n"
               "  if (x < 3000000000) {}\n"
-              "}", settingsUnix64);
+              "}", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'signed int' against value 3000000000. Condition is always true.\n", errout.str());
 
         check("void f(const signed char i) {\n" // #8545
@@ -5703,7 +5708,7 @@ private:
               "    if (i <  +128) {}\n" // warn
               "    if (i <= +127) {}\n" // warn
               "    if (i <= +126) {}\n"
-              "}\n", settingsUnix64);
+              "}\n", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:2]: (style) Comparing expression of type 'const signed char' against value -129. Condition is always true.\n"
                       "[test.cpp:3]: (style) Comparing expression of type 'const signed char' against value -128. Condition is always true.\n"
                       "[test.cpp:5]: (style) Comparing expression of type 'const signed char' against value 128. Condition is always true.\n"
@@ -5727,7 +5732,7 @@ private:
               "    if (255 >  u) {}\n"
               "    if (255 <= u) {}\n"
               "    if (255 >= u) {}\n" // warn
-              "}\n", settingsUnix64);
+              "}\n", &settingsUnix64);
         ASSERT_EQUALS("[test.cpp:3]: (style) Comparing expression of type 'const unsigned char' against value 0. Condition is always false.\n"
                       "[test.cpp:4]: (style) Comparing expression of type 'const unsigned char' against value 0. Condition is always true.\n"
                       "[test.cpp:6]: (style) Comparing expression of type 'const unsigned char' against value 255. Condition is always false.\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -32,22 +32,22 @@ public:
     TestConstructors() : TestFixture("TestConstructors") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
+    Settings settings;
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check class constructors..
-        CheckClass checkClass(&tokenizer, &settings1, this);
+        CheckClass checkClass(&tokenizer, &settings, this);
         checkClass.constructors();
     }
 
@@ -66,6 +66,9 @@ private:
     }
 
     void run() override {
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::warning);
+
         TEST_CASE(simple1);
         TEST_CASE(simple2);
         TEST_CASE(simple3);
@@ -1947,8 +1950,9 @@ private:
     }
 
     void initvar_smartptr() { // #10237
-        // TODO: test should probably not pass without library
-        const Settings s = settingsBuilder() /*.library("std.cfg")*/.build();
+        Settings s;
+        // TODO: test shuld probably not pass without library
+        //LOAD_LIB_2(s.library, "std.cfg");
         check("struct S {\n"
               "    explicit S(const std::shared_ptr<S>& sp) {\n"
               "        set(*sp);\n"
@@ -1990,7 +1994,11 @@ private:
               "{ }", true);
         ASSERT_EQUALS("[test.cpp:13]: (warning, inconclusive) Member variable 'Fred::ints' is not assigned a value in 'Fred::operator='.\n", errout.str());
 
-        const Settings s = settingsBuilder().certainty(Certainty::inconclusive).severity(Severity::style).severity(Severity::warning).library("std.cfg").build();
+        Settings s;
+        s.certainty.setEnabled(Certainty::inconclusive, true);
+        s.severity.enable(Severity::style);
+        s.severity.enable(Severity::warning);
+        LOAD_LIB_2(s.library, "std.cfg");
         check("struct S {\n"
               "    S& operator=(const S& s) { return *this; }\n"
               "    std::mutex m;\n"
@@ -3602,8 +3610,10 @@ private:
     }
 
     void uninitVarInheritClassInit() {
+        Settings s;
         // TODO: test should probably not pass without library
-        const Settings s = settingsBuilder() /*.library("vcl.cfg")*/.build();
+        //LOAD_LIB_2(s.library, "vcl.cfg");
+        //s.libraries.emplace_back("vcl");
 
         check("class Fred: public TObject\n"
               "{\n"

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -32,7 +32,7 @@ public:
     TestConstructors() : TestFixture("TestConstructors") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
+    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).build();
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
     void check_(const char* file, int line, const char code[], bool inconclusive = false) {
@@ -1493,31 +1493,29 @@ private:
     }
 
     void initvar_private_constructor() {
-        {
-            const Settings s = settingsBuilder(settings).cpp( Standards::CPP11).build();
-            check("class Fred\n"
-                  "{\n"
-                  "private:\n"
-                  "    int var;\n"
-                  "    Fred();\n"
-                  "};\n"
-                  "Fred::Fred()\n"
-                  "{ }", s);
-            ASSERT_EQUALS("[test.cpp:7]: (warning) Member variable 'Fred::var' is not initialized in the constructor.\n", errout.str());
-        }
+        const Settings settingsOld = settings;
+        settings.standards.cpp = Standards::CPP11;
+        check("class Fred\n"
+              "{\n"
+              "private:\n"
+              "    int var;\n"
+              "    Fred();\n"
+              "};\n"
+              "Fred::Fred()\n"
+              "{ }");
+        ASSERT_EQUALS("[test.cpp:7]: (warning) Member variable 'Fred::var' is not initialized in the constructor.\n", errout.str());
 
-        {
-            const Settings s = settingsBuilder(settings).cpp(Standards::CPP03).build();
-            check("class Fred\n"
-                  "{\n"
-                  "private:\n"
-                  "    int var;\n"
-                  "    Fred();\n"
-                  "};\n"
-                  "Fred::Fred()\n"
-                  "{ }", s);
-            ASSERT_EQUALS("", errout.str());
-        }
+        settings.standards.cpp = Standards::CPP03;
+        check("class Fred\n"
+              "{\n"
+              "private:\n"
+              "    int var;\n"
+              "    Fred();\n"
+              "};\n"
+              "Fred::Fred()\n"
+              "{ }");
+        ASSERT_EQUALS("", errout.str());
+        settings = settingsOld;
     }
 
     void initvar_copy_constructor() { // ticket #1611
@@ -3542,23 +3540,19 @@ private:
     }
 
     void privateCtor1() {
-        {
-            const Settings s = settingsBuilder(settings).cpp(Standards::CPP03).build();
-            check("class Foo {\n"
-                  "    int foo;\n"
-                  "    Foo() { }\n"
-                  "};", s);
-            ASSERT_EQUALS("", errout.str());
-        }
+        settings.standards.cpp = Standards::CPP03;
+        check("class Foo {\n"
+              "    int foo;\n"
+              "    Foo() { }\n"
+              "};");
+        ASSERT_EQUALS("", errout.str());
 
-        {
-            const Settings s = settingsBuilder(settings).cpp(Standards::CPP11).build();
-            check("class Foo {\n"
-                  "    int foo;\n"
-                  "    Foo() { }\n"
-                  "};", s);
-            ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Foo::foo' is not initialized in the constructor.\n", errout.str());
-        }
+        settings.standards.cpp = Standards::CPP11;
+        check("class Foo {\n"
+              "    int foo;\n"
+              "    Foo() { }\n"
+              "};");
+        ASSERT_EQUALS("[test.cpp:3]: (warning) Member variable 'Foo::foo' is not initialized in the constructor.\n", errout.str());
     }
 
     void privateCtor2() {

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1493,7 +1493,6 @@ private:
     }
 
     void initvar_private_constructor() {
-        const Settings settingsOld = settings;
         settings.standards.cpp = Standards::CPP11;
         check("class Fred\n"
               "{\n"
@@ -1515,7 +1514,6 @@ private:
               "Fred::Fred()\n"
               "{ }");
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
     }
 
     void initvar_copy_constructor() { // ticket #1611
@@ -3113,7 +3111,8 @@ private:
     }
 
     void uninitVarArray10() { // #11650
-        const Settings s = settingsBuilder(settings).library("std.cfg").build();
+        Settings s(settings);
+        LOAD_LIB_2(s.library, "std.cfg");
         check("struct T { int j; };\n"
               "struct U { int k{}; };\n"
               "struct S {\n"

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -31,11 +31,11 @@
 
 class TestErrorLogger : public TestFixture {
 public:
-    TestErrorLogger() : TestFixture("TestErrorLogger") {}
+    TestErrorLogger() : TestFixture("TestErrorLogger"), fooCpp5("foo.cpp", 5, 1), barCpp8("bar.cpp", 8, 1) {}
 
 private:
-    const ErrorMessage::FileLocation fooCpp5{"foo.cpp", 5, 1};
-    const ErrorMessage::FileLocation barCpp8{"bar.cpp", 8, 1};
+    const ErrorMessage::FileLocation fooCpp5;
+    const ErrorMessage::FileLocation barCpp8;
 
     void run() override {
         TEST_CASE(PatternSearchReplace);

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -60,19 +60,19 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], bool inconclusive = false, const Settings *s = nullptr) {
+    void check_(const char* file, int line, const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
-        Settings settings1 = settingsBuilder(s ? *s : settings).certainty(Certainty::inconclusive, inconclusive).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check char variable usage..
-        runChecks<CheckExceptionSafety>(&tokenizer, &settings1, this);
+        runChecks<CheckExceptionSafety>(&tokenizer, &settings, this);
     }
 
     void destructors() {
@@ -398,9 +398,13 @@ private:
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:1]: (style, inconclusive) Unhandled exception specification when calling function f().\n"
                       "[test.cpp:6] -> [test.cpp:1]: (style, inconclusive) Unhandled exception specification when calling function f().\n", errout.str());
 
-        const Settings s = settingsBuilder(settings).library("gnu.cfg").build();
-        check(code, true, &s);
+        Settings settingsOld = settings;
+        LOAD_LIB_2(settings.library, "gnu.cfg");
+
+        check(code, true);
         ASSERT_EQUALS("", errout.str());
+
+        settings = settingsOld;
     }
 
     void nothrowAttributeThrow() {

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -29,7 +29,8 @@
 
 class TestFileLister : public TestFixture {
 public:
-    TestFileLister() : TestFixture("TestFileLister") {}
+    TestFileLister()
+        : TestFixture("TestFileLister") {}
 
 private:
     void run() override {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -33,10 +33,20 @@ public:
     TestFunctions() : TestFixture("TestFunctions") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).severity(Severity::warning).severity(Severity::performance).severity(Severity::portability).
-                        certainty(Certainty::inconclusive).c(Standards::C11).cpp(Standards::CPP11).library("std.cfg").library("posix.cfg").build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::performance);
+        settings.severity.enable(Severity::portability);
+        settings.certainty.enable(Certainty::inconclusive);
+        settings.standards.c = Standards::C11;
+        settings.standards.cpp = Standards::CPP11;
+        LOAD_LIB_2(settings.library, "std.cfg");
+        LOAD_LIB_2(settings.library, "posix.cfg");
+        settings.libraries.emplace_back("posix");
+
         // Prohibited functions
         TEST_CASE(prohibitedFunctions_posix);
         TEST_CASE(prohibitedFunctions_index);

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -262,7 +262,6 @@ private:
               "}", "test.c");
         ASSERT_EQUALS("[test.c:3]: (warning) Obsolete function 'alloca' called. In C99 and later it is recommended to use a variable length array instead.\n", errout.str());
 
-        const Settings settingsOld = settings;
         settings.standards.c = Standards::C89;
         settings.standards.cpp = Standards::CPP03;
         check("void f()\n"
@@ -282,7 +281,8 @@ private:
               "    char *x = alloca(10);\n"
               "}", "test.c");
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
+        settings.standards.c = Standards::C11;
+        settings.standards.cpp = Standards::CPP11;
     }
 
     // ticket #3121
@@ -1291,7 +1291,8 @@ private:
     }
 
     void checkIgnoredReturnValue() {
-        Settings settings2 = settingsBuilder().severity(Severity::warning).build();
+        Settings settings2;
+        settings2.severity.enable(Severity::warning);
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def version=\"2\">\n"
                                "  <function name=\"mystrcmp,foo::mystrcmp\">\n"
@@ -1443,7 +1444,8 @@ private:
     }
 
     void checkIgnoredErrorCode() {
-        Settings settings2 = settingsBuilder().severity(Severity::style).build();
+        Settings settings2;
+        settings2.addEnabled("style");
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def version=\"2\">\n"
                                "  <function name=\"mystrcmp\">\n"

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -35,9 +35,10 @@ public:
     TestGarbage() : TestFixture("TestGarbage") {}
 
 private:
-    Settings settings = settingsBuilder().debugwarnings().build();
+    Settings settings;
 
     void run() override {
+        settings.debugwarnings = true;
         settings.severity.fill();
         settings.certainty.fill();
 

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -35,13 +35,13 @@ public:
     TestIncompleteStatement() : TestFixture("TestIncompleteStatement") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).build();
+    Settings settings;
 
     void check(const char code[], bool inconclusive = false) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -54,16 +54,18 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for incomplete statements..
-        CheckOther checkOther(&tokenizer, &settings1, this);
+        CheckOther checkOther(&tokenizer, &settings, this);
         checkOther.checkIncompleteStatement();
     }
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+
         TEST_CASE(test1);
         TEST_CASE(test2);
         TEST_CASE(test3);

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -87,7 +87,6 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        // TODO: using dedicated Settings (i.e. copying it) object causes major slowdown
         settings1.severity.clear();
         settings1.severity.enable(Severity::warning);
         settings1.severity.enable(Severity::style);

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -35,10 +35,14 @@ public:
     TestIO() : TestFixture("TestIO") {}
 
 private:
-    const Settings settings = settingsBuilder().library("std.cfg").library("windows.cfg").library("qt.cfg").build();
-    Settings settings1 = settingsBuilder().library("std.cfg").library("windows.cfg").library("qt.cfg").build();
+    Settings settings;
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+        LOAD_LIB_2(settings.library, "windows.cfg");
+        LOAD_LIB_2(settings.library, "qt.cfg");
+        settings.libraries.emplace_back("qt");
+
         TEST_CASE(coutCerrMisusage);
 
         TEST_CASE(wrongMode_simple);
@@ -87,22 +91,22 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        settings1.severity.clear();
-        settings1.severity.enable(Severity::warning);
-        settings1.severity.enable(Severity::style);
+        settings.severity.clear();
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::style);
         if (portability)
-            settings1.severity.enable(Severity::portability);
-        settings1.certainty.setEnabled(Certainty::inconclusive, inconclusive);
-        PLATFORM(settings1.platform, platform);
+            settings.severity.enable(Severity::portability);
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        PLATFORM(settings.platform, platform);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         const std::string file_in = cpp ? "test.cpp" : "test.c";
         ASSERT_LOC(tokenizer.tokenize(istr, file_in.c_str()), file, line);
 
         // Check..
-        CheckIO checkIO(&tokenizer, &settings1, this);
+        CheckIO checkIO(&tokenizer, &settings, this);
         checkIO.checkWrongPrintfScanfArguments();
         if (!onlyFormatStr) {
             checkIO.checkCoutCerrMisusage();

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -2654,7 +2654,7 @@ public:
     TestLeakAutoVarRecursiveCountLimit() : TestFixture("TestLeakAutoVarRecursiveCountLimit") {}
 
 private:
-    const Settings settings = settingsBuilder().library("std.cfg").checkLibrary().build();
+    Settings settings;
 
     void checkP(const char code[], bool cpp = false) {
         // Clear the error buffer..
@@ -2675,11 +2675,15 @@ private:
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
+        settings.checkLibrary = true;
+
         // Check for leaks..
         runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
     }
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(recursiveCountLimit); // #5872 #6157 #9097
     }
 
@@ -2710,7 +2714,7 @@ public:
     TestLeakAutoVarStrcpy() : TestFixture("TestLeakAutoVarStrcpy") {}
 
 private:
-    const Settings settings = settingsBuilder().library("std.cfg").checkLibrary().build();
+    Settings settings;
 
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
@@ -2721,11 +2725,15 @@ private:
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
+        settings.checkLibrary = true;
+
         // Check for leaks..
         runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
     }
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(returnedValue); // #9298
         TEST_CASE(deallocuse2);
         TEST_CASE(fclose_false_positive); // #9575
@@ -2770,7 +2778,7 @@ public:
     TestLeakAutoVarWindows() : TestFixture("TestLeakAutoVarWindows") {}
 
 private:
-    const Settings settings = settingsBuilder().library("windows.cfg").build();
+    Settings settings;
 
     void check_(const char* file, int line, const char code[]) {
         // Clear the error buffer..
@@ -2786,6 +2794,8 @@ private:
     }
 
     void run() override {
+        LOAD_LIB_2(settings.library, "windows.cfg");
+
         TEST_CASE(heapDoubleFree);
     }
 

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -225,19 +225,19 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], bool cpp = false, const Settings *s = nullptr) {
+    void check_(const char* file, int line, const char code[], bool cpp = false) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(s ? *s : settings).checkLibrary().build();
-
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, cpp ? "test.cpp" : "test.c"), file, line);
 
+        settings.checkLibrary = true;
+
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings1, this);
+        runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
     }
 
     void check_(const char* file, int line, const char code[], const Settings & s) {
@@ -469,7 +469,9 @@ private:
     }
 
     void assign23() {
-        const Settings s = settingsBuilder(settings).library("posix.cfg").build();
+        const Settings settingsOld = settings;
+        LOAD_LIB_2(settings.library, "posix.cfg");
+        settings.libraries.emplace_back("posix");
         check("void f() {\n"
               "    int n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11, n12, n13, n14;\n"
               "    *&n1 = open(\"xx.log\", O_RDONLY);\n"
@@ -486,7 +488,7 @@ private:
               "    ((*&n12)) = open(\"xx.log\", O_RDONLY);\n"
               "    *(&(*&n13)) = open(\"xx.log\", O_RDONLY);\n"
               "    ((*&(*&n14))) = open(\"xx.log\", O_RDONLY);\n"
-              "}\n", true, &s);
+              "}\n", true);
         ASSERT_EQUALS("[test.cpp:17]: (error) Resource leak: n1\n"
                       "[test.cpp:17]: (error) Resource leak: n2\n"
                       "[test.cpp:17]: (error) Resource leak: n3\n"
@@ -502,6 +504,7 @@ private:
                       "[test.cpp:17]: (error) Resource leak: n13\n"
                       "[test.cpp:17]: (error) Resource leak: n14\n",
                       errout.str());
+        settings = settingsOld;
     }
 
     void assign24() {
@@ -2622,6 +2625,8 @@ private:
     }
 
     void functionCallLeakIgnoreConfig() { // #7923
+        Settings settingsLeakIgnore = settings;
+
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def format=\"2\">\n"
                                "  <function name=\"SomeClass::someMethod\">\n"
@@ -2630,7 +2635,7 @@ private:
                                "    <arg nr=\"1\" direction=\"in\"/>\n"
                                "  </function>\n"
                                "</def>\n";
-        const Settings settingsLeakIgnore = settingsBuilder(settings).libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settingsLeakIgnore.library.loadxmldata(xmldata, sizeof(xmldata)));
         check("void f() {\n"
               "    double* a = new double[1024];\n"
               "    SomeClass::someMethod(a);\n"

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -41,7 +41,7 @@ public:
     TestLibrary() : TestFixture("TestLibrary") {}
 
 private:
-    const Settings settings;
+    Settings settings;
 
     void run() override {
         TEST_CASE(isCompliantValidationExpression);

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -71,12 +71,6 @@ private:
         TEST_CASE(loadLibErrors);
     }
 
-    static bool loadxmldata(Library &lib, const char xmldata[], std::size_t len)
-    {
-        tinyxml2::XMLDocument doc;
-        return (tinyxml2::XML_SUCCESS == doc.Parse(xmldata, len)) && (lib.load(doc).errorcode == Library::ErrorCode::OK);
-    }
-
     void isCompliantValidationExpression() const {
         ASSERT_EQUALS(true, Library::isCompliantValidationExpression("-1"));
         ASSERT_EQUALS(true, Library::isCompliantValidationExpression("1"));
@@ -103,7 +97,7 @@ private:
         // Reading an empty library file is considered to be OK
         const char xmldata[] = "<?xml version=\"1.0\"?>\n<def/>";
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
     }
 
@@ -121,7 +115,7 @@ private:
         tokenList.front()->next()->astOperand1(tokenList.front());
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 1U);
         ASSERT(library.functions.at("foo").argumentChecks.empty());
         ASSERT(library.isnotnoreturn(tokenList.front()));
@@ -136,7 +130,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         {
             TokenList tokenList(nullptr);
             std::istringstream istr("fred.foo(123);"); // <- wrong scope, not library function
@@ -168,7 +162,7 @@ private:
         tokenList.createAst();
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.isNotLibraryFunction(tokenList.front()));
     }
 
@@ -182,7 +176,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         {
             TokenList tokenList(nullptr);
@@ -237,7 +231,7 @@ private:
         tokenList.front()->next()->varId(1);
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.isNotLibraryFunction(tokenList.front()->next()));
     }
 
@@ -254,7 +248,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[1].notuninit);
         ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[2].notnull);
         ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[3].formatstr);
@@ -273,7 +267,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
     }
 
@@ -287,7 +281,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
 
         TokenList tokenList(nullptr);
@@ -313,7 +307,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d);");
@@ -345,7 +339,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d,e,f,g,h,i,j,k);");
@@ -487,7 +481,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("foo(a,b,c,d,e);");
@@ -546,7 +540,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 2U);
         ASSERT(library.functions.at("Foo::foo").argumentChecks.empty());
         ASSERT(library.functions.at("bar").argumentChecks.empty());
@@ -575,7 +569,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT_EQUALS(library.functions.size(), 1U);
 
         {
@@ -602,7 +596,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         {
             Tokenizer tokenizer(&settings, nullptr);
@@ -631,7 +625,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         TokenList tokenList(nullptr);
         std::istringstream istr("a(); b();");
@@ -665,7 +659,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
@@ -692,8 +686,8 @@ private:
                                 "</def>";
 
         Library library;
-        ASSERT_EQUALS(true, loadxmldata(library, xmldata1, sizeof(xmldata1)));
-        ASSERT_EQUALS(true, loadxmldata(library, xmldata2, sizeof(xmldata2)));
+        ASSERT_EQUALS(true, library.loadxmldata(xmldata1, sizeof(xmldata1)));
+        ASSERT_EQUALS(true, library.loadxmldata(xmldata2, sizeof(xmldata2)));
 
         ASSERT_EQUALS(library.deallocId("free"), library.allocId("malloc"));
         ASSERT_EQUALS(library.deallocId("free"), library.allocId("foo"));
@@ -708,7 +702,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
@@ -727,7 +721,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         ASSERT(library.functions.empty());
 
         ASSERT(Library::isresource(library.allocId("CreateX")));
@@ -744,7 +738,7 @@ private:
                                    "  <podtype name=\"s16\" sign=\"s\" size=\"2\"/>\n"
                                    "</def>";
             Library library;
-            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
             // s8
             {
                 const struct Library::PodType * const type = library.podtype("s8");
@@ -822,7 +816,7 @@ private:
                                "</def>";
 
         Library library;
-        ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+        ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
 
         Library::Container& A = library.containers["A"];
         Library::Container& B = library.containers["B"];
@@ -937,14 +931,14 @@ private:
                                    "<def>\n"
                                    "</def>";
             Library library;
-            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         }
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                    "<def format=\"1\">\n"
                                    "</def>";
             Library library;
-            ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
+            ASSERT(library.loadxmldata(xmldata, sizeof(xmldata)));
         }
         {
             const char xmldata[] = "<?xml version=\"1.0\"?>\n"

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -41,9 +41,12 @@ public:
     TestNullPointer() : TestFixture("TestNullPointer") {}
 
 private:
-    const Settings settings = settingsBuilder().library("std.cfg").severity(Severity::warning).build();
+    Settings settings;
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+        settings.severity.enable(Severity::warning);
+
         TEST_CASE(nullpointerAfterLoop);
         TEST_CASE(nullpointer1);
         TEST_CASE(nullpointer2);
@@ -181,22 +184,22 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
+        runChecks<CheckNullPointer>(&tokenizer, &settings, this);
     }
 
     void checkP(const char code[]) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, false);
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -209,12 +212,12 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenizer..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
+        runChecks<CheckNullPointer>(&tokenizer, &settings, this);
     }
 
 
@@ -4062,7 +4065,7 @@ private:
     }
 
     void functioncalllibrary() {
-        const Settings settings1;
+        Settings settings1;
         Tokenizer tokenizer(&settings1,this);
         std::istringstream code("void f() { int a,b,c; x(a,b,c); }");
         ASSERT_EQUALS(true, tokenizer.tokenize(code, "test.c"));

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6160,6 +6160,7 @@ private:
     }
 
     void duplicateExpression3() {
+        Settings settings;
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def>\n"
                                "  <function name=\"mystrcmp\">\n"
@@ -6168,7 +6169,7 @@ private:
                                "    <arg nr=\"2\"/>\n"
                                "  </function>\n"
                                "</def>";
-        Settings settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        ASSERT(settings.library.loadxmldata(xmldata, sizeof(xmldata)));
 
         check("void foo() {\n"
               "    if (x() || x()) {}\n"

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -1619,8 +1619,9 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        // #5560 - set c++03
-        const Settings settings = settingsBuilder().severity(Severity::style).cpp(Standards::CPP03).build();
+        Settings settings;
+        settings.severity.enable(Severity::style);
+        settings.standards.cpp = Standards::CPP03; // #5560
 
         Preprocessor preprocessor(settings);
 
@@ -1821,7 +1822,11 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability, portability).certainty(Certainty::inconclusive, inconclusive).build();
+        Settings settings;
+        settings.severity.enable(Severity::warning);
+        if (portability)
+            settings.severity.enable(Severity::portability);
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
         settings.platform.defaultSign = 's';
 
         Preprocessor preprocessor(settings);
@@ -2095,7 +2100,8 @@ private:
                       "[test.cpp:18]: (performance) Function parameter 'v' should be passed by const reference.\n",
                       errout.str());
 
-        Settings settings1 = settingsBuilder().platform(cppcheck::Platform::Type::Win64).build();
+        Settings settings1;
+        PLATFORM(settings1.platform, cppcheck::Platform::Type::Win64);
         check("using ui64 = unsigned __int64;\n"
               "ui64 Test(ui64 one, ui64 two) { return one + two; }\n",
               /*filename*/ nullptr, /*inconclusive*/ true, /*runSimpleChecks*/ true, /*verbose*/ false, &settings1);
@@ -2240,11 +2246,13 @@ private:
                                 "};\n"
                                 "void f(X x) {}";
 
-            Settings s32 = settingsBuilder(_settings).platform(cppcheck::Platform::Type::Unix32).build();
+            Settings s32(_settings);
+            PLATFORM(s32.platform, cppcheck::Platform::Type::Unix32);
             check(code, &s32);
             ASSERT_EQUALS("[test.cpp:5]: (performance) Function parameter 'x' should be passed by const reference.\n", errout.str());
 
-            Settings s64 = settingsBuilder(_settings).platform(cppcheck::Platform::Type::Unix64).build();
+            Settings s64(_settings);
+            PLATFORM(s64.platform, cppcheck::Platform::Type::Unix64);
             check(code, &s64);
             ASSERT_EQUALS("", errout.str());
         }
@@ -7683,10 +7691,11 @@ private:
         }
 
         {
-            Settings s = settingsBuilder().checkUnusedTemplates().build();
+            Settings keepTemplates;
+            keepTemplates.checkUnusedTemplates = true;
             check("template<int n> void foo(unsigned int x) {\n"
                   "if (x <= 0);\n"
-                  "}", &s);
+                  "}", &keepTemplates);
             ASSERT_EQUALS("[test.cpp:2]: (style) Checking if unsigned expression 'x' is less than zero.\n", errout.str());
         }
 
@@ -7701,7 +7710,8 @@ private:
         ASSERT_EQUALS("[test.cpp:3]: (style) Checking if unsigned expression 'value' is less than zero.\n", errout.str());
 
         // #9040
-        Settings settings1 = settingsBuilder().platform(cppcheck::Platform::Type::Win64).build();
+        Settings settings1;
+        PLATFORM(settings1.platform, cppcheck::Platform::Type::Win64);
         check("using BOOL = unsigned;\n"
               "int i;\n"
               "bool f() {\n"
@@ -10517,13 +10527,14 @@ private:
     }
 
     void forwardAndUsed() {
-        Settings s = settingsBuilder().checkUnusedTemplates().build();
+        Settings keepTemplates;
+        keepTemplates.checkUnusedTemplates = true;
 
         check("template<typename T>\n"
               "void f(T && t) {\n"
               "    g(std::forward<T>(t));\n"
               "    T s = t;\n"
-              "}", &s);
+              "}", &keepTemplates);
         ASSERT_EQUALS("[test.cpp:4]: (warning) Access of forwarded variable 't'.\n", errout.str());
     }
 

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -25,13 +25,18 @@
 
 class TestPathMatch : public TestFixture {
 public:
-    TestPathMatch() : TestFixture("TestPathMatch") {}
+    TestPathMatch()
+        : TestFixture("TestPathMatch")
+        , emptyMatcher(std::vector<std::string>())
+        , srcMatcher(std::vector<std::string>(1, "src/"))
+        , fooCppMatcher(std::vector<std::string>(1, "foo.cpp"))
+        , srcFooCppMatcher(std::vector<std::string>(1, "src/foo.cpp")) {}
 
 private:
-    const PathMatch emptyMatcher{std::vector<std::string>()};
-    const PathMatch srcMatcher{std::vector<std::string>(1, "src/")};
-    const PathMatch fooCppMatcher{std::vector<std::string>(1, "foo.cpp")};
-    const PathMatch srcFooCppMatcher{std::vector<std::string>(1, "src/foo.cpp")};
+    const PathMatch emptyMatcher;
+    const PathMatch srcMatcher;
+    const PathMatch fooCppMatcher;
+    const PathMatch srcFooCppMatcher;
 
     void run() override {
         TEST_CASE(emptymaskemptyfile);

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -30,7 +30,7 @@ public:
     TestPostfixOperator() : TestFixture("TestPostfixOperator") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::performance).build();
+    Settings settings;
 
 #define check(code) check_(code, __FILE__, __LINE__)
     void check_(const char code[], const char* file, int line) {
@@ -48,6 +48,8 @@ private:
     }
 
     void run() override {
+        settings.severity.enable(Severity::performance);
+
         TEST_CASE(testsimple);
         TEST_CASE(testfor);
         TEST_CASE(testvolatile);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -58,7 +58,7 @@ public:
             simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI(), &outputList);
 
             if (errorLogger) {
-                const Settings settings;
+                Settings settings;
                 Preprocessor p(settings, errorLogger);
                 p.reportOutput(outputList, true);
             }
@@ -68,7 +68,7 @@ public:
     };
 
 private:
-    const Settings settings0 = settingsBuilder().severity(Severity::information).build();
+    Settings settings0 = settingsBuilder().severity(Severity::information).build();
     Preprocessor preprocessor0{settings0, this};
 
     void run() override {
@@ -468,6 +468,9 @@ private:
     }
 
     void setPlatformInfo() {
+        Settings settings;
+        Preprocessor preprocessor(settings, this);
+
         // read code with simplecpp..
         const char filedata[] = "#if sizeof(long) == 4\n"
                                 "1\n"
@@ -479,20 +482,14 @@ private:
         simplecpp::TokenList tokens(istr, files, "test.c");
 
         // preprocess code with unix32 platform..
-        {
-            const Settings settings = settingsBuilder().platform(cppcheck::Platform::Type::Unix32).build();
-            Preprocessor preprocessor(settings, this);
-            preprocessor.setPlatformInfo(&tokens);
-            ASSERT_EQUALS("\n1", preprocessor.getcode(tokens, "", files, false));
-        }
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix32);
+        preprocessor.setPlatformInfo(&tokens);
+        ASSERT_EQUALS("\n1", preprocessor.getcode(tokens, "", files, false));
 
         // preprocess code with unix64 platform..
-        {
-            const Settings settings = settingsBuilder().platform(cppcheck::Platform::Type::Unix64).build();
-            Preprocessor preprocessor(settings, this);
-            preprocessor.setPlatformInfo(&tokens);
-            ASSERT_EQUALS("\n\n\n2", preprocessor.getcode(tokens, "", files, false));
-        }
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
+        preprocessor.setPlatformInfo(&tokens);
+        ASSERT_EQUALS("\n\n\n2", preprocessor.getcode(tokens, "", files, false));
     }
 
     void includeguard1() {

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -43,7 +43,11 @@ class ErrorLogger;
 
 class TestPreprocessor : public TestFixture {
 public:
-    TestPreprocessor() : TestFixture("TestPreprocessor") {}
+    TestPreprocessor()
+        : TestFixture("TestPreprocessor")
+        , preprocessor0(settings0, this) {
+        settings0.severity.enable(Severity::information);
+    }
 
     class OurPreprocessor : public Preprocessor {
     public:
@@ -68,8 +72,8 @@ public:
     };
 
 private:
-    Settings settings0 = settingsBuilder().severity(Severity::information).build();
-    Preprocessor preprocessor0{settings0, this};
+    Settings settings0;
+    Preprocessor preprocessor0;
 
     void run() override {
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -39,7 +39,7 @@ public:
     TestProcessExecutor() : TestFixture("TestProcessExecutor") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings;
 
     static std::string fprefix()
     {
@@ -85,6 +85,8 @@ private:
 
     void run() override {
 #if !defined(WIN32) && !defined(__MINGW32__) && !defined(__CYGWIN__)
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(deadlock_with_many_errors);
         TEST_CASE(many_threads);
         TEST_CASE(many_threads_showtime);

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -37,10 +37,14 @@ public:
     TestSimplifyTemplate() : TestFixture("TestSimplifyTemplate") {}
 
 private:
-    // If there are unused templates, keep those
-    const Settings settings = settingsBuilder().severity(Severity::portability).checkUnusedTemplates().build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::portability);
+
+        // If there are unused templates, keep those
+        settings.checkUnusedTemplates = true;
+
         TEST_CASE(template1);
         TEST_CASE(template2);
         TEST_CASE(template3);
@@ -309,9 +313,9 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool debugwarnings = false, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
-        PLATFORM(settings1.platform, type);
-        Tokenizer tokenizer(&settings1, this);
+        settings.debugwarnings = debugwarnings;
+        PLATFORM(settings.platform, type);
+        Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -309,7 +309,8 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool debugwarnings = false, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).platform(type).build();
+        Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
+        PLATFORM(settings1.platform, type);
         Tokenizer tokenizer(&settings1, this);
 
         std::istringstream istr(code);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -167,7 +167,8 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool simplify = true, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        const Settings settings = settingsBuilder(settings0).platform(type).build();
+        Settings settings = settings0;
+        PLATFORM(settings.platform, type);
         Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);
@@ -193,7 +194,9 @@ private:
     std::string tokenizeAndStringify_(const char* file, int linenr, const char code[], bool simplify = false, bool expand = true, cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const char* filename = "test.cpp", bool cpp11 = true) {
         errout.str("");
 
-        const Settings settings = settingsBuilder(settings1).debugwarnings().platform(platform).cpp(cpp11 ? Standards::CPP11 : Standards::CPP03).build();
+        Settings settings = settingsBuilder(settings1).debugwarnings().build();
+        PLATFORM(settings.platform, platform);
+        settings.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
 
         // tokenize..
         Tokenizer tokenizer(&settings, this);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -34,13 +34,24 @@ public:
 
 
 private:
-    // If there are unused templates, keep those
-    const Settings settings0 = settingsBuilder().severity(Severity::portability).checkUnusedTemplates().build();
-    const Settings settings1 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
-    const Settings settings_std = settingsBuilder().library("std.cfg").checkUnusedTemplates().build();
-    const Settings settings_windows = settingsBuilder().library("windows.cfg").severity(Severity::portability).checkUnusedTemplates().build();
+    Settings settings0;
+    Settings settings1;
+    Settings settings_std;
+    Settings settings_windows;
 
     void run() override {
+        LOAD_LIB_2(settings_std.library, "std.cfg");
+        LOAD_LIB_2(settings_windows.library, "windows.cfg");
+        settings0.severity.enable(Severity::portability);
+        settings1.severity.enable(Severity::style);
+        settings_windows.severity.enable(Severity::portability);
+
+        // If there are unused templates, keep those
+        settings0.checkUnusedTemplates = true;
+        settings1.checkUnusedTemplates = true;
+        settings_std.checkUnusedTemplates = true;
+        settings_windows.checkUnusedTemplates = true;
+
         TEST_CASE(combine_strings);
         TEST_CASE(combine_wstrings);
         TEST_CASE(combine_ustrings);
@@ -167,12 +178,13 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool simplify = true, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native) {
         errout.str("");
 
-        Settings settings = settings0;
-        PLATFORM(settings.platform, type);
-        Tokenizer tokenizer(&settings, this);
+        PLATFORM(settings0.platform, type);
+        Tokenizer tokenizer(&settings0, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
+
+        (void)simplify;
 
         return tokenizer.tokens()->stringifyList(nullptr, !simplify);
     }
@@ -194,12 +206,12 @@ private:
     std::string tokenizeAndStringify_(const char* file, int linenr, const char code[], bool simplify = false, bool expand = true, cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const char* filename = "test.cpp", bool cpp11 = true) {
         errout.str("");
 
-        Settings settings = settingsBuilder(settings1).debugwarnings().build();
-        PLATFORM(settings.platform, platform);
-        settings.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
+        settings1.debugwarnings = true;
+        PLATFORM(settings1.platform, platform);
+        settings1.standards.cpp = cpp11 ? Standards::CPP11 : Standards::CPP03;
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -232,7 +232,8 @@ private:
         errout.str("");
 
         // show warnings about unhandled typedef
-        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
+        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
+        PLATFORM(settings.platform, type);
         Tokenizer tokenizer(&settings, this);
 
         std::istringstream istr(code);

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -40,12 +40,19 @@ public:
 
 
 private:
-    // If there are unused templates, keep those
-    const Settings settings0 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
-    const Settings settings1 = settingsBuilder().severity(Severity::portability).checkUnusedTemplates().build();
-    const Settings settings2 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
+    Settings settings0;
+    Settings settings1;
+    Settings settings2;
 
     void run() override {
+        settings0.severity.enable(Severity::style);
+        settings2.severity.enable(Severity::style);
+
+        // If there are unused templates, keep those
+        settings0.checkUnusedTemplates = true;
+        settings1.checkUnusedTemplates = true;
+        settings2.checkUnusedTemplates = true;
+
         TEST_CASE(c1);
         TEST_CASE(c2);
         TEST_CASE(canreplace1);
@@ -231,10 +238,10 @@ private:
     std::string tok_(const char* file, int line, const char code[], bool simplify = true, cppcheck::Platform::Type type = cppcheck::Platform::Type::Native, bool debugwarnings = true) {
         errout.str("");
 
-        // show warnings about unhandled typedef
-        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
-        PLATFORM(settings.platform, type);
-        Tokenizer tokenizer(&settings, this);
+        settings0.certainty.enable(Certainty::inconclusive);
+        settings0.debugwarnings = debugwarnings;   // show warnings about unhandled typedef
+        PLATFORM(settings0.platform, type);
+        Tokenizer tokenizer(&settings0, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -283,9 +290,9 @@ private:
     void checkSimplifyTypedef_(const char code[], const char* file, int line) {
         errout.str("");
         // Tokenize..
-        // show warnings about unhandled typedef
-        const Settings settings = settingsBuilder(settings2).certainty(Certainty::inconclusive).debugwarnings().build();
-        Tokenizer tokenizer(&settings, this);
+        settings2.certainty.enable(Certainty::inconclusive);
+        settings2.debugwarnings = true;   // show warnings about unhandled typedef
+        Tokenizer tokenizer(&settings2, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
     }

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -411,7 +411,7 @@ private:
         const char code[] = "typedef int f(int);\n"
                             "typedef const f cf;\n";
         simplifyTypedefC(code);
-        ASSERT_EQUALS("[file.c:2]: (portability) It is unspecified behavior to const qualify a function type.\n", errout.str());
+        TODO_ASSERT_EQUALS("[file.c:2]: (portability) It is unspecified behavior to const qualify a function type.\n", "", errout.str());
     }
 
     void cfp1() {

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -39,12 +39,19 @@ public:
 
 
 private:
-    // If there are unused templates, keep those
-    const Settings settings0 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
-    const Settings settings1 = settingsBuilder().checkUnusedTemplates().build();
-    const Settings settings2 = settingsBuilder().severity(Severity::style).checkUnusedTemplates().build();
+    Settings settings0;
+    Settings settings1;
+    Settings settings2;
 
     void run() override {
+        settings0.severity.enable(Severity::style);
+        settings2.severity.enable(Severity::style);
+
+        // If there are unused templates, keep those
+        settings0.checkUnusedTemplates = true;
+        settings1.checkUnusedTemplates = true;
+        settings2.checkUnusedTemplates = true;
+
         TEST_CASE(simplifyUsing1);
         TEST_CASE(simplifyUsing2);
         TEST_CASE(simplifyUsing3);
@@ -100,9 +107,10 @@ private:
     std::string tok_(const char* file, int line, const char code[], cppcheck::Platform::Type type = cppcheck::Platform::Type::Native, bool debugwarnings = true, bool preprocess = false) {
         errout.str("");
 
-        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
-        PLATFORM(settings.platform, type);
-        Tokenizer tokenizer(&settings, this);
+        settings0.certainty.enable(Certainty::inconclusive);
+        settings0.debugwarnings = debugwarnings;
+        PLATFORM(settings0.platform, type);
+        Tokenizer tokenizer(&settings0, this);
 
         if (preprocess) {
             std::vector<std::string> files{ "test.cpp" };

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -100,8 +100,8 @@ private:
     std::string tok_(const char* file, int line, const char code[], cppcheck::Platform::Type type = cppcheck::Platform::Type::Native, bool debugwarnings = true, bool preprocess = false) {
         errout.str("");
 
-        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
-
+        Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).build();
+        PLATFORM(settings.platform, type);
         Tokenizer tokenizer(&settings, this);
 
         if (preprocess) {

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -41,7 +41,7 @@ protected:
     TestSingleExecutorBase(const char * const name, bool useFS) : TestFixture(name), useFS(useFS) {}
 
 private:
-    Settings settings
+    Settings settings;
     bool useFS;
 
     std::string fprefix() const

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -41,7 +41,7 @@ protected:
     TestSingleExecutorBase(const char * const name, bool useFS) : TestFixture(name), useFS(useFS) {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings
     bool useFS;
 
     std::string fprefix() const
@@ -113,6 +113,8 @@ private:
     }
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(many_files);
         TEST_CASE(many_files_showtime);
         TEST_CASE(many_files_plist);

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -36,9 +36,13 @@ public:
     TestSizeof() : TestFixture("TestSizeof") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::portability).certainty(Certainty::inconclusive).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::portability);
+        settings.certainty.enable(Certainty::inconclusive);
+
         TEST_CASE(sizeofsizeof);
         TEST_CASE(sizeofCalculation);
         TEST_CASE(sizeofFunction);

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -35,9 +35,14 @@ public:
     TestStl() : TestFixture("TestStl") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).severity(Severity::performance).library("std.cfg").build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::style);
+        settings.severity.enable(Severity::performance);
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(outOfBounds);
         TEST_CASE(outOfBoundsSymbolic);
         TEST_CASE(outOfBoundsIndexExpression);
@@ -180,15 +185,17 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).cpp(cppstandard).build();
+        settings.certainty.setEnabled(Certainty::inconclusive, inconclusive);
+        settings.standards.cpp = cppstandard;
+
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
 
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        runChecks<CheckStl>(&tokenizer, &settings1, this);
+        runChecks<CheckStl>(&tokenizer, &settings, this);
     }
 
     void check_(const char* file, int line, const std::string& code, const bool inconclusive = false) {

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -32,9 +32,12 @@ public:
     TestString() : TestFixture("TestString") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+        settings.severity.enable(Severity::style);
+
         TEST_CASE(stringLiteralWrite);
 
         TEST_CASE(alwaysTrueFalseStringCompare);

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -44,7 +44,7 @@ private:
         errout.str("");
 
         // tokenize..
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7997,13 +7997,14 @@ private:
         ASSERT_EQUALS("unsigned long long", typeOf("enum E : unsigned long long { }; void foo() { E e[3]; bar(e[0]); }", "[ 0"));
 
 #define CHECK_LIBRARY_FUNCTION_RETURN_TYPE(type) do { \
+        Settings sF; \
         const char xmldata[] = "<?xml version=\"1.0\"?>\n" \
                                "<def>\n" \
                                "<function name=\"g\">\n" \
                                "<returnValue type=\"" #type "\"/>\n" \
                                "</function>\n" \
                                "</def>";              \
-        const Settings sF = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build(); \
+        ASSERT(sF.library.loadxmldata(xmldata, sizeof(xmldata))); \
         ASSERT_EQUALS(#type, typeOf("void f() { auto x = g(); }", "x", "test.cpp", &sF)); \
 } while (false)
         // *INDENT-OFF*

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -63,14 +63,16 @@ class TestSymbolDatabase;
 
 class TestSymbolDatabase : public TestFixture {
 public:
-    TestSymbolDatabase() : TestFixture("TestSymbolDatabase") {}
+    TestSymbolDatabase()
+        : TestFixture("TestSymbolDatabase")
+        ,vartok(nullptr)
+        ,typetok(nullptr) {}
 
 private:
-    const Token* vartok{nullptr};
-    const Token* typetok{nullptr};
-    // If there are unused templates, keep those
-    Settings settings1 = settingsBuilder().library("std.cfg").checkUnusedTemplates().build();
-    Settings settings2 = settingsBuilder().checkUnusedTemplates().build();
+    const Token* vartok;
+    const Token* typetok;
+    Settings settings1;
+    Settings settings2;
 
     void reset() {
         vartok = nullptr;
@@ -115,7 +117,12 @@ private:
     }
 
     void run() override {
+        LOAD_LIB_2(settings1.library, "std.cfg");
         PLATFORM(settings2.platform, cppcheck::Platform::Type::Unspecified);
+
+        // If there are unused templates, keep those
+        settings1.checkUnusedTemplates = true;
+        settings2.checkUnusedTemplates = true;
 
         TEST_CASE(array);
         TEST_CASE(array_ptr);
@@ -2304,15 +2311,17 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder(settings1).debugwarnings(debug).build();
+        settings1.debugwarnings = debug;
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(&settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // force symbol database creation
         tokenizer.createSymbolDatabase();
+
+        settings1.debugwarnings = false;
     }
 
     void functionArgs1() {

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -39,7 +39,7 @@ public:
     TestThreadExecutor() : TestFixture("TestThreadExecutor") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings;
 
     static std::string fprefix()
     {
@@ -69,13 +69,12 @@ private:
             }
         }
 
-        Settings settings1 = settings;
-        settings1.jobs = jobs;
-        settings1.showtime = showtime;
+        settings.jobs = jobs;
+        settings.showtime = showtime;
         if (plistOutput)
-            settings1.plistOutput = plistOutput;
+            settings.plistOutput = plistOutput;
         // TODO: test with settings.project.fileSettings;
-        ThreadExecutor executor(filemap, settings1, *this);
+        ThreadExecutor executor(filemap, settings, *this);
         std::vector<std::unique_ptr<ScopedFile>> scopedfiles;
         scopedfiles.reserve(filemap.size());
         for (std::map<std::string, std::size_t>::const_iterator i = filemap.cbegin(); i != filemap.cend(); ++i)
@@ -85,6 +84,8 @@ private:
     }
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(deadlock_with_many_errors);
         TEST_CASE(many_threads);
         TEST_CASE(many_threads_showtime);

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -135,7 +135,7 @@ private:
 
 #define MatchCheck(...) MatchCheck_(__FILE__, __LINE__, __VA_ARGS__)
     bool MatchCheck_(const char* file, int line, const std::string& code, const std::string& pattern, unsigned int varid = 0) {
-        const Settings settings;
+        static const Settings settings;
         Tokenizer tokenizer(&settings, this);
         std::istringstream istr(";" + code + ";");
         try {
@@ -395,7 +395,7 @@ private:
 
     void getStrSize() const {
         Token tok;
-        const Settings settings;
+        Settings settings;
 
         tok.str("\"\"");
         ASSERT_EQUALS(sizeof(""), Token::getStrSize(&tok, &settings));

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -30,7 +30,7 @@ public:
     TestTokenList() : TestFixture("TestTokenList") {}
 
 private:
-    const Settings settings;
+    Settings settings;
 
     void run() override {
         TEST_CASE(testaddtoken1);
@@ -40,18 +40,17 @@ private:
     }
 
     // inspired by #5895
-    void testaddtoken1() const {
+    void testaddtoken1() {
         const std::string code = "0x89504e470d0a1a0a";
         TokenList tokenlist(&settings);
         tokenlist.addtoken(code, 1, 1, false);
         ASSERT_EQUALS("0x89504e470d0a1a0a", tokenlist.front()->str());
     }
 
-    void testaddtoken2() const {
+    void testaddtoken2() {
         const std::string code = "0xF0000000";
-        Settings settings1;
-        settings1.platform.int_bit = 32;
-        TokenList tokenlist(&settings1);
+        settings.platform.int_bit = 32;
+        TokenList tokenlist(&settings);
         tokenlist.addtoken(code, 1, 1, false);
         ASSERT_EQUALS("0xF0000000", tokenlist.front()->str());
     }
@@ -69,7 +68,7 @@ private:
         ASSERT(Token::simpleMatch(tokenlist.front(), "a + + 1 ; 1 + + b ;"));
     }
 
-    void isKeyword() const {
+    void isKeyword() {
 
         const char code[] = "for a int delete true";
 

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -101,7 +101,7 @@ private:
     }
 
     void scopeExample() const {
-        const Settings settings;
+        Settings settings;
         Tokenizer tokenizer{ &settings, nullptr };
         std::istringstream sample("void a(){} void main(){ if(true){a();} }");
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -238,8 +238,9 @@ private:
     }
 
     void checkIntegerOverflow() {
-        Settings settings = settingsBuilder().severity(Severity::warning).build();
+        Settings settings;
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unix32);
+        settings.severity.enable(Severity::warning);
 
         check("x = (int)0x10000 * (int)0x10000;", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Signed integer overflow for expression '(int)0x10000*(int)0x10000'.\n", errout.str());
@@ -330,7 +331,8 @@ private:
     }
 
     void longCastAssign() {
-        Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings;
+        settings.severity.enable(Severity::style);
         PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
 
         check("long f(int x, int y) {\n"
@@ -361,7 +363,8 @@ private:
     }
 
     void longCastReturn() {
-        Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings;
+        settings.severity.enable(Severity::style);
 
         check("long f(int x, int y) {\n"
               "  return x * y;\n"

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -45,37 +45,40 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], const Settings& settings, const char filename[] = "test.cpp", Standards::cppstd_t standard = Standards::cppstd_t::CPP11) {
+    void check_(const char* file, int line, const char code[], Settings* settings, const char filename[] = "test.cpp", const std::string& standard = "c++11") {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).severity(Severity::warning).severity(Severity::portability).cpp(standard).build();
+        settings->severity.enable(Severity::warning);
+        settings->severity.enable(Severity::portability);
+        settings->standards.setCPP(standard);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check..
-        runChecks<CheckType>(&tokenizer, &settings1, this);
+        runChecks<CheckType>(&tokenizer, settings, this);
     }
 
     void checkTooBigShift_Unix32() {
-        const Settings settings0;
-        const Settings settings = settingsBuilder().platform(cppcheck::Platform::Type::Unix32).build();
+        Settings settings0;
+        Settings settings;
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix32);
 
         // unsigned types getting promoted to int sizeof(int) = 4 bytes
         // and unsigned types having already a size of 4 bytes
         {
             const std::string types[] = {"unsigned char", /*[unsigned]*/ "char", "bool", "unsigned short", "unsigned int", "unsigned long"};
             for (const std::string& type : types) {
-                check((type + " f(" + type +" x) { return x << 31; }").c_str(), settings);
+                check((type + " f(" + type +" x) { return x << 31; }").c_str(), &settings);
                 ASSERT_EQUALS("", errout.str());
-                check((type + " f(" + type +" x) { return x << 33; }").c_str(), settings);
+                check((type + " f(" + type +" x) { return x << 33; }").c_str(), &settings);
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 33 bits is undefined behaviour\n", errout.str());
-                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), settings);
+                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), &settings);
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n", errout.str());
-                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), settings);
+                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), &settings);
                 ASSERT_EQUALS("", errout.str());
             }
         }
@@ -85,68 +88,68 @@ private:
             const std::string types[] = {"signed char", "signed short", /*[signed]*/ "short", "wchar_t", /*[signed]*/ "int", "signed int", /*[signed]*/ "long", "signed long"};
             for (const std::string& type : types) {
                 // c++11
-                check((type + " f(" + type +" x) { return x << 33; }").c_str(), settings);
+                check((type + " f(" + type +" x) { return x << 33; }").c_str(), &settings);
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 33 bits is undefined behaviour\n", errout.str());
-                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), settings);
+                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), &settings);
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n", errout.str());
-                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), settings);
+                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), &settings);
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting signed 32-bit value by 31 bits is undefined behaviour\n", errout.str());
-                check((type + " foo(" + type + " x) { return x << 30; }").c_str(), settings);
+                check((type + " foo(" + type + " x) { return x << 30; }").c_str(), &settings);
                 ASSERT_EQUALS("", errout.str());
 
                 // c++14
-                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), settings, "test.cpp", Standards::cppstd_t::CPP14);
+                check((type + " foo(" + type + " x) { return x << 31; }").c_str(), &settings, "test.cpp", "c++14");
                 ASSERT_EQUALS("[test.cpp:1]: (portability) Shifting signed 32-bit value by 31 bits is implementation-defined behaviour\n", errout.str());
-                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), settings, "test.cpp", Standards::cppstd_t::CPP14);
+                check((type + " f(int x) { return (x = (" + type + ")x << 32); }").c_str(), &settings, "test.cpp", "c++14");
                 ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n", errout.str());
             }
         }
         // 64 bit width types
         {
             // unsigned long long
-            check("unsigned long long foo(unsigned long long x) { return x << 64; }",settings);
+            check("unsigned long long foo(unsigned long long x) { return x << 64; }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("unsigned long long f(int x) { return (x = (unsigned long long)x << 64); }",settings);
+            check("unsigned long long f(int x) { return (x = (unsigned long long)x << 64); }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("unsigned long long f(unsigned long long x) { return x << 63; }",settings);
+            check("unsigned long long f(unsigned long long x) { return x << 63; }",&settings);
             ASSERT_EQUALS("", errout.str());
             // [signed] long long
-            check("long long foo(long long x) { return x << 64; }",settings);
+            check("long long foo(long long x) { return x << 64; }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("long long f(int x) { return (x = (long long)x << 64); }",settings);
+            check("long long f(int x) { return (x = (long long)x << 64); }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("long long f(long long x) { return x << 63; }",settings);
+            check("long long f(long long x) { return x << 63; }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting signed 64-bit value by 63 bits is undefined behaviour\n", errout.str());
-            check("long long f(long long x) { return x << 62; }",settings);
+            check("long long f(long long x) { return x << 62; }",&settings);
             ASSERT_EQUALS("", errout.str());
             // signed long long
-            check("signed long long foo(signed long long x) { return x << 64; }",settings);
+            check("signed long long foo(signed long long x) { return x << 64; }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("signed long long f(long long x) { return (x = (signed long long)x << 64); }",settings);
+            check("signed long long f(long long x) { return (x = (signed long long)x << 64); }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("signed long long f(signed long long x) { return x << 63; }",settings);
+            check("signed long long f(signed long long x) { return x << 63; }",&settings);
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting signed 64-bit value by 63 bits is undefined behaviour\n", errout.str());
-            check("signed long long f(signed long long x) { return x << 62; }",settings);
+            check("signed long long f(signed long long x) { return x << 62; }",&settings);
             ASSERT_EQUALS("", errout.str());
 
             // c++14
-            check("signed long long foo(signed long long x) { return x << 64; }",settings, "test.cpp", Standards::cppstd_t::CPP14);
+            check("signed long long foo(signed long long x) { return x << 64; }",&settings, "test.cpp", "c++14");
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("signed long long f(long long x) { return (x = (signed long long)x << 64); }",settings, "test.cpp", Standards::cppstd_t::CPP14);
+            check("signed long long f(long long x) { return (x = (signed long long)x << 64); }",&settings, "test.cpp", "c++14");
             ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 64-bit value by 64 bits is undefined behaviour\n", errout.str());
-            check("signed long long f(signed long long x) { return x << 63; }",settings, "test.cpp", Standards::cppstd_t::CPP14);
+            check("signed long long f(signed long long x) { return x << 63; }",&settings, "test.cpp", "c++14");
             ASSERT_EQUALS("[test.cpp:1]: (portability) Shifting signed 64-bit value by 63 bits is implementation-defined behaviour\n", errout.str());
-            check("signed long long f(signed long long x) { return x << 62; }",settings);
+            check("signed long long f(signed long long x) { return x << 62; }",&settings);
             ASSERT_EQUALS("", errout.str());
         }
 
-        check("void f() { int x; x = 1 >> 64; }", settings);
+        check("void f() { int x; x = 1 >> 64; }", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Shifting 32-bit value by 64 bits is undefined behaviour\n", errout.str());
 
         check("void foo() {\n"
               "  QList<int> someList;\n"
               "  someList << 300;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("", errout.str());
 
         // Ticket #6793
@@ -154,14 +157,14 @@ private:
               "const unsigned int f = foo<31>(0);\n"
               "const unsigned int g = foo<100>(0);\n"
               "template<unsigned int I> int hoo(unsigned int x) { return x << 32; }\n"
-              "const unsigned int h = hoo<100>(0);", settings);
+              "const unsigned int h = hoo<100>(0);", &settings);
         ASSERT_EQUALS("[test.cpp:4]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n"
                       "[test.cpp:1]: (error) Shifting 32-bit value by 100 bits is undefined behaviour\n", errout.str());
 
         // #7266: C++, shift in macro
         check("void f(unsigned int x) {\n"
               "    UINFO(x << 1234);\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         // #8640
@@ -171,7 +174,7 @@ private:
               "    constexpr const int shift[1] = {32};\n"
               "    constexpr const int ret = a << shift[0];\n" // shift too many bits
               "    return ret;\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("[test.cpp:5]: (error) Shifting 32-bit value by 32 bits is undefined behaviour\n"
                       "[test.cpp:5]: (error) Signed integer overflow for expression 'a<<shift[0]'.\n", errout.str());
 
@@ -182,7 +185,7 @@ private:
               "  if (k > 32)\n"
               "    return 0;\n"
               "  return rm>> k;\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS(
             "[test.cpp:4] -> [test.cpp:6]: (warning) Shifting signed 32-bit value by 31 bits is undefined behaviour. See condition at line 4.\n",
             errout.str());
@@ -194,7 +197,7 @@ private:
               "    return 0;\n"
               "  else\n"
               "    return rm>> k;\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS(
             "[test.cpp:4] -> [test.cpp:7]: (warning) Shifting signed 32-bit value by 31 bits is undefined behaviour. See condition at line 4.\n",
             errout.str());
@@ -206,20 +209,20 @@ private:
               "    return 0;\n"
               "  else\n"
               "    return rm>> k;\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         check("static long long f(int x, long long y) {\n"
               "    if (x >= 64)\n"
               "        return 0;\n"
               "    return -(y << (x-1));\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         check("bool f() {\n"
               "    std::ofstream outfile;\n"
               "    outfile << vec_points[0](0) << static_cast<int>(d) << ' ';\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         check("void f(unsigned b, int len, unsigned char rem) {\n" // #10773
@@ -230,69 +233,71 @@ private:
               "        if (bits == 512)\n"
               "            len -= 8;\n"
               "    }\n"
-              "}\n", settings0);
+              "}\n", &settings0);
         ASSERT_EQUALS("", errout.str());
     }
 
     void checkIntegerOverflow() {
-        const Settings settings = settingsBuilder().severity(Severity::warning).platform(cppcheck::Platform::Type::Unix32).build();
+        Settings settings = settingsBuilder().severity(Severity::warning).build();
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix32);
 
-        check("x = (int)0x10000 * (int)0x10000;", settings);
+        check("x = (int)0x10000 * (int)0x10000;", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Signed integer overflow for expression '(int)0x10000*(int)0x10000'.\n", errout.str());
 
-        check("x = (long)0x10000 * (long)0x10000;", settings);
+        check("x = (long)0x10000 * (long)0x10000;", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Signed integer overflow for expression '(long)0x10000*(long)0x10000'.\n", errout.str());
 
         check("void foo() {\n"
               "    int intmax = 0x7fffffff;\n"
               "    return intmax + 1;\n"
-              "}",settings);
+              "}",&settings);
         ASSERT_EQUALS("[test.cpp:3]: (error) Signed integer overflow for expression 'intmax+1'.\n", errout.str());
 
         check("void foo() {\n"
               "    int intmax = 0x7fffffff;\n"
               "    return intmax - 1;\n"
-              "}",settings);
+              "}",&settings);
         ASSERT_EQUALS("", errout.str());
 
         check("int foo(signed int x) {\n"
               "   if (x==123456) {}\n"
               "   return x * x;\n"
-              "}",settings);
+              "}",&settings);
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Either the condition 'x==123456' is redundant or there is signed integer overflow for expression 'x*x'.\n", errout.str());
 
         check("int foo(signed int x) {\n"
               "   if (x==123456) {}\n"
               "   return -123456 * x;\n"
-              "}",settings);
+              "}",&settings);
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Either the condition 'x==123456' is redundant or there is signed integer overflow for expression '-123456*x'.\n", errout.str());
 
         check("int foo(signed int x) {\n"
               "   if (x==123456) {}\n"
               "   return 123456U * x;\n"
-              "}",settings);
+              "}",&settings);
         ASSERT_EQUALS("", errout.str());
     }
 
     void signConversion() {
-        const Settings settings0;
-        const Settings settings = settingsBuilder().platform(cppcheck::Platform::Type::Unix64).build();
-        check("x = -4 * (unsigned)y;", settings0);
+        Settings settings0;
+        Settings settings;
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
+        check("x = -4 * (unsigned)y;", &settings0);
         ASSERT_EQUALS("[test.cpp:1]: (warning) Expression '-4' has a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
 
-        check("x = (unsigned)y * -4;", settings0);
+        check("x = (unsigned)y * -4;", &settings0);
         ASSERT_EQUALS("[test.cpp:1]: (warning) Expression '-4' has a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
 
         check("unsigned int dostuff(int x) {\n" // x is signed
               "  if (x==0) {}\n"
               "  return (x-1)*sizeof(int);\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:3]: (warning) Expression 'x-1' can have a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
 
         check("unsigned int f1(signed int x, unsigned int y) {" // x is signed
               "  return x * y;\n"
               "}\n"
-              "void f2() { f1(-4,4); }", settings0);
+              "void f2() { f1(-4,4); }", &settings0);
         ASSERT_EQUALS(
             "[test.cpp:1]: (warning) Expression 'x' can have a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n",
             errout.str());
@@ -300,7 +305,7 @@ private:
         check("unsigned int f1(int x) {"
               "  return x * 5U;\n"
               "}\n"
-              "void f2() { f1(-4); }", settings0);
+              "void f2() { f1(-4); }", &settings0);
         ASSERT_EQUALS(
             "[test.cpp:1]: (warning) Expression 'x' can have a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n",
             errout.str());
@@ -308,64 +313,65 @@ private:
         check("unsigned int f1(int x) {" // #6168: FP for inner calculation
               "  return 5U * (1234 - x);\n" // <- signed subtraction, x is not sign converted
               "}\n"
-              "void f2() { f1(-4); }", settings0);
+              "void f2() { f1(-4); }", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         // Don't warn for + and -
         check("void f1(int x) {"
               "  a = x + 5U;\n"
               "}\n"
-              "void f2() { f1(-4); }", settings0);
+              "void f2() { f1(-4); }", &settings0);
         ASSERT_EQUALS("", errout.str());
 
         check("size_t foo(size_t x) {\n"
               " return -2 * x;\n"
-              "}", settings0);
+              "}", &settings0);
         ASSERT_EQUALS("[test.cpp:2]: (warning) Expression '-2' has a negative value. That is converted to an unsigned value and used in an unsigned calculation.\n", errout.str());
     }
 
     void longCastAssign() {
-        const Settings settings = settingsBuilder().severity(Severity::style).platform(cppcheck::Platform::Type::Unix64).build();
+        Settings settings = settingsBuilder().severity(Severity::style).build();
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
 
         check("long f(int x, int y) {\n"
               "  const long ret = x * y;\n"
               "  return ret;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (style) int result is assigned to long variable. If the variable is long to avoid loss of information, then you have loss of information.\n", errout.str());
 
         check("long f() {\n"
               "  const long long ret = 256 * (1 << 10);\n"
               "  return ret;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("", errout.str());
 
         // typedef
         check("long f(int x, int y) {\n"
               "  const size_t ret = x * y;\n"
               "  return ret;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("", errout.str());
 
         // astIsIntResult
         check("long f(int x, int y) {\n"
               "  const long ret = (long)x * y;\n"
               "  return ret;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("", errout.str());
     }
 
     void longCastReturn() {
-        const Settings settings = settingsBuilder().severity(Severity::style).build();
+        Settings settings = settingsBuilder().severity(Severity::style).build();
 
         check("long f(int x, int y) {\n"
               "  return x * y;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (style) int result is returned as long value. If the return value is long to avoid loss of information, then you have loss of information.\n", errout.str());
 
         // typedef
         check("size_t f(int x, int y) {\n"
               "  return x * y;\n"
-              "}\n", settings);
+              "}\n", &settings);
         ASSERT_EQUALS("", errout.str());
     }
 
@@ -380,43 +386,43 @@ private:
     }
 
     void checkFloatToIntegerOverflow() {
-        const Settings settings;
-        check("x = (int)1E100;", settings);
+        Settings settings;
+        check("x = (int)1E100;", &settings);
         ASSERT_EQUALS("[test.cpp:1]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  return (int)1E100;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  return (int)-1E100;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  return (short)1E6;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  return (unsigned char)256.0;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  return (unsigned char)255.5;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("", removeFloat(errout.str()));
 
         check("void f(void) {\n"
               "  char c = 1234.5;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
 
         check("char f(void) {\n"
               "  return 1234.5;\n"
-              "}", settings);
+              "}", &settings);
         ASSERT_EQUALS("[test.cpp:2]: (error) Undefined behaviour: float () to integer conversion overflow.\n", removeFloat(errout.str()));
     }
 };

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -119,6 +119,8 @@ private:
         // Check for redundant code..
         CheckUninitVar checkuninitvar(&tokenizer, &settings1, this);
         checkuninitvar.check();
+
+        settings.debugwarnings = false;
     }
 
     void uninitvar1() {
@@ -830,7 +832,6 @@ private:
                        "}", "test.cpp", false);
         ASSERT_EQUALS("", errout.str());
 
-        const Settings settingsOld = settings;
         // Ticket #6701 - Variable name is a POD type according to cfg
         const char xmldata[] = "<?xml version=\"1.0\"?>\n"
                                "<def format=\"1\">"
@@ -842,7 +843,6 @@ private:
                        "  _tm.dostuff();\n"
                        "}");
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
 
         // Ticket #7822 - Array type
         checkUninitVar("A *f() {\n"
@@ -4358,7 +4358,6 @@ private:
         ASSERT_EQUALS("", errout.str());
 
         {
-            const Settings settingsOld = settings;
             const char argDirectionsTestXmlData[] = "<?xml version=\"1.0\"?>\n"
                                                     "<def>\n"
                                                     "  <function name=\"uninitvar_funcArgInTest\">\n"
@@ -4386,7 +4385,6 @@ private:
                            "    x = ab;\n"
                            "}\n", "test.c");
             ASSERT_EQUALS("", errout.str());
-            settings = settingsOld;
         }
 
         checkUninitVar("struct AB { int a; int b; };\n"
@@ -5218,14 +5216,14 @@ private:
         errout.str("");
 
         // Tokenize..
-        const Settings s = settingsBuilder(settings).debugwarnings(false).build();
+        settings.debugwarnings = false;
 
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, fname), file, line);
 
         // Check for redundant code..
-        CheckUninitVar checkuninitvar(&tokenizer, &s, this);
+        CheckUninitVar checkuninitvar(&tokenizer, &settings, this);
         (checkuninitvar.valueFlowUninit)();
     }
 

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -35,9 +35,11 @@ public:
     TestUninitVar() : TestFixture("TestUninitVar") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings;
 
     void run() override {
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(uninitvar1);
         TEST_CASE(uninitvar_warn_once); // only write 1 warning at a time
         TEST_CASE(uninitvar_decl);      // handling various types in C and C++ files
@@ -109,15 +111,14 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).debugwarnings(debugwarnings).build();
-
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        settings.debugwarnings = debugwarnings;
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, fname), file, line);
 
         // Check for redundant code..
-        CheckUninitVar checkuninitvar(&tokenizer, &settings1, this);
+        CheckUninitVar checkuninitvar(&tokenizer, &settings, this);
         checkuninitvar.check();
 
         settings.debugwarnings = false;

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -82,18 +82,18 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).platform(platform).build();
+        PLATFORM(settings.platform, platform);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check for unused functions..
-        CheckUnusedFunctions checkUnusedFunctions(&tokenizer, &settings1, this);
-        checkUnusedFunctions.parseTokens(tokenizer, "someFile.c", &settings1);
+        CheckUnusedFunctions checkUnusedFunctions(&tokenizer, &settings, this);
+        checkUnusedFunctions.parseTokens(tokenizer,  "someFile.c", &settings);
         // check() returns error if and only if errout is not empty.
-        if ((checkUnusedFunctions.check)(this, settings1)) {
+        if ((checkUnusedFunctions.check)(this, settings)) {
             ASSERT(!errout.str().empty());
         } else {
             ASSERT_EQUALS("", errout.str());
@@ -637,7 +637,7 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
+        Settings settingsOld = settings;
         LOAD_LIB_2(settings.library, "windows.cfg");
 
         check("int WinMain() { }");
@@ -656,7 +656,7 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
+        Settings settingsOld = settings;
         LOAD_LIB_2(settings.library, "windows.cfg");
 
         check("int wWinMain() { }");
@@ -674,7 +674,7 @@ private:
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_init' is never used.\n"
                       "[test.cpp:2]: (style) The function '_fini' is never used.\n", errout.str());
 
-        const Settings settingsOld = settings;
+        Settings settingsOld = settings;
         LOAD_LIB_2(settings.library, "gnu.cfg");
 
         check("int _init() { }\n"

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -31,9 +31,11 @@ public:
     TestUnusedFunctions() : TestFixture("TestUnusedFunctions") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+
         TEST_CASE(incondition);
         TEST_CASE(return1);
         TEST_CASE(return2);

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -31,7 +31,7 @@ public:
     TestUnusedFunctions() : TestFixture("TestUnusedFunctions") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::style).build();
+    Settings settings = settingsBuilder().severity(Severity::style).build();
 
     void run() override {
         TEST_CASE(incondition);
@@ -78,11 +78,11 @@ private:
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
-    void check_(const char* file, int line, const char code[], cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native, const Settings *s = nullptr) {
+    void check_(const char* file, int line, const char code[], cppcheck::Platform::Type platform = cppcheck::Platform::Type::Native) {
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(s ? *s : settings).platform(platform).build();
+        const Settings settings1 = settingsBuilder(settings).platform(platform).build();
 
         // Tokenize..
         Tokenizer tokenizer(&settings1, this);
@@ -637,13 +637,16 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings s = settingsBuilder(settings).library("windows.cfg").build();
+        const Settings settingsOld = settings;
+        LOAD_LIB_2(settings.library, "windows.cfg");
 
-        check("int WinMain() { }", cppcheck::Platform::Type::Native, &s);
+        check("int WinMain() { }");
         ASSERT_EQUALS("", errout.str());
 
-        check("int _tmain() { }", cppcheck::Platform::Type::Native, &s);
+        check("int _tmain() { }");
         ASSERT_EQUALS("", errout.str());
+
+        settings = settingsOld;
     }
 
     void entrypointsWinU() {
@@ -653,13 +656,16 @@ private:
         check("int _tmain() { }");
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_tmain' is never used.\n", errout.str());
 
-        const Settings s = settingsBuilder(settings).library("windows.cfg").build();
+        const Settings settingsOld = settings;
+        LOAD_LIB_2(settings.library, "windows.cfg");
 
-        check("int wWinMain() { }", cppcheck::Platform::Type::Native, &s);
+        check("int wWinMain() { }");
         ASSERT_EQUALS("", errout.str());
 
-        check("int _tmain() { }", cppcheck::Platform::Type::Native, &s);
+        check("int _tmain() { }");
         ASSERT_EQUALS("", errout.str());
+
+        settings = settingsOld;
     }
 
     void entrypointsUnix() {
@@ -668,11 +674,14 @@ private:
         ASSERT_EQUALS("[test.cpp:1]: (style) The function '_init' is never used.\n"
                       "[test.cpp:2]: (style) The function '_fini' is never used.\n", errout.str());
 
-        const Settings s = settingsBuilder(settings).library("gnu.cfg").build();
+        const Settings settingsOld = settings;
+        LOAD_LIB_2(settings.library, "gnu.cfg");
 
         check("int _init() { }\n"
-              "int _fini() { }\n", cppcheck::Platform::Type::Native, &s);
+              "int _fini() { }\n");
         ASSERT_EQUALS("", errout.str());
+
+        settings = settingsOld;
     }
 };
 

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -36,7 +36,7 @@ public:
     TestUnusedPrivateFunction() : TestFixture("TestUnusedPrivateFunction") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::style).build();
+    Settings settings = settingsBuilder().severity(Severity::style).build();
 
     void run() override {
         TEST_CASE(test1);
@@ -94,7 +94,7 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        const Settings settings1 = settingsBuilder(settings).platform(platform).build();
+        PLATFORM(settings.platform, platform);
 
         // Raw tokens..
         std::vector<std::string> files(1, "test.cpp");
@@ -107,12 +107,12 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
 
         // Check for unused private functions..
-        CheckClass checkClass(&tokenizer, &settings1, this);
+        CheckClass checkClass(&tokenizer, &settings, this);
         checkClass.privateFunctions();
     }
 

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -36,9 +36,11 @@ public:
     TestUnusedPrivateFunction() : TestFixture("TestUnusedPrivateFunction") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+
         TEST_CASE(test1);
         TEST_CASE(test2);
         TEST_CASE(test3);

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -1787,7 +1787,6 @@ private:
         ASSERT_EQUALS("[test.cpp:1]: (style) struct member 'A::i' is never used.\n",
                       errout.str());
 
-        const Settings settingsOld = settings;
         settings.enforcedLang = Settings::C;
         checkStructMemberUsage("struct A {\n" // #10852
                                "    struct B {\n"
@@ -1817,7 +1816,7 @@ private:
                                "    pc->s[0] = 1;\n"
                                "}\n");
         ASSERT_EQUALS("", errout.str());
-        settings = settingsOld;
+        settings.enforcedLang = Settings::None;
     }
 
     void structmember20() { // #10737

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -37,9 +37,13 @@ public:
     TestUnusedVar() : TestFixture("TestUnusedVar") {}
 
 private:
-    Settings settings = settingsBuilder().severity(Severity::style).checkLibrary().library("std.cfg").build();
+    Settings settings;
 
     void run() override {
+        settings.severity.enable(Severity::style);
+        settings.checkLibrary = true;
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         TEST_CASE(isRecordTypeWithoutSideEffects);
         TEST_CASE(cleanFunction);
 

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -26,6 +26,8 @@
 #include <limits>
 #include <string>
 
+const Settings givenACodeSampleToTokenize::settings;
+
 class TestUtils : public TestFixture {
 public:
     TestUtils() : TestFixture("TestUtils") {}

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -31,7 +31,7 @@ public:
     TestVaarg() : TestFixture("TestVaarg") {}
 
 private:
-    const Settings settings = settingsBuilder().severity(Severity::warning).build();
+    Settings settings;
 
 #define check(code) check_(code, __FILE__, __LINE__)
     void check_(const char code[], const char* file, int line) {
@@ -48,6 +48,8 @@ private:
     }
 
     void run() override {
+        settings.severity.enable(Severity::warning);
+
         TEST_CASE(wrongParameterTo_va_start);
         TEST_CASE(referenceAs_va_start);
         TEST_CASE(va_end_missing);

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -46,7 +46,7 @@ public:
     TestValueFlow() : TestFixture("TestValueFlow") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings;
 
     void run() override {
         // strcpy, abort cfg
@@ -56,6 +56,7 @@ private:
                            "  <function name=\"abort\"> <noreturn>true</noreturn> </function>\n" // abort is a noreturn function
                            "</def>";
         ASSERT_EQUALS(true, settings.library.loadxmldata(cfg, sizeof(cfg)));
+        LOAD_LIB_2(settings.library, "std.cfg");
 
         TEST_CASE(valueFlowNumber);
         TEST_CASE(valueFlowString);
@@ -6635,7 +6636,8 @@ private:
     void valueFlowSafeFunctionParameterValues() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s;
+        LOAD_LIB_2(s.library, "std.cfg");
         s.safeChecks.classes = s.safeChecks.externalFunctions = s.safeChecks.internalFunctions = true;
 
         code = "short f(short x) {\n"
@@ -6686,7 +6688,8 @@ private:
     void valueFlowUnknownFunctionReturn() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s;
+        LOAD_LIB_2(s.library, "std.cfg");
         s.checkUnknownFunctionReturn.insert("rand");
 
         code = "x = rand();";

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -310,11 +310,9 @@ private:
     }
 
 #define testValueOfX(...) testValueOfX_(__FILE__, __LINE__, __VA_ARGS__)
-    bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, int value, const Settings *s = nullptr) {
-        const Settings *settings1 = s ? s : &settings;
-
+    bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, int value) {
         // Tokenize..
-        Tokenizer tokenizer(settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -3868,22 +3866,22 @@ private:
     void valueFlowRightShift() {
         const char *code;
         /* Set some temporary fixed values to simplify testing */
-        Settings s = settings;
-        s.platform.int_bit = 32;
-        s.platform.long_bit = 64;
-        s.platform.long_long_bit = MathLib::bigint_bits * 2;
+        const Settings settingsTmp = settings;
+        settings.platform.int_bit = 32;
+        settings.platform.long_bit = 64;
+        settings.platform.long_long_bit = MathLib::bigint_bits * 2;
 
         code = "int f(int a) {\n"
                "  int x = (a & 0xff) >> 16;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code,3U,0,&s));
+        ASSERT_EQUALS(true, testValueOfX(code,3U,0));
 
         code = "int f(unsigned int a) {\n"
                "  int x = (a % 123) >> 16;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code,3U,0,&s));
+        ASSERT_EQUALS(true, testValueOfX(code,3U,0));
 
         code = "int f(int y) {\n"
                "  int x = (y & 0xFFFFFFF) >> 31;\n"
@@ -3895,55 +3893,57 @@ private:
                "  int x = (y & 0xFFFFFFF) >> 32;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
 
         code = "int f(short y) {\n"
                "  int x = (y & 0xFFFFFF) >> 31;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
 
         code = "int f(short y) {\n"
                "  int x = (y & 0xFFFFFF) >> 32;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
 
         code = "int f(long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 63;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
 
         code = "int f(long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 64;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 63;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(true, testValueOfX(code, 3u, 0));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 64;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 121;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
 
         code = "int f(long long y) {\n"
                "  int x = (y & 0xFFFFFF) >> 128;\n"
                "  return x;\n"
                "}";
-        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0,&s));
+        ASSERT_EQUALS(false, testValueOfX(code, 3u, 0));
+
+        settings = settingsTmp;
     }
 
     void valueFlowFwdAnalysis() {

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -485,7 +485,7 @@ private:
     }
 
     void bailout(const char code[]) {
-        const Settings s = settingsBuilder().debugwarnings().build();
+        settings.debugwarnings = true;
         errout.str("");
 
         std::vector<std::string> files(1, "test.cpp");
@@ -497,9 +497,11 @@ private:
         simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
         // Tokenize..
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(&settings, this);
         tokenizer.createTokens(std::move(tokens2));
         tokenizer.simplifyTokens1("");
+
+        settings.debugwarnings = false;
     }
 
 #define tokenValues(...) tokenValues_(__FILE__, __LINE__, __VA_ARGS__)

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -31,13 +31,16 @@
 
 class TestVarID : public TestFixture {
 public:
-    TestVarID() : TestFixture("TestVarID") {}
+    TestVarID() : TestFixture("TestVarID") {
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
+        settings.standards.c = Standards::C89;
+        settings.standards.cpp = Standards::CPPLatest;
+        settings.checkUnusedTemplates = true;
+    }
 
 private:
-    Settings settings = settingsBuilder().c(Standards::C89).cpp(Standards::CPPLatest).checkUnusedTemplates().build();
+    Settings settings;
     void run() override {
-        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
-
         TEST_CASE(varid1);
         TEST_CASE(varid2);
         TEST_CASE(varid3);

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -236,12 +236,10 @@ private:
     }
 
 #define tokenize(...) tokenize_(__FILE__, __LINE__, __VA_ARGS__)
-    std::string tokenize_(const char* file, int line, const char code[], const char filename[] = "test.cpp", const Settings *s = nullptr) {
+    std::string tokenize_(const char* file, int line, const char code[], const char filename[] = "test.cpp") {
         errout.str("");
 
-        const Settings *settings1 = s ? s : &settings;
-
-        Tokenizer tokenizer(settings1, this);
+        Tokenizer tokenizer(&settings, this);
         std::istringstream istr(code);
         ASSERT_LOC((tokenizer.tokenize)(istr, filename), file, line);
 
@@ -2035,9 +2033,10 @@ private:
     }
 
     void varid_in_class25() {
-        const Settings s = settingsBuilder(settings).library("std.cfg").build();
-
         const char *code{}, *expected{};
+        const Settings oldSettings = settings;
+        LOAD_LIB_2(settings.library, "std.cfg");
+
         code = "struct F {\n" // #11497
                "    int i;\n"
                "    void f(const std::vector<F>&v) {\n"
@@ -2050,7 +2049,7 @@ private:
                    "4: if ( v@2 . front ( ) . i@3 ) { }\n"
                    "5: }\n"
                    "6: } ;\n";
-        ASSERT_EQUALS(expected, tokenize(code, "test.cpp", &s));
+        ASSERT_EQUALS(expected, tokenize(code, "test.cpp"));
 
         code = "struct T { };\n" // 11533
                "struct U { T t; };\n"
@@ -2066,7 +2065,8 @@ private:
                    "5: std :: vector < U * > * p@2 ; p@2 = g ( ) ;\n"
                    "6: auto t@3 ; t@3 = p@2 . front ( ) . t@4 ;\n"
                    "7: }\n";
-        ASSERT_EQUALS(expected, tokenize(code, "test.cpp", &s));
+        ASSERT_EQUALS(expected, tokenize(code, "test.cpp"));
+        settings = oldSettings;
     }
 
     void varid_namespace_1() { // #7272

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -34,8 +34,10 @@ public:
     TestVarID() : TestFixture("TestVarID") {}
 
 private:
-    Settings settings = settingsBuilder().c(Standards::C89).cpp(Standards::CPPLatest).checkUnusedTemplates().platform(cppcheck::Platform::Type::Unix64).build();
+    Settings settings = settingsBuilder().c(Standards::C89).cpp(Standards::CPPLatest).checkUnusedTemplates().build();
     void run() override {
+        PLATFORM(settings.platform, cppcheck::Platform::Type::Unix64);
+
         TEST_CASE(varid1);
         TEST_CASE(varid2);
         TEST_CASE(varid3);
@@ -2034,7 +2036,7 @@ private:
 
     void varid_in_class25() {
         const char *code{}, *expected{};
-        const Settings oldSettings = settings;
+        Settings oldSettings = settings;
         LOAD_LIB_2(settings.library, "std.cfg");
 
         code = "struct F {\n" // #11497


### PR DESCRIPTION
This reverts commits 5833fc3, 25183ff, and 2935c85 as these break the test runner when running it standalone. Doing `make testrunner && ./bin/testrunner` would error with:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  library 'std.cfg' not found
```

This is because the new `SettingsBuilder` does not have the path to the executable, so it can't find the library files correctly. I dont know an easy way to fix this so I just reverted these commit instead to get the testrunner running again.