### PR TITLE
removed unnecessary `Settings` parameter from `Check::runChecks()` and made `Tokenizer` a reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ $(libcppdir)/tokenlist.o: lib/tokenlist.cpp externals/simplecpp/simplecpp.h lib/
 $(libcppdir)/utils.o: lib/utils.cpp lib/config.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/utils.cpp
 
-$(libcppdir)/valueflow.o: lib/valueflow.cpp lib/analyzer.h lib/astutils.h lib/calculate.h lib/check.h lib/checkuninitvar.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/forwardanalyzer.h lib/importproject.h lib/infer.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/programmemory.h lib/reverseanalyzer.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenlist.h lib/utils.h lib/valueflow.h lib/valueptr.h lib/vfvalue.h
+$(libcppdir)/valueflow.o: lib/valueflow.cpp lib/analyzer.h lib/astutils.h lib/calculate.h lib/check.h lib/checkuninitvar.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/forwardanalyzer.h lib/importproject.h lib/infer.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/programmemory.h lib/reverseanalyzer.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/valueflow.h lib/valueptr.h lib/vfvalue.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/valueflow.cpp
 
 $(libcppdir)/vfvalue.o: lib/vfvalue.cpp lib/config.h lib/errortypes.h lib/mathlib.h lib/templatesimplifier.h lib/token.h lib/utils.h lib/vfvalue.h

--- a/lib/check.h
+++ b/lib/check.h
@@ -77,7 +77,7 @@ public:
     static std::list<Check *> &instances();
 
     /** run checks, the token list is not simplified */
-    virtual void runChecks(const Tokenizer *, const Settings *, ErrorLogger *) = 0;
+    virtual void runChecks(const Tokenizer &, ErrorLogger *) = 0;
 
     /** get error messages */
     virtual void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const = 0;

--- a/lib/check64bit.h
+++ b/lib/check64bit.h
@@ -24,13 +24,13 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 
 /// @addtogroup Checks
@@ -50,8 +50,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        Check64BitPortability check64BitPortability(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        Check64BitPortability check64BitPortability(&tokenizer, tokenizer.getSettings(), errorLogger);
         check64BitPortability.pointerassignment();
     }
 

