### PR TITLE
Revert "testrunner: use structs with designated initialization to pass options (#4975)"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,10 +35,6 @@ if (BUILD_TESTS)
         target_compile_definitions(testrunner PRIVATE CPPCHECKLIB_IMPORT SIMPLECPP_IMPORT)
         target_link_libraries(testrunner cppcheck-core)
     endif()
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # $ is used in dinit() dessignated initialization helper
-        target_compile_options_safe(testrunner -Wno-dollar-in-identifier-extension)
-    endif()
 
     if (NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
         target_precompile_headers(testrunner PRIVATE precompiled.h)

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -92,31 +92,4 @@ public:
     static std::string getcode(Preprocessor &preprocessor, const std::string &filedata, const std::string &cfg, const std::string &filename, Suppressions *inlineSuppression = nullptr);
 };
 
-/* designated initialization helper
-    Usage:
-    struct S
-    {
-        int i;
-    };
-
-    const auto s = dinit(S,
-        $.i = 1
-    );
- */
-#define dinit(T, ...) \
-    ([&] { T ${}; __VA_ARGS__; return $; }())
-
-#if (defined(__GNUC__) && (__GNUC__ >= 5)) || defined(__clang__)
-// work around Clang compilation error
-// error: default member initializer for 'y' needed within definition of enclosing class 'X' outside of member functions
-// work around GCC compilation error
-// error: default member initializer for ‘x::y::z’ required before the end of its enclosing class
-// see https://stackoverflow.com/questions/53408962
-#define DINIT_NOEXCEPT noexcept
-#else
-// work around GCC 4.8 compilation error
-// error: function 'x()' defaulted on its first declaration with an exception-specification that differs from the implicit declaration 'x()'
-#define DINIT_NOEXCEPT
-#endif
-
 #endif // helpersH

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -61,21 +61,13 @@ private:
         return std::to_string(i);
     }
 
-    struct CheckOptions
-    {
-        CheckOptions() DINIT_NOEXCEPT = default;
-        SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
-        const char* plistOutput = nullptr;
-        std::vector<std::string> filesList;
-    };
-
-    void check(int files, int result, const std::string &data, const CheckOptions &opt = {}) {
+    void check(int files, int result, const std::string &data, SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE, const char* const plistOutput = nullptr, const std::vector<std::string>& filesList = {}) {
         errout.str("");
         output.str("");
         settings.project.fileSettings.clear();
 
         std::map<std::string, std::size_t> filemap;
-        if (opt.filesList.empty()) {
+        if (filesList.empty()) {
             for (int i = 1; i <= files; ++i) {
                 const std::string s = fprefix() + "_" + zpad3(i) + ".cpp";
                 filemap[s] = data.size();
@@ -87,7 +79,7 @@ private:
             }
         }
         else {
-            for (const auto& f : opt.filesList)
+            for (const auto& f : filesList)
             {
                 filemap[f] = data.size();
                 if (useFS) {
@@ -98,9 +90,9 @@ private:
             }
         }
 
-        settings.showtime = opt.showtime;
-        if (opt.plistOutput)
-            settings.plistOutput = opt.plistOutput;
+        settings.showtime = showtime;
+        if (plistOutput)
+            settings.plistOutput = plistOutput;
         // NOLINTNEXTLINE(performance-unnecessary-value-param)
         CppCheck cppcheck(*this, true, [](std::string,std::vector<std::string>,std::string,std::string&){
             return false;
@@ -160,7 +152,7 @@ private:
               "{\n"
               "  char *a = malloc(10);\n"
               "  return 0;\n"
-              "}", dinit(CheckOptions, $.showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY));
+              "}", SHOWTIME_MODES::SHOWTIME_SUMMARY);
     }
 
     void many_files_plist() {
@@ -172,7 +164,7 @@ private:
               "{\n"
               "  char *a = malloc(10);\n"
               "  return 0;\n"
-              "}", dinit(CheckOptions, $.plistOutput = plistOutput));
+              "}", SHOWTIME_MODES::SHOWTIME_NONE, plistOutput);
     }
 
     void no_errors_more_files() {
@@ -233,7 +225,7 @@ private:
               "  char *a = malloc(10);\n"
               "  return 0;\n"
               "}",
-              dinit(CheckOptions, $.filesList = files));
+              SHOWTIME_MODES::SHOWTIME_NONE, nullptr, files);
         // TODO: filter out the "files checked" messages
         ASSERT_EQUALS("Checking " + fprefix() + "_2.cpp ...\n"
                       "1/4 files checked 25% done\n"


### PR DESCRIPTION
This reverts commit 5d201c4e871585d11474d129df483ec201eae316. This causes compile errors on clang++-13:

```
cppcheck/test/testthreadexecutor.cpp:61:110: error: default member initializer for 'showtime' needed within definition of enclosing class 'TestThreadExecutor' outside of member functions
    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                                             ^
cppcheck/test/testthreadexecutor.cpp:52:24: note: default member initializer declared here
        SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
                       ^
cppcheck/test/testthreadexecutor.cpp:61:103: warning: unused parameter 'opt' [-Wunused-parameter]
    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                                      ^
cppcheck/test/testprocessexecutor.cpp:61:110: error: default member initializer for 'showtime' needed within definition of enclosing class 'TestProcessExecutor' outside of member functions
    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                                             ^
cppcheck/test/testprocessexecutor.cpp:52:24: note: default member initializer declared here
        SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
                       ^
cppcheck/test/testprocessexecutor.cpp:61:103: warning: unused parameter 'opt' [-Wunused-parameter]
    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                                      ^
cppcheck/test/testsingleexecutor.cpp:72:91: error: default member initializer for 'showtime' needed within definition of enclosing class 'TestSingleExecutorBase' outside of member functions
    void check(int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                          ^
cppcheck/test/testsingleexecutor.cpp:67:24: note: default member initializer declared here
        SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
                       ^
cppcheck/test/testsingleexecutor.cpp:72:84: warning: unused parameter 'opt' [-Wunused-parameter]
    void check(int files, int result, const std::string &data, const CheckOptions &opt = {}) {
                                                                                   ^
```

I revert this for now, until a better solution can be found.