### PR TITLE
Add missing rebinding trait to TaggedAllocator (complete #5015)

### DIFF
--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -41,6 +41,17 @@ struct TaggedAllocator : std::allocator<T>
     TaggedAllocator(Ts&&... ts)
         : std::allocator<T>(std::forward<Ts>(ts)...)
     {}
+
+    template<class U>
+    // cppcheck-suppress noExplicitConstructor
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    TaggedAllocator(const TaggedAllocator<U, N> ) {}
+
+    template<class U>
+    struct rebind
+    {
+        using other = TaggedAllocator<U, N>;
+    };
 };
 
 template<typename T, std::size_t N = DefaultSmallVectorSize>

--- a/lib/smallvector.h
+++ b/lib/smallvector.h
@@ -45,7 +45,7 @@ struct TaggedAllocator : std::allocator<T>
     template<class U>
     // cppcheck-suppress noExplicitConstructor
     // NOLINTNEXTLINE(google-explicit-constructor)
-    TaggedAllocator(const TaggedAllocator<U, N> ) {}
+    TaggedAllocator(const TaggedAllocator<U, N> /*unused*/) {}
 
     template<class U>
     struct rebind


### PR DESCRIPTION
#5015 seems to have stalled, but the fix is already being used downstream.
We should probably add gcc13 to our CI.