### PR TITLE
aligned and optimized unique error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -740,7 +740,7 @@ test/testcondition.o: test/testcondition.cpp externals/simplecpp/simplecpp.h lib
 test/testconstructors.o: test/testconstructors.cpp lib/addoninfo.h lib/check.h lib/checkclass.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testconstructors.cpp
 
-test/testcppcheck.o: test/testcppcheck.cpp lib/addoninfo.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h
+test/testcppcheck.o: test/testcppcheck.cpp lib/addoninfo.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/filesettings.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/tokenize.h lib/tokenlist.h lib/utils.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcppcheck.cpp
 
 test/testerrorlogger.o: test/testerrorlogger.cpp externals/tinyxml2/tinyxml2.h lib/addoninfo.h lib/analyzerinfo.h lib/check.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h lib/xml.h test/fixture.h

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -140,7 +140,8 @@ private:
     /**
      * Used to filter out duplicate error messages.
      */
-    std::set<std::string> mShownErrors;
+    // TODO: store hashes instead of the full messages
+    std::unordered_set<std::string> mShownErrors;
 
     /**
      * Report progress time
@@ -390,6 +391,8 @@ void CppCheckExecutor::StdLogger::reportErr(const ErrorMessage &msg)
         return;
     }
 
+    // TODO: we generate a different message here then we log below
+    // TODO: there should be no need for verbose and default messages here
     // Alert only about unique errors
     if (!mShownErrors.insert(msg.toString(mSettings.verbose)).second)
         return;

--- a/cli/executor.cpp
+++ b/cli/executor.cpp
@@ -41,6 +41,7 @@ bool Executor::hasToLog(const ErrorMessage &msg)
 {
     if (!mSuppressions.isSuppressed(msg, {}))
     {
+        // TODO: there should be no need for verbose messages here
         std::string errmsg = msg.toString(mSettings.verbose);
 
         std::lock_guard<std::mutex> lg(mErrorListSync);

--- a/cli/executor.cpp
+++ b/cli/executor.cpp
@@ -45,7 +45,7 @@ bool Executor::hasToLog(const ErrorMessage &msg)
 
     if (!mSuppressions.isSuppressed(msg, {}))
     {
-        // TODO: there should be no need for verbose messages here
+        // TODO: there should be no need for verbose and default messages here
         std::string errmsg = msg.toString(mSettings.verbose);
         if (errmsg.empty())
             return false;

--- a/cli/executor.cpp
+++ b/cli/executor.cpp
@@ -37,12 +37,18 @@ Executor::Executor(const std::list<std::pair<std::string, std::size_t>> &files, 
     assert(!(!files.empty() && !fileSettings.empty()));
 }
 
+// TODO: this logic is duplicated in CppCheck::reportErr()
 bool Executor::hasToLog(const ErrorMessage &msg)
 {
+    if (!mSettings.library.reportErrors(msg.file0))
+        return false;
+
     if (!mSuppressions.isSuppressed(msg, {}))
     {
         // TODO: there should be no need for verbose messages here
         std::string errmsg = msg.toString(mSettings.verbose);
+        if (errmsg.empty())
+            return false;
 
         std::lock_guard<std::mutex> lg(mErrorListSync);
         if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) == mErrorList.cend()) {

--- a/cli/executor.cpp
+++ b/cli/executor.cpp
@@ -51,8 +51,7 @@ bool Executor::hasToLog(const ErrorMessage &msg)
             return false;
 
         std::lock_guard<std::mutex> lg(mErrorListSync);
-        if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) == mErrorList.cend()) {
-            mErrorList.emplace_back(std::move(errmsg));
+        if (mErrorList.emplace(std::move(errmsg)).second) {
             return true;
         }
     }

--- a/cli/executor.h
+++ b/cli/executor.h
@@ -75,7 +75,7 @@ protected:
 
 private:
     std::mutex mErrorListSync;
-    // TODO: store hashes instead of full messages
+    // TODO: store hashes instead of the full messages
     std::unordered_set<std::string> mErrorList;
 };
 

--- a/cli/executor.h
+++ b/cli/executor.h
@@ -23,6 +23,7 @@
 #include <list>
 #include <mutex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 class Settings;
@@ -75,7 +76,7 @@ protected:
 private:
     std::mutex mErrorListSync;
     // TODO: store hashes instead of full messages
-    std::list<std::string> mErrorList;
+    std::unordered_set<std::string> mErrorList;
 };
 
 /// @}

--- a/cli/executor.h
+++ b/cli/executor.h
@@ -74,6 +74,7 @@ protected:
 
 private:
     std::mutex mErrorListSync;
+    // TODO: store hashes instead of full messages
     std::list<std::string> mErrorList;
 };
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1598,7 +1598,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
         return;
 
     // Alert only about unique errors
-    if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) != mErrorList.cend())
+    if (!mErrorList.emplace(std::move(errmsg)).second)
         return;
 
     if (!mSettings.buildDir.empty())
@@ -1607,8 +1607,6 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (!mSettings.nofail.isSuppressed(errorMessage) && !mSettings.nomsg.isSuppressed(errorMessage)) {
         mExitCode = 1;
     }
-
-    mErrorList.emplace_back(std::move(errmsg));
 
     mErrorLogger.reportErr(msg);
     // check if plistOutput should be populated and the current output file is open and the error is not suppressed

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1575,6 +1575,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (!mSettings.library.reportErrors(msg.file0))
         return;
 
+    // TODO: there should be no need for the verbose messages here
     const std::string errmsg = msg.toString(mSettings.verbose);
     if (errmsg.empty())
         return;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1565,6 +1565,7 @@ void CppCheck::purgedConfigurationMessage(const std::string &file, const std::st
 
 //---------------------------------------------------------------------------
 
+// TODO: part of this logic is duplicated in Executor::hasToLog()
 void CppCheck::reportErr(const ErrorMessage &msg)
 {
     if (msg.severity == Severity::none && (msg.id == "logChecker" || endsWith(msg.id, "-logChecker"))) {
@@ -1574,18 +1575,6 @@ void CppCheck::reportErr(const ErrorMessage &msg)
 
     if (!mSettings.library.reportErrors(msg.file0))
         return;
-
-    // TODO: there should be no need for the verbose messages here
-    std::string errmsg = msg.toString(mSettings.verbose);
-    if (errmsg.empty())
-        return;
-
-    // Alert only about unique errors
-    if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) != mErrorList.cend())
-        return;
-
-    if (!mSettings.buildDir.empty())
-        mAnalyzerInformation.reportErr(msg);
 
     std::set<std::string> macroNames;
     if (!msg.callStack.empty()) {
@@ -1602,6 +1591,18 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (mSettings.nomsg.isSuppressed(errorMessage, mUseGlobalSuppressions)) {
         return;
     }
+
+    // TODO: there should be no need for the verbose messages here
+    std::string errmsg = msg.toString(mSettings.verbose);
+    if (errmsg.empty())
+        return;
+
+    // Alert only about unique errors
+    if (std::find(mErrorList.cbegin(), mErrorList.cend(), errmsg) != mErrorList.cend())
+        return;
+
+    if (!mSettings.buildDir.empty())
+        mAnalyzerInformation.reportErr(msg);
 
     if (!mSettings.nofail.isSuppressed(errorMessage) && !mSettings.nomsg.isSuppressed(errorMessage)) {
         mExitCode = 1;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1576,7 +1576,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
         return;
 
     // TODO: there should be no need for the verbose messages here
-    const std::string errmsg = msg.toString(mSettings.verbose);
+    std::string errmsg = msg.toString(mSettings.verbose);
     if (errmsg.empty())
         return;
 
@@ -1607,7 +1607,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
         mExitCode = 1;
     }
 
-    mErrorList.push_back(errmsg);
+    mErrorList.emplace_back(std::move(errmsg));
 
     mErrorLogger.reportErr(msg);
     // check if plistOutput should be populated and the current output file is open and the error is not suppressed

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1597,7 +1597,9 @@ void CppCheck::reportErr(const ErrorMessage &msg)
     if (errmsg.empty())
         return;
 
-    // Alert only about unique errors
+    // Alert only about unique errors.
+    // This makes sure the errors of a single check() call are unique.
+    // TODO: get rid of this? This is forwarded to another ErrorLogger which is also doing this
     if (!mErrorList.emplace(std::move(errmsg)).second)
         return;
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1592,7 +1592,7 @@ void CppCheck::reportErr(const ErrorMessage &msg)
         return;
     }
 
-    // TODO: there should be no need for the verbose messages here
+    // TODO: there should be no need for the verbose and default messages here
     std::string errmsg = msg.toString(mSettings.verbose);
     if (errmsg.empty())
         return;

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -215,6 +215,7 @@ private:
      */
     void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
 
