### PR TITLE
CI-windows.yml: perform debug and release builds in separate jobs

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -70,6 +70,7 @@ jobs:
       matrix:
         os: [windows-2019, windows-2022]
         arch: [x64, x86]
+        config: [debug, release]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -82,6 +83,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.11
+        if: matrix.config == 'release'
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
@@ -124,6 +126,7 @@ jobs:
           CL: /MP
 
       - name: Install missing Python packages
+        if: matrix.config == 'release'
         run: |
           python -m pip install pip --upgrade || exit /b !errorlevel!
           python -m pip install pytest || exit /b !errorlevel!
@@ -140,6 +143,7 @@ jobs:
           cmake -S . -B build -DBUILD_TESTS=On || exit /b !errorlevel!
 
       - name: Build CLI debug configuration using MSBuild
+        if: matrix.config == 'debug'
         run: |
           set ARCH=${{ matrix.arch }}
           if "${{ matrix.arch }}" == "x86" (
@@ -149,9 +153,11 @@ jobs:
           msbuild -m cppcheck.sln /p:Configuration=Debug-PCRE;Platform=%ARCH% -maxcpucount || exit /b !errorlevel!
 
       - name: Run Debug test
+        if: matrix.config == 'debug'
         run: .\bin\debug\testrunner.exe || exit /b !errorlevel!
 
       - name: Build CLI release configuration using MSBuild
+        if: matrix.config == 'release'
         run: |
           set ARCH=${{ matrix.arch }}
           if "${{ matrix.arch }}" == "x86" (
@@ -161,9 +167,11 @@ jobs:
           msbuild -m cppcheck.sln /p:Configuration=Release-PCRE;Platform=%ARCH% -maxcpucount || exit /b !errorlevel!
 
       - name: Run Release test
+        if: matrix.config == 'release'
         run: .\bin\testrunner.exe || exit /b !errorlevel!
 
       - name: Run test/cli
+        if: matrix.config == 'release'
         run: |
           :: since FILESDIR is not set copy the binary to the root so the addons are found
           :: copy .\build\bin\Release\cppcheck.exe .\cppcheck.exe || exit /b !errorlevel!
@@ -179,6 +187,7 @@ jobs:
           python -m pytest test-suppress-syntaxError.py || exit /b !errorlevel!
 
       - name: Test addons
+        if: matrix.config == 'release'
         run: |
           .\cppcheck --addon=threadsafety addons\test\threadsafety || exit /b !errorlevel!
           .\cppcheck --addon=threadsafety --std=c++03 addons\test\threadsafety || exit /b !errorlevel!


### PR DESCRIPTION
The Windows jobs are along the longer jobs to run (~14 minutes) by splitting these up we reduce the peak time to about half of that.