### PR TITLE
donate-cpu: fixed #11276 (donate-cpu: Improve library detection) / respect `--no-upload` in "nodata" uploads

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -218,9 +218,10 @@ while True:
     source_path, source_found = lib.unpack_package(work_path, tgz, skip_files=skip_files)
     if not source_found:
         print("No files to process")
-        lib.upload_nodata(package)
-        print('Sleep 5 seconds..')
-        time.sleep(5)
+        if do_upload:
+            lib.upload_nodata(package)
+            print('Sleep 5 seconds..')
+            time.sleep(5)
         continue
     crash = False
     timeout = False

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -15,7 +15,7 @@ import shlex
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.46"
+CLIENT_VERSION = "1.3.47"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -10,6 +10,7 @@ import re
 import signal
 import tarfile
 import shlex
+import copy
 
 
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
@@ -746,7 +747,8 @@ class LibraryIncludes:
         print('Detecting library usage...')
         libraries = ['posix', 'gnu']
 
-        library_includes_re = self.__library_includes_re
+        # explicitly copy as assignments in python are references
+        library_includes_re = copy.copy(self.__library_includes_re)
 
         def has_include(filedata):
             lib_del = []

--- a/tools/test_donate_cpu_lib.py
+++ b/tools/test_donate_cpu_lib.py
@@ -18,8 +18,11 @@
 
 from donate_cpu_lib import *
 
-def _test_library_includes(tmpdir, libs, content):
-    library_includes = LibraryIncludes()
+def _test_library_includes(tmpdir, libs, content, libinc_obj=None):
+    if libinc_obj is None:
+        library_includes = LibraryIncludes()
+    else:
+        library_includes = libinc_obj
 
     src_file = os.path.join(str(tmpdir), "file.cpp")
     with open(src_file, 'w') as f:
@@ -52,3 +55,10 @@ def test_library_includes(tmpdir):
     _test_library_includes(tmpdir, ['posix', 'gnu', 'opengl'], '#include\t  <GL/glut.h>')
     _test_library_includes(tmpdir, ['posix', 'gnu', 'nspr'], '#include\t"prtypes.h"')
     _test_library_includes(tmpdir, ['posix', 'gnu', 'lua'], '#include  \t<lua.h>')
+
+def test_match_multiple_time(tmpdir):
+    libinc = LibraryIncludes()
+
+    # there was a bug that we would only match each library once successfully
+    _test_library_includes(tmpdir, ['posix', 'gnu', 'zlib'], '#include <zlib.h>', libinc)
+    _test_library_includes(tmpdir, ['posix', 'gnu', 'zlib'], '#include <zlib.h>', libinc)


### PR DESCRIPTION
We were only matching each library once as the entry was removed from the container stored in the class as we did not modify a copy but a reference.