### PR TITLE
gtk: add g_file_info_get_* exceptions

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -2889,6 +2889,18 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
+  <function name="g_file_info_get_attribute_object">
+    <leak-ignore/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="g_file_info_get_icon">
+    <leak-ignore/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="g_file_info_get_symbolic_icon">
+    <leak-ignore/>
+    <noreturn>false</noreturn>
+  </function>
   <!-- gint g_fprintf (FILE *file, gchar const *format, ...); -->
   <function name="g_fprintf">
     <leak-ignore/>


### PR DESCRIPTION
These are annotated as `(transfer none)`.