### PR TITLE
perform logging in `CmdLineParser` through an interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -639,10 +639,10 @@ $(libcppdir)/utils.o: lib/utils.cpp lib/config.h lib/utils.h
 $(libcppdir)/vfvalue.o: lib/vfvalue.cpp lib/config.h lib/errortypes.h lib/mathlib.h lib/templatesimplifier.h lib/token.h lib/utils.h lib/vfvalue.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/vfvalue.cpp
 
-cli/cmdlineparser.o: cli/cmdlineparser.cpp cli/cmdlineparser.h cli/cppcheckexecutor.h cli/filelister.h externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h
+cli/cmdlineparser.o: cli/cmdlineparser.cpp cli/cmdlinelogger.h cli/cmdlineparser.h cli/cppcheckexecutor.h cli/filelister.h externals/tinyxml2/tinyxml2.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/timer.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/cmdlineparser.cpp
 
-cli/cppcheckexecutor.o: cli/cppcheckexecutor.cpp cli/cmdlineparser.h cli/cppcheckexecutor.h cli/cppcheckexecutorseh.h cli/cppcheckexecutorsig.h cli/executor.h cli/filelister.h cli/processexecutor.h cli/singleexecutor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/checkers.h lib/checkersreport.h lib/checkunusedfunctions.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
+cli/cppcheckexecutor.o: cli/cppcheckexecutor.cpp cli/cmdlinelogger.h cli/cmdlineparser.h cli/cppcheckexecutor.h cli/cppcheckexecutorseh.h cli/cppcheckexecutorsig.h cli/executor.h cli/filelister.h cli/processexecutor.h cli/singleexecutor.h cli/threadexecutor.h lib/analyzerinfo.h lib/check.h lib/checkers.h lib/checkersreport.h lib/checkunusedfunctions.h lib/color.h lib/config.h lib/cppcheck.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/path.h lib/pathmatch.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_CLI} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ cli/cppcheckexecutor.cpp
 
 cli/cppcheckexecutorseh.o: cli/cppcheckexecutorseh.cpp cli/cppcheckexecutor.h cli/cppcheckexecutorseh.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/utils.h
@@ -720,7 +720,7 @@ test/testclangimport.o: test/testclangimport.cpp lib/check.h lib/clangimport.h l
 test/testclass.o: test/testclass.cpp externals/simplecpp/simplecpp.h lib/check.h lib/checkclass.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/preprocessor.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testclass.cpp
 
-test/testcmdlineparser.o: test/testcmdlineparser.cpp cli/cmdlineparser.h cli/cppcheckexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h test/redirect.h
+test/testcmdlineparser.o: test/testcmdlineparser.cpp cli/cmdlinelogger.h cli/cmdlineparser.h cli/cppcheckexecutor.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/timer.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h test/redirect.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testcmdlineparser.cpp
 
 test/testcolor.o: test/testcolor.cpp lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/importproject.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h

--- a/cli/cmdlinelogger.h
+++ b/cli/cmdlinelogger.h
@@ -1,0 +1,33 @@
+/*
+ * Cppcheck - A tool for static C/C++ code analysis
+ * Copyright (C) 2007-2023 Cppcheck team.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CMD_LINE_LOGGER_H
+#define CMD_LINE_LOGGER_H
+
+#include <string>
+
+class CmdLineLogger
+{
+public:
+    virtual ~CmdLineLogger() = default;
+
+    virtual void printMessage(const std::string &message) = 0;
+    virtual void printError(const std::string &message) = 0;
+};
+
+#endif // CMD_LINE_LOGGER_H

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "cmdlinelogger.h"
 #include "utils.h"
 
 class Settings;
@@ -44,12 +45,13 @@ class CmdLineParser {
 public:
     /**
      * The constructor.
+     * @param logger The logger instance to log messages through
      * @param settings Settings instance that will be modified according to
      * options user has given.
      * @param suppressions Suppressions instance that keeps the suppressions
      * @param suppressionsNoFail Suppressions instance that keeps the "do not fail" suppressions
      */
