### PR TITLE
Fix #11886 performance regression (hang) in 2.12dev

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4353,13 +4353,12 @@ const Function *Function::getOverriddenFunction(bool *foundAllBaseClasses) const
 // prevent recursion if base is the same except for different template parameters
 static bool isDerivedFromItself(const std::string& thisName, const std::string& baseName)
 {
+    if (thisName.back() != '>')
+        return false;
     const auto pos = thisName.find('<');
     if (pos == std::string::npos)
         return false;
-    const auto posBase = baseName.find('<');
-    if (posBase != pos)
-        return false;
-    return thisName.compare(0, pos, baseName, 0, pos) == 0;
+    return thisName.compare(0, pos + 1, baseName, 0, pos + 1) == 0;
 }
 
 const Function * Function::getOverriddenFunctionRecursive(const ::Type* baseType, bool *foundAllBaseClasses) const

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4353,13 +4353,13 @@ const Function *Function::getOverriddenFunction(bool *foundAllBaseClasses) const
 // prevent recursion if base is the same except for different template parameters
 static bool isDerivedFromItself(const std::string& thisName, const std::string& baseName)
 {
-    const auto posThis = thisName.find('<');
-    if (posThis == std::string::npos)
+    const auto pos = thisName.find('<');
+    if (pos == std::string::npos)
         return false;
     const auto posBase = baseName.find('<');
-    if (posBase == std::string::npos)
+    if (posBase != pos)
         return false;
-    return posThis == posBase && thisName.compare(0, posThis, baseName);
+    return thisName.compare(0, pos, baseName, 0, pos) == 0;
 }
 
 const Function * Function::getOverriddenFunctionRecursive(const ::Type* baseType, bool *foundAllBaseClasses) const

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -5548,7 +5548,7 @@ static void valueFlowSymbolicOperators(const SymbolDatabase& symboldatabase, con
                     ValueFlow::Value v = value;
                     v.bound = ValueFlow::Value::Bound::Point;
                     v.valueType = ValueFlow::Value::ValueType::INT;
-                    v.errorPath.emplace_back(strlenTok, "Return index of string to the first element that is 0");
+                    v.errorPath.emplace_back(strlenTok, "Return index of first '\\0' character in string");
                     setTokenValue(tok, std::move(v), settings);
                 }
             }

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -183,6 +183,7 @@ private:
         TEST_CASE(const89);
         TEST_CASE(const90);
         TEST_CASE(const91);
+        TEST_CASE(const92);
 
         TEST_CASE(const_handleDefaultParameters);
         TEST_CASE(const_passThisToMemberOfOtherClass);
@@ -6652,6 +6653,20 @@ private:
                    "    return s.get<const int>();\n"
                    "}\n");
         ASSERT_EQUALS("", errout.str());
+    }
+
+    void const92() { // #11886
+        checkConst("void g(int);\n"
+                   "template<int n>\n"
+                   "struct S : public S<n - 1> {\n"
+                   "    void f() {\n"
+                   "        g(n - 1);\n"
+                   "    }\n"
+                   "};\n"
+                   "template<>\n"
+                   "struct S<0> {};\n"
+                   "struct D : S<150> {};\n");
+        // don't hang
     }
 
     void const_handleDefaultParameters() {


### PR DESCRIPTION
Or maybe we should just limit the recursion depth.