### PR TITLE
optimized `Library::detectContainerInternal()` a bit

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -419,7 +419,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
 
             const char* const inherits = node->Attribute("inherits");
             if (inherits) {
-                const std::map<std::string, Container>::const_iterator i = containers.find(inherits);
+                const std::unordered_map<std::string, Container>::const_iterator i = containers.find(inherits);
                 if (i != containers.end())
                     container = i->second; // Take values from parent and overwrite them if necessary
                 else

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1182,13 +1182,15 @@ const Library::Container* Library::detectContainerInternal(const Token* typeStar
                 continue;
 
             const bool matchedStartPattern = Token::Match(typeStart, container.startPattern2.c_str() + offset);
+            if (!matchedStartPattern)
+                break;
 
-            if (detect != ContainerOnly && matchedStartPattern && Token::Match(tok->link(), container.itEndPattern.c_str())) {
+            if (detect != ContainerOnly && Token::Match(tok->link(), container.itEndPattern.c_str())) {
                 if (isIterator)
                     *isIterator = true;
                 return &container;
             }
-            if (detect != IteratorOnly && matchedStartPattern && Token::Match(tok->link(), container.endPattern.c_str())) {
+            if (detect != IteratorOnly && Token::Match(tok->link(), container.endPattern.c_str())) {
                 if (isIterator)
                     *isIterator = false;
                 return &container;

--- a/lib/library.h
+++ b/lib/library.h
@@ -282,7 +282,7 @@ public:
         static Yield yieldFrom(const std::string& yieldName);
         static Action actionFrom(const std::string& actionName);
     };
-    std::map<std::string, Container> containers;
+    std::unordered_map<std::string, Container> containers;
     const Container* detectContainer(const Token* typeStart) const;
     const Container* detectIterator(const Token* typeStart) const;
     const Container* detectContainerOrIterator(const Token* typeStart, bool* isIterator = nullptr, bool withoutStd = false) const;


### PR DESCRIPTION
Scanning `cli/filelister.cpp` with `DISABLE_VALUEFLOW=1` and `--enable=all -Ilib -D__GNUC__`

Clang 15 `111,300,996` -> `106,883,955`
GCC 13 `110,555,879` -> `105,983,608`