### PR TITLE
Revert "Fix #11765 FN: minsize not checked for string literal, buffer…

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -5011,6 +5011,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="4"/>
       <strz/>
     </arg>
     <arg nr="4" direction="in">
@@ -5096,6 +5097,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="3" direction="in">
       <not-null/>
       <not-uninit/>
+      <minsize type="argvalue" arg="4"/>
       <strz/>
     </arg>
     <arg nr="4" direction="in">
@@ -5211,6 +5213,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-null/>
       <not-uninit/>
       <strz/>
+      <minsize type="argvalue" arg="3"/>
     </arg>
     <arg nr="3" direction="in">
       <not-uninit/>

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -219,12 +219,14 @@ void bufferAccessOutOfBounds(void)
     strncpy_s(a,5,"abcd",5);
     // string will be truncated, error is returned, but no buffer overflow
     strncpy_s(a,5,"abcde",6);
+    // TODO cppcheck-suppress bufferAccessOutOfBounds
     strncpy_s(a,5,"a",6);
     strncpy_s(a,5,"abcdefgh",4);
     // valid call
     strncat_s(a,5,"1",2);
     // cppcheck-suppress bufferAccessOutOfBounds
     strncat_s(a,10,"1",2);
+    // TODO cppcheck-suppress bufferAccessOutOfBounds
     strncat_s(a,5,"1",5);
     fread(a,1,5,stdin);
     // cppcheck-suppress bufferAccessOutOfBounds
@@ -516,6 +518,7 @@ void nullpointer(int value)
     wcstok(NULL,L"xyz",&pWcsUninit);
 
     strxfrm(0,"foo",0);
+    // TODO: error message (#6306 and http://trac.cppcheck.net/changeset/d11eb4931aea51cf2cb74faccdcd2a3289b818d6/)
     strxfrm(0,"foo",42);
     wcsxfrm(0,L"foo",0);
     // TODO: error message when arg1==NULL and arg3!=0 #6306: https://trac.cppcheck.net/ticket/6306#comment:2


### PR DESCRIPTION
… access out of bounds not found (#5154)"

This reverts commit 9ad18f51af3dffc0cf860e8c8ec78db3d8b9414d.