### PR TITLE
windows.cfg: Fixed wrong configuration of GetModuleHandle(A|W)-functions

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -4825,7 +4825,7 @@ HFONT CreateFont(
       <not-uninit/>
       <not-bool/>
     </arg>
-    <arg nr="2" direction="in">
+    <arg nr="2" direction="out">
       <not-uninit/>
       <strz/>
       <minsize type="argvalue" arg="3"/>

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -8,14 +8,23 @@
 //
 
 #include <windows.h>
-#include <stdio.h>
+#include <cstdio>
 #include <direct.h>
-#include <stdlib.h>
-#include <time.h>
+#include <cstdlib>
+#include <ctime>
 #include <memory.h>
 #include <mbstring.h>
 #include <wchar.h>
 #include <atlstr.h>
+#include <string>
+
+/// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
+std::string constVariable_GetModuleFileName(void) {
+    char path[42];
+    if(GetModuleFileNameA(NULL, path, sizeof(path))==0)
+		return std::string();
+	return std::string{path};
+}
 
 int stringCompare_mbscmp(const unsigned char *string1, const unsigned char *string2)
 {

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -21,9 +21,9 @@
 /// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
 std::string constVariable_GetModuleFileName(void) {
     char path[42];
-    if(GetModuleFileNameA(NULL, path, sizeof(path))==0)
-		return std::string();
-	return std::string{path};
+    if (GetModuleFileNameA(NULL, path, sizeof(path))==0)
+        return std::string();
+    return std::string{path};
 }
 
 int stringCompare_mbscmp(const unsigned char *string1, const unsigned char *string2)


### PR DESCRIPTION
This fixes a FP: `Variable 'path' can be declared as const array [constVariable]`

The reason was the wrong direction attribute of GetModuleHandle()