### PR TITLE
Consider pcre debug suffix for Windows

### DIFF
--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -31,7 +31,7 @@ endif()
 
 if (HAVE_RULES)
     find_path(PCRE_INCLUDE pcre.h)
-    find_library(PCRE_LIBRARY pcre)
+    find_library(PCRE_LIBRARY NAMES pcre pcred)
     if (NOT PCRE_LIBRARY OR NOT PCRE_INCLUDE)
         message(FATAL_ERROR "pcre dependency for RULES has not been found")
     endif()


### PR DESCRIPTION
I'm suggesting this patch from the conan recipe: https://github.com/conan-io/conan-center-index/blob/afcf3ba/recipes/cppcheck/all/patches/0003-pcre-debuglib-name.patch

I just added the latest version without applying it to see if it works: https://github.com/conan-io/conan-center-index/pull/19724
