### PR TITLE
added `--strict` and `-vv` to pytest calls

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -366,11 +366,11 @@ jobs:
       - name: Run test/cli
         run: |
           cd test/cli
-          python3 -m pytest test-*.py
+          python3 -m pytest --strict -vv test-*.py
           cd ../../..
           ln -s cppcheck 'cpp check'
           cd 'cpp check/test/cli'
-          python3 -m pytest test-*.py
+          python3 -m pytest --strict -vv test-*.py
 
       - name: Run cfg tests
         if: matrix.os != 'ubuntu-22.04'

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -168,13 +168,13 @@ jobs:
           copy .\bin\cppcheck.exe .\cppcheck.exe || exit /b !errorlevel!
           copy .\bin\cppcheck-core.dll .\cppcheck-core.dll || exit /b !errorlevel!
           cd test/cli || exit /b !errorlevel!
-          :: python -m pytest --suppress-no-test-exit-code test-clang-import.py || exit /b !errorlevel!
-          python -m pytest test-helloworld.py || exit /b !errorlevel!
-          python -m pytest test-inline-suppress.py || exit /b !errorlevel!
-          python -m pytest test-more-projects.py || exit /b !errorlevel!
-          python -m pytest test-other.py || exit /b !errorlevel!
-          python -m pytest test-proj2.py || exit /b !errorlevel!
-          python -m pytest test-suppress-syntaxError.py || exit /b !errorlevel!
+          :: python -m pytest --strict -vv --suppress-no-test-exit-code test-clang-import.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-helloworld.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-inline-suppress.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-more-projects.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-other.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-proj2.py || exit /b !errorlevel!
+          python -m pytest --strict -vv test-suppress-syntaxError.py || exit /b !errorlevel!
 
       - name: Test addons
         if: matrix.config == 'release'

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: test addons
         run: |
-          python -m pytest -v addons/test/test-*.py
+          python -m pytest --strict -vv addons/test/test-*.py
         env:
           PYTHONPATH: ./addons
 
@@ -149,21 +149,21 @@ jobs:
 
       - name: test reduce
         run: |
-          python -m pytest -v tools/test_reduce.py
+          python -m pytest --strict -vv tools/test_reduce.py
         env:
           PYTHONPATH: ./tools
 
       - name: test donate_cpu_lib
         if: matrix.python-version != '2.7'
         run: |
-          python -m pytest -v tools/test_donate_cpu_lib.py
+          python -m pytest --strict -vv tools/test_donate_cpu_lib.py
         env:
           PYTHONPATH: ./tools
 
       - name: test donate_cpu_server
         if: matrix.python-version != '2.7'
         run: |
-          python -m pytest -v tools/test_donate_cpu_server.py
+          python -m pytest --strict -vv tools/test_donate_cpu_server.py
         env:
           PYTHONPATH: ./tools
 


### PR DESCRIPTION
`--strict` ensures e.g. all the markers are known and `-vv` provides more verbose output making it easier to see why a test failed.