### PR TITLE
Fix constParameterPointer regression

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -4445,7 +4445,7 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
       <not-uninit/>
       <valid>0:</valid>
     </arg>
-    <arg nr="4" direction="in">
+    <arg nr="4">
       <not-null/>
       <not-uninit/>
       <not-bool/>

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -3808,6 +3808,11 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:1]: (style) Parameter 'p' can be declared as pointer to const\n",
                       errout.str());
+
+        check("void f(void *p, size_t nmemb, size_t size, int (*cmp)(const void *, const void *)) {\n"
+              "    qsort(p, nmemb, size, cmp);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void switchRedundantAssignmentTest() {


### PR DESCRIPTION
Commit 73251544a ("Fix #11842 FN constParameterPointer with library function (#5257)") most likely introduced a regression for (C) function pointers passed to functions provided by the standard library that cppcheck has knowledge about.