### PR TITLE
Don't suggest const for smartptr::get()

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8559,7 +8559,6 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
     <use-retval/>
     <leak-ignore/>
     <noreturn>false</noreturn>
-    <const/>
     <returnValue type="void *"/>
   </function>
   <memory>

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -2531,7 +2531,7 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
                 return false;
             }
         }
-        if (settings && settings->library.isFunctionConst(ftok) || (astIsSmartPointer(tok) && ftok->str() == "get")) // TODO: replace with action/yield?
+        if ((settings && settings->library.isFunctionConst(ftok)) || (astIsSmartPointer(tok) && ftok->str() == "get")) // TODO: replace with action/yield?
             return false;
 
         const Function * fun = ftok->function();

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -2531,7 +2531,7 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
                 return false;
             }
         }
-        if (settings && settings->library.isFunctionConst(ftok))
+        if (settings && settings->library.isFunctionConst(ftok) || (astIsSmartPointer(tok) && ftok->str() == "get")) // TODO: replace with action/yield?
             return false;
 
         const Function * fun = ftok->function();

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -4714,3 +4714,11 @@ void smartPtr_get()
     //cppcheck-suppress nullPointer
     *p = 1;
 }
+
+void smartPtr_get2(std::vector<std::unique_ptr<int>>& v) 
+{
+    for (auto& u : v) {
+        int* p = u.get();
+        *p = 0;
+    }
+}

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -4731,7 +4731,6 @@ void smartPtr_get2(std::vector<std::unique_ptr<int>>& v)
         *p = 0;
     }
 }
-}
 
 void smartPtr_reset()
 {

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -6511,7 +6511,7 @@ private:
                       errout.str());
 
         checkConst("struct S {\n"
-                   "    bool f() { return p.get() != nullptr; }\n"
+                   "    bool f() { return p != nullptr; }\n"
                    "    std::shared_ptr<int> p;\n"
                    "};\n");
         ASSERT_EQUALS("[test.cpp:2]: (style, inconclusive) Technically the member function 'S::f' can be const.\n",


### PR DESCRIPTION
`get()` is actually const (https://en.cppreference.com/w/cpp/memory/unique_ptr/get), but that makes it hard to model ownership.