### PR TITLE
Fix hang on huge array (followup to #11649)

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -942,7 +942,7 @@ static void setTokenValue(Token* tok,
                     if (Token::simpleMatch(parent, "-") && value2.bound == result.bound &&
                         value2.bound != ValueFlow::Value::Bound::Point)
                         result.invertBound();
-                    setTokenValue(parent, result, settings);
+                    setTokenValue(parent, result, settings, isInitList);
                 }
             }
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1363,7 +1363,7 @@ static void valueFlowNumber(TokenList *tokenlist, const Settings* settings)
     bool isInitList = false;
     const Token* endInit{};
     for (Token *tok = tokenlist->front(); tok;) {
-        if (!isInitList && tok->str() == "{" && Token::simpleMatch(tok->astOperand1(), ",")) {
+        if (!isInitList && tok->str() == "{" && (Token::simpleMatch(tok->astOperand1(), ",") || Token::simpleMatch(tok->astOperand2(), ","))) {
             isInitList = true;
             endInit = tok->link();
         }


### PR DESCRIPTION
`const std::array<unsigned char, 222236> a{{ 0x00, ... }};`
E.g. https://github.com/yuzu-emu/yuzu/blob/master/src/core/file_sys/system_archive/data/font_chinese_traditional.cpp

Init list with operators, e.g.
https://github.com/ClickHouse/ClickHouse/blob/master/contrib/consistent-hashing/popcount.cpp