### PR TITLE
std.cfg: remove wrong macro replacements for UINT32_C etc.

### DIFF
--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -696,6 +696,7 @@ static void misra_10_3(uint32_t u32a, uint32_t u32b) {
     res = 2U + 3U; // no warning, utlr=unsigned char
     res = 0.1f; // 10.3
     const char c = '0'; // no-warning
+    uint32_t u = UINT32_C(10); // no-warning
 }
 
 static void misra_10_4(u32 x, s32 y) {

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <def format="2">
-  <!-- helpers -->
-  <define name="__CONCATenate(left, right)" value="left ## right"/>
-  <define name="__CONCAT(left, right)" value="__CONCATenate(left, right)"/>
   <!-- stdint.h -->
   <define name="INT8_MIN" value="-128"/>
   <define name="INT16_MIN" value="-32768"/>
@@ -40,17 +37,6 @@
   <define name="UINT_LEAST16_MAX" value="65535U"/>
   <define name="UINT_LEAST32_MAX" value="4294967295U"/>
   <define name="UINT_LEAST64_MAX" value="18446744073709551615U"/>
-  <!-- Macros for integer constants -->
-  <define name="INT8_C(value)" value="((int8_t) value)"/>
-  <define name="UINT8_C(value)" value="((uint8_t) __CONCAT(value, U))"/>
-  <define name="INT16_C(value)" value="value"/>
-  <define name="UINT16_C(value)" value="__CONCAT(value, U)"/>
-  <define name="INT32_C(value)" value="__CONCAT(value, L)"/>
-  <define name="UINT32_C(value)" value="__CONCAT(value, UL)"/>
-  <define name="INT64_C(value)" value="__CONCAT(value, LL)"/>
-  <define name="UINT64_C(value)" value="__CONCAT(value, ULL)"/>
-  <define name="INTMAX_C(value)" value="__CONCAT(value, LL)"/>
-  <define name="UINTMAX_C(value)" value="__CONCAT(value, ULL)"/>
   <!-- math.h -->
   <define name="M_E" value="2.7182818284590452354"/>
   <define name="M_LOG2E" value="1.4426950408889634074"/>


### PR DESCRIPTION
 The replacements should be platform dependent. And I am skeptic that i.e. UINT32_C(10L) should be replaced with 10LUL i.e. making it a long long.