### PR TITLE
test: Add parallel addon running test

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -342,6 +342,7 @@ jobs:
           python3 -m pip install pip --upgrade
           python3 -m pip install pytest
           python3 -m pip install pytest-timeout
+          python3 -m pip install asyncio
 
       - name: Build cppcheck
         run: |

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -134,6 +134,7 @@ jobs:
           python -m pip install pytest || exit /b !errorlevel!
           python -m pip install pytest-custom_exit_code || exit /b !errorlevel!
           python -m pip install pytest-timeout || exit /b !errorlevel!
+          python -m pip install asyncio || exit /b !errorlevel!
 
       - name: Run CMake
         if: false # TODO: enable


### PR DESCRIPTION
Follow up from comment: https://github.com/danmar/cppcheck/pull/5491#issuecomment-1748494789

I verified this test passes on https://github.com/danmar/cppcheck/commit/f054feba8
but fails on d9a8909d2

Optional to test that would catch https://trac.cppcheck.net/ticket/12015 
It might be a bad idea to include this test because its non-deterministic and might be platform-specific.
