### PR TITLE
Update type for Settings::checksMaxTime.

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -263,7 +263,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             }
 
             else if (std::strncmp(argv[i], "--checks-max-time=", 18) == 0) {
-                if (!parseNumberArg(argv[i], 18, mSettings.checksMaxTime))
+                if (!parseNumberArg(argv[i], 18, mSettings.checksMaxTime, true))
                     return false;
             }
 

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -123,9 +123,8 @@ protected:
 private:
     bool isCppcheckPremium() const;
 
-    // TODO: get rid of is_signed
     template<typename T>
-    static bool parseNumberArg(const char* const arg, std::size_t offset, T& num, bool is_signed = false)
+    static bool parseNumberArg(const char* const arg, std::size_t offset, T& num, bool mustBePositive = false)
     {
         T tmp;
         std::string err;
@@ -133,7 +132,7 @@ private:
             printError("argument to '" + std::string(arg, offset) + "' is not valid - " + err + ".");
             return false;
         }
-        if (is_signed && tmp < 0) {
+        if (mustBePositive && tmp < 0) {
             printError("argument to '" + std::string(arg, offset) + "' needs to be a positive integer.");
             return false;
         }

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -128,7 +128,7 @@ public:
     bool checkLibrary;
 
     /** @brief The maximum time in seconds for the checks of a single file */
-    std::size_t checksMaxTime;
+    int checksMaxTime;
 
     /** @brief check unknown function return values */
     std::set<std::string> checkUnknownFunctionReturn;

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -1694,7 +1694,7 @@ private:
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--checks-max-time=-1", "file.cpp"};
         ASSERT(!defParser.parseFromArgs(3, argv));
-        ASSERT_EQUALS("cppcheck: error: argument to '--checks-max-time=' is not valid - needs to be positive.\n", GET_REDIRECT_OUTPUT);
+        ASSERT_EQUALS("cppcheck: error: argument to '--checks-max-time=' needs to be a positive integer.\n", GET_REDIRECT_OUTPUT);
     }
 
     void checksMaxTimeInvalid() {

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -1684,7 +1684,7 @@ private:
     void checksMaxTime() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "--checks-max-time=12", "file.cpp"};
-        settings.checksMaxTime = SIZE_MAX;
+        settings.checksMaxTime = 0;
         ASSERT(defParser.parseFromArgs(3, argv));
         ASSERT_EQUALS(12, settings.checksMaxTime);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);


### PR DESCRIPTION
It's a time offset not a size. It should not have value SIZE_MAX that makes it ineffective (overflow in calculation of stop time).