### PR TITLE
Ignore zero valued enum entries from badBitmaskCheck

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -317,8 +317,15 @@ void CheckCondition::checkBadBitmaskCheck()
 
             const bool isZero1 = (tok->astOperand1()->hasKnownIntValue() && tok->astOperand1()->values().front().intvalue == 0);
             const bool isZero2 = (tok->astOperand2()->hasKnownIntValue() && tok->astOperand2()->values().front().intvalue == 0);
+            if (!isZero1 && !isZero2)
+                continue;
 
-            if ((isZero1 || isZero2) && !tok->isExpandedMacro() && !(isZero1 && tok->astOperand1()->isExpandedMacro()) && !(isZero2 && tok->astOperand2()->isExpandedMacro()))
+            auto isOperandExpanded = [](const Token *op) {
+                return op->isExpandedMacro() || op->isEnumerator();
+            };
+            if (!tok->isExpandedMacro() &&
+                !(isZero1 && isOperandExpanded(tok->astOperand1())) &&
+                !(isZero2 && isOperandExpanded(tok->astOperand2())))
                 badBitmaskCheckError(tok, /*isNoOp*/ true);
         }
     }

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -912,6 +912,11 @@ private:
               "#endif\n"
               "    0;");
         ASSERT_EQUALS("", errout.str());
+
+        check("enum precedence { PC0, UNARY };\n"
+              "int x = PC0   | UNARY;\n"
+              "int y = UNARY | PC0;\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
Usage of zero valued enum entries can be used for documenting purposes and should be ignored just like zeroes expanded from macros.