### PR TITLE
Fix #11828 False positive when getting a span via an out argument

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -8326,9 +8326,6 @@ bool ValueFlow::isContainerSizeChanged(const Token* tok, int indirect, const Set
     if (astIsLHS(tok) && Token::Match(tok->astParent(), "%assign%|<<"))
         return true;
     const Library::Container* container = tok->valueType()->container;
-    // Views cannot change container size
-    if (container->view)
-        return false;
     if (astIsLHS(tok) && Token::simpleMatch(tok->astParent(), "["))
         return container->stdAssociativeLike;
     const Library::Container::Action action = astContainerAction(tok);

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -920,9 +920,9 @@ private:
         checkNormal("char h() {\n"
                     "    std::string s;\n"
                     "    std::string_view sv(s);\n"
-                    "    return s[0];\n"
+                    "    return s[2];\n"
                     "}\n");
-        TODO_ASSERT_EQUALS("test.cpp:4:error:Out of bounds access in expression 's[0]' because 's' is empty.\n", "", errout.str());
+        TODO_ASSERT_EQUALS("test.cpp:4:error:Out of bounds access in expression 's[2]' because 's' is empty.\n", "", errout.str());
     }
 
     void outOfBoundsSymbolic()

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -908,6 +908,21 @@ private:
                     "    if (x.Set(42U)) {}\n"
                     "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        checkNormal("struct S { void g(std::span<int>& r) const; };\n" // #11828
+                    "int f(const S& s) {\n"
+                    "    std::span<int> t;\n"
+                    "    s.g(t);\n"
+                    "    return t[0];\n"
+                    "}\n");
+        ASSERT_EQUALS("", errout.str());
+
+        checkNormal("char h() {\n"
+                    "    std::string s;\n"
+                    "    std::string_view sv(s);\n"
+                    "    return s[0];\n"
+                    "}\n");
+        TODO_ASSERT_EQUALS("test.cpp:4:error:Out of bounds access in expression 's[0]' because 's' is empty.\n", "", errout.str());
     }
 
     void outOfBoundsSymbolic()


### PR DESCRIPTION
We didn't warn for the TODO even before this change.