### PR TITLE
ProcessExecutor: removed unnecessary `\0` passing in message reading/writing - fixes stray `\0` characters in output

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -109,7 +109,7 @@ private:
             writeToPipeInternal(type, &t, 1);
         }
 
-        const unsigned int len = static_cast<unsigned int>(data.length() + 1);
+        const unsigned int len = static_cast<unsigned int>(data.length());
         {
             static constexpr std::size_t l_size = sizeof(unsigned int);
             writeToPipeInternal(type, &len, l_size);
@@ -162,9 +162,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
         std::exit(EXIT_FAILURE);
     }
 
-    // Don't rely on incoming data being null-terminated.
-    // Allocate +1 element and null-terminate the buffer.
-    std::string buf(len + 1, '\0');
+    std::string buf(len, '\0');
     char *data_start = &buf[0];
     bytes_to_read = len;
     do {
@@ -177,7 +175,6 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
         bytes_to_read -= bytes_read;
         data_start += bytes_read;
     } while (bytes_to_read != 0);
-    buf[len] = '\0';
 
     bool res = true;
     if (type == PipeWriter::REPORT_OUT) {

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -71,4 +71,15 @@ def test_invalid_library(tmpdir):
                       "cppcheck: Failed to load library configuration file 'none2'. File not found\n")
     assert stderr == ""
 
+
+def test_message_j(tmpdir):
+    test_file = os.path.join(tmpdir, 'test.c')
+    with open(test_file, 'wt') as f:
+        f.write("")
+
+    args = ['-j2', '--platform=native', test_file]
+
+    _, stdout, _ = cppcheck(args)
+    assert stdout == "Checking {} ...\n".format(test_file) # we were adding stray \0 characters at the end
+
 # TODO: test missing std.cfg


### PR DESCRIPTION
This was introduced in #5279. We were transferring the terminating `\0` via the pipe and also added another one in the parsing. As we are now directly writing into a `std::string` these extra characters will now show up in it. So just get rid of them.