### PR TITLE
Fix copy-paste-error

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -5613,7 +5613,7 @@ const Function* Scope::findFunction(const Token *tok, bool requireConst) const
                 }
                 const Token* valuetok = arguments[j];
                 if (valuetok->str() == "::") {
-                    const Token* rml = nextAfterAstRightmostLeaf(vartok);
+                    const Token* rml = nextAfterAstRightmostLeaf(valuetok);
                     if (rml)
                         valuetok = rml->previous();
                 }


### PR DESCRIPTION
This is a warning we found during static analyis with CodeSecure CodeSonar.

It flagged a suspicious copy-paste error, where it finds code that seems to have been copied from another location, with some, but not all, variables substituted.

Unclear to me if this truly is a problem, or intentional, but I wanted to provide the feedback as I am not sure how to test this.

Lines 5614 to 5619 in lib/symboldatabase.cpp are a copy from 5597-5602 with vartok replaced by valuetok, except for line 5616