### PR TITLE
adjusted tests to reduce the amount of `friend` declarations necessary

### DIFF
--- a/lib/checkassert.h
+++ b/lib/checkassert.h
@@ -41,8 +41,6 @@ class Token;
  */
 
 class CPPCHECKLIB CheckAssert : public Check {
-    friend class TestFixture;
-
 public:
     CheckAssert() : Check(myName()) {}
 

--- a/lib/checkautovariables.h
+++ b/lib/checkautovariables.h
@@ -45,8 +45,6 @@ namespace ValueFlow {
 
 
 class CPPCHECKLIB CheckAutoVariables : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckClass */
     CheckAutoVariables() : Check(myName()) {}

--- a/lib/checkbool.h
+++ b/lib/checkbool.h
@@ -39,8 +39,6 @@ class Token;
 /** @brief checks dealing with suspicious usage of boolean type (not for evaluating conditions) */
 
 class CPPCHECKLIB CheckBool : public Check {
-    friend class TestFixture;
-
 public:
     /** @brief This constructor is used when registering the CheckClass */
     CheckBool() : Check(myName()) {}

--- a/lib/checkboost.h
+++ b/lib/checkboost.h
@@ -38,8 +38,6 @@ class Token;
 
 /** @brief %Check Boost usage */
 class CPPCHECKLIB CheckBoost : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckClass */
     CheckBoost() : Check(myName()) {}

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -58,7 +58,6 @@ class Token;
  */
 class CPPCHECKLIB CheckBufferOverrun : public Check {
     friend class TestBufferOverrun;
-    friend class TestFixture;
 
 public:
     /** This constructor is used when registering the CheckClass */

--- a/lib/checkbufferoverrun.h
+++ b/lib/checkbufferoverrun.h
@@ -57,8 +57,6 @@ class Token;
  * other function and pass a buffer and reads or writes too much data.
  */
 class CPPCHECKLIB CheckBufferOverrun : public Check {
-    friend class TestBufferOverrun;
-
 public:
     /** This constructor is used when registering the CheckClass */
     CheckBufferOverrun() : Check(myName()) {}

--- a/lib/checkcondition.h
+++ b/lib/checkcondition.h
@@ -48,8 +48,6 @@ namespace ValueFlow {
  */
 
 class CPPCHECKLIB CheckCondition : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckAssignIf */
     CheckCondition() : Check(myName()) {}

--- a/lib/checkexceptionsafety.h
+++ b/lib/checkexceptionsafety.h
@@ -45,8 +45,6 @@ class Token;
  */
 
 class CPPCHECKLIB CheckExceptionSafety : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckClass */
     CheckExceptionSafety() : Check(myName()) {}

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -49,8 +49,6 @@ namespace ValueFlow {
  */
 
 class CPPCHECKLIB CheckFunctions : public Check {
-    friend class TestFunctions;
-
 public:
     /** This constructor is used when registering the CheckFunctions */
     CheckFunctions() : Check(myName()) {}

--- a/lib/checkfunctions.h
+++ b/lib/checkfunctions.h
@@ -50,7 +50,6 @@ namespace ValueFlow {
 
 class CPPCHECKLIB CheckFunctions : public Check {
     friend class TestFunctions;
-    friend class TestFixture;
 
 public:
     /** This constructor is used when registering the CheckFunctions */

--- a/lib/checkinternal.h
+++ b/lib/checkinternal.h
@@ -39,7 +39,6 @@ class Token;
 
 /** @brief %Check Internal cppcheck API usage */
 class CPPCHECKLIB CheckInternal : public Check {
-    friend class TestFixture;
 public:
     /** This constructor is used when registering the CheckClass */
     CheckInternal() : Check(myName()) {}

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -107,8 +107,6 @@ public:
  */
 
 class CPPCHECKLIB CheckLeakAutoVar : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckLeakAutoVar */
     CheckLeakAutoVar() : Check(myName()) {}

--- a/lib/checknullpointer.h
+++ b/lib/checknullpointer.h
@@ -48,7 +48,6 @@ namespace tinyxml2 {
 
 class CPPCHECKLIB CheckNullPointer : public Check {
     friend class TestNullPointer;
-    friend class TestFixture;
 
 public:
     /** @brief This constructor is used when registering the CheckNullPointer */

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -50,7 +50,6 @@ class CPPCHECKLIB CheckOther : public Check {
     friend class TestCharVar;
     friend class TestIncompleteStatement;
     friend class TestOther;
-    friend class TestFixture;
 
 public:
     /** @brief This constructor is used when registering the CheckClass */

--- a/lib/checksizeof.h
+++ b/lib/checksizeof.h
@@ -39,8 +39,6 @@ class Token;
 /** @brief checks on usage of sizeof() operator */
 
 class CPPCHECKLIB CheckSizeof : public Check {
-    friend class TestFixture;
-
 public:
     /** @brief This constructor is used when registering the CheckClass */
     CheckSizeof() : Check(myName()) {}

--- a/lib/checkstl.h
+++ b/lib/checkstl.h
@@ -43,8 +43,6 @@ class ErrorLogger;
 
 /** @brief %Check STL usage (invalidation of iterators, mismatching containers, etc) */
 class CPPCHECKLIB CheckStl : public Check {
-    friend class TestFixture;
-
 public:
     /** This constructor is used when registering the CheckClass */
     CheckStl() : Check(myName()) {}

--- a/lib/checkstring.h
+++ b/lib/checkstring.h
@@ -39,8 +39,6 @@ class Token;
 /** @brief Detect misusage of C-style strings and related standard functions */
 
 class CPPCHECKLIB CheckString : public Check {
-    friend class TestFixture;
-
 public:
     /** @brief This constructor is used when registering the CheckClass */
     CheckString() : Check(myName()) {}

--- a/lib/checktype.h
+++ b/lib/checktype.h
@@ -42,8 +42,6 @@ class ValueType;
 /** @brief Various small checks */
 
 class CPPCHECKLIB CheckType : public Check {
-    friend class TestFixture;
-
 public:
     /** @brief This constructor is used when registering the CheckClass */
     CheckType() : Check(myName()) {}

--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -44,8 +44,6 @@ namespace CTU {
 /// @{
 
 class CPPCHECKLIB CheckUnusedFunctions : public Check {
-    friend class TestUnusedFunctions;
-
 public:
     /** @brief This constructor is used when registering the CheckUnusedFunctions */
     CheckUnusedFunctions() : Check(myName()) {}

--- a/lib/checkvaarg.h
+++ b/lib/checkvaarg.h
@@ -40,8 +40,6 @@ class Token;
  */
 
 class CPPCHECKLIB CheckVaarg : public Check {
-    friend class TestFixture;
-
 public:
     CheckVaarg() : Check(myName()) {}
 

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -127,7 +127,7 @@ protected:
     template<typename T>
     static void runChecks(const Tokenizer &tokenizer, ErrorLogger *errorLogger)
     {
-        T& check = getCheck<T>();
+        Check& check = getCheck<T>();
         check.runChecks(tokenizer, errorLogger);
     }
 

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -4966,7 +4966,8 @@ private:
 
     void getErrorMessages() {
         // Ticket #2292: segmentation fault when using --errorlist
-        getCheck<CheckBufferOverrun>().getErrorMessages(this, nullptr);
+        Check& c = getCheck<CheckBufferOverrun>();
+        c.getErrorMessages(this, nullptr);
     }
 
     void arrayIndexThenCheck() {
@@ -5161,9 +5162,9 @@ private:
 
         // Check code..
         std::list<Check::FileInfo*> fileInfo;
-        CheckBufferOverrun checkBO(&tokenizer, &settings0, this);
-        fileInfo.push_back(checkBO.getFileInfo(&tokenizer, &settings0));
-        checkBO.analyseWholeProgram(ctu, fileInfo, settings0, *this);
+        Check& c = getCheck<CheckBufferOverrun>();
+        fileInfo.push_back(c.getFileInfo(&tokenizer, &settings0));
+        c.analyseWholeProgram(ctu, fileInfo, settings0, *this);
         while (!fileInfo.empty()) {
             delete fileInfo.back();
             fileInfo.pop_back();

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -4966,7 +4966,7 @@ private:
 
     void getErrorMessages() {
         // Ticket #2292: segmentation fault when using --errorlist
-        Check& c = getCheck<CheckBufferOverrun>();
+        const Check& c = getCheck<CheckBufferOverrun>();
         c.getErrorMessages(this, nullptr);
     }
 

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -8777,7 +8777,7 @@ private:
 
     void ctu(const std::vector<std::string> &code) {
         const Settings settings;
-        auto &check = getCheck<CheckClass>();
+        Check &check = getCheck<CheckClass>();
 
         // getFileInfo
         std::list<Check::FileInfo*> fileInfo;
@@ -8835,9 +8835,8 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        CheckClass checkClass(&tokenizer, &settings1, this);
-
-        Check::FileInfo * fileInfo = (checkClass.getFileInfo)(&tokenizer, &settings1);
+        Check& c = getCheck<CheckClass>();
+        Check::FileInfo * fileInfo = (c.getFileInfo)(&tokenizer, &settings1);
 
         delete fileInfo;
     }

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -8835,7 +8835,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
         // Check..
-        Check& c = getCheck<CheckClass>();
+        const Check& c = getCheck<CheckClass>();
         Check::FileInfo * fileInfo = (c.getFileInfo)(&tokenizer, &settings1);
 
         delete fileInfo;

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -102,13 +102,12 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, file_in.c_str()), file, line);
 
         // Check..
-        CheckIO checkIO(&tokenizer, &settings1, this);
-        checkIO.checkWrongPrintfScanfArguments();
-        if (!onlyFormatStr) {
-            checkIO.checkCoutCerrMisusage();
-            checkIO.checkFileUsage();
-            checkIO.invalidScanf();
+        if (onlyFormatStr) {
+            CheckIO checkIO(&tokenizer, &settings1, this);
+            checkIO.checkWrongPrintfScanfArguments();
+            return;
         }
+        runChecks<CheckIO>(tokenizer, this);
     }
 
     void coutCerrMisusage() {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -4412,9 +4412,9 @@ private:
 
         // Check code..
         std::list<Check::FileInfo*> fileInfo;
-        CheckNullPointer checkNullPointer(&tokenizer, &settings, this);
-        fileInfo.push_back(checkNullPointer.getFileInfo(&tokenizer, &settings));
-        checkNullPointer.analyseWholeProgram(ctu, fileInfo, settings, *this);
+        Check& c = getCheck<CheckNullPointer>();
+        fileInfo.push_back(c.getFileInfo(&tokenizer, &settings));
+        c.analyseWholeProgram(ctu, fileInfo, settings, *this);
         while (!fileInfo.empty()) {
             delete fileInfo.back();
             fileInfo.pop_back();

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -7371,9 +7371,9 @@ private:
 
         // Check code..
         std::list<Check::FileInfo*> fileInfo;
-        CheckUninitVar check(&tokenizer, &settings, this);
-        fileInfo.push_back(check.getFileInfo(&tokenizer, &settings));
-        check.analyseWholeProgram(ctu, fileInfo, settings, *this);
+        Check& c = getCheck<CheckUninitVar>();
+        fileInfo.push_back(c.getFileInfo(&tokenizer, &settings));
+        c.analyseWholeProgram(ctu, fileInfo, settings, *this);
         while (!fileInfo.empty()) {
             delete fileInfo.back();
             fileInfo.pop_back();


### PR DESCRIPTION
We were calling several interface functions through their inherited classes instead of using the base classes requiring us to add `friend` declarations to make the implementations accessible. This adjusts several of those cases.