+    // TODO: store hashes instead of the full messages
     std::list<std::string> mErrorList;
     Settings mSettings;
 

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -216,7 +217,7 @@ private:
     void reportOut(const std::string &outmsg, Color c = Color::Reset) override;
 
     // TODO: store hashes instead of the full messages
-    std::list<std::string> mErrorList;
+    std::unordered_set<std::string> mErrorList;
     Settings mSettings;
 
     void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -623,6 +623,7 @@ std::string ErrorMessage::toString(bool verbose, const std::string &templateForm
     // Save this ErrorMessage in plain text.
 
     // No template is given
+    // (not 100%) equivalent templateFormat: {callstack} ({severity}{inconclusive:, inconclusive}) {message}
     if (templateFormat.empty()) {
         std::string text;
         if (!callStack.empty()) {

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -618,10 +618,12 @@ static void replaceColors(std::string& source) {
     replace(source, substitutionMap);
 }
 
+// TODO: remove default parameters
 std::string ErrorMessage::toString(bool verbose, const std::string &templateFormat, const std::string &templateLocation) const
 {
     // Save this ErrorMessage in plain text.
 
+    // TODO: should never happen - remove this
     // No template is given
     // (not 100%) equivalent templateFormat: {callstack} ({severity}{inconclusive:, inconclusive}) {message}
     if (templateFormat.empty()) {

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -70,6 +70,10 @@ public:
         return mFullPath;
     }
 
+    const std::string& name() const {
+        return mName;
+    }
+
     ScopedFile(const ScopedFile&) = delete;
     ScopedFile(ScopedFile&&) = delete;
     ScopedFile& operator=(const ScopedFile&) = delete;

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -86,7 +86,7 @@ private:
         ASSERT(foundTooManyConfigs);
     }
 
-    void checkWithFile()
+    void checkWithFile() const
     {
         ScopedFile file("test.cpp",
                         "int main()\n"
@@ -106,7 +106,7 @@ private:
         ASSERT_EQUALS("nullPointer", *errorLogger.ids.cbegin());
     }
 
-    void checkWithFS()
+    void checkWithFS() const
     {
         ScopedFile file("test.cpp",
                         "int main()\n"
@@ -128,7 +128,7 @@ private:
         ASSERT_EQUALS("nullPointer", *errorLogger.ids.cbegin());
     }
 
-    void suppress_error_library()
+    void suppress_error_library() const
     {
         ScopedFile file("test.cpp",
                         "int main()\n"
@@ -151,7 +151,7 @@ private:
     }
 
     // TODO: hwo to actually get duplicated findings
-    void unique_errors()
+    void unique_errors() const
     {
         ScopedFile file("inc.h",
                         "inline void f()\n"

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -346,6 +346,7 @@ private:
     }
 
     // TODO: test whole program analysis
+    // TODO: test unique errors
 };
 
 class TestProcessExecutorFiles : public TestProcessExecutorBase {

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -149,6 +149,7 @@ private:
         TEST_CASE(showtime_file);
         TEST_CASE(showtime_summary);
         TEST_CASE(showtime_file_total);
+        TEST_CASE(suppress_error_library);
 #endif // !WIN32
     }
 
@@ -327,6 +328,21 @@ private:
         const std::string output_s = GET_REDIRECT_OUTPUT;
         TODO_ASSERT(output_s.find("Check time: " + fprefix() + "_1.cpp: ") != std::string::npos);
         TODO_ASSERT(output_s.find("Check time: " + fprefix() + "_2.cpp: ") != std::string::npos);
+    }
+
+    void suppress_error_library() {
+        SUPPRESS;
+        const Settings settingsOld = settings;
+        const char xmldata[] = R"(<def format="2"><markup ext=".cpp" reporterrors="false"/></def>)";
+        settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        check(2, 1, 0,
+              "int main()\n"
+              "{\n"
+              "  int i = *((int*)0);\n"
+              "  return 0;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        settings = settingsOld;
     }
 
     // TODO: test whole program analysis

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -345,8 +345,20 @@ private:
         settings = settingsOld;
     }
 
+    void unique_errors() {
+        SUPPRESS;
+        ScopedFile inc_h(fprefix() + ".h",
+                         "inline void f()\n"
+                         "{\n"
+                         "  (void)*((int*)0);\n"
+                         "}");
+        check(2, 2, 2,
+              "#include \"" + inc_h.name() +"\"");
+        // this is made unique by the executor
+        ASSERT_EQUALS("[" + inc_h.name() + ":3]: (error) Null pointer dereference: (int*)0\n", errout.str());
+    }
+
     // TODO: test whole program analysis
-    // TODO: test unique errors
 };
 
 class TestProcessExecutorFiles : public TestProcessExecutorBase {

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -153,6 +153,7 @@ private:
         TEST_CASE(showtime_file);
         TEST_CASE(showtime_summary);
         TEST_CASE(showtime_file_total);
+        TEST_CASE(suppress_error_library);
     }
 
     void many_files() {
@@ -319,6 +320,21 @@ private:
         const std::string output_s = GET_REDIRECT_OUTPUT;
         ASSERT(output_s.find("Check time: " + fprefix() + "_" + zpad3(1) + ".cpp: ") != std::string::npos);
         ASSERT(output_s.find("Check time: " + fprefix() + "_" + zpad3(2) + ".cpp: ") != std::string::npos);
+    }
+
+    void suppress_error_library() {
+        SUPPRESS;
+        const Settings settingsOld = settings;
+        const char xmldata[] = R"(<def format="2"><markup ext=".cpp" reporterrors="false"/></def>)";
+        settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        check(1, 0,
+              "int main()\n"
+              "{\n"
+              "  int i = *((int*)0);\n"
+              "  return 0;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        settings = settingsOld;
     }
 
     // TODO: test whole program analysis

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -338,6 +338,7 @@ private:
     }
 
     // TODO: test whole program analysis
+    // TODO: test unique errors
 };
 
 class TestSingleExecutorFiles : public TestSingleExecutorBase {

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -154,6 +154,7 @@ private:
         TEST_CASE(showtime_summary);
         TEST_CASE(showtime_file_total);
         TEST_CASE(suppress_error_library);
+        TEST_CASE(unique_errors);
     }
 
     void many_files() {
@@ -335,6 +336,19 @@ private:
               "}");
         ASSERT_EQUALS("", errout.str());
         settings = settingsOld;
+    }
+
+    void unique_errors() {
+        SUPPRESS;
+        ScopedFile inc_h(fprefix() + ".h",
+                         "inline void f()\n"
+                         "{\n"
+                         "  (void)*((int*)0);\n"
+                         "}");
+        check(2, 2,
+              "#include \"" + inc_h.name() + "\"");
+        // these are not actually made unique by the implementation. That needs to be done by the given ErrorLogger
+        ASSERT_EQUALS("[" + inc_h.name() + ":3]: (error) Null pointer dereference: (int*)0\n", errout.str());
     }
 
     // TODO: test whole program analysis

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -150,6 +150,7 @@ private:
         TEST_CASE(showtime_summary);
         TEST_CASE(showtime_file_total);
         TEST_CASE(suppress_error_library);
+        TEST_CASE(unique_errors);
     }
 
     void deadlock_with_many_errors() {
@@ -342,8 +343,20 @@ private:
         settings = settingsOld;
     }
 
+    void unique_errors() {
+        SUPPRESS;
+        ScopedFile inc_h(fprefix() + ".h",
+                         "inline void f()\n"
+                         "{\n"
+                         "  (void)*((int*)0);\n"
+                         "}");
+        check(2, 2, 2,
+              "#include \"" + inc_h.name() +"\"");
+        // this is made unique by the executor
+        ASSERT_EQUALS("[" + inc_h.name() + ":3]: (error) Null pointer dereference: (int*)0\n", errout.str());
+    }
+
     // TODO: test whole program analysis
-    // TODO: test unique errors
 };
 
 class TestThreadExecutorFiles : public TestThreadExecutorBase {

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -343,6 +343,7 @@ private:
     }
 
     // TODO: test whole program analysis
