### PR TITLE
CI-unixish-docker.yml: use `ubuntu:23.04` in `build_make`

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -91,7 +91,7 @@ jobs:
 
     strategy:
       matrix:
-        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04", "ubuntu:18.04", "ubuntu:22.10"]
+        image: ["centos:7", "ubuntu:14.04", "ubuntu:16.04", "ubuntu:18.04", "ubuntu:23.04"]
       fail-fast: false # Prefer quick result
 
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Forgot to update this in #4992.