### PR TITLE
Use intrinsics for source location if available

### DIFF
--- a/lib/sourcelocation.h
+++ b/lib/sourcelocation.h
@@ -19,12 +19,12 @@
 #ifndef sourcelocationH
 #define sourcelocationH
 
-#ifndef __has_builtin         // Optional of course.
-  #define __has_builtin(x) 0  // Compatibility with non-clang compilers.
+#ifndef __has_builtin      // Optional of course.
+#define __has_builtin(x) 0 // Compatibility with non-clang compilers.
 #endif
 
-#ifndef __has_include         // Optional of course.
-  #define __has_include(x) 0  // Compatibility with non-clang compilers.
+#ifndef __has_include      // Optional of course.
+#define __has_include(x) 0 // Compatibility with non-clang compilers.
 #endif
 
 #ifdef __CPPCHECK__
@@ -63,9 +63,10 @@ using SourceLocation = std::experimental::source_location;
 struct SourceLocation {
 #if CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS
     static SourceLocation current(std::uint_least32_t line = __builtin_LINE(),
-    std::uint_least32_t column = __builtin_COLUMN(),
-    const char* file_name = __builtin_FILE(),
-    const char* function_name = __builtin_FUNCTION()) {
+                                  std::uint_least32_t column = __builtin_COLUMN(),
+                                  const char* file_name = __builtin_FILE(),
+                                  const char* function_name = __builtin_FUNCTION())
+    {
         SourceLocation result{};
         result.m_line = line;
         result.m_column = column;

--- a/lib/sourcelocation.h
+++ b/lib/sourcelocation.h
@@ -19,10 +19,20 @@
 #ifndef sourcelocationH
 #define sourcelocationH
 
+#ifndef __has_builtin         // Optional of course.
+  #define __has_builtin(x) 0  // Compatibility with non-clang compilers.
+#endif
+
+#ifndef __has_include         // Optional of course.
+  #define __has_include(x) 0  // Compatibility with non-clang compilers.
+#endif
+
 #ifdef __CPPCHECK__
 #define CPPCHECK_HAS_SOURCE_LOCATION 0
 #define CPPCHECK_HAS_SOURCE_LOCATION_TS 0
-#elif defined(__has_include)
+#define CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS 0
+#else
+
 #if __has_include(<source_location>) && __cplusplus >= 202003L
 #define CPPCHECK_HAS_SOURCE_LOCATION 1
 #else
@@ -33,9 +43,13 @@
 #else
 #define CPPCHECK_HAS_SOURCE_LOCATION_TS 0
 #endif
+
+#if __has_builtin(__builtin_FILE)
+#define CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS 1
 #else
-#define CPPCHECK_HAS_SOURCE_LOCATION 0
-#define CPPCHECK_HAS_SOURCE_LOCATION_TS 0
+#define CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS 0
+#endif
+
 #endif
 
 #if CPPCHECK_HAS_SOURCE_LOCATION
@@ -47,9 +61,23 @@ using SourceLocation = std::experimental::source_location;
 #else
 #include <cstdint>
 struct SourceLocation {
+#if CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS
+    static SourceLocation current(std::uint_least32_t line = __builtin_LINE(),
+    std::uint_least32_t column = __builtin_COLUMN(),
+    const char* file_name = __builtin_FILE(),
+    const char* function_name = __builtin_FUNCTION()) {
+        SourceLocation result{};
+        result.m_line = line;
+        result.m_column = column;
+        result.m_file_name = file_name;
+        result.m_function_name = function_name;
+        return result;
+    }
+#else
     static SourceLocation current() {
         return SourceLocation();
     }
+#endif
     std::uint_least32_t m_line = 0;
     std::uint_least32_t m_column = 0;
     const char* m_file_name = "";

--- a/lib/sourcelocation.h
+++ b/lib/sourcelocation.h
@@ -19,11 +19,11 @@
 #ifndef sourcelocationH
 #define sourcelocationH
 
-#ifndef __has_builtin      // Optional of course.
+#ifndef __has_builtin
 #define __has_builtin(x) 0 // Compatibility with non-clang compilers.
 #endif
 
-#ifndef __has_include      // Optional of course.
+#ifndef __has_include
 #define __has_include(x) 0 // Compatibility with non-clang compilers.
 #endif
 

--- a/lib/sourcelocation.h
+++ b/lib/sourcelocation.h
@@ -46,6 +46,9 @@
 
 #if __has_builtin(__builtin_FILE)
 #define CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS 1
+#if !__has_builtin(__builtin_COLUMN)
+#define __builtin_COLUMN() 0
+#endif
 #else
 #define CPPCHECK_HAS_SOURCE_LOCATION_INTRINSICS 0
 #endif


### PR DESCRIPTION
Sometimes the compiler supports the intrinsic even if the C++ runtime doesnt yet.