### PR TITLE
CmdLineParser: deprecated `--template <template>` and `--template-location <template>`

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -899,7 +899,6 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 }
             }
 
-            // TODO: deprecate "--template <template>"
             // Output formatter
             else if (std::strcmp(argv[i], "--template") == 0 ||
                      std::strncmp(argv[i], "--template=", 11) == 0) {
@@ -907,6 +906,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (argv[i][10] == '=')
                     mSettings.templateFormat = argv[i] + 11;
                 else if ((i+1) < argc && argv[i+1][0] != '-') {
+                    printMessage("'--template <template>' is deprecated and will be removed in 2.13 - please use '--template=<template>' instead");
                     ++i;
                     mSettings.templateFormat = argv[i];
                 } else {
@@ -935,13 +935,13 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 }
             }
 
-            // TODO: deprecate "--template-location <template>"
             else if (std::strcmp(argv[i], "--template-location") == 0 ||
                      std::strncmp(argv[i], "--template-location=", 20) == 0) {
                 // "--template-location format"
                 if (argv[i][19] == '=')
                     mSettings.templateLocation = argv[i] + 20;
                 else if ((i+1) < argc && argv[i+1][0] != '-') {
+                    printMessage("'--template-location <template>' is deprecated and will be removed in 2.13 - please use '--template-location=<template>' instead");
                     ++i;
                     mSettings.templateLocation = argv[i];
                 } else {

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -1,4 +1,4 @@
-release notes for cppcheck-2.12
+Release Notes for Cppcheck 2.12
 
 New checks:
 - uselessOverride finds overriding functions that either duplicate code from or delegate back to the base class implementation
@@ -14,6 +14,8 @@ Changed interface:
 
 Deprecations:
 - The qmake build system has been deprecated and will be removed in a future version.
+- Command-line option '--template <template>' is deprecated and will be removed in 2.13 - please use '--template=<template>' instead.
+- Command-line option '--template-location <template>' is deprecated and will be removed in 2.13 - please use '--template-location=<template>' instead.
 
 Other:
 - "USE_QT6=On" will no longer fallback to Qt5 when Qt6 is not found.

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -1335,10 +1335,10 @@ private:
 
     void templates() {
         REDIRECT;
-        const char * const argv[] = {"cppcheck", "--template", "{file}:{line},{severity},{id},{message}", "--template-location={file}:{line}:{column} {info}", "file.cpp"};
+        const char * const argv[] = {"cppcheck", "--template={file}:{line},{severity},{id},{message}", "--template-location={file}:{line}:{column} {info}", "file.cpp"};
         settings->templateFormat.clear();
         settings->templateLocation.clear();
-        ASSERT(parser->parseFromArgs(5, argv));
+        ASSERT(parser->parseFromArgs(4, argv));
         ASSERT_EQUALS("{file}:{line},{severity},{id},{message}", settings->templateFormat);
         ASSERT_EQUALS("{file}:{line}:{column} {info}", settings->templateLocation);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
@@ -1346,10 +1346,10 @@ private:
 
     void templatesGcc() {
         REDIRECT;
-        const char * const argv[] = {"cppcheck", "--template", "gcc", "file.cpp"};
+        const char * const argv[] = {"cppcheck", "--template=gcc", "file.cpp"};
         settings->templateFormat.clear();
         settings->templateLocation.clear();
-        ASSERT(parser->parseFromArgs(4, argv));
+        ASSERT(parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("{file}:{line}:{column}: warning: {message} [{id}]\n{code}", settings->templateFormat);
         ASSERT_EQUALS("{file}:{line}:{column}: note: {info}\n{code}", settings->templateLocation);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
@@ -1357,10 +1357,10 @@ private:
 
     void templatesVs() {
         REDIRECT;
-        const char * const argv[] = {"cppcheck", "--template", "vs", "file.cpp"};
+        const char * const argv[] = {"cppcheck", "--template=vs", "file.cpp"};
         settings->templateFormat.clear();
         settings->templateLocation.clear();
-        ASSERT(parser->parseFromArgs(4, argv));
+        ASSERT(parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("{file}({line}): {severity}: {message}", settings->templateFormat);
         ASSERT_EQUALS("", settings->templateLocation);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
@@ -1368,10 +1368,10 @@ private:
 
     void templatesEdit() {
         REDIRECT;
-        const char * const argv[] = {"cppcheck", "--template", "edit", "file.cpp"};
+        const char * const argv[] = {"cppcheck", "--template=edit", "file.cpp"};
         settings->templateFormat.clear();
         settings->templateLocation.clear();
-        ASSERT(parser->parseFromArgs(4, argv));
+        ASSERT(parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("{file} +{line}: {severity}: {message}", settings->templateFormat);
         ASSERT_EQUALS("", settings->templateLocation);
         ASSERT_EQUALS("", GET_REDIRECT_OUTPUT);
@@ -1439,7 +1439,9 @@ private:
         ASSERT(!parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("file.cpp", settings->templateFormat);
         ASSERT_EQUALS("", settings->templateLocation);
-        TODO_ASSERT_EQUALS("cppcheck: error: argument to '--template' is missing.\n", "cppcheck: error: no C or C++ source files found.\n", GET_REDIRECT_OUTPUT);
+        TODO_ASSERT_EQUALS("cppcheck: error: argument to '--template' is missing.\n",
+                           "cppcheck: '--template <template>' is deprecated and will be removed in 2.13 - please use '--template=<template>' instead\n"
+                           "cppcheck: error: no C or C++ source files found.\n", GET_REDIRECT_OUTPUT);
     }
 
     // will use the default
@@ -1462,7 +1464,7 @@ private:
         ASSERT_EQUALS("cppcheck: error: argument to '--template-location' is missing.\n", GET_REDIRECT_OUTPUT);
     }
 
-    // TODO: will not error out as he next option does not start with a "-"
+    // TODO: will not error out as the next option does not start with a "-"
     void templateLocationInvalid2() {
         REDIRECT;
         settings->templateFormat.clear();
@@ -1471,7 +1473,9 @@ private:
         ASSERT(!parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("{file}:{line}:{column}: {inconclusive:}{severity}:{inconclusive: inconclusive:} {message} [{id}]\n{code}", settings->templateFormat);
         ASSERT_EQUALS("file.cpp", settings->templateLocation);
-        TODO_ASSERT_EQUALS("", "cppcheck: error: no C or C++ source files found.\n", GET_REDIRECT_OUTPUT);
+        TODO_ASSERT_EQUALS("",
+                           "cppcheck: '--template-location <template>' is deprecated and will be removed in 2.13 - please use '--template-location=<template>' instead\n"
+                           "cppcheck: error: no C or C++ source files found.\n", GET_REDIRECT_OUTPUT);
     }
 
     // will use the default


### PR DESCRIPTION
Both are bugprone since they just take the next parameter which doesn't start with `-`.

Also `--template` has not been documented since 17842394c00fd0288abfed509baad76aa3a5f2e9 back in 2011(!). And `--template-location` has never been documented since its induction in f058d9ad083a6111e9339b4b3506c5da7db579e0. That's also why we can have a short deprecation period.