### PR TITLE
removed `ErrorLogger::reportProgress()` and command-line option `--report-progress`

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -760,11 +760,6 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 }
             }
 
-            // Report progress
-            else if (std::strcmp(argv[i], "--report-progress") == 0) {
-                mSettings.reportProgress = true;
-            }
-
 #ifdef HAVE_RULES
             // Rule given at command line
             else if (std::strncmp(argv[i], "--rule=", 7) == 0) {
@@ -1295,7 +1290,6 @@ void CmdLineParser::printHelp()
         "                         using e.g. ~ for home folder does not work. It is\n"
         "                         currently only possible to apply the base paths to\n"
         "                         files that are on a lower level in the directory tree.\n"
-        "    --report-progress    Report progress messages while checking a file.\n"
 #ifdef HAVE_RULES
     "    --rule=<rule>        Match regular expression.\n"
     "    --rule-file=<file>   Use given rule file. For more information, see:\n"

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -70,7 +70,7 @@
 /*static*/ FILE* CppCheckExecutor::mExceptionOutput = stdout;
 
 CppCheckExecutor::CppCheckExecutor()
-    : mSettings(nullptr), mLatestProgressOutputTime(0), mErrorOutput(nullptr), mShowAllErrors(false)
+    : mSettings(nullptr), mErrorOutput(nullptr), mShowAllErrors(false)
 {}
 
 CppCheckExecutor::~CppCheckExecutor()
@@ -262,9 +262,6 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
 {
     Settings& settings = cppcheck.settings();
 
-    if (settings.reportProgress)
-        mLatestProgressOutputTime = std::time(nullptr);
-
     if (!settings.outputFile.empty()) {
         mErrorOutput = new std::ofstream(settings.outputFile);
     }
@@ -392,29 +389,6 @@ void CppCheckExecutor::reportOut(const std::string &outmsg, Color c)
         std::cout << ansiToOEM(outmsg, true) << std::endl;
     else
         std::cout << c << ansiToOEM(outmsg, true) << Color::Reset << std::endl;
-}
-
-void CppCheckExecutor::reportProgress(const std::string &filename, const char stage[], const std::size_t value)
-{
-    (void)filename;
-
-    if (!mLatestProgressOutputTime)
-        return;
-
-    // Report progress messages every 10 seconds
-    const std::time_t currentTime = std::time(nullptr);
-    if (currentTime >= (mLatestProgressOutputTime + 10)) {
-        mLatestProgressOutputTime = currentTime;
-
-        // format a progress message
-        std::ostringstream ostr;
-        ostr << "progress: "
-             << stage
-             << ' ' << value << '%';
-
-        // Report progress message
-        reportOut(ostr.str());
-    }
 }
 
 void CppCheckExecutor::reportErr(const ErrorMessage &msg)

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -79,8 +79,6 @@ public:
     /** xml output of errors */
     void reportErr(const ErrorMessage &msg) override;
 
-    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;
-
     /**
      * @param exceptionOutput Output file
      */
@@ -165,11 +163,6 @@ private:
      * Filename associated with size of file
      */
     std::map<std::string, std::size_t> mFiles;
-
-    /**
-     * Report progress time
-     */
-    std::time_t mLatestProgressOutputTime;
 
     /**
      * Output file name for exception handler

--- a/democlient/democlient.cpp
+++ b/democlient/democlient.cpp
@@ -72,14 +72,7 @@ public:
             std::fprintf(logfile, "%s\n", s.c_str());
     }
 
-    void reportProgress(const std::string& /*filename*/,
-                        const char /*stage*/[],
-                        const std::size_t /*value*/) override {
-        if (std::time(nullptr) >= stoptime) {
-            std::cout << "Time to analyse the code exceeded 2 seconds. Terminating.\n\n";
-            Settings::terminate();
-        }
-    }
+    // TODO: we want it to run a maximum amount of 2 seconds - provide a (reliable) way t o bail out
 };
 
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1626,11 +1626,6 @@ void CppCheck::reportOut(const std::string &outmsg, Color c)
     mErrorLogger.reportOut(outmsg, c);
 }
 
