### PR TITLE
Add special function to match lifetimes

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -710,7 +710,9 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                         if (!suppressErrors && Token::Match(tok, "%name% . %name%") && tok->strAt(2) == membervar && Token::Match(tok->next()->astParent(), "%cop%|return|throw|?"))
                             uninitStructMemberError(tok, tok->str() + "." + membervar);
                         else if (mTokenizer->isCPP() && !suppressErrors && Token::Match(tok, "%name%") && Token::Match(tok->astParent(), "return|throw|?")) {
-                            if (std::any_of(tok->values().cbegin(), tok->values().cend(), std::mem_fn(&ValueFlow::Value::isUninitValue)))
+                            if (std::any_of(tok->values().cbegin(), tok->values().cend(), [](const ValueFlow::Value& v) {
+                                return v.isUninitValue() && !v.isInconclusive();
+                            }))
                                 uninitStructMemberError(tok, tok->str() + "." + membervar);
                         }
                     }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2829,7 +2829,8 @@ struct ValueFlowAnalyzer : Analyzer {
                 if (inconclusiveRef && a.isModified())
                     return Action::Inconclusive;
                 return a;
-            } else if (la.isRead()) {
+            } 
+            if (la.isRead()) {
                 return isAliasModified(tok);
             }
             return Action::None;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2429,16 +2429,16 @@ struct ValueFlowAnalyzer : Analyzer {
         return settings;
     }
 
-    Action matchLifetime(const Token* tok) const
+    Action analyzeLifetime(const Token* tok) const
     {
         if (!tok)
             return Action::None;
         if (match(tok))
             return Action::Match;
-        if (Token::simpleMatch(tok, ".") && matchLifetime(tok->astOperand1()) != Action::None)
+        if (Token::simpleMatch(tok, ".") && analyzeLifetime(tok->astOperand1()) != Action::None)
             return Action::Read;
         if (astIsRHS(tok) && Token::simpleMatch(tok->astParent(), "."))
-            return matchLifetime(tok->astParent());
+            return analyzeLifetime(tok->astParent());
         return Action::None;
     }
 
@@ -2817,7 +2817,7 @@ struct ValueFlowAnalyzer : Analyzer {
             }
             if (!lifeTok)
                 return Action::None;
-            Action la = matchLifetime(lifeTok);
+            Action la = analyzeLifetime(lifeTok);
             if (la.matches()) {
                 Action a = Action::Read;
                 if (isModified(tok).isModified())

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2429,7 +2429,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return settings;
     }
 
