### PR TITLE
Fix FP deallocuse regression

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -1068,7 +1068,7 @@ void CheckLeakAutoVar::ret(const Token *tok, VarInfo &varInfo, const bool isEndO
                     tok2 = tok3->next();
                 else if (Token::Match(tok3, "& %varid% . %name%", varid))
                     tok2 = tok3->tokAt(4);
-                else if (Token::simpleMatch(tok3, "*"))
+                else if (Token::simpleMatch(tok3, "*") && tok3->next()->varId() == varid)
                     tok2 = tok3;
                 else
                     continue;

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -113,6 +113,7 @@ private:
         TEST_CASE(deallocuse9); // #9781
         TEST_CASE(deallocuse10);
         TEST_CASE(deallocuse11); // #8302
+        TEST_CASE(deallocuse12);
 
         TEST_CASE(doublefree1);
         TEST_CASE(doublefree2);
@@ -856,6 +857,17 @@ private:
               "  return array[1];" // <<
               "}");
         ASSERT_EQUALS("[test.c:3] -> [test.c:4]: (error) Returning/dereferencing 'array' after it is deallocated / released\n", errout.str());
+    }
+
+    void deallocuse12() {
+        check("struct foo { int x; }\n"
+              "void f1(struct foo *f) {\n"
+              "  free(f);\n"
+              "}\n"
+              "void f2(struct foo *f, int *out) {\n"
+              "  *out = f->x;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void doublefree1() {  // #3895


### PR DESCRIPTION
Introduced in commit 69116c838 ("Fix #11758 Regression: memleak / Fix #11746 FN: deallocuse (#5139)").