### PR TITLE
Support importing projects with project-name

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -1232,6 +1232,8 @@ bool ImportProject::importCppcheckGuiProject(std::istream &istr, Settings *setti
                     temp.premiumArgs += std::string(" --") + child->GetText();
             }
         }
+        else if (strcmp(node->Name(), CppcheckXml::ProjectNameElementName) == 0)
+            ; // no-op
         else {
             printError("Unknown element '" + std::string(node->Name()) + "' in Cppcheck project file");
             return false;

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -340,6 +340,7 @@ private:
                            "    <exclude>\n"
                            "        <path name=\"gui/temp/\"/>\n"
                            "    </exclude>\n"
+                           "    <project-name>test test</project-name>\n"
                            "</project>\n";
         std::istringstream istr(xml);
         Settings s;


### PR DESCRIPTION
Projects created with GUI contain project-name tag. The tag was not supported by cmd line importer,
which caused cppcheck to fail.


My use case was:
1. Create the project with GUI on Windows
2. Run cppcheck on multiple cores with _-j_ flag