-void CppCheck::reportProgress(const std::string &filename, const char stage[], const std::size_t value)
-{
-    mErrorLogger.reportProgress(filename, stage, value);
-}
-
 void CppCheck::getErrorMessages(ErrorLogger &errorlogger)
 {
     Settings s;

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -210,8 +210,6 @@ private:
     std::list<std::string> mErrorList;
     Settings mSettings;
 
-    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;
-
     ErrorLogger &mErrorLogger;
 
     /** @brief Current preprocessor configuration */

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -239,18 +239,6 @@ public:
     virtual void reportErr(const ErrorMessage &msg) = 0;
 
     /**
-     * Report progress to client
-     * @param filename main file that is checked
-     * @param stage for example preprocess / tokenize / simplify / check
-     * @param value progress value (0-100)
-     */
-    virtual void reportProgress(const std::string &filename, const char stage[], const std::size_t value) {
-        (void)filename;
-        (void)stage;
-        (void)value;
-    }
-
-    /**
      * Report unmatched suppressions
      * @param unmatched list of unmatched suppressions (from Settings::Suppressions::getUnmatched(Local|Global)Suppressions)
      * @return true is returned if errors are reported

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -67,7 +67,6 @@ Settings::Settings()
     preprocessOnly(false),
     quiet(false),
     relativePaths(false),
-    reportProgress(false),
     showtime(SHOWTIME_MODES::SHOWTIME_NONE),
     templateMaxTime(0),
     typedefMaxTime(0),

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -266,9 +266,6 @@ public:
     /** @brief Use relative paths in output. */
     bool relativePaths;
 
-    /** @brief --report-progress */
-    bool reportProgress;
-
     /** Rule */
     class CPPCHECKLIB Rule {
     public:

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -156,11 +156,6 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
 
     // find all scopes
     for (const Token *tok = mTokenizer.tokens(); tok; tok = tok ? tok->next() : nullptr) {
-        // #5593 suggested to add here:
-        if (mErrorLogger)
-            mErrorLogger->reportProgress(mTokenizer.list.getSourceFilePath(),
-                                         "SymbolDatabase",
-                                         tok->progressValue());
         // Locate next class
         if ((mTokenizer.isCPP() && tok->isKeyword() &&
              ((Token::Match(tok, "class|struct|union|namespace ::| %name% final| {|:|::|<") &&

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3159,8 +3159,6 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
             continue;
 
         Token * const tok2 = instantiation.token();
-        if (mErrorLogger && !mTokenList.getFiles().empty())
-            mErrorLogger->reportProgress(mTokenList.getFiles()[0], "TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {
@@ -3230,8 +3228,6 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
     // TODO: remove the specialized check and handle all uninstantiated templates someday.
     if (!instantiated && specialized) {
         Token * tok2 = const_cast<Token *>(templateDeclaration.nameToken());
-        if (mErrorLogger && !mTokenList.getFiles().empty())
-            mErrorLogger->reportProgress(mTokenList.getFiles()[0], "TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1127,9 +1127,6 @@ void Tokenizer::simplifyTypedefCpp()
     const std::time_t maxTime = mSettings->typedefMaxTime > 0 ? std::time(nullptr) + mSettings->typedefMaxTime: 0;
 
     for (Token *tok = list.front(); tok; tok = tok->next()) {
-        if (mErrorLogger && !list.getFiles().empty())
-            mErrorLogger->reportProgress(list.getFiles()[0], "Tokenize (typedef)", tok->progressValue());
-
         if (Settings::terminated())
             return;
 
@@ -2832,9 +2829,6 @@ bool Tokenizer::simplifyUsing()
     std::list<Using> usingList;
 
     for (Token *tok = list.front(); tok; tok = tok->next()) {
-        if (mErrorLogger && !list.getFiles().empty())
-            mErrorLogger->reportProgress(list.getFiles()[0], "Tokenize (using)", tok->progressValue());
-
         if (Settings::terminated())
             return substitute;
 

--- a/man/cppcheck.1.xml
+++ b/man/cppcheck.1.xml
@@ -181,9 +181,6 @@ man(1), man(7), http://www.tldp.org/HOWTO/Man-Page/
         <option>--relative-paths=&lt;paths&gt;</option>
       </arg>
       <arg choice="opt">
-        <option>--report-progress</option>
-      </arg>
-      <arg choice="opt">
         <option>--rule=&lt;rule&gt;</option>
       </arg>
       <arg choice="opt">
@@ -517,14 +514,6 @@ There are false positives with this option. Each result must be carefully invest
         </term>
         <listitem>
           <para>Use relative paths in output. When given, &lt;paths&gt; are used as base. You can separate multiple paths by ';'. Otherwise path where source files are searched is used. E.g. if given value is test, when checking test/test.cpp, the path in output will be test.cpp instead of test/test.cpp. The feature uses string comparison to create relative paths, so using e.g. ~ for home folder does not work. It is currently only possible to apply the base paths to files that are on a lower level in the directory tree.</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>
-          <option>--report-progress</option>
-        </term>
-        <listitem>
-          <para>Report progress when checking a file.</para>
         </listitem>
       </varlistentry>
       <varlistentry>

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -9,3 +9,4 @@ GUI:
 Changed interface:
 
 Other:
+- removed command-line option "--report-progress" as it didn't provide much of a progress

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -132,7 +132,6 @@ private:
         TEST_CASE(maxConfigsMissingCount);
         TEST_CASE(maxConfigsInvalid);
         TEST_CASE(maxConfigsTooSmall);
-        TEST_CASE(reportProgressTest); // "Test" suffix to avoid hiding the parent's reportProgress
         TEST_CASE(stdc99);
         TEST_CASE(stdcpp11);
         TEST_CASE(stdunknown);
@@ -1022,15 +1021,6 @@ private:
         // Fails since limit must be greater than 0
         ASSERT_EQUALS(false, defParser.parseFromArgs(3, argv));
         ASSERT_EQUALS("cppcheck: error: argument to '--max-configs=' must be greater than 0.\n", GET_REDIRECT_OUTPUT);
-    }
-
-    void reportProgressTest() {
-        REDIRECT;
-        const char * const argv[] = {"cppcheck", "--report-progress", "file.cpp"};
-        settings.reportProgress = false;
-        ASSERT(defParser.parseFromArgs(3, argv));
-        ASSERT(settings.reportProgress);
-        ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
     }
 
     void stdc99() {


### PR DESCRIPTION
As detailed in https://github.com/danmar/cppcheck/pull/4985#discussion_r1171846635 it doesn't provide much progress and adds unnecessary complexity to the `ErrorLogger` and `CppcheckExecutor`.

We should probably remove `TokenImpl::mProgressValue` as well.