### PR TITLE
Fix #11727 Limit check to selected VS configurations does not work

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -498,7 +498,12 @@ void MainWindow::doAnalyzeProject(ImportProject p, const bool checkLibrary, cons
 
         if (!mProjectFile->getAnalyzeAllVsConfigs()) {
             const cppcheck::Platform::Type platform = (cppcheck::Platform::Type) mSettings->value(SETTINGS_CHECKED_PLATFORM, 0).toInt();
-            p.selectOneVsConfig(platform);
+            std::vector<std::string> configurations;
+            const QStringList configs = mProjectFile->getVsConfigurations();
+            std::transform(configs.cbegin(), configs.cend(), std::back_inserter(configurations), [](const QString& e) {
+                return e.toStdString();
+            });
+            p.selectVsConfigurations(platform, configurations);
         }
     } else {
         enableProjectActions(false);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1319,7 +1319,7 @@ void ImportProject::selectVsConfigurations(cppcheck::Platform::Type platform, co
             continue;
         }
         const ImportProject::FileSettings &fs = *it;
-        auto config = fs.cfg.substr(0, fs.cfg.find('|'));
+        const auto config = fs.cfg.substr(0, fs.cfg.find('|'));
         bool remove = false;
         if (std::find(configurations.begin(), configurations.end(), config) == configurations.end())
             remove = true;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1311,6 +1311,30 @@ void ImportProject::selectOneVsConfig(cppcheck::Platform::Type platform)
     }
 }
 
+void ImportProject::selectVsConfigurations(cppcheck::Platform::Type platform, const std::vector<std::string> &configurations)
+{
+    for (std::list<ImportProject::FileSettings>::iterator it = fileSettings.begin(); it != fileSettings.end();) {
+        if (it->cfg.empty()) {
+            ++it;
+            continue;
+        }
+        const ImportProject::FileSettings &fs = *it;
+        auto config = fs.cfg.substr(0, fs.cfg.find('|'));
+        bool remove = false;
+        if (std::find(configurations.begin(), configurations.end(), config) == configurations.end())
+            remove = true;
+        if (platform == cppcheck::Platform::Type::Win64 && fs.platformType != platform)
+            remove = true;
+        else if ((platform == cppcheck::Platform::Type::Win32A || platform == cppcheck::Platform::Type::Win32W) && fs.platformType == cppcheck::Platform::Type::Win64)
+            remove = true;
+        if (remove) {
+            it = fileSettings.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 std::list<std::string> ImportProject::getVSConfigs()
 {
     return std::list<std::string>(mAllVSConfigs.cbegin(), mAllVSConfigs.cend());

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1300,8 +1300,6 @@ void ImportProject::selectOneVsConfig(cppcheck::Platform::Type platform)
             remove = true;
         else if ((platform == cppcheck::Platform::Type::Win32A || platform == cppcheck::Platform::Type::Win32W) && fs.platformType == cppcheck::Platform::Type::Win64)
             remove = true;
-        else if (fs.platformType != cppcheck::Platform::Type::Win64 && platform == cppcheck::Platform::Type::Win64)
-            remove = true;
         else if (filenames.find(fs.filename) != filenames.end())
             remove = true;
         if (remove) {

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -91,6 +91,7 @@ public:
     ImportProject& operator=(const ImportProject&) = default;
 
     void selectOneVsConfig(cppcheck::Platform::Type platform);
+    void selectVsConfigurations(cppcheck::Platform::Type platform, const std::vector<std::string> &configurations);
 
     std::list<std::string> getVSConfigs();
 


### PR DESCRIPTION
Selection of VS configurations did not work. Instead, always the first Debug configuration was picked.

I added a method to ImportProject that allows to pass multiple configurations to be checked and called this method (instead of selectOneVsConfig) from MainWindow.