### PR TITLE
Fix #11081 GUI: Windows release build crashes

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -1,8 +1,6 @@
 if (MSVC)
     # Visual Studio only sets _DEBUG
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_definitions(-DDEBUG)
-    endif()
+    add_compile_definitions($<$<CONFIG:Debug>:-DDEBUG>)
 
     add_definitions(-DWIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)

--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -131,26 +131,20 @@ if (MSVC)
     # No Whole Program Optimization
 
     # C/C++ - Optimization
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        add_compile_options(/O2) # Optimization - Maximum Optimization (Favor Speed)
-        add_compile_options(/Ob2) # Inline Function Expansion - Any Suitable
-        add_compile_options(/Oi) # Enable Intrinsic Functions
-        add_compile_options(/Ot) # Favor fast code
-        add_compile_options(/Oy) # Omit Frame Pointers
-    else()
-        add_compile_options(/Od) # Optimization - Disabled
-    endif()
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/O2>) # Optimization - Maximum Optimization (Favor Speed)
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/Ob2>) # Inline Function Expansion - Any Suitable
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/Oi>) # Enable Intrinsic Functions
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/Ot>) # Favor fast code
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/Oy>) # Omit Frame Pointers
+    add_compile_options($<$<CONFIG:Debug>:/Od>) # Optimization - Disabled
 
     # C/C++ - Code Generation
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        add_compile_options(/GF) # Enable String Pooling
-        add_compile_options(/MD) # Runtime Library - Multi-threaded DLL
-        add_compile_options(/GS-) # Disable Security Check
-        add_compile_options(/Gy) # Enable Function-Level Linking
-    else()
-        add_compile_options(/MDd) # Runtime Library - Multi-threaded Debug DLL
-        add_compile_options(/GS) # Enable Security Check
-    endif()
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/GF>) # Enable String Pooling
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/MD>) # Runtime Library - Multi-threaded DLL
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/GS->) # Disable Security Check
+    add_compile_options($<$<NOT:$<CONFIG:Debug>>:/Gy>) # Enable Function-Level Linking
+    add_compile_options($<$<CONFIG:Debug>:/MDd>) # Runtime Library - Multi-threaded Debug DLL
+    add_compile_options($<$<CONFIG:Debug>:/GS>) # Enable Security Check
 
     # C/C++ - Language
     add_compile_options(/Zc:rvalueCast) # Enforce type conversion rules
@@ -179,9 +173,8 @@ if (MSVC)
     add_compile_options(/Zc:throwingNew /Zc:__cplusplus) # Additional Options
 
     # Linker - General
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        add_link_options(/INCREMENTAL) # Enable Incremental Linking - Yes
-    endif()
+    add_link_options($<$<CONFIG:Debug>:/INCREMENTAL>) # Enable Incremental Linking - Yes
+
     add_link_options(/NOLOGO) # SUppress Startup Banner - Yes
     # Ignore Import Library - Yes
 
@@ -198,9 +191,7 @@ if (MSVC)
     add_link_options(/OPT:ICF) # Enable COMDAT Folding - Yes
 
     # Linker - Advanced
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        add_link_options(/RELEASE) # Set Checksum - Yes
-    endif()
+    add_link_options($<$<NOT:$<CONFIG:Debug>>:/RELEASE>) # Set Checksum - Yes
 endif()
 
 # TODO: check if this can be enabled again - also done in Makefile

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -9,13 +9,10 @@ CheckOptions:
   - { key: HeaderFileExtensions,          value: 'x' }
 ")
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        add_definitions(-DQT_NO_DEBUG)
-        add_definitions(-DQT_NO_DEBUG_OUTPUT)
-        add_definitions(-DQT_NO_WARNING_OUTPUT)
-    else()
-        add_definitions(-DQT_DEBUG)
-    endif()
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_DEBUG>)
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_DEBUG_OUTPUT>)
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_WARNING_OUTPUT>)
+    add_compile_definitions($<$<CONFIG:Debug>:-DQT_DEBUG>)
 
     file(GLOB hdrs "*.h")
     file(GLOB srcs "*.cpp")

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -58,6 +58,10 @@ CheckOptions:
         target_compile_definitions(cppcheck-gui PRIVATE CPPCHECKLIB_IMPORT TINYXML2_IMPORT)
         target_link_libraries(cppcheck-gui cppcheck-core)
     endif()
+    if(MSVC)
+        # compilation will fail as e.g. QList::realloc would be replaced by MSVC's macro definition
+        target_compile_definitions(cppcheck-gui PRIVATE $<$<CONFIG:Debug>:DISABLE_CRTDBG_MAP_ALLOC>)
+    endif()
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # Q_UNUSED() in generated code
         target_compile_options_safe(cppcheck-gui -Wno-extra-semi-stmt)

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,26 @@ For release builds it is recommended that you use:
 
 Using cmake you can generate project files for Visual Studio,XCode,etc.
 
+#### Building a specific configuration
+
+For single-configuration generators (like "Unix Makefiles") you can generate and build a specific configuration (e.g. "RelWithDebInfo") using:
+
+```shell
+mkdir build_RelWithDebInfo
+cd build_RelWithDebInfo
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+cmake --build . --config RelWithDebInfo
+```
+
+For multi-configuration generators (like "Visual Studio 17 2022") the same is achieved using:
+
+```shell
+mkdir build
+cd build
+cmake ..
+cmake --build . --config RelWithDebInfo
+```
+
 ### qmake
 
 You can use the gui/gui.pro file to build the GUI.

--- a/tools/triage/CMakeLists.txt
+++ b/tools/triage/CMakeLists.txt
@@ -8,13 +8,10 @@ CheckOptions:
   - { key: HeaderFileExtensions,          value: 'x' }
 ")
 
-    if (CMAKE_BUILD_TYPE STREQUAL "Release")
-        add_definitions(-DQT_NO_DEBUG)
-        add_definitions(-DQT_NO_DEBUG_OUTPUT)
-        add_definitions(-DQT_NO_WARNING_OUTPUT)
-    else()
-        add_definitions(-DQT_DEBUG)
-    endif()
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_DEBUG>)
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_DEBUG_OUTPUT>)
+    add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:-DQT_NO_WARNING_OUTPUT>)
+    add_compile_definitions($<$<CONFIG:Debug>:-DQT_DEBUG>)
 
     file(GLOB hdrs "*.h")
     file(GLOB srcs "*.cpp")


### PR DESCRIPTION
Use generator expressions rather than if statements when adding compiler options or definitions.

Side note: The CMake support seems outdated and may need rework - but probably by someone who knows CMake better than me...