### PR TITLE
Suppress unused struct members from types expanded from macros

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -1443,6 +1443,9 @@ void CheckUnusedVar::checkStructMemberUsage()
         if (scope.bodyStart->fileIndex() != 0 || scope.className.empty())
             continue;
 
+        if (scope.classDef->isExpandedMacro())
+            continue;
+
         // Packed struct => possibly used by lowlevel code. Struct members might be required by hardware.
         if (scope.bodyEnd->isAttributePacked())
             continue;

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -71,6 +71,7 @@ private:
         TEST_CASE(structmember21); // #4759
         TEST_CASE(structmember22); // #11016
         TEST_CASE(structmember23);
+        TEST_CASE(structmember_macro);
         TEST_CASE(classmember);
 
         TEST_CASE(localvar1);
@@ -271,6 +272,31 @@ private:
         CheckUnusedVar checkUnusedVar(&tokenizer, settings1, this);
         (checkUnusedVar.checkStructMemberUsage)();
     }
+
+    void checkStructMemberUsageP(const char code[]) {
+        // Raw tokens..
+        std::vector<std::string> files(1, "test.cpp");
+        std::istringstream istr(code);
+        const simplecpp::TokenList tokens1(istr, files, files[0]);
+
+        // Preprocess..
+        simplecpp::TokenList tokens2(files);
+        std::map<std::string, simplecpp::TokenList*> filedata;
+        simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
+
+        Preprocessor preprocessor(settings);
+        preprocessor.setDirectives(tokens1);
+
+        // Tokenizer..
+        Tokenizer tokenizer(&settings, this, &preprocessor);
+        tokenizer.createTokens(std::move(tokens2));
+        tokenizer.simplifyTokens1("");
+
+        // Check for unused variables..
+        CheckUnusedVar checkUnusedVar(&tokenizer, &settings, this);
+        (checkUnusedVar.checkStructMemberUsage)();
+    }
+
 
     void checkFunctionVariableUsageP(const char code[], const char* filename = "test.cpp") {
         // Raw tokens..
@@ -1875,6 +1901,12 @@ private:
                                "    std::map<int, N::S> m = { { 0, { \"abc\" } } };\n"
                                "    return m[0].s;\n"
                                "}\n");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void structmember_macro() {
+        checkStructMemberUsageP("#define S(n) struct n { int a, b, c; };\n"
+                                "S(unused);\n");
         ASSERT_EQUALS("", errout.str());
     }
 


### PR DESCRIPTION
Using types declared with TAILQ_HEAD() from OpenBSD occasionally causes cppcheck to report unused struct members. This in turn is caused by the usage of queue. If one never access the first element through TAILQ_FIRST() for instance, tqh_first will be reported as being unused.

This is a bit annoying as the definition of the struct is beyond one's reach. Not sure this is the best way to do it but it gets problematic as the struct expanded by TAILQ_HEAD() could be named anything. I therefore ended up prefixing the suppressed fields with `::`.