+    // TODO: test unique errors
 };
 
 class TestThreadExecutorFiles : public TestThreadExecutorBase {

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -149,6 +149,7 @@ private:
         TEST_CASE(showtime_file);
         TEST_CASE(showtime_summary);
         TEST_CASE(showtime_file_total);
+        TEST_CASE(suppress_error_library);
     }
 
     void deadlock_with_many_errors() {
@@ -324,6 +325,21 @@ private:
         const std::string output_s = GET_REDIRECT_OUTPUT;
         ASSERT(output_s.find("Check time: " + fprefix() + "_1.cpp: ") != std::string::npos);
         ASSERT(output_s.find("Check time: " + fprefix() + "_2.cpp: ") != std::string::npos);
+    }
+
+    void suppress_error_library() {
+        SUPPRESS;
+        const Settings settingsOld = settings;
+        const char xmldata[] = R"(<def format="2"><markup ext=".cpp" reporterrors="false"/></def>)";
+        settings = settingsBuilder().libraryxml(xmldata, sizeof(xmldata)).build();
+        check(2, 1, 0,
+              "int main()\n"
+              "{\n"
+              "  int i = *((int*)0);\n"
+              "  return 0;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        settings = settingsOld;
     }
 
     // TODO: test whole program analysis


### PR DESCRIPTION
The handling in `CppCheck::reportErr()` and `Executor::hasToLog()` was slightly different. I hope this can somehow be shared after the executor reworking.

We were also using a very inappropriate container for the error list which caused a lot of overhead.

`-D__GNUC__ --debug-warnings --template=daca2 --check-library -j2 ../test/testsymboldatabase.cpp`

Clang 15
main process  `284,218,587` -> `175,691,241`
worker process `9,123,697,183` -> `8,951,903,360`