### PR TITLE
Fix FP badBitmaskCheck in nested binary expressions

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -290,6 +290,17 @@ static bool inBooleanFunction(const Token *tok)
     return false;
 }
 
+static bool isOperandExpanded(const Token *tok)
+{
+    if (tok->isExpandedMacro() || tok->isEnumerator())
+        return true;
+    if (tok->astOperand1() && isOperandExpanded(tok->astOperand1()))
+        return true;
+    if (tok->astOperand2() && isOperandExpanded(tok->astOperand2()))
+        return true;
+    return false;
+}
+
 void CheckCondition::checkBadBitmaskCheck()
 {
     if (!mSettings->severity.isEnabled(Severity::style))
@@ -320,9 +331,6 @@ void CheckCondition::checkBadBitmaskCheck()
             if (!isZero1 && !isZero2)
                 continue;
 
-            auto isOperandExpanded = [](const Token *op) {
-                return op->isExpandedMacro() || op->isEnumerator();
-            };
             if (!tok->isExpandedMacro() &&
                 !(isZero1 && isOperandExpanded(tok->astOperand1())) &&
                 !(isZero2 && isOperandExpanded(tok->astOperand2())))

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -916,6 +916,11 @@ private:
               "int x = PC0   | UNARY;\n"
               "int y = UNARY | PC0;\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("#define MASK 0\n"
+              "#define SHIFT 1\n"
+              "int x = 1 | (MASK << SHIFT);\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
 


### PR DESCRIPTION
If one operand is another binary expression, recursively ensure that no nested operands are expanded macros.