### PR TITLE
fixed #6316 (Use std::to_string() in place of MathLib::toString() ...) - deleted default implementation of `Mathlib::toString()`

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -341,7 +341,7 @@ static bool match(const Token *tok, const std::string &rhs)
 {
     if (tok->str() == rhs)
         return true;
-    if (!tok->varId() && tok->hasKnownIntValue() && MathLib::toString(tok->values().front().intvalue) == rhs)
+    if (!tok->varId() && tok->hasKnownIntValue() && std::to_string(tok->values().front().intvalue) == rhs)
         return true;
     return false;
 }

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -119,7 +119,7 @@ static int getMinFormatStringOutputLength(const std::vector<const Token*> &param
                 i_d_x_f_found = true;
                 parameterLength = 1;
                 if (inputArgNr < parameters.size() && parameters[inputArgNr]->hasKnownIntValue())
-                    parameterLength = MathLib::toString(parameters[inputArgNr]->getKnownIntValue()).length();
+                    parameterLength = std::to_string(parameters[inputArgNr]->getKnownIntValue()).length();
 
                 handleNextParameter = true;
                 break;
@@ -362,7 +362,7 @@ void CheckBufferOverrun::arrayIndex()
 static std::string stringifyIndexes(const std::string& array, const std::vector<ValueFlow::Value>& indexValues)
 {
     if (indexValues.size() == 1)
-        return MathLib::toString(indexValues[0].intvalue);
+        return std::to_string(indexValues[0].intvalue);
 
     std::ostringstream ret;
     ret << array;
@@ -383,7 +383,7 @@ static std::string arrayIndexMessage(const Token* tok,
                                      const Token* condition)
 {
     auto add_dim = [](const std::string &s, const Dimension &dim) {
-        return s + "[" + MathLib::toString(dim.num) + "]";
+        return s + "[" + std::to_string(dim.num) + "]";
     };
     const std::string array = std::accumulate(dimensions.cbegin(), dimensions.cend(), tok->astOperand1()->expressionString(), add_dim);
 
@@ -528,7 +528,7 @@ void CheckBufferOverrun::pointerArithmeticError(const Token *tok, const Token *i
 
     std::string errmsg;
     if (indexValue->condition)
-        errmsg = "Undefined behaviour, when '" + indexToken->expressionString() + "' is " + MathLib::toString(indexValue->intvalue) + " the pointer arithmetic '" + tok->expressionString() + "' is out of bounds.";
+        errmsg = "Undefined behaviour, when '" + indexToken->expressionString() + "' is " + std::to_string(indexValue->intvalue) + " the pointer arithmetic '" + tok->expressionString() + "' is out of bounds.";
     else
         errmsg = "Undefined behaviour, pointer arithmetic '" + tok->expressionString() + "' is out of bounds.";
 
@@ -992,13 +992,13 @@ bool CheckBufferOverrun::analyseWholeProgram1(const std::map<std::string, std::l
     if (type == 1) {
         errorId = "ctuArrayIndex";
         if (unsafeUsage.value > 0)
-            errmsg = "Array index out of bounds; '" + unsafeUsage.myArgumentName + "' buffer size is " + MathLib::toString(functionCall->callArgValue) + " and it is accessed at offset " + MathLib::toString(unsafeUsage.value) + ".";
+            errmsg = "Array index out of bounds; '" + unsafeUsage.myArgumentName + "' buffer size is " + std::to_string(functionCall->callArgValue) + " and it is accessed at offset " + std::to_string(unsafeUsage.value) + ".";
         else
-            errmsg = "Array index out of bounds; buffer '" + unsafeUsage.myArgumentName + "' is accessed at offset " + MathLib::toString(unsafeUsage.value) + ".";
+            errmsg = "Array index out of bounds; buffer '" + unsafeUsage.myArgumentName + "' is accessed at offset " + std::to_string(unsafeUsage.value) + ".";
         cwe = (unsafeUsage.value > 0) ? CWE_BUFFER_OVERRUN : CWE_BUFFER_UNDERRUN;
     } else {
         errorId = "ctuPointerArith";
-        errmsg = "Pointer arithmetic overflow; '" + unsafeUsage.myArgumentName + "' buffer size is " + MathLib::toString(functionCall->callArgValue);
+        errmsg = "Pointer arithmetic overflow; '" + unsafeUsage.myArgumentName + "' buffer size is " + std::to_string(functionCall->callArgValue);
         cwe = CWE_POINTER_ARITHMETIC_OVERFLOW;
     }
 

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2845,7 +2845,7 @@ void CheckClass::virtualFunctionCallInConstructorError(
     }
 
     reportError(errorPath, Severity::style, "virtualCallInConstructor",
-                "Virtual function '" + funcname + "' is called from " + scopeFunctionTypeName + " '" + constructorName + "' at line " + MathLib::toString(lineNumber) + ". Dynamic binding is not used.", CWE(0U), Certainty::normal);
+                "Virtual function '" + funcname + "' is called from " + scopeFunctionTypeName + " '" + constructorName + "' at line " + std::to_string(lineNumber) + ". Dynamic binding is not used.", CWE(0U), Certainty::normal);
 }
 
 void CheckClass::pureVirtualFunctionCallInConstructorError(

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1039,7 +1039,7 @@ static bool parseComparison(const Token *comp, bool &not1, std::string &op, std:
             return false;
         op = invertOperatorForOperandSwap(comp->str());
         if (op1->enumerator() && op1->enumerator()->value_known)
-            value = MathLib::toString(op1->enumerator()->value);
+            value = std::to_string(op1->enumerator()->value);
         else
             value = op1->str();
         expr = op2;
@@ -1048,7 +1048,7 @@ static bool parseComparison(const Token *comp, bool &not1, std::string &op, std:
             return false;
         op = comp->str();
         if (op2->enumerator() && op2->enumerator()->value_known)
-            value = MathLib::toString(op2->enumerator()->value);
+            value = std::to_string(op2->enumerator()->value);
         else
             value = op2->str();
         expr = op1;

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3518,7 +3518,7 @@ void CheckOther::funcArgNamesDifferent(const std::string & functionName, nonneg 
     std::list<const Token *> tokens = { declaration,definition };
     reportError(tokens, Severity::style, "funcArgNamesDifferent",
                 "$symbol:" + functionName + "\n"
-                "Function '$symbol' argument " + MathLib::toString(index + 1) + " names different: declaration '" +
+                "Function '$symbol' argument " + std::to_string(index + 1) + " names different: declaration '" +
                 (declaration ? declaration->str() : std::string("A")) + "' definition '" +
                 (definition ? definition->str() : std::string("B")) + "'.", CWE628, Certainty::inconclusive);
 }

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -203,14 +203,14 @@ void CheckStl::outOfBounds()
 static std::string indexValueString(const ValueFlow::Value& indexValue, const std::string& containerName = emptyString)
 {
     if (indexValue.isIteratorStartValue())
-        return "at position " + MathLib::toString(indexValue.intvalue) + " from the beginning";
+        return "at position " + std::to_string(indexValue.intvalue) + " from the beginning";
     if (indexValue.isIteratorEndValue())
-        return "at position " + MathLib::toString(-indexValue.intvalue) + " from the end";
-    std::string indexString = MathLib::toString(indexValue.intvalue);
+        return "at position " + std::to_string(-indexValue.intvalue) + " from the end";
+    std::string indexString = std::to_string(indexValue.intvalue);
     if (indexValue.isSymbolicValue()) {
         indexString = containerName + ".size()";
         if (indexValue.intvalue != 0)
-            indexString += "+" + MathLib::toString(indexValue.intvalue);
+            indexString += "+" + std::to_string(indexValue.intvalue);
     }
     if (indexValue.bound == ValueFlow::Value::Bound::Lower)
         return "greater or equal to " + indexString;
@@ -242,11 +242,11 @@ void CheckStl::outOfBoundsError(const Token *tok, const std::string &containerNa
             errmsg = "Out of bounds access in expression '" + expression + "' because '$symbol' is empty.";
     } else if (indexValue) {
         if (containerSize->condition)
-            errmsg = ValueFlow::eitherTheConditionIsRedundant(containerSize->condition) + " or $symbol size can be " + MathLib::toString(containerSize->intvalue) + ". Expression '" + expression + "' cause access out of bounds.";
+            errmsg = ValueFlow::eitherTheConditionIsRedundant(containerSize->condition) + " or $symbol size can be " + std::to_string(containerSize->intvalue) + ". Expression '" + expression + "' cause access out of bounds.";
         else if (indexValue->condition)
             errmsg = ValueFlow::eitherTheConditionIsRedundant(indexValue->condition) + " or '" + index + "' can have the value " + indexValueString(*indexValue) + ". Expression '" + expression + "' cause access out of bounds.";
         else
-            errmsg = "Out of bounds access in '" + expression + "', if '$symbol' size is " + MathLib::toString(containerSize->intvalue) + " and '" + index + "' is " + indexValueString(*indexValue);
+            errmsg = "Out of bounds access in '" + expression + "', if '$symbol' size is " + std::to_string(containerSize->intvalue) + " and '" + index + "' is " + indexValueString(*indexValue);
     } else {
         // should not happen
         return;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -807,7 +807,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             const std::list<Directive> &directives = preprocessor.getDirectives();
             for (const Directive &dir : directives) {
                 if (dir.str.compare(0,8,"#define ") == 0 || dir.str.compare(0,9,"#include ") == 0)
-                    code += "#line " + MathLib::toString(dir.linenr) + " \"" + dir.file + "\"\n" + dir.str + '\n';
+                    code += "#line " + std::to_string(dir.linenr) + " \"" + dir.file + "\"\n" + dir.str + '\n';
             }
             Tokenizer tokenizer2(&mSettings, this);
             std::istringstream istr2(code);
@@ -945,7 +945,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
 
             } catch (const simplecpp::Output &o) {
                 // #error etc during preprocessing
-                configurationError.push_back((mCurrentConfig.empty() ? "\'\'" : mCurrentConfig) + " : [" + o.location.file() + ':' + MathLib::toString(o.location.line) + "] " + o.msg);
+                configurationError.push_back((mCurrentConfig.empty() ? "\'\'" : mCurrentConfig) + " : [" + o.location.file() + ':' + std::to_string(o.location.line) + "] " + o.msg);
                 --checkCount; // don't count invalid configurations
                 continue;
 

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -59,7 +59,7 @@ int CTU::maxCtuDepth = 2;
 
 std::string CTU::getFunctionId(const Tokenizer *tokenizer, const Function *function)
 {
-    return tokenizer->list.file(function->tokenDef) + ':' + MathLib::toString(function->tokenDef->linenr()) + ':' + MathLib::toString(function->tokenDef->column());
+    return tokenizer->list.file(function->tokenDef) + ':' + std::to_string(function->tokenDef->linenr()) + ':' + std::to_string(function->tokenDef->column());
 }
 
 CTU::FileInfo::Location::Location(const Tokenizer *tokenizer, const Token *tok)
@@ -579,7 +579,7 @@ std::list<ErrorMessage::FileLocation> CTU::FileInfo::getErrorPath(InvalidValueTy
         }
 
         ErrorMessage::FileLocation fileLoc(path[index]->location.fileName, path[index]->location.lineNumber, path[index]->location.column);
-        fileLoc.setinfo("Calling function " + path[index]->callFunctionName + ", " + MathLib::toString(path[index]->callArgNr) + getOrdinalText(path[index]->callArgNr) + " argument is " + value1);
+        fileLoc.setinfo("Calling function " + path[index]->callFunctionName + ", " + std::to_string(path[index]->callArgNr) + getOrdinalText(path[index]->callArgNr) + " argument is " + value1);
         locationList.push_back(std::move(fileLoc));
     }
 

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -240,8 +240,8 @@ std::string ErrorMessage::serialize() const
     std::string oss;
     serializeString(oss, id);
     serializeString(oss, Severity::toString(severity));
-    serializeString(oss, MathLib::toString(cwe.id));
-    serializeString(oss, MathLib::toString(hash));
+    serializeString(oss, std::to_string(cwe.id));
+    serializeString(oss, std::to_string(hash));
     serializeString(oss, file0);
     if (certainty == Certainty::inconclusive) {
         const std::string text("inconclusive");
@@ -461,7 +461,7 @@ std::string ErrorMessage::toXML() const
     if (cwe.id)
         printer.PushAttribute("cwe", cwe.id);
     if (hash)
-        printer.PushAttribute("hash", MathLib::toString(hash).c_str());
+        printer.PushAttribute("hash", std::to_string(hash).c_str());
     if (certainty == Certainty::inconclusive)
         printer.PushAttribute("inconclusive", "true");
 
@@ -624,14 +624,14 @@ std::string ErrorMessage::toString(bool verbose, const std::string &templateForm
         pos1 = result.find("{inconclusive:", pos1);
     }
     findAndReplace(result, "{severity}", Severity::toString(severity));
-    findAndReplace(result, "{cwe}", MathLib::toString(cwe.id));
+    findAndReplace(result, "{cwe}", std::to_string(cwe.id));
     findAndReplace(result, "{message}", verbose ? mVerboseMessage : mShortMessage);
     if (!callStack.empty()) {
         if (result.find("{callstack}") != std::string::npos)
             findAndReplace(result, "{callstack}", ErrorLogger::callStackToString(callStack));
         findAndReplace(result, "{file}", callStack.back().getfile());
-        findAndReplace(result, "{line}", MathLib::toString(callStack.back().line));
-        findAndReplace(result, "{column}", MathLib::toString(callStack.back().column));
+        findAndReplace(result, "{line}", std::to_string(callStack.back().line));
+        findAndReplace(result, "{column}", std::to_string(callStack.back().column));
         if (result.find("{code}") != std::string::npos) {
             const std::string::size_type pos = result.find('\r');
             const char *endl;
@@ -660,8 +660,8 @@ std::string ErrorMessage::toString(bool verbose, const std::string &templateForm
             std::string text = templateLocation;
 
             findAndReplace(text, "{file}", fileLocation.getfile());
-            findAndReplace(text, "{line}", MathLib::toString(fileLocation.line));
-            findAndReplace(text, "{column}", MathLib::toString(fileLocation.column));
+            findAndReplace(text, "{line}", std::to_string(fileLocation.line));
+            findAndReplace(text, "{column}", std::to_string(fileLocation.column));
             findAndReplace(text, "{info}", fileLocation.getinfo().empty() ? mShortMessage : fileLocation.getinfo());
             if (text.find("{code}") != std::string::npos) {
                 const std::string::size_type pos = text.find('\r');

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -1059,7 +1059,7 @@ std::string MathLib::add(const std::string & first, const std::string & second)
     return (value(first) + value(second)).str();
 #else
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return toString(toLongNumber(first) + toLongNumber(second)) + intsuffix(first, second);
+        return std::to_string(toLongNumber(first) + toLongNumber(second)) + intsuffix(first, second);
     }
 
     double d1 = toDoubleNumber(first);
@@ -1081,7 +1081,7 @@ std::string MathLib::subtract(const std::string &first, const std::string &secon
     return (value(first) - value(second)).str();
 #else
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return toString(toLongNumber(first) - toLongNumber(second)) + intsuffix(first, second);
+        return std::to_string(toLongNumber(first) - toLongNumber(second)) + intsuffix(first, second);
     }
 
     if (first == second)
@@ -1112,7 +1112,7 @@ std::string MathLib::divide(const std::string &first, const std::string &second)
             throw InternalError(nullptr, "Internal Error: Division by zero");
         if (a == std::numeric_limits<bigint>::min() && std::abs(b)<=1)
             throw InternalError(nullptr, "Internal Error: Division overflow");
-        return toString(toLongNumber(first) / b) + intsuffix(first, second);
+        return std::to_string(toLongNumber(first) / b) + intsuffix(first, second);
     }
     if (isNullValue(second)) {
         if (isNullValue(first))
@@ -1129,7 +1129,7 @@ std::string MathLib::multiply(const std::string &first, const std::string &secon
     return (value(first) * value(second)).str();
 #else
     if (MathLib::isInt(first) && MathLib::isInt(second)) {
-        return toString(toLongNumber(first) * toLongNumber(second)) + intsuffix(first, second);
+        return std::to_string(toLongNumber(first) * toLongNumber(second)) + intsuffix(first, second);
     }
     return toString(toDoubleNumber(first) * toDoubleNumber(second));
 #endif
@@ -1144,7 +1144,7 @@ std::string MathLib::mod(const std::string &first, const std::string &second)
         const bigint b = toLongNumber(second);
         if (b == 0)
             throw InternalError(nullptr, "Internal Error: Division by zero");
-        return toString(toLongNumber(first) % b) + intsuffix(first, second);
+        return std::to_string(toLongNumber(first) % b) + intsuffix(first, second);
     }
     return toString(std::fmod(toDoubleNumber(first),toDoubleNumber(second)));
 #endif
@@ -1169,13 +1169,13 @@ std::string MathLib::calculate(const std::string &first, const std::string &seco
         return MathLib::mod(first, second);
 
     case '&':
-        return MathLib::toString(MathLib::toLongNumber(first) & MathLib::toLongNumber(second)) + intsuffix(first,second);
+        return std::to_string(MathLib::toLongNumber(first) & MathLib::toLongNumber(second)) + intsuffix(first,second);
 
     case '|':
-        return MathLib::toString(MathLib::toLongNumber(first) | MathLib::toLongNumber(second)) + intsuffix(first,second);
+        return std::to_string(MathLib::toLongNumber(first) | MathLib::toLongNumber(second)) + intsuffix(first,second);
 
     case '^':
-        return MathLib::toString(MathLib::toLongNumber(first) ^ MathLib::toLongNumber(second)) + intsuffix(first,second);
+        return std::to_string(MathLib::toLongNumber(first) ^ MathLib::toLongNumber(second)) + intsuffix(first,second);
 
     default:
         throw InternalError(nullptr, std::string("Unexpected action '") + action + "' in MathLib::calculate(). Please report this to Cppcheck developers.");

--- a/lib/mathlib.h
+++ b/lib/mathlib.h
@@ -74,9 +74,7 @@ public:
     /** @brief for conversion of numeric literals - for atoi-like conversions please use strToInt() */
     static biguint toULongNumber(const std::string & str);
 
-    template<class T> static std::string toString(T value) {
-        return std::to_string(value);
-    }
+    template<class T> static std::string toString(T value) = delete;
     /** @brief for conversion of numeric literals */
     static double toDoubleNumber(const std::string & str);
 
@@ -147,7 +145,7 @@ MathLib::value operator^(const MathLib::value &v1, const MathLib::value &v2);
 MathLib::value operator<<(const MathLib::value &v1, const MathLib::value &v2);
 MathLib::value operator>>(const MathLib::value &v1, const MathLib::value &v2);
 
-template<> CPPCHECKLIB std::string MathLib::toString<double>(double value); // Declare specialization to avoid linker problems
+template<> CPPCHECKLIB std::string MathLib::toString<double>(double value);
 
 /// @}
 //---------------------------------------------------------------------------

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -356,11 +356,11 @@ std::string Suppressions::Suppression::getText() const
     if (!fileName.empty())
         ret += " fileName=" + fileName;
     if (lineNumber != NO_LINE)
-        ret += " lineNumber=" + MathLib::toString(lineNumber);
+        ret += " lineNumber=" + std::to_string(lineNumber);
     if (!symbolName.empty())
         ret += " symbolName=" + symbolName;
     if (hash > 0)
-        ret += " hash=" + MathLib::toString(hash);
+        ret += " hash=" + std::to_string(hash);
     if (ret.compare(0,1," ")==0)
         return ret.substr(1);
     return ret;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -7637,7 +7637,7 @@ void ValueType::setDebugPath(const Token* tok, SourceLocation ctx, SourceLocatio
     std::string file = ctx.file_name();
     if (file.empty())
         return;
-    std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
+    std::string s = Path::stripDirectoryPart(file) + ":" + std::to_string(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name();
     debugPath.emplace_back(tok, std::move(s));
 }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -2483,17 +2483,17 @@ void TemplateSimplifier::simplifyTemplateArgs(Token *start, const Token *end, st
                 }
 
                 else if (Token::Match(tok->next(), "( %type% * )")) {
-                    tok->str(MathLib::toString(mTokenizer.sizeOfType(tok->tokAt(3))));
+                    tok->str(std::to_string(mTokenizer.sizeOfType(tok->tokAt(3))));
                     tok->deleteNext(4);
                     again = true;
                 } else if (Token::simpleMatch(tok->next(), "( * )")) {
-                    tok->str(MathLib::toString(mTokenizer.sizeOfType(tok->tokAt(2))));
+                    tok->str(std::to_string(mTokenizer.sizeOfType(tok->tokAt(2))));
                     tok->deleteNext(3);
                     again = true;
                 } else if (Token::Match(tok->next(), "( %type% )")) {
                     const unsigned int size = mTokenizer.sizeOfType(tok->tokAt(2));
                     if (size > 0) {
-                        tok->str(MathLib::toString(size));
+                        tok->str(std::to_string(size));
                         tok->deleteNext(3);
                         again = true;
                     }
@@ -2678,7 +2678,7 @@ bool TemplateSimplifier::simplifyCalculations(Token* frontToken, const Token *ba
 
         if (validTokenEnd(bounded, tok, backToken, 3) &&
             Token::Match(tok->previous(), "(|&&|%oror% %char% %comp% %num% &&|%oror%|)")) {
-            tok->str(MathLib::toString(MathLib::toLongNumber(tok->str())));
+            tok->str(std::to_string(MathLib::toLongNumber(tok->str())));
         }
 
         if (validTokenEnd(bounded, tok, backToken, 5) &&
@@ -3085,7 +3085,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
                                               Severity::information,
                                               "templateRecursion",
                                               "TemplateSimplifier: max template recursion ("
-                                              + MathLib::toString(mSettings.maxTemplateRecursion)
+                                              + std::to_string(mSettings.maxTemplateRecursion)
                                               + ") reached for template '"+typeForNewName+"'. You might want to limit Cppcheck recursion.",
                                               Certainty::normal);
                     mErrorLogger->reportErr(errmsg);

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1571,7 +1571,7 @@ static void astStringXml(const Token *tok, nonneg int indent, std::ostream &out)
 
     out << strindent << "<token str=\"" << tok->str() << '\"';
     if (tok->varId())
-        out << " varId=\"" << MathLib::toString(tok->varId()) << '\"';
+        out << " varId=\"" << std::to_string(tok->varId()) << '\"';
     if (tok->variable())
         out << " variable=\"" << tok->variable() << '\"';
     if (tok->function())

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1571,7 +1571,7 @@ static void astStringXml(const Token *tok, nonneg int indent, std::ostream &out)
 
     out << strindent << "<token str=\"" << tok->str() << '\"';
     if (tok->varId())
-        out << " varId=\"" << std::to_string(tok->varId()) << '\"';
+        out << " varId=\"" << tok->varId() << '\"';
     if (tok->variable())
         out << " variable=\"" << tok->variable() << '\"';
     if (tok->function())

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5861,9 +5861,9 @@ void Tokenizer::dump(std::ostream &out) const
         if (tok->link())
             out << " link=\"" << tok->link() << '\"';
         if (tok->varId() > 0)
-            out << " varId=\"" << std::to_string(tok->varId()) << '\"';
+            out << " varId=\"" << tok->varId() << '\"';
         if (tok->exprId() > 0)
-            out << " exprId=\"" << std::to_string(tok->exprId()) << '\"';
+            out << " exprId=\"" << tok->exprId() << '\"';
         if (tok->variable())
             out << " variable=\"" << tok->variable() << '\"';
         if (tok->function())

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -448,7 +448,7 @@ static Token *splitDefinitionFromTypedef(Token *tok, nonneg int *unnamedCount)
             if (Token::Match(tok1->next(), "%type%"))
                 name = tok1->next()->str();
             else // create a unique name
-                name = "Unnamed" + MathLib::toString((*unnamedCount)++);
+                name = "Unnamed" + std::to_string((*unnamedCount)++);
             tok->next()->insertToken(name);
         } else
             return nullptr;
@@ -2920,7 +2920,7 @@ bool Tokenizer::simplifyUsing()
                 if (structEnd->strAt(2) == ";")
                     newName = name;
                 else
-                    newName = "Unnamed" + MathLib::toString(mUnnamedCount++);
+                    newName = "Unnamed" + std::to_string(mUnnamedCount++);
                 TokenList::copyTokens(structEnd->next(), tok, start);
                 structEnd->tokAt(5)->insertToken(newName, emptyString);
                 start->insertToken(newName, emptyString);
@@ -3737,7 +3737,7 @@ void Tokenizer::arraySize()
         Token* endStmt{};
         if (const Token* strTok = getStrTok(tok, addlength, &endStmt)) {
             const int sz = Token::getStrArraySize(strTok);
-            tok->next()->insertToken(MathLib::toString(sz));
+            tok->next()->insertToken(std::to_string(sz));
             tok = endStmt;
         }
 
@@ -3767,7 +3767,7 @@ void Tokenizer::arraySize()
             }
 
             if (sz != 0)
-                tok->insertToken(MathLib::toString(sz));
+                tok->insertToken(std::to_string(sz));
 
             tok = end->next() ? end->next() : end;
         }
@@ -3899,7 +3899,7 @@ void Tokenizer::simplifyCaseRange()
                 tok->insertToken("case");
                 for (MathLib::bigint i = end-1; i > start; i--) {
                     tok->insertToken(":");
-                    tok->insertToken(MathLib::toString(i));
+                    tok->insertToken(std::to_string(i));
                     tok->insertToken("case");
                 }
             }
@@ -5785,7 +5785,7 @@ void Tokenizer::printDebugOutput(int simplification) const
                 reportError(var->typeStartToken(),
                             Severity::debug,
                             "debug",
-                            "Variable::typeStartToken() of variable '" + var->name() + "' is not located before Variable::typeEndToken(). The location of the typeStartToken() is '" + var->typeStartToken()->str() + "' at line " + MathLib::toString(var->typeStartToken()->linenr()));
+                            "Variable::typeStartToken() of variable '" + var->name() + "' is not located before Variable::typeEndToken(). The location of the typeStartToken() is '" + var->typeStartToken()->str() + "' at line " + std::to_string(var->typeStartToken()->linenr()));
             }
         }
     }
@@ -5861,9 +5861,9 @@ void Tokenizer::dump(std::ostream &out) const
         if (tok->link())
             out << " link=\"" << tok->link() << '\"';
         if (tok->varId() > 0)
-            out << " varId=\"" << MathLib::toString(tok->varId()) << '\"';
+            out << " varId=\"" << std::to_string(tok->varId()) << '\"';
         if (tok->exprId() > 0)
-            out << " exprId=\"" << MathLib::toString(tok->exprId()) << '\"';
+            out << " exprId=\"" << std::to_string(tok->exprId()) << '\"';
         if (tok->variable())
             out << " variable=\"" << tok->variable() << '\"';
         if (tok->function())
@@ -8592,14 +8592,14 @@ void Tokenizer::simplifyStructDecl()
         // check for anonymous struct/union
         if (Token::Match(tok, "struct|union {")) {
             if (Token::Match(tok->next()->link(), "} const| *|&| const| %type% ,|;|[|(|{|=")) {
-                tok->insertToken("Anonymous" + MathLib::toString(count++));
+                tok->insertToken("Anonymous" + std::to_string(count++));
             }
         }
         // check for derived anonymous class/struct
         else if (cpp && Token::Match(tok, "class|struct :")) {
             const Token *tok1 = Token::findsimplematch(tok, "{");
             if (tok1 && Token::Match(tok1->link(), "} const| *|&| const| %type% ,|;|[|(|{")) {
-                tok->insertToken("Anonymous" + MathLib::toString(count++));
+                tok->insertToken("Anonymous" + std::to_string(count++));
             }
         }
         // check for anonymous enum
@@ -8612,7 +8612,7 @@ void Tokenizer::simplifyStructDecl()
                 start->next()->link()->deleteThis();
                 start->next()->deleteThis();
             }
-            tok->insertToken("Anonymous" + MathLib::toString(count++));
+            tok->insertToken("Anonymous" + std::to_string(count++));
         }
     }
 
@@ -9850,7 +9850,7 @@ void Tokenizer::simplifyOperatorName()
             tok->insertToken("(");
             str->insertToken(")");
             Token::createMutualLinks(tok->next(), str->next());
-            str->insertToken(MathLib::toString(Token::getStrLength(str)));
+            str->insertToken(std::to_string(Token::getStrLength(str)));
             str->insertToken(",");
         }
     }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -385,9 +385,9 @@ std::size_t TokenList::calculateHash() const
 {
     std::string hashData;
     for (const Token* tok = front(); tok; tok = tok->next()) {
-        hashData += MathLib::toString(tok->flags());
-        hashData += MathLib::toString(tok->varId());
-        hashData += MathLib::toString(tok->tokType());
+        hashData += std::to_string(tok->flags());
+        hashData += std::to_string(tok->varId());
+        hashData += std::to_string(tok->tokType());
         hashData += tok->str();
         hashData += tok->originalName();
     }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -132,7 +132,7 @@ static void bailoutInternal(const std::string& type, TokenList &tokenlist, Error
         function = "(valueFlow)";
     std::list<ErrorMessage::FileLocation> callstack(1, ErrorMessage::FileLocation(tok, &tokenlist));
     ErrorMessage errmsg(callstack, tokenlist.getSourceFilePath(), Severity::debug,
-                        Path::stripDirectoryPart(file) + ":" + MathLib::toString(line) + ":" + function + " bailout: " + what, type, Certainty::normal);
+                        Path::stripDirectoryPart(file) + ":" + std::to_string(line) + ":" + function + " bailout: " + what, type, Certainty::normal);
     errorLogger->reportErr(errmsg);
 }
 
@@ -169,7 +169,7 @@ static void setSourceLocation(ValueFlow::Value& v,
     std::string file = ctx.file_name();
     if (file.empty())
         return;
-    std::string s = Path::stripDirectoryPart(file) + ":" + MathLib::toString(ctx.line()) + ": " + ctx.function_name() +
+    std::string s = Path::stripDirectoryPart(file) + ":" + std::to_string(ctx.line()) + ": " + ctx.function_name() +
                     " => " + local.function_name() + ": " + debugString(v);
     v.debugPath.emplace_back(tok, std::move(s));
 }
@@ -7613,7 +7613,7 @@ static void valueFlowSubFunction(TokenList& tokenlist, SymbolDatabase& symboldat
 
                 // Error path..
                 for (ValueFlow::Value &v : argvalues) {
-                    const std::string nr = MathLib::toString(argnr + 1) + getOrdinalText(argnr + 1);
+                    const std::string nr = std::to_string(argnr + 1) + getOrdinalText(argnr + 1);
 
                     v.errorPath.emplace_back(argtok,
                                              "Calling function '" +
@@ -9038,7 +9038,7 @@ static void valueFlowDynamicBufferSize(const TokenList& tokenlist, const SymbolD
                 continue;
 
             ValueFlow::Value value(sizeValue);
-            value.errorPath.emplace_back(tok->tokAt(2), "Assign " + tok->strAt(1) + ", buffer with size " + MathLib::toString(sizeValue));
+            value.errorPath.emplace_back(tok->tokAt(2), "Assign " + tok->strAt(1) + ", buffer with size " + std::to_string(sizeValue));
             value.valueType = ValueFlow::Value::ValueType::BUFFER_SIZE;
             value.setKnown();
             valueFlowForward(const_cast<Token*>(rhs), functionScope->bodyEnd, tok->next(), std::move(value), tokenlist, settings);
@@ -9189,12 +9189,12 @@ static void valueFlowSafeFunctions(TokenList& tokenlist, const SymbolDatabase& s
             std::list<ValueFlow::Value> argValues;
             if (isLow) {
                 argValues.emplace_back(low);
-                argValues.back().errorPath.emplace_back(arg.nameToken(), std::string(safeLow ? "Safe checks: " : "") + "Assuming argument has value " + MathLib::toString(low));
+                argValues.back().errorPath.emplace_back(arg.nameToken(), std::string(safeLow ? "Safe checks: " : "") + "Assuming argument has value " + std::to_string(low));
                 argValues.back().safe = safeLow;
             }
             if (isHigh) {
                 argValues.emplace_back(high);
-                argValues.back().errorPath.emplace_back(arg.nameToken(), std::string(safeHigh ? "Safe checks: " : "") + "Assuming argument has value " + MathLib::toString(high));
+                argValues.back().errorPath.emplace_back(arg.nameToken(), std::string(safeHigh ? "Safe checks: " : "") + "Assuming argument has value " + std::to_string(high));
                 argValues.back().safe = safeHigh;
             }
 

--- a/lib/vfvalue.cpp
+++ b/lib/vfvalue.cpp
@@ -96,7 +96,7 @@ namespace ValueFlow {
     std::string Value::infoString() const {
         switch (valueType) {
         case ValueType::INT:
-            return MathLib::toString(intvalue);
+            return std::to_string(intvalue);
         case ValueType::TOK:
             return tokvalue->str();
         case ValueType::FLOAT:
@@ -107,19 +107,19 @@ namespace ValueFlow {
             return "<Uninit>";
         case ValueType::BUFFER_SIZE:
         case ValueType::CONTAINER_SIZE:
-            return "size=" + MathLib::toString(intvalue);
+            return "size=" + std::to_string(intvalue);
         case ValueType::ITERATOR_START:
-            return "start=" + MathLib::toString(intvalue);
+            return "start=" + std::to_string(intvalue);
         case ValueType::ITERATOR_END:
-            return "end=" + MathLib::toString(intvalue);
+            return "end=" + std::to_string(intvalue);
         case ValueType::LIFETIME:
             return "lifetime=" + tokvalue->str();
         case ValueType::SYMBOLIC:
             std::string result = "symbolic=" + tokvalue->expressionString();
             if (intvalue > 0)
-                result += "+" + MathLib::toString(intvalue);
+                result += "+" + std::to_string(intvalue);
             else if (intvalue < 0)
-                result += "-" + MathLib::toString(-intvalue);
+                result += "-" + std::to_string(-intvalue);
             return result;
         }
         throw InternalError(nullptr, "Invalid ValueFlow Value type");

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -311,7 +311,7 @@ private:
         } catch (InternalError& e) {
             if (e.id != "syntaxError")
                 return "";
-            return "[test.cpp:" + MathLib::toString(e.token->linenr()) + "] " + e.errorMessage;
+            return "[test.cpp:" + std::to_string(e.token->linenr()) + "] " + e.errorMessage;
         }
         return "";
     }

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -1463,23 +1463,12 @@ private:
         ASSERT_EQUALS("0.0", MathLib::toString(0.0));
         ASSERT_EQUALS("0.0", MathLib::toString(+0.0));
         ASSERT_EQUALS("0.0", MathLib::toString(-0.0));
-        // float (trailing f or F)
-        ASSERT_EQUALS("0.000000", MathLib::toString(0.0f));
-        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0f));
-        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0f));
-        ASSERT_EQUALS("0.000000", MathLib::toString(0.0F));
-        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0F));
-        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0F));
-        // double (tailing l or L)
-        ASSERT_EQUALS("0.000000",  MathLib::toString(0.0l));
-        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0l));
-        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0l));
-        ASSERT_EQUALS("0.000000",  MathLib::toString(0.0L));
-        ASSERT_EQUALS("0.000000",  MathLib::toString(+0.0L));
-        ASSERT_EQUALS("-0.000000", MathLib::toString(-0.0L));
 
         ASSERT_EQUALS("1e-08", MathLib::toString(0.00000001));
         ASSERT_EQUALS("-1e-08", MathLib::toString(-0.00000001));
+
+        ASSERT_EQUALS("2.22507385851e-308", MathLib::toString(std::numeric_limits<double>::min()));
+        ASSERT_EQUALS("1.79769313486e+308", MathLib::toString(std::numeric_limits<double>::max()));
     }
 
     void CPP14DigitSeparators() const { // Ticket #7137, #7565

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -2122,7 +2122,7 @@ private:
     }
 
     static std::string getLine(const std::string &code, int lineNumber) {
-        std::string nr = MathLib::toString(lineNumber);
+        std::string nr = std::to_string(lineNumber);
         const std::string::size_type pos1 = code.find('\n' + nr + ": ");
         if (pos1 == std::string::npos)
             return "";


### PR DESCRIPTION
It was also used inconsistently and seemed to imply there is some special handling which wasn't the case. It was just an alias for `std::to_string()` for non-`double` types. So there was no need for it.