### PR TITLE
tokenlist.cpp: fixed GCC `-Wunused-variable` warning

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1747,7 +1747,7 @@ void TokenList::validateAst() const
             continue;
         }
 
-        if (const Token* lambdaEnd = findLambdaEndToken(tok)) { // skip lambda captures
+        if (findLambdaEndToken(tok)) { // skip lambda captures
             tok = tok->link();
             continue;
         }


### PR DESCRIPTION
Added https://trac.cppcheck.net/ticket/11847 about the false negative.