### PR TITLE
Fix #11789 FP knownConditionTrueFalse with std::vector::size()

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8855,7 +8855,6 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
   <podtype name="uintptr_t,std::uintptr_t" sign="u"/>
   <podtype name="intmax_t,std::intmax_t" sign="s"/>
   <podtype name="uintmax_t,std::uintmax_t" sign="u"/>
-  <podtype name="size_t,std::size_t" sign="u"/>
   <podtype name="std::string::size_type" sign="u"/>
   <podtype name="std::wstring::size_type" sign="u"/>
   <podtype name="std::u16string::size_type" sign="u"/>

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -4895,6 +4895,16 @@ private:
               "    return p != NULL && q != NULL && p == NULL;\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:2]: (style) Return value 'p==NULL' is always false\n", errout.str());
+
+        check("struct S {\n" // #11789
+              "    std::vector<int> v;\n"
+              "    void f(int i) const;\n"
+              "};\n"
+              "void S::f(int i) const {\n"
+              "    int j = i - v.size();\n"
+              "    if (j >= 0) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void alwaysTrueContainer() {


### PR DESCRIPTION
There is special handling for `size_t` in `ValueType::fromLibraryType()`, which gets preempted if it is also configured as a podtype.