### PR TITLE
Do not crash on GUI shutdown

### DIFF
--- a/gui/checkthread.h
+++ b/gui/checkthread.h
@@ -24,6 +24,8 @@
 #include "importproject.h"
 #include "suppressions.h"
 
+#include <atomic>
+
 #include <QList>
 #include <QObject>
 #include <QString>
@@ -118,9 +120,9 @@ protected:
     };
 
     /**
-     * @brief Thread's current execution state.
+     * @brief Thread's current execution state. Can be changed from outside
      */
-    State mState = Ready;
+    std::atomic<State> mState{Ready};
 
     ThreadResult &mResult;
     /**

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -148,7 +148,8 @@ void ThreadHandler::setThreadCount(const int count)
 void ThreadHandler::removeThreads()
 {
     for (CheckThread* thread : mThreads) {
-        thread->terminate();
+        thread->quit();
+        thread->wait();
         disconnect(thread, &CheckThread::done,
                    this, &ThreadHandler::threadDone);
         disconnect(thread, &CheckThread::fileChecked,

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -148,8 +148,10 @@ void ThreadHandler::setThreadCount(const int count)
 void ThreadHandler::removeThreads()
 {
     for (CheckThread* thread : mThreads) {
-        thread->quit();
-        thread->wait();
+        if (thread->isRunning()) {
+            thread->terminate();
+            thread->wait();
+        }
         disconnect(thread, &CheckThread::done,
                    this, &ThreadHandler::threadDone);
         disconnect(thread, &CheckThread::fileChecked,


### PR DESCRIPTION
Seems current code for worker threads termination is too brutal which leads to crash on termination:
```
QThread::start: Thread termination error: No such process
Segmentation fault (core dumped)
```
Seems better to use `quit()` and `wait()`, like in an example:  https://doc.qt.io/qt-6/qthread.html#details

tested: Ubuntu Linux 20