--- a/lib/checkassert.h
+++ b/lib/checkassert.h
@@ -24,6 +24,7 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
@@ -31,7 +32,6 @@ class ErrorLogger;
 class Scope;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -48,8 +48,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** run checks, the token list is not simplified */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckAssert checkAssert(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckAssert checkAssert(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkAssert.assertWithSideEffects();
     }
 

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -25,13 +25,13 @@
 #include "check.h"
 #include "config.h"
 #include "errortypes.h"
+#include "tokenize.h"
 
 #include <string>
 #include <set>
 
 class Settings;
 class Token;
-class Tokenizer;
 class ErrorLogger;
 class Variable;
 
@@ -54,8 +54,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckAutoVariables checkAutoVariables(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckAutoVariables checkAutoVariables(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkAutoVariables.assignFunctionArg();
         checkAutoVariables.checkVarLifetime();
         checkAutoVariables.autoVariables();

--- a/lib/checkbool.h
+++ b/lib/checkbool.h
@@ -24,13 +24,13 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -48,8 +48,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckBool checkBool(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckBool checkBool(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // Checks
         checkBool.checkComparisonOfBoolExpressionWithInt();

--- a/lib/checkboost.h
+++ b/lib/checkboost.h
@@ -47,11 +47,11 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (!tokenizer->isCPP())
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (!tokenizer.isCPP())
             return;
 
-        CheckBoost checkBoost(tokenizer, settings, errorLogger);
+        CheckBoost checkBoost(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkBoost.checkBoostForeachModification();
     }
 

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -28,6 +28,7 @@
 #include "errortypes.h"
 #include "mathlib.h"
 #include "symboldatabase.h"
+#include "tokenize.h"
 #include "vfvalue.h"
 
 #include <list>
@@ -42,7 +43,6 @@ namespace tinyxml2 {
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -66,8 +66,8 @@ public:
     CheckBufferOverrun(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckBufferOverrun checkBufferOverrun(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckBufferOverrun checkBufferOverrun(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkBufferOverrun.arrayIndex();
         checkBufferOverrun.pointerArithmetic();
         checkBufferOverrun.bufferOverflow();

--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -59,11 +59,11 @@ public:
     CheckClass(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger);
 
     /** @brief Run checks on the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (tokenizer->isC())
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (tokenizer.isC())
             return;
 
-        CheckClass checkClass(tokenizer, settings, errorLogger);
+        CheckClass checkClass(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // can't be a simplified check .. the 'sizeof' is used.
         checkClass.checkMemset();

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -26,13 +26,13 @@
 #include "config.h"
 #include "mathlib.h"
 #include "errortypes.h"
+#include "tokenize.h"
 
 #include <set>
 #include <string>
 
 class Settings;
 class Token;
-class Tokenizer;
 class ErrorLogger;
 class ValueType;
 
@@ -56,8 +56,8 @@ public:
     CheckCondition(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckCondition checkCondition(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckCondition checkCondition(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkCondition.multiCondition();
         checkCondition.clarifyCondition();   // not simplified because ifAssign
         checkCondition.multiCondition2();

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -53,11 +53,11 @@ public:
     CheckExceptionSafety(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (tokenizer->isC())
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (tokenizer.isC())
             return;
 
-        CheckExceptionSafety checkExceptionSafety(tokenizer, settings, errorLogger);
+        CheckExceptionSafety checkExceptionSafety(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkExceptionSafety.destructors();
         checkExceptionSafety.deallocThrow();
         checkExceptionSafety.checkRethrowCopy();

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -27,13 +27,13 @@
 #include "errortypes.h"
 #include "library.h"
 #include "settings.h"
+#include "tokenize.h"
 
 #include <map>
 #include <string>
 #include <utility>
 
 class Token;
-class Tokenizer;
 class ErrorLogger;
 
 namespace ValueFlow {
@@ -58,8 +58,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckFunctions checkFunctions(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckFunctions checkFunctions(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         checkFunctions.checkIgnoredReturnValue();
         checkFunctions.checkMissingReturn();  // Missing "return" in exit path

--- a/lib/checkinternal.h
+++ b/lib/checkinternal.h
@@ -26,12 +26,12 @@
 #include "config.h"
 #include "errortypes.h"
 #include "settings.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -47,11 +47,11 @@ public:
     CheckInternal(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (!settings->checks.isEnabled(Checks::internalCheck))
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (!tokenizer.getSettings()->checks.isEnabled(Checks::internalCheck))
             return;
 
-        CheckInternal checkInternal(tokenizer, settings, errorLogger);
+        CheckInternal checkInternal(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         checkInternal.checkTokenMatchPatterns();
         checkInternal.checkTokenSimpleMatchPatterns();

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -24,6 +24,7 @@
 #include "check.h"
 #include "config.h"
 #include "errortypes.h"
+#include "tokenize.h"
 
 #include <ostream>
 #include <string>
@@ -31,7 +32,6 @@
 class Function;
 class Settings;
 class Token;
-class Tokenizer;
 class Variable;
 class ErrorLogger;
 
@@ -49,8 +49,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks on the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckIO checkIO(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckIO checkIO(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         checkIO.checkWrongPrintfScanfArguments();
         checkIO.checkCoutCerrMisusage();

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -25,6 +25,7 @@
 #include "check.h"
 #include "config.h"
 #include "library.h"
+#include "tokenize.h"
 
 #include <map>
 #include <set>
@@ -34,7 +35,6 @@
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 
 class CPPCHECKLIB VarInfo {
@@ -115,8 +115,8 @@ public:
     CheckLeakAutoVar(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckLeakAutoVar checkLeakAutoVar(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckLeakAutoVar checkLeakAutoVar(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkLeakAutoVar.check();
     }
 

--- a/lib/checkmemoryleak.h
+++ b/lib/checkmemoryleak.h
@@ -172,8 +172,8 @@ public:
     CheckMemoryLeakInFunction(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckMemoryLeakInFunction checkMemoryLeak(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckMemoryLeakInFunction checkMemoryLeak(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkMemoryLeak.checkReallocUsage();
     }
 
@@ -224,11 +224,11 @@ public:
     CheckMemoryLeakInClass(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizr, const Settings *settings, ErrorLogger *errLog) override {
-        if (!tokenizr->isCPP())
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (!tokenizer.isCPP())
             return;
 
-        CheckMemoryLeakInClass checkMemoryLeak(tokenizr, settings, errLog);
+        CheckMemoryLeakInClass checkMemoryLeak(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkMemoryLeak.check();
     }
 
@@ -269,8 +269,8 @@ public:
     CheckMemoryLeakStructMember(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckMemoryLeakStructMember checkMemoryLeak(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckMemoryLeakStructMember checkMemoryLeak(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkMemoryLeak.check();
     }
 
@@ -305,8 +305,8 @@ public:
     CheckMemoryLeakNoVar(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger), CheckMemoryLeak(tokenizer, errorLogger, settings) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckMemoryLeakNoVar checkMemoryLeak(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckMemoryLeakNoVar checkMemoryLeak(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkMemoryLeak.check();
     }
 

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -25,6 +25,7 @@
 #include "check.h"
 #include "config.h"
 #include "ctu.h"
+#include "tokenize.h"
 #include "vfvalue.h"
 
 #include <list>
@@ -34,7 +35,6 @@ class ErrorLogger;
 class Library;
 class Settings;
 class Token;
-class Tokenizer;
 
 namespace tinyxml2 {
     class XMLElement;
@@ -56,8 +56,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckNullPointer checkNullPointer(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckNullPointer checkNullPointer(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkNullPointer.nullPointer();
         checkNullPointer.arithmetic();
         checkNullPointer.nullConstantDereference();

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -25,6 +25,7 @@
 #include "check.h"
 #include "config.h"
 #include "errortypes.h"
+#include "tokenize.h"
 
 #include <string>
 #include <vector>
@@ -35,7 +36,6 @@ namespace ValueFlow {
 
 class Settings;
 class Token;
-class Tokenizer;
 class Function;
 class Variable;
 class ErrorLogger;
@@ -56,8 +56,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckOther checkOther(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckOther checkOther(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // Checks
         checkOther.warningOldStylePointerCast();

--- a/lib/checkpostfixoperator.h
+++ b/lib/checkpostfixoperator.h
@@ -48,11 +48,11 @@ public:
     CheckPostfixOperator(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (tokenizer->isC())
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (tokenizer.isC())
             return;
 
-        CheckPostfixOperator checkPostfixOperator(tokenizer, settings, errorLogger);
+        CheckPostfixOperator checkPostfixOperator(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkPostfixOperator.postfixOperator();
     }
 

--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -24,13 +24,13 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -48,8 +48,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer* tokenizer, const Settings* settings, ErrorLogger* errorLogger) override {
-        CheckSizeof checkSizeof(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer& tokenizer, ErrorLogger* errorLogger) override {
+        CheckSizeof checkSizeof(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // Checks
         checkSizeof.sizeofsizeof();

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -52,12 +52,12 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** run checks, the token list is not simplified */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        if (!tokenizer->isCPP()) {
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        if (!tokenizer.isCPP()) {
             return;
         }
 
-        CheckStl checkStl(tokenizer, settings, errorLogger);
+        CheckStl checkStl(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkStl.erase();
         checkStl.if_find();
         checkStl.checkFindInsert();

--- a/lib/checkstring.h
+++ b/lib/checkstring.h
@@ -24,13 +24,13 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -48,8 +48,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckString checkString(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckString checkString(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // Checks
         checkString.strPlusChar();

--- a/lib/checktype.h
+++ b/lib/checktype.h
@@ -24,6 +24,7 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 #include "vfvalue.h"
 
 #include <list>
@@ -32,7 +33,6 @@
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 class ValueType;
 
 /// @addtogroup Checks
@@ -51,9 +51,9 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
         // These are not "simplified" because casts can't be ignored
-        CheckType checkType(tokenizer, settings, errorLogger);
+        CheckType checkType(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkType.checkTooBigBitwiseShift();
         checkType.checkIntegerOverflow();
         checkType.checkSignConversion();

--- a/lib/checkuninitvar.h
+++ b/lib/checkuninitvar.h
@@ -27,6 +27,7 @@
 #include "ctu.h"
 #include "mathlib.h"
 #include "errortypes.h"
+#include "tokenize.h"
 #include "vfvalue.h"
 
 #include <list>
@@ -36,7 +37,6 @@
 
 class Scope;
 class Token;
-class Tokenizer;
 class Variable;
 class ErrorLogger;
 class Settings;
@@ -69,8 +69,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckUninitVar checkUninitVar(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckUninitVar checkUninitVar(&tokenizer, tokenizer.getSettings(), errorLogger);
         checkUninitVar.valueFlowUninit();
         checkUninitVar.check();
     }

--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -84,7 +84,7 @@ private:
         CheckUnusedFunctions::unusedFunctionError(errorLogger, emptyString, 0, "funcName");
     }
 
-    void runChecks(const Tokenizer * /*tokenizer*/, const Settings * /*settings*/, ErrorLogger * /*errorLogger*/) override {}
+    void runChecks(const Tokenizer & /*tokenizer*/, ErrorLogger * /*errorLogger*/) override {}
 
     /**
      * Dummy implementation, just to provide error for --errorlist

--- a/lib/checkunusedvar.h
+++ b/lib/checkunusedvar.h
@@ -23,6 +23,7 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <list>
 #include <map>
@@ -32,7 +33,6 @@ class ErrorLogger;
 class Scope;
 class Settings;
 class Token;
-class Tokenizer;
 class Type;
 class Variables;
 class Variable;
@@ -54,8 +54,8 @@ public:
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
     /** @brief Run checks against the normal token list */
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckUnusedVar checkUnusedVar(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckUnusedVar checkUnusedVar(&tokenizer, tokenizer.getSettings(), errorLogger);
 
         // Coding style checks
         checkUnusedVar.checkStructMemberUsage();

--- a/lib/checkvaarg.h
+++ b/lib/checkvaarg.h
@@ -24,13 +24,13 @@
 
 #include "check.h"
 #include "config.h"
+#include "tokenize.h"
 
 #include <string>
 
 class ErrorLogger;
 class Settings;
 class Token;
-class Tokenizer;
 
 /// @addtogroup Checks
 /// @{
@@ -46,8 +46,8 @@ public:
     CheckVaarg(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
         : Check(myName(), tokenizer, settings, errorLogger) {}
 
-    void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger) override {
-        CheckVaarg check(tokenizer, settings, errorLogger);
+    void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger) override {
+        CheckVaarg check(&tokenizer, tokenizer.getSettings(), errorLogger);
         check.va_start_argument();
         check.va_list_usage();
     }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1096,7 +1096,7 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
             continue;
 
         Timer timerRunChecks(check->name() + "::runChecks", mSettings.showtime, &s_timerResults);
-        check->runChecks(&tokenizer, &mSettings, this);
+        check->runChecks(tokenizer, this);
     }
 
     if (mSettings.clang)

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -124,10 +124,10 @@ protected:
     }
 
     template<typename T>
-    static void runChecks(const Tokenizer *tokenizer, const Settings *settings, ErrorLogger *errorLogger)
+    static void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger)
     {
         T& check = getCheck<T>();
-        check.runChecks(tokenizer, settings, errorLogger);
+        check.runChecks(tokenizer, errorLogger);
     }
 
     class SettingsBuilder

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -44,7 +44,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check..
-        runChecks<CheckAssert>(&tokenizer, &settings, this);
+        runChecks<CheckAssert>(tokenizer, this);
     }
 
     void run() override {

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -44,7 +44,7 @@ private:
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
-        runChecks<CheckAutoVariables>(&tokenizer, &settings1, this);
+        runChecks<CheckAutoVariables>(tokenizer, this);
     }
 
     void run() override {

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -87,7 +87,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check...
-        runChecks<CheckBool>(&tokenizer, &settings, this);
+        runChecks<CheckBool>(tokenizer, this);
     }
 
 

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -47,7 +47,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        runChecks<CheckBoost>(&tokenizer, &settings, this);
+        runChecks<CheckBoost>(tokenizer, this);
     }
 
     void BoostForeachContainerModification() {

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -56,7 +56,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check for buffer overruns..
-        runChecks<CheckBufferOverrun>(&tokenizer, &settings, this);
+        runChecks<CheckBufferOverrun>(tokenizer, this);
     }
 
     void check_(const char* file, int line, const char code[], const Settings &settings, const char filename[] = "test.cpp") {
@@ -68,7 +68,7 @@ private:
         errout.str("");
 
         // Check for buffer overruns..
-        runChecks<CheckBufferOverrun>(&tokenizer, &settings, this);
+        runChecks<CheckBufferOverrun>(tokenizer, this);
     }
 
     void checkP(const char code[], const char* filename = "test.cpp")
@@ -95,7 +95,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Check for buffer overruns..
-        runChecks<CheckBufferOverrun>(&tokenizer, &settings, this);
+        runChecks<CheckBufferOverrun>(tokenizer, this);
     }
 
     void run() override {

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -150,7 +150,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Run checks..
-        runChecks<CheckCondition>(&tokenizer, &settings, this);
+        runChecks<CheckCondition>(tokenizer, this);
     }
 
     void check(const char code[], const char* filename = "test.cpp", bool inconclusive = false) {
@@ -554,7 +554,7 @@ private:
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        runChecks<CheckCondition>(&tokenizer, &settings1, this);
+        runChecks<CheckCondition>(tokenizer, this);
     }
 
     void overlappingElseIfCondition() {

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -71,7 +71,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check char variable usage..
-        runChecks<CheckExceptionSafety>(&tokenizer, &settings1, this);
+        runChecks<CheckExceptionSafety>(tokenizer, this);
     }
 
     void destructors() {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -127,7 +127,7 @@ private:
                 errout << errline << "\n";
         }
 
-        runChecks<CheckFunctions>(&tokenizer, settings_, this);
+        runChecks<CheckFunctions>(tokenizer, this);
     }
 
     void prohibitedFunctions_posix() {

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -296,7 +296,7 @@ private:
 
         // call all "runChecks" in all registered Check classes
         for (std::list<Check *>::const_iterator it = Check::instances().cbegin(); it != Check::instances().cend(); ++it) {
-            (*it)->runChecks(&tokenizer, &settings, this);
+            (*it)->runChecks(tokenizer, this);
         }
 
         return tokenizer.tokens()->stringifyList(false, false, false, true, false, nullptr, nullptr);

--- a/test/testinternal.cpp
+++ b/test/testinternal.cpp
@@ -59,7 +59,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        runChecks<CheckInternal>(&tokenizer, &settings, this);
+        runChecks<CheckInternal>(tokenizer, this);
     }
 
     void simplePatternInTokenMatch() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -242,7 +242,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, cpp ? "test.cpp" : "test.c"), file, line);
 
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings1, this);
+        runChecks<CheckLeakAutoVar>(tokenizer, this);
     }
 
     void check_(const char* file, int line, const char code[], const Settings & s) {
@@ -257,7 +257,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings0, this);
+        runChecks<CheckLeakAutoVar>(tokenizer, this);
     }
 
     void assign1() {
@@ -2847,7 +2847,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
+        runChecks<CheckLeakAutoVar>(tokenizer, this);
     }
 
     void run() override {
@@ -2893,7 +2893,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
+        runChecks<CheckLeakAutoVar>(tokenizer, this);
     }
 
     void run() override {
@@ -2953,7 +2953,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.c"), file, line);
 
         // Check for leaks..
-        runChecks<CheckLeakAutoVar>(&tokenizer, &settings, this);
+        runChecks<CheckLeakAutoVar>(tokenizer, this);
     }
 
     void run() override {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -189,7 +189,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
+        runChecks<CheckNullPointer>(tokenizer, this);
     }
 
     void checkP(const char code[]) {
@@ -214,7 +214,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Check for null pointer dereferences..
-        runChecks<CheckNullPointer>(&tokenizer, &settings1, this);
+        runChecks<CheckNullPointer>(tokenizer, this);
     }
 
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -317,7 +317,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename ? filename : "test.cpp"), file, line);
 
         // Check..
