### PR TITLE
[nit] Fixed lib/tokenize.cpp:2815:2: warning: extra ‘;’ [-Wpedantic]

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2812,7 +2812,7 @@ static unsigned int tokDistance(const Token* tok1, const Token* tok2) {
         tok = tok->next();
     }
     return dist;
-};
+}
 
 bool Tokenizer::simplifyUsing()
 {


### PR DESCRIPTION
Single character fix removing extra semi colon.