### PR TITLE
Check if --cppcheck-build-dir exists

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -45,6 +45,7 @@
 #include <set>
 #include <sstream> // IWYU pragma: keep
 #include <stdexcept>
+#include <sys/stat.h>
 #include <unordered_set>
 #include <utility>
 
@@ -290,10 +291,15 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
             }
 
             else if (std::strncmp(argv[i], "--cppcheck-build-dir=", 21) == 0) {
-                // TODO: bail out when the folder does not exist? will silently do nothing
                 mSettings.buildDir = Path::fromNativeSeparators(argv[i] + 21);
                 if (endsWith(mSettings.buildDir, '/'))
                     mSettings.buildDir.pop_back();
+
+                struct stat info;
+                if (stat(mSettings.buildDir.c_str(), &info) != 0 || !(info.st_mode & S_IFDIR)) {
+                    printError("Directory '" + mSettings.buildDir + "' specified by --cppcheck-build-dir argument has to be existent.");
+                    return false;
+                }
             }
 
             // Show --debug output after the first simplifications

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -45,7 +45,6 @@
 #include <set>
 #include <sstream> // IWYU pragma: keep
 #include <stdexcept>
-#include <sys/stat.h>
 #include <unordered_set>
 #include <utility>
 
@@ -295,8 +294,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (endsWith(mSettings.buildDir, '/'))
                     mSettings.buildDir.pop_back();
 
-                struct stat info;
-                if (stat(mSettings.buildDir.c_str(), &info) != 0 || !(info.st_mode & S_IFDIR)) {
+                if (!Path::directoryExists(mSettings.buildDir)) {
                     printError("Directory '" + mSettings.buildDir + "' specified by --cppcheck-build-dir argument has to be existent.");
                     return false;
                 }

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <sys/stat.h>
 #include <utility>
 
 #include <simplecpp.h>
@@ -264,6 +265,13 @@ bool Path::fileExists(const std::string &file)
 {
     std::ifstream f(file.c_str());
     return f.is_open();
+}
+
+
+bool Path::directoryExists(const std::string &path)
+{
+    struct stat info;
+    return stat(path.c_str(), &info) == 0 && (info.st_mode & S_IFDIR);
 }
 
 std::string Path::join(std::string path1, std::string path2) {

--- a/lib/path.h
+++ b/lib/path.h
@@ -188,6 +188,13 @@ public:
     static bool fileExists(const std::string &file);
 
     /**
+     * @brief Checks if a directory exists
+     * @param path Path to be checked
+     * @return true if given path is a directory
+     */
+    static bool directoryExists(const std::string &path);
+
+    /**
      * join 2 paths with '/' separators
      */
     static std::string join(std::string path1, std::string path2);

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -237,6 +237,10 @@ private:
         TEST_CASE(undefs_noarg3);
         TEST_CASE(undefs);
         TEST_CASE(undefs2);
+
+        TEST_CASE(cppcheckBuildDirExistent);
+        TEST_CASE(cppcheckBuildDirNonExistent);
+        TEST_CASE(cppcheckBuildDirEmpty);
     }
 
 
@@ -1946,6 +1950,27 @@ private:
         // Fails since -U has no param
         ASSERT_EQUALS(false, defParser.parseFromArgs(4, argv));
         ASSERT_EQUALS("cppcheck: error: argument to '-U' is missing.\n", GET_REDIRECT_OUTPUT);
+    }
+
+    void cppcheckBuildDirExistent() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--cppcheck-build-dir=."};
+        ASSERT_EQUALS(true, defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
+    }
+
+    void cppcheckBuildDirNonExistent() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--cppcheck-build-dir=non-existent-path"};
+        ASSERT_EQUALS(false, defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("cppcheck: error: Directory 'non-existent-path' specified by --cppcheck-build-dir argument has to be existent.\n", GET_REDIRECT_OUTPUT);
+    }
+
+    void cppcheckBuildDirEmpty() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--cppcheck-build-dir="};
+        ASSERT_EQUALS(false, defParser.parseFromArgs(2, argv));
+        ASSERT_EQUALS("cppcheck: error: Directory '' specified by --cppcheck-build-dir argument has to be existent.\n", GET_REDIRECT_OUTPUT);
     }
 };
 


### PR DESCRIPTION
Cppcheck does not report that cppcheck build dir does not exist and also does not report any write issues to the non-existent directory. 

This means that cppcheck build dir is actually not used.

We should either create the directory or fail.