### PR TITLE
#11733 FP unusedFunction with templates and --cppcheck-build-dir

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -454,7 +454,7 @@ void CheckUnusedFunctions::analyseWholeProgram(const Settings &settings, ErrorLo
     }
 
     for (std::map<std::string, Location>::const_iterator decl = decls.cbegin(); decl != decls.cend(); ++decl) {
-        const std::string &functionName = decl->first;
+        const std::string &functionName = stripTemplateParameters(decl->first);
 
         if (settings.library.isentrypoint(functionName))
             continue;

--- a/test/cli/proj-inline-suppress/template.cpp
+++ b/test/cli/proj-inline-suppress/template.cpp
@@ -1,0 +1,13 @@
+namespace {
+	template <typename T>
+	T f() { return T(); }
+}
+
+// cppcheck-suppress unusedFunction
+int g(int i) {
+	if (i == 0)
+		return f<char>();
+	if (i == 1)
+		return f<short>();
+	return f<int>();
+}

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -83,6 +83,15 @@ def test_build_dir():
         assert ret == 0, stdout
         assert len(stderr) == 0
 
+def test_build_dir_unused_template():
+    with tempfile.TemporaryDirectory() as tempdir:
+        args = f'--cppcheck-build-dir={tempdir} --enable=all --inline-suppr proj-inline-suppress/template.cpp'.split()
+
+        ret, stdout, stderr = cppcheck(args)
+        assert ret == 0, stdout
+        assert len(stderr) == 0
+
+
 def test_suppress_unmatched_inline_suppression(): # 11172
     ret, stdout, stderr = cppcheck(['--enable=all', '--suppress=unmatchedSuppression', '--inline-suppr', 'proj-inline-suppress/2.c'])
     assert ret == 0, stdout


### PR DESCRIPTION
There are no tests at all for `--cppcheck-build-dir`