### PR TITLE
Typos and stilistic updates

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -15,7 +15,7 @@ import subprocess
 try:
     import pathlib
 except ImportError:
-    message = "Failed to load pathlib. Upgrade python to 3.x or install pathlib with 'pip install pathlib'."
+    message = "Failed to load pathlib. Upgrade Python to 3.x or install pathlib with 'pip install pathlib'."
     error_id = 'pythonError'
     if '--cli' in sys.argv:
         msg = { 'file': '',
@@ -222,8 +222,8 @@ class Token:
         isSigned           Is this token a signed type
         isExpandedMacro    Is this token a expanded macro token
         isRemovedVoidParameter  Has void parameter been removed?
-        isSplittedVarDeclComma  Is this a comma changed to semicolon in a splitted variable declaration ('int a,b;' => 'int a; int b;')
-        isSplittedVarDeclEq     Is this a '=' changed to semicolon in a splitted variable declaration ('int a=5;' => 'int a; a=5;')
+        isSplittedVarDeclComma  Is this a comma changed to semicolon in a split variable declaration ('int a,b;' => 'int a; int b;')
+        isSplittedVarDeclEq     Is this a '=' changed to semicolon in a split variable declaration ('int a=5;' => 'int a; a=5;')
         isImplicitInt      Is this token an implicit "int"?
         varId              varId for token, each variable has a unique non-zero id
         variable           Variable information for this token. See the Variable class.

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -181,7 +181,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
 
     bool res = true;
     if (type == PipeWriter::REPORT_OUT) {
-        // the first charcater is the color
+        // the first character is the color
         const Color c = static_cast<Color>(buf[0]);
         mErrorLogger.reportOut(buf + 1, c);
     } else if (type == PipeWriter::REPORT_ERROR) {

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -139,7 +139,7 @@ private:
         /** unsafe array index usage */
         std::list<CTU::FileInfo::UnsafeUsage> unsafeArrayIndex;
 
-        /** unsafe pointer arithmetics */
+        /** unsafe pointer arithmetic */
         std::list<CTU::FileInfo::UnsafeUsage> unsafePointerArith;
 
         /** Convert MyFileInfo data into xml string */

--- a/man/writing-addons.md
+++ b/man/writing-addons.md
@@ -17,7 +17,7 @@ This document provides an overview about writing Cppcheck addons.
 
 See class `Token` in cppcheckdata.py
 
-Cppcheck splits up the code in tokens. Operators, numbers, identifiers, etc.
+Cppcheck splits the code up in tokens: operators, numbers, identifiers, etc.
 
 Example C code:
 
@@ -49,7 +49,7 @@ The `cfg.tokenlist` does not always match the raw input code exactly. For instan
  * The `cfg.tokenlist` is preprocessed.
  * There is no typedefs in `cfg.tokenlist`.
  * C++ templates are instantiated when possible in `cfg.tokenlist`.
- * Variable declarations are sometimes splitted up.
+ * Variable declarations are sometimes split up.
  * If you don't write {} around the body for a if/else/while/for etc then those are inserted in the `cfg.tokenlist`.
  * ...
 

--- a/tools/bisect/README.md
+++ b/tools/bisect/README.md
@@ -12,10 +12,10 @@ To learn more about bisecting please refer to https://git-scm.com/docs/git-bisec
 
 `hash-good` the latest known good commit hash or tag<br/>
 `hash-bad` the earliest known bad commit hash or tag<br/>
-`cppcheck-options` the options for the Cppcheck invokatio<br/>
-`expected` (optional) a string that is expected in the output. Will be used instead of the exitcode
+`cppcheck-options` the options for the Cppcheck invocation<br/>
+`expected` (optional) a string that is expected in the output; when provided it will be used instead of the exitcode
 
-If possible use `main` as the function to test stuff with since it won't emit an `unusedFunction` warning.
+If possible use `main` as the function to test with, since it won't emit an `unusedFunction` warning.
 
 ## Bisecting result regressions
 
@@ -33,7 +33,7 @@ If a crash occurs it is treated as a _bad_ commit.
 
 ### False positive
 
-Provide a code sample which will trigger a single(!) false postive only. Trying to bisect multiple issues at the same time will most likely result in an incorrect result (see below).
+Provide a code sample which will trigger a single(!) false positive only. Trying to bisect multiple issues at the same time will most likely result in an incorrect result (see below).
 
 ```cpp
 // cppcheck-suppress unusedFunction
@@ -87,7 +87,7 @@ Provide the expected error ID (`unreadVariable`) as the `expected` parameter.
 
 It is also possible to bisect for a regression in scan time.
 
-This is done by determinaing the time it took for the "good" commit to finish and setting a timeout twice that size for the calls to determine the "bad" commit.
+This is done by determining the time it took for the "good" commit to finish and setting a timeout twice that size for the calls to determine the "bad" commit.
 
 To bisect these kinds of regressions you currently need to adjust the `bisect.sh` script and set the `hang` variable to appropriate value:<br/>
 `1` - find the commit which started the hang<br/>
@@ -100,15 +100,15 @@ As we are currently using the process exitcode to pass the elapsed time to the s
 In case the run-time before the regression was very short (<= 1 second) you might need to adjust the `elapsed_time` variable in `bisect.sh` to a higher value to avoid potential false positives.
 This might also be necessary to determine one of multiple regressions in the commit range. 
 
-After the bisect finished you should take a look at the output and make sure the elpased time of the repective commit looks as expected.
+After the bisect finished you should take a look at the output and make sure the elpased time of the respective commit looks as expected.
 
 ### daca@home notes
 
 We use daca@home to track differences in scan time. An overview of regressions in scan time can be found at http://cppcheck1.osuosl.org:8000/time_gt.html.
 
-If the overall scan time regressed you need to specify the whole folder.
+If the overall scan time regressed, then you need to specify the whole folder.
 
-If a timeout (potential hang) was introduced you can simply specify the file from `error: Internal error: Child process crashed with signal 15 [cppcheckError]`.
+If a timeout (potential hang) was introduced, then you can simply specify the file from `error: Internal error: Child process crashed with signal 15 [cppcheckError]`.
 
 ## Notes
 

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -69,10 +69,10 @@ if not elapsed_time:
     sys.exit(round(run_time + .5))  # return the time
 
 if run_res is None:
-    sys.exit(EC_SKIP)  # error occured
+    sys.exit(EC_SKIP)  # error occurred
 
 if not run_res:
-    sys.exit(EC_BAD if not invert else EC_GOOD)  # timeout occured
+    sys.exit(EC_BAD if not invert else EC_GOOD)  # timeout occurred
 
 print('run_time: {}'.format(run_time))
 

--- a/tools/bisect/bisect_res.py
+++ b/tools/bisect/bisect_res.py
@@ -14,7 +14,7 @@ def run(cppcheck_path, options):
     if p.returncode > 1:
         print('error')
         return None, None, None
-    # signals are report as negative exitcode (e.g. SIGSEGV -> -11)
+    # signals are reported as negative exitcode (e.g. SIGSEGV -> -11)
     if p.returncode < 0:
         print('crash')
         return p.returncode, stderr, stdout
@@ -53,14 +53,14 @@ print(run_stderr)
 
 # if no ec is set we encountered an unexpected error
 if run_ec is None:
-    sys.exit(EC_SKIP)  # error occured
+    sys.exit(EC_SKIP)  # error occurred
 elif run_ec < 0:
-    sys.exit(EC_BAD) # crash occured
+    sys.exit(EC_BAD) # crash occurred
 
 # check output for expected string
 if expected is not None:
     if (expected not in run_stderr) and (expected not in run_stdout):
-        sys.exit(EC_BAD)  # output not found occured
+        sys.exit(EC_BAD)  # output not found occurred
 
     sys.exit(EC_GOOD)  # output found
 

--- a/tools/dmake.cpp
+++ b/tools/dmake.cpp
@@ -169,7 +169,7 @@ static int write_vcxproj(const std::string &proj_name, const std::function<void(
     std::string outstr;
 
     {
-        // treat as binary to prevent inplicit line ending conversions
+        // treat as binary to prevent implicit line ending conversions
         std::ifstream in(proj_name, std::ios::binary);
         if (!in.is_open()) {
             std::cerr << "Could not open " << proj_name << std::endl;
@@ -214,7 +214,7 @@ static int write_vcxproj(const std::string &proj_name, const std::function<void(
             outstr.resize(pos+1, '\0');
     }
 
-    // treat as binary to prevent inplicit line ending conversions
+    // treat as binary to prevent implicit line ending conversions
     std::ofstream out(proj_name, std::ios::binary|std::ios::trunc);
     out << outstr;
 

--- a/tools/triage_py/triage_version.py
+++ b/tools/triage_py/triage_version.py
@@ -154,7 +154,7 @@ for entry in versions:
         else:
             # TODO: re-add inconclusive: {callstack}: ({severity}{inconclusive:, inconclusive}) {message
             cmd.append('--template={callstack}: ({severity}) {message} [{id}]')
-    # TODO: how to pass addtional options?
+    # TODO: how to pass additional options?
     if args.perf:
         cmd.append('--error-exitcode=0')
     cmd.append(input_file)


### PR DESCRIPTION
* Most updates from `codespell`
* * The supine of 'to split' is 'split', not 'splitted'