### PR TITLE
Add --project= example usage

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1276,6 +1276,9 @@ void CmdLineParser::printHelp()
         "                         or Borland C++ Builder 6 (*.bpr). The files to analyse,\n"
         "                         include paths, defines, platform and undefines in\n"
         "                         the specified file will be used.\n"
+        "                         <file> also defines the configuration(s) that are checked.\n"
+        "                         To increase the number of configurations checked,\n"
+        "                         --force and --max-configs can be used in combination with this option.\n"
         "    --project-configuration=<config>\n"
         "                         If used together with a Visual Studio Solution (*.sln)\n"
         "                         or Visual Studio Project (*.vcxproj) you can limit\n"
@@ -1383,6 +1386,10 @@ void CmdLineParser::printHelp()
     "  # Check f.cpp and search include files from inc1/ and inc2/:\n"
     "  cppcheck -I inc1/ -I inc2/ f.cpp\n"
     "\n"
+    "  # Note that no [files or paths], nor any -I <dir> are needed.\n"
+    "  # Check CMake project (CMake's CMAKE_EXPORT_COMPILE_COMMANDS has to be enabled):\n"
+    "  cppcheck --project=build/compile_command.json\n"
+    "\n"
     "For more information:\n"
     "    " << manualUrl << "\n"
         "\n"
@@ -1390,7 +1397,7 @@ void CmdLineParser::printHelp()
         " * tinyxml2 -- loading project/library/ctu files.\n"
         " * picojson -- loading compile database.\n"
         " * pcre -- rules.\n"
-        " * qt -- used in GUI\n";
+        " * qt -- used in GUI.\n";
 }
 
 bool CmdLineParser::isCppcheckPremium() const {


### PR DESCRIPTION
I am a bit confused about the relationship of --project and --max-configs/--force. 

It it true that, for compile_commands.json, --max-configs=0 is implied?
Multiple configs (Debug, Relese, Win32, ...) are checked for Windows?

I would like to use PR as means to understand it better and improve `cppcheck --help` along the way as I bet that I am not the one confused.