### PR TITLE
Fixed `std::vector::data` return type

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6773,7 +6773,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
   <function name="std::array::data,std::vector::data,std::span::data">
     <use-retval/>
     <const/>
-    <returnValue type="void *"/>
+    <returnValue type="const T *"/>
     <noreturn>false</noreturn>
   </function>
   <!-- https://en.cppreference.com/w/cpp/container/deque/swap -->

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -4740,3 +4740,10 @@ void smartPtr_release()
     //cppcheck-suppress nullPointer
     *p = 1;
 }
+
+void std_vector_data_arithmetic()
+{
+	std::vector<char> buf;
+	buf.resize(1);
+	memcpy(buf.data() + 0, "", 1);
+}


### PR DESCRIPTION
This caused many `arithOperationsOnVoidPointer` false positives in my project which uses `std::vector<uint8_t>` in many places.