### PR TITLE
donate-cpu-server.py: added `pkgs` query parameter to `check_library-*`, `incomplete_var-*` and `unknown_macro-*` reports

### DIFF
--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -1003,6 +1003,13 @@ def check_library_function_name(result_path: str, function_name: str, query_para
         package_url = None
         cppcheck_options = None
         for line in open(filename, 'rt'):
+            if line.startswith('cppcheck: '):
+                if OLD_VERSION not in line:
+                    # Package results seem to be too old, skip
+                    break
+                else:
+                    # Current package, parse on
+                    continue
             if line.startswith('ftp://'):
                 package_url = line
                 continue

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -987,10 +987,10 @@ def check_library_report(result_path: str, message_id: str) -> str:
 # Lists all checkLibrary* messages regarding the given function name
 def check_library_function_name(result_path: str, function_name: str, query_params: dict, nonfunc_id: str='') -> str:
     pkgs = '' if query_params.get('pkgs') == '1' else None
+    function_name = urllib.parse.unquote_plus(function_name)
     if nonfunc_id:
         id = '[' + nonfunc_id
     else:
-        function_name = urllib.parse.unquote_plus(function_name)
         if function_name.endswith('()'):
             id = '[checkLibrary'
         else:

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -985,7 +985,8 @@ def check_library_report(result_path: str, message_id: str) -> str:
 
 
 # Lists all checkLibrary* messages regarding the given function name
-def check_library_function_name(result_path: str, function_name: str, nonfunc_id: str='') -> str:
+def check_library_function_name(result_path: str, function_name: str, query_params: dict, nonfunc_id: str='') -> str:
+    pkgs = '' if query_params.get('pkgs') == '1' else None
     if nonfunc_id:
         id = '[' + nonfunc_id
     else:
@@ -999,11 +1000,11 @@ def check_library_function_name(result_path: str, function_name: str, nonfunc_id
         if not os.path.isfile(filename) or filename.endswith('.diff'):
             continue
         info_messages = False
-        url = None
+        package_url = None
         cppcheck_options = None
         for line in open(filename, 'rt'):
             if line.startswith('ftp://'):
-                url = line
+                package_url = line
                 continue
             if line.startswith('cppcheck-options:'):
                 cppcheck_options = line
@@ -1014,16 +1015,23 @@ def check_library_function_name(result_path: str, function_name: str, nonfunc_id
                     continue
                 if not info_messages:
                     continue
-            if id in line:
-                if (' ' + function_name + ' ') in line:
-                    if url:
-                        output_lines_list.append(url)
-                        url = None
-                    if cppcheck_options:
-                        output_lines_list.append(cppcheck_options)
-                        cppcheck_options = None
-                    output_lines_list.append(line)
+            if id not in line:
+                continue
+            if not (' ' + function_name + ' ') in line:
+                continue
+            if pkgs is not None and package_url is not None:
+                pkgs += '{}\n'.format(package_url.strip())
+                break
+            if package_url:
+                output_lines_list.append(package_url)
+                package_url = None
+            if cppcheck_options:
+                output_lines_list.append(cppcheck_options)
+                cppcheck_options = None
+            output_lines_list.append(line)
 
+    if pkgs is not None:
+        return pkgs
     return ''.join(output_lines_list)
 
 
@@ -1144,7 +1152,7 @@ class HttpClientThread(Thread):
                 httpGetResponse(self.connection, text, 'text/html')
             elif url.startswith('/check_library-'):
                 function_name = url[len('/check_library-'):]
-                text = check_library_function_name(self.infoPath, function_name)
+                text = check_library_function_name(self.infoPath, function_name, queryParams)
                 httpGetResponse(self.connection, text, 'text/plain')
             elif url == '/value_flow_bailout_incomplete_var.html':
                 text = check_library_report(self.resultPath, message_id='valueFlowBailoutIncompleteVar')
@@ -1154,11 +1162,11 @@ class HttpClientThread(Thread):
                 httpGetResponse(self.connection, text, 'text/html')
             elif url.startswith('/incomplete_var-'):
                 var_name = url[len('/incomplete_var-'):]
-                text = check_library_function_name(self.resultPath, var_name, nonfunc_id='valueFlowBailoutIncompleteVar')
+                text = check_library_function_name(self.resultPath, var_name, queryParams, nonfunc_id='valueFlowBailoutIncompleteVar')
                 httpGetResponse(self.connection, text, 'text/plain')
             elif url.startswith('/unknown_macro-'):
                 var_name = url[len('/unknown_macro-'):]
-                text = check_library_function_name(self.resultPath, var_name, nonfunc_id='unknownMacro')
+                text = check_library_function_name(self.resultPath, var_name, queryParams, nonfunc_id='unknownMacro')
                 httpGetResponse(self.connection, text, 'text/plain')
             else:
                 filename = resultPath + url

--- a/tools/donate-cpu-server.py
+++ b/tools/donate-cpu-server.py
@@ -26,7 +26,7 @@ from urllib.parse import urlparse
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-SERVER_VERSION = "1.3.43"
+SERVER_VERSION = "1.3.44"
 
 OLD_VERSION = '2.12.0'
 


### PR DESCRIPTION
This also fixes the missing results for `;` and filters out outdated results.