-    CmdLineParser(Settings &settings, Suppressions &suppressions, Suppressions &suppressionsNoFail);
+    CmdLineParser(CmdLineLogger &logger, Settings &settings, Suppressions &suppressions, Suppressions &suppressionsNoFail);
 
     /**
      * Parse given command line.
@@ -99,35 +101,27 @@ protected:
      */
     void printHelp();
 
-    /**
-     * Print message (to stdout).
-     */
-    static void printMessage(const std::string &message);
-
-    /**
-     * Print error message (to stdout).
-     */
-    static void printError(const std::string &message);
-
 private:
     bool isCppcheckPremium() const;
 
     template<typename T>
-    static bool parseNumberArg(const char* const arg, std::size_t offset, T& num, bool mustBePositive = false)
+    bool parseNumberArg(const char* const arg, std::size_t offset, T& num, bool mustBePositive = false)
     {
         T tmp;
         std::string err;
         if (!strToInt(arg + offset, tmp, &err)) {
-            printError("argument to '" + std::string(arg, offset) + "' is not valid - " + err + ".");
+            mLogger.printError("argument to '" + std::string(arg, offset) + "' is not valid - " + err + ".");
             return false;
         }
         if (mustBePositive && tmp < 0) {
-            printError("argument to '" + std::string(arg, offset) + "' needs to be a positive integer.");
+            mLogger.printError("argument to '" + std::string(arg, offset) + "' needs to be a positive integer.");
             return false;
         }
         num = tmp;
         return true;
     }
+
+    CmdLineLogger &mLogger;
 
     std::vector<std::string> mPathNames;
     std::vector<std::string> mIgnoredPaths;

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -85,6 +85,22 @@ class XMLErrorMessagesLogger : public ErrorLogger
     {}
 };
 
+class CmdLineLoggerStd : public CmdLineLogger
+{
+public:
+    CmdLineLoggerStd() = default;
+
+    void printMessage(const std::string &message) override
+    {
+        std::cout << "cppcheck: " << message << std::endl;
+    }
+
+    void printError(const std::string &message) override
+    {
+        printMessage("error: " + message);
+    }
+};
+
 // TODO: do not directly write to stdout
 
 /*static*/ FILE* CppCheckExecutor::mExceptionOutput = stdout;
@@ -96,7 +112,8 @@ CppCheckExecutor::~CppCheckExecutor()
 
 bool CppCheckExecutor::parseFromArgs(Settings &settings, int argc, const char* const argv[])
 {
-    CmdLineParser parser(settings, settings.nomsg, settings.nofail);
+    CmdLineLoggerStd logger;
+    CmdLineParser parser(logger, settings, settings.nomsg, settings.nofail);
     const bool success = parser.parseFromArgs(argc, argv);
 
     if (success) {

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <iostream>
 #include <list>
 #include <set>
 #include <string>
@@ -43,12 +44,29 @@ public:
     {}
 
 private:
+    class CmdLineLoggerTest : public CmdLineLogger
+    {
+    public:
+        CmdLineLoggerTest() = default;
+
+        void printMessage(const std::string &message) override
+        {
+            std::cout << "cppcheck: " << message << std::endl;
+        }
+
+        void printError(const std::string &message) override
+        {
+            printMessage("error: " + message);
+        }
+    };
+
+    CmdLineLoggerTest logger;
     std::unique_ptr<Settings> settings;
     std::unique_ptr<CmdLineParser> parser;
 
     void prepareTestInternal() override {
         settings.reset(new Settings());
-        parser.reset(new CmdLineParser(*settings, settings->nomsg, settings->nofail));
+        parser.reset(new CmdLineParser(logger, *settings, settings->nomsg, settings->nofail));
     }
 
     void run() override {


### PR DESCRIPTION
This is in preparation of avoiding accessing `std::cout` directly as well as streamlining and improving the logging during the settings parsing. There are no functional changes yet.