### PR TITLE
qt library: Make Q_PROPERTY a variadic macro to avoid preprocessorErrorDirective

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5084,7 +5084,8 @@
   <define name="Q_OBJECT" value=""/>
   <define name="Q_PRIVATE_SLOT(d, signature)" value=""/>
   <define name="Q_SLOTS" value=""/>
-  <define name="Q_PROPERTY(X)" value=""/>
+  <!-- Treat as variadic macro to avoid preprocessorErrorDirective -->
+  <define name="Q_PROPERTY(...)" value=""/>
   <define name="Q_Q(Class)" value="Class * const q = q_func()"/>
   <define name="Q_RETURN_ARG(type, data)" value="QReturnArgument&lt;type &gt;(#type, data)"/>
   <define name="Q_UNLIKELY(expr)" value="expr"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -573,4 +573,10 @@ namespace {
     // simplifyQtSignalsSlots2
     namespace Foo { class Bar; }
     class Foo::Bar : public QObject { private slots: };
+
+    // Q_PROPERTY with templates inducing a ',' should not produce a preprocessorErrorDirective
+    class AssocProperty : public QObject {
+    public:
+        Q_PROPERTY(QHash<QString, int> hash READ hash WRITE setHash)
+    };
 }


### PR DESCRIPTION
Treat Q_PROPERTY as variadic macro to avoid preprocessorErrorDirective with associative container templates itroducing a "," like for example `QHash<QString, int>`. Using templates is totally fine in the context of a moc compiler.

The macro Q_PROPERTY is defined as variadic in qobjectdefs.h/qtmetaobject.h when not compiling using the moc compiler.

See following references:
* For Qt 5.15 https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qobjectdefs.h?h=5.15#n104
* For Qt 6.6 https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/kernel/qtmetamacros.h?h=6.6#n5