### PR TITLE
Add some macros for Boost.Log

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -60,6 +60,8 @@
   <define name="BOOST_REQUIRE_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
   <define name="BOOST_REQUIRE_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
   <define name="BOOST_LOG_ATTRIBUTE_KEYWORD(keyword, name_, value_type_)" value="value_type_ keyword;"/>
+  <define name="BOOST_LOG_GLOBAL_LOGGER(tag_name, logger)" value="struct tag_name { typedef logger logger_type; static logger_type construct_logger(); static inline logger_type &amp; get(); };"/>
+  <define name="BOOST_LOG_GLOBAL_LOGGER_INIT(tag_name, logger)" value="tag_name::logger_type tag_name::construct_logger()"/>
   <define name="BOOST_TEST_DONT_PRINT_LOG_VALUE(the_type)" value="" />
   <!--Boost.Math Macros -->
   <define name="BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS" value=""/>


### PR DESCRIPTION
Macro values were adapted from https://github.com/boostorg/log/blob/develop/include/boost/log/sources/global_logger_storage.hpp