-    bool matchEqual(const Token* tok) const {
+    bool matchLifetime(const Token* tok) const {
         if (match(tok))
             return true;
         if(astIsRHS(tok) && Token::simpleMatch(tok->astParent(), "."))
@@ -2810,7 +2810,7 @@ struct ValueFlowAnalyzer : Analyzer {
                     return Action::None;
                 lifeTok = v.tokvalue;
             }
-            if (lifeTok && matchEqual(lifeTok)) {
+            if (lifeTok && matchLifetime(lifeTok)) {
                 Action a = Action::Read;
                 if (isModified(tok).isModified())
                     a = Action::Invalid;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -641,9 +641,10 @@ static void setTokenValue(Token* tok,
         }
     }
 
-    if (Token::simpleMatch(parent, "=") && astIsRHS(tok) && !value.isLifetimeValue()) {
+    if (Token::simpleMatch(parent, "=") && astIsRHS(tok)) {
         setTokenValue(parent, std::move(value), settings);
-        return;
+        if (!value.isUninitValue())
+            return;
     }
 
     if (value.isContainerSizeValue() && astIsContainer(tok)) {
@@ -3342,6 +3343,8 @@ static std::string lifetimeType(const Token *tok, const ValueFlow::Value *val)
     case ValueFlow::Value::LifetimeKind::SubObject:
     case ValueFlow::Value::LifetimeKind::Address:
         if (astIsPointer(tok))
+            result = "pointer";
+        else if (Token::simpleMatch(tok, "=") && astIsPointer(tok->astOperand2()))
             result = "pointer";
         else
             result = "object";

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2429,6 +2429,7 @@ struct ValueFlowAnalyzer : Analyzer {
         return settings;
     }
 
+    // Returns Action::Match if its an exact match, return Action::Read if it partially matches the lifetime
     Action analyzeLifetime(const Token* tok) const
     {
         if (!tok)

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -642,7 +642,7 @@ static void setTokenValue(Token* tok,
     }
 
     if (Token::simpleMatch(parent, "=") && astIsRHS(tok)) {
-        setTokenValue(parent, std::move(value), settings);
+        setTokenValue(parent, value, settings);
         if (!value.isUninitValue())
             return;
     }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2829,7 +2829,7 @@ struct ValueFlowAnalyzer : Analyzer {
                 if (inconclusiveRef && a.isModified())
                     return Action::Inconclusive;
                 return a;
-            } 
+            }
             if (la.isRead()) {
                 return isAliasModified(tok);
             }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7973,7 +7973,6 @@ static void valueFlowUninit(TokenList& tokenlist, const Settings* settings)
         Token* start = findStartToken(var, tok->next(), &settings->library);
 
         std::map<Token*, ValueFlow::Value> partialReads;
-        Analyzer::Result result;
         if (const Scope* scope = var->typeScope()) {
             if (Token::findsimplematch(scope->bodyStart, "union", scope->bodyEnd))
                 continue;
@@ -7988,7 +7987,7 @@ static void valueFlowUninit(TokenList& tokenlist, const Settings* settings)
                     continue;
                 }
                 MemberExpressionAnalyzer analyzer(memVar.nameToken()->str(), tok, uninitValue, tokenlist, settings);
-                result = valueFlowGenericForward(start, tok->scope()->bodyEnd, analyzer, *settings);
+                valueFlowGenericForward(start, tok->scope()->bodyEnd, analyzer, *settings);
 
                 for (auto&& p : *analyzer.partialReads) {
                     Token* tok2 = p.first;
@@ -8018,8 +8017,7 @@ static void valueFlowUninit(TokenList& tokenlist, const Settings* settings)
         if (partial)
             continue;
 
-        if (result.terminate != Analyzer::Terminate::Modified)
-            valueFlowForward(start, tok->scope()->bodyEnd, var->nameToken(), uninitValue, tokenlist, settings);
+        valueFlowForward(start, tok->scope()->bodyEnd, var->nameToken(), uninitValue, tokenlist, settings);
     }
 }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2429,6 +2429,14 @@ struct ValueFlowAnalyzer : Analyzer {
         return settings;
     }
 
+    bool matchEqual(const Token* tok) const {
+        if (match(tok))
+            return true;
+        if(astIsRHS(tok) && Token::simpleMatch(tok->astParent(), "."))
+            return match(tok->astParent());
+        return false;
+    }
+
     struct ConditionState {
         bool dependent = true;
         bool unknown = true;
@@ -2802,7 +2810,7 @@ struct ValueFlowAnalyzer : Analyzer {
                     return Action::None;
                 lifeTok = v.tokvalue;
             }
-            if (lifeTok && match(lifeTok)) {
+            if (lifeTok && matchEqual(lifeTok)) {
                 Action a = Action::Read;
                 if (isModified(tok).isModified())
                     a = Action::Invalid;
@@ -3294,12 +3302,6 @@ struct MemberExpressionAnalyzer : SubExpressionAnalyzer {
     MemberExpressionAnalyzer(std::string varname, const Token* e, ValueFlow::Value val, const TokenList& t, const Settings* s)
         : SubExpressionAnalyzer(e, std::move(val), t, s), varname(std::move(varname))
     {}
-
-    bool match(const Token* tok) const override
-    {
-        return SubExpressionAnalyzer::match(tok) ||
-               (Token::simpleMatch(tok->astParent(), ".") && SubExpressionAnalyzer::match(tok->astParent()));
-    }
 
     bool submatch(const Token* tok, bool exact) const override
     {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2429,10 +2429,11 @@ struct ValueFlowAnalyzer : Analyzer {
         return settings;
     }
 
-    bool matchLifetime(const Token* tok) const {
+    bool matchLifetime(const Token* tok) const
+    {
         if (match(tok))
             return true;
-        if(astIsRHS(tok) && Token::simpleMatch(tok->astParent(), "."))
+        if (astIsRHS(tok) && Token::simpleMatch(tok->astParent(), "."))
             return match(tok->astParent());
         return false;
     }

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -6925,7 +6925,7 @@ private:
                         "    int a = ab.a;\n"
                         "    int b = ab.b;\n"
                         "}");
-        TODO_ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: ab.b\n", "", errout.str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: ab.b\n", errout.str());
 
         // STL class member
         valueFlowUninit("struct A {\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -7009,8 +7009,7 @@ private:
                         "    memcpy(in, s, sizeof(S));\n"
                         "    s->p = NULL;\n"
                         "}\n");
-        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: s\n",
-                      errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: s\n", errout.str());
 
         valueFlowUninit("struct S {\n" // #11321
                         "    int a = 0;\n"

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -6181,7 +6181,7 @@ private:
                         "    memcpy(wcsin, x, sizeof(wcsstruct));\n" // <- warning
                         "    x->wcsprm = NULL;\n" // <- no warning
                         "}");
-        ASSERT_EQUALS("[test.cpp:7]: (error) Uninitialized variable: x.wcsprm\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:7]: (error) Uninitialized variable: x\n", errout.str());
 
         valueFlowUninit("struct wcsstruct {\n"
                         "    int *wcsprm;\n"
@@ -6897,7 +6897,7 @@ private:
                         "    int a = ab.a;\n"
                         "    int b = ab.b;\n"
                         "}");
-        ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: ab.b\n", errout.str());
+        TODO_ASSERT_EQUALS("[test.cpp:5]: (error) Uninitialized variable: ab.b\n", "", errout.str());
 
         // STL class member
         valueFlowUninit("struct A {\n"
@@ -7009,7 +7009,7 @@ private:
                         "    memcpy(in, s, sizeof(S));\n"
                         "    s->p = NULL;\n"
                         "}\n");
-        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: s.p\n",
+        ASSERT_EQUALS("[test.cpp:4]: (error) Uninitialized variable: s\n",
                       errout.str());
 
         valueFlowUninit("struct S {\n" // #11321
@@ -7270,7 +7270,7 @@ private:
                         "    A::B b;\n"
                         "    x.push_back(b);\n"
                         "}\n");
-        ASSERT_EQUALS("[test.cpp:9]: (error) Uninitialized variable: b.i\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:9]: (error) Uninitialized variable: b\n", errout.str());
 
         valueFlowUninit("struct A {\n"
                         "    struct B {\n"
@@ -7294,7 +7294,7 @@ private:
                         "    A a;\n"
                         "    x.push_back(a);\n"
                         "}\n");
-        ASSERT_EQUALS("[test.cpp:9]: (error) Uninitialized variable: a.j\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:9]: (error) Uninitialized variable: a\n", errout.str());
 
         valueFlowUninit("struct S { struct T { int* p; } t[2]; };\n" // #11018
                         "void f() {\n"


### PR DESCRIPTION
This also removes the termination checking in `valueFlowUninit` as this causes a lot of FNs.