### PR TITLE
refs #11993 - error out in `TestFileLister::recursiveAddFiles()` instead of looping infinitely when repository root directory is not found

### DIFF
--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -43,7 +43,11 @@ private:
     static std::string findBaseDir() {
         std::string basedir;
         while (!Path::isDirectory(Path::join(basedir, ".github"))) {
+            const std::string abspath = Path::getAbsoluteFilePath(basedir);
             basedir += "../";
+            // no more going up
+            if (Path::getAbsoluteFilePath(basedir) == abspath)
+                throw std::runtime_error("could not find repository root directory");
         }
         return basedir;
     }


### PR DESCRIPTION
Not a proper fix yet but at least it prevents the hang and gives some feedback.