### PR TITLE
removed uninitMemberVar when memseter is struct constructor is existing

### DIFF
--- a/lib/checkclass.h
+++ b/lib/checkclass.h
@@ -156,6 +156,9 @@ public:
     /** @brief Unsafe class check - const reference member */
     void checkUnsafeClassRefMember();
 
+    /** @brief Checks if the token is struct mem setter 
+    + skips uninitialized members validation if true*/
+    bool isTokenMemSetter(const std::string token_str) const;
 
     /* multifile checking; one definition rule violations */
     class MyFileInfo : public Check::FileInfo {


### PR DESCRIPTION
Being in the context of validating constructors of structures, reporting errors for uninitialized variables when 'Memsetters' are available, those are "SecureZeroMemory, ZeroMemory, memset, memset_s" is removed, because the memory block is being set to 0 in this case.