### PR TITLE
Fix #11877 FP misra 10.4 On array member comparison

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -466,9 +466,15 @@ def getEssentialTypeCategory(expr):
             return expr.valueType.sign
     if expr.valueType and expr.valueType.typeScope and expr.valueType.typeScope.className:
         return "enum<" + expr.valueType.typeScope.className + ">"
+    # Unwrap membership, dereferences and array indexing
     vartok = expr
-    while simpleMatch(vartok, '[') or (vartok and vartok.str == '*' and vartok.astOperand2 is None):
-        vartok = vartok.astOperand1
+    while True:
+        if simpleMatch(vartok, '[') or (vartok and vartok.str == '*' and vartok.astOperand2 is None):
+            vartok = vartok.astOperand1
+        elif simpleMatch(vartok, '.'):
+            vartok = vartok.astOperand2
+        else:
+            break
     if vartok and vartok.variable:
         typeToken = vartok.variable.typeStartToken
         while typeToken and typeToken.isName:

--- a/addons/test/misra/misra-test-avr8.c
+++ b/addons/test/misra/misra-test-avr8.c
@@ -1,5 +1,5 @@
 // To test:
-// ~/cppcheck/cppcheck --addon=misra --platform=avr8 misra-test-avr8.c
+// ~/cppcheck/cppcheck--dump -DDUMMY --suppress=uninitvar --inline-suppr misra/misra-test-avr8.c --std=c89 --platform=avr8 && python3 ../misra.py -verify misra/misra-test-avr8.c.dump
 
 static void misra_10_4(void)
 {

--- a/addons/test/misra/misra-test-avr8.c
+++ b/addons/test/misra/misra-test-avr8.c
@@ -7,6 +7,20 @@ static void misra_10_4(void)
     const char buf[1] = {'f'};
     const char c = '0';
     x = buf[0] - c;
+
+    const char buf[2] = {0};
+    x = 'a' == buf[0]; // no-warning
+
+    typedef struct  {
+      int t;
+      char buf[2];
+    } foo_t;
+    const foo_t cmd = {0};
+    x = 'b' == cmd.buf[0]; // no-warning
+
+    const foo_t * pcmd = &cmd;
+    x='c' == pcmd->buf[0]; // no-warning
+    (void)cmd.t;
 }
 
 static void misra_12_2(void) {

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -709,6 +709,14 @@ static void misra_10_4(u32 x, s32 y) {
   if ('0' == buf[x]) // no-warning
   {
   }
+
+  const struct foo_s{
+    int t;
+    char buf[2];
+  } cmd = {0};
+  if ('\0' == cmd.buf[0]) //no-warning
+  {
+  }
 }
 
 static void misra_10_5(uint16_t x) {


### PR DESCRIPTION
I also changed the comment header to run tests on misra-test-avr8.c because I thought that was the intention to use it like misra-test.c; if not, I can revert.