### PR TITLE
unusedFunction disabled warning is not printed if --cppcheck-build-dir is used

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1031,7 +1031,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
     else if ((def || mSettings.preprocessOnly) && !maxconfigs)
         mSettings.maxConfigs = 1U;
 
-    if (mSettings.checks.isEnabled(Checks::unusedFunction) && mSettings.jobs > 1) {
+    if (mSettings.checks.isEnabled(Checks::unusedFunction) && mSettings.jobs > 1 && mSettings.buildDir.empty()) {
         printMessage("unusedFunction check can't be used with '-j' option. Disabling unusedFunction check.");
     }
 


### PR DESCRIPTION
ususedFunction check is enabled if cppcheck build dir is used. Warning about disabled unusedFunction check should not be printed in such case.