-        runChecks<CheckOther>(&tokenizer, settings, this);
+        runChecks<CheckOther>(tokenizer, this);
 
         (void)runSimpleChecks; // TODO Remove this
     }
@@ -358,7 +358,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Check..
-        runChecks<CheckOther>(&tokenizer, settings, this);
+        runChecks<CheckOther>(tokenizer, this);
     }
 
     void checkInterlockedDecrement(const char code[]) {

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -62,7 +62,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check...
-        runChecks<CheckSizeof>(&tokenizer, &settings, this);
+        runChecks<CheckSizeof>(tokenizer, this);
     }
 
     void checkP(const char code[]) {
@@ -85,7 +85,7 @@ private:
         tokenizer.simplifyTokens1("");
 
         // Check...
-        runChecks<CheckSizeof>(&tokenizer, &settings, this);
+        runChecks<CheckSizeof>(tokenizer, this);
     }
 
     void sizeofsizeof() {

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -188,7 +188,7 @@ private:
 
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
-        runChecks<CheckStl>(&tokenizer, &settings1, this);
+        runChecks<CheckStl>(tokenizer, this);
     }
 
     void check_(const char* file, int line, const std::string& code, const bool inconclusive = false) {
@@ -206,7 +206,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        runChecks<CheckStl>(&tokenizer, &settings, this);
+        runChecks<CheckStl>(tokenizer, this);
     }
 
     void outOfBounds() {

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -71,7 +71,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check char variable usage..
-        runChecks<CheckString>(&tokenizer, &settings, this);
+        runChecks<CheckString>(tokenizer, this);
     }
 
     void stringLiteralWrite() {

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -56,7 +56,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
         // Check..
-        runChecks<CheckType>(&tokenizer, &settings1, this);
+        runChecks<CheckType>(tokenizer, this);
     }
 
     void checkTooBigShift_Unix32() {

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -43,7 +43,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        runChecks<CheckVaarg>(&tokenizer, &settings, this);
+        runChecks<CheckVaarg>(tokenizer, this);
     }
 
     void run() override {


### PR DESCRIPTION
There was no need for the `Tokenizer` parameter to be a pointer as it could never be `nullptr` and was also dereferenced without checking first.

As a reference to the `Settings` was already available via the `Tokenizer` there was no need to pass it separately. In the production code there will only be one instance of it but in the tests we could have accidentally passed a different one.