### PR TITLE
matchcompiler.h: fixed some clang-tidy warnings

### DIFF
--- a/lib/matchcompiler.h
+++ b/lib/matchcompiler.h
@@ -46,7 +46,7 @@ namespace MatchCompiler {
     }
 
     template<>
-    inline bool equalN<0>(const char[], const char[])
+    inline bool equalN<0>(const char /*s1*/[], const char /*s2*/[])
     {
         return true;
     }

--- a/lib/matchcompiler.h
+++ b/lib/matchcompiler.h
@@ -27,7 +27,7 @@ namespace MatchCompiler {
     template<unsigned int n>
     class ConstString {
     public:
-        typedef const char(&StringRef)[n];
+        using StringRef = const char (&)[n];
         explicit ConstString(StringRef s)
             : _s(s) {}
 


### PR DESCRIPTION
These do not show up in the CI since we only scan the non-matchcompiled code.