### PR TITLE
Fix #11735: GUI: Adding suppression with empty file name does not match

### DIFF
--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -755,7 +755,10 @@ void ProjectFileDialog::addSingleSuppression(const Suppressions::Suppression &su
 {
     Suppressions::Suppression sup = suppression;
 
-    if (sup.fileName.find('*') == std::string::npos) {
+    if (sup.fileName.empty()) {
+        // Empty file name, replace by wildcard
+        sup.fileName = "*";
+    } else if (sup.fileName.find('*') == std::string::npos) {
         // File name does not contain wildcard, enforce absolute path (dir is ignored if fileName already is absolute)
         QFileInfo inf(QFileInfo(mProjectFile->getFilename()).absoluteDir(), QString::fromStdString(sup.fileName));
         if (inf.exists()) {

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -753,34 +753,18 @@ void ProjectFileDialog::setLibraries(const QStringList &libraries)
 
 void ProjectFileDialog::addSingleSuppression(const Suppressions::Suppression &suppression)
 {
-    QString suppression_name;
-    static const char sep = QDir::separator().toLatin1();
-    bool found_relative = false;
+    Suppressions::Suppression sup = suppression;
 
-    // Replace relative file path in the suppression with the absolute one
-    if ((suppression.fileName.find('*') == std::string::npos) &&
-        (suppression.fileName.find(sep) == std::string::npos)) {
-        QFileInfo inf(mProjectFile->getFilename());
-        QString rootpath = inf.absolutePath();
-        if (QFile::exists(QString{"%1%2%3"}.arg(rootpath,
-                                                QDir::separator(),
-                                                QString::fromStdString(suppression.fileName)))) {
-            Suppressions::Suppression sup = suppression;
-            sup.fileName = rootpath.toLatin1().constData();
-            sup.fileName += sep;
-            sup.fileName += suppression.fileName;
-            mSuppressions += sup;
-            suppression_name = QString::fromStdString(sup.getText());
-            found_relative = true;
+    if (sup.fileName.find('*') == std::string::npos) {
+        // File name does not contain wildcard, enforce absolute path (dir is ignored if fileName already is absolute)
+        QFileInfo inf(QFileInfo(mProjectFile->getFilename()).absoluteDir(), QString::fromStdString(sup.fileName));
+        if (inf.exists()) {
+            sup.fileName = QDir::toNativeSeparators(inf.absoluteFilePath()).toStdString();
         }
     }
 
-    if (!found_relative) {
-        mSuppressions += suppression;
-        suppression_name = QString::fromStdString(suppression.getText());
-    }
-
-    mUI->mListSuppressions->addItem(suppression_name);
+    mSuppressions += sup;
+    mUI->mListSuppressions->addItem(QString::fromStdString(sup.getText()));
 }
 
 void ProjectFileDialog::setSuppressions(const QList<Suppressions::Suppression> &suppressions)


### PR DESCRIPTION
When the file name was left empty when defining a suppression, it got replaced with the directory path of the project file and did not match any file during analysis.

Now, an empty file name is changed to the wildcard pattern ("*"), matching all files - which is probably more intuitive.