### PR TITLE
testrunner: fix clang compile error related to `dinit`

### DIFF
--- a/test/helpers.h
+++ b/test/helpers.h
@@ -120,10 +120,11 @@ public:
 #endif
 
 // Default construct object to avoid bug in clang
-struct default_
+// error: default member initializer for 'y' needed within definition of enclosing class 'X' outside of member functions
+struct make_default_obj
 {
     template<class T>
-    operator T() const
+    operator T() const // NOLINT
     {
         return T{};
     }

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -106,21 +106,9 @@ public:
 #define dinit(T, ...) \
     ([&] { T ${}; __VA_ARGS__; return $; }())
 
-#if (defined(__GNUC__) && (__GNUC__ >= 5)) || defined(__clang__)
-// work around Clang compilation error
-// error: default member initializer for 'y' needed within definition of enclosing class 'X' outside of member functions
-// work around GCC compilation error
-// error: default member initializer for ‘x::y::z’ required before the end of its enclosing class
-// see https://stackoverflow.com/questions/53408962
-#define DINIT_NOEXCEPT noexcept
-#else
-// work around GCC 4.8 compilation error
-// error: function 'x()' defaulted on its first declaration with an exception-specification that differs from the implicit declaration 'x()'
-#define DINIT_NOEXCEPT
-#endif
-
 // Default construct object to avoid bug in clang
 // error: default member initializer for 'y' needed within definition of enclosing class 'X' outside of member functions
+// see https://stackoverflow.com/questions/53408962
 struct make_default_obj
 {
     template<class T>

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -119,4 +119,14 @@ public:
 #define DINIT_NOEXCEPT
 #endif
 
+// Default construct object to avoid bug in clang
+struct default_
+{
+    template<class T>
+    operator T() const
+    {
+        return T{};
+    }
+};
+
 #endif // helpersH

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions& opt = make_default_obj{}) {
         errout.str("");
         output.str("");
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = default_{}) {
         errout.str("");
         output.str("");
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -48,7 +48,7 @@ private:
 
     struct CheckOptions
     {
-        CheckOptions() DINIT_NOEXCEPT = default;
+        CheckOptions() = default;
         SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
         const char* plistOutput = nullptr;
         std::vector<std::string> filesList;

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = default_{}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
         errout.str("");
         output.str("");
 

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -63,7 +63,7 @@ private:
 
     struct CheckOptions
     {
-        CheckOptions() DINIT_NOEXCEPT = default;
+        CheckOptions() = default;
         SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
         const char* plistOutput = nullptr;
         std::vector<std::string> filesList;

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -69,7 +69,7 @@ private:
         std::vector<std::string> filesList;
     };
 
-    void check(int files, int result, const std::string &data, const CheckOptions &opt = {}) {
+    void check(int files, int result, const std::string &data, CheckOptions opt = default_{}) {
         errout.str("");
         output.str("");
         settings.project.fileSettings.clear();

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -69,7 +69,7 @@ private:
         std::vector<std::string> filesList;
     };
 
-    void check(int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
+    void check(int files, int result, const std::string &data, const CheckOptions& opt = make_default_obj{}) {
         errout.str("");
         output.str("");
         settings.project.fileSettings.clear();

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -69,7 +69,7 @@ private:
         std::vector<std::string> filesList;
     };
 
-    void check(int files, int result, const std::string &data, CheckOptions opt = default_{}) {
+    void check(int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
         errout.str("");
         output.str("");
         settings.project.fileSettings.clear();

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions& opt = make_default_obj{}) {
         errout.str("");
         output.str("");
 

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, const CheckOptions &opt = {}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = default_{}) {
         errout.str("");
         output.str("");
 

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -48,7 +48,7 @@ private:
 
     struct CheckOptions
     {
-        CheckOptions() DINIT_NOEXCEPT = default;
+        CheckOptions() = default;
         SHOWTIME_MODES showtime = SHOWTIME_MODES::SHOWTIME_NONE;
         const char* plistOutput = nullptr;
         std::vector<std::string> filesList;

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -58,7 +58,7 @@ private:
      * Execute check using n jobs for y files which are have
      * identical data, given within data.
      */
-    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = default_{}) {
+    void check(unsigned int jobs, int files, int result, const std::string &data, CheckOptions opt = make_default_obj{}) {
         errout.str("");
         output.str("");
 


### PR DESCRIPTION
This fixes the compile error introduced in 5d201c4. 