### PR TITLE
windows.cfg: Fix wrong FlushConsoleInputBuffer configuration

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -4791,7 +4791,7 @@ HFONT CreateFont(
   </function>
   <!--BOOL WINAPI FlushConsoleInputBuffer(_In_ HANDLE hConsoleInput);-->
   <function name="FlushConsoleInputBuffer">
-    <noreturn>true</noreturn>
+    <noreturn>false</noreturn>
     <returnValue type="BOOL"/>
     <leak-ignore/>
     <arg nr="1" direction="in">

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -7,7 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
-#include <windows.h>
+#include <Windows.h>
+#include <WinCon.h>
 #include <cstdio>
 #include <direct.h>
 #include <cstdlib>
@@ -17,6 +18,15 @@
 #include <wchar.h>
 #include <atlstr.h>
 #include <string>
+
+/// https://learn.microsoft.com/en-us/windows/console/flushconsoleinputbuffer
+BOOL unreachableCode_FlushConsoleInputBuffer(int &val)
+{
+   const BOOL retVal = FlushConsoleInputBuffer(GetStdHandle(STD_INPUT_HANDLE));
+   // still reachable after call FlushConsoleInputBuffer()
+   val = 42;
+   return retVal;
+}
 
 /// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew
 std::string constVariable_GetModuleFileName(void) {

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -22,10 +22,10 @@
 /// https://learn.microsoft.com/en-us/windows/console/flushconsoleinputbuffer
 BOOL unreachableCode_FlushConsoleInputBuffer(int &val)
 {
-   const BOOL retVal = FlushConsoleInputBuffer(GetStdHandle(STD_INPUT_HANDLE));
-   // still reachable after call FlushConsoleInputBuffer()
-   val = 42;
-   return retVal;
+    const BOOL retVal = FlushConsoleInputBuffer(GetStdHandle(STD_INPUT_HANDLE));
+    // still reachable after call FlushConsoleInputBuffer()
+    val = 42;
+    return retVal;
 }
 
 /// https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamew


### PR DESCRIPTION
After flushing, the function returns. Before it was configured to not-return.
A proper regression test was added.