### PR TITLE
Fix Cert C++ warnings reported by Cppcheck Premium

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2189,10 +2189,9 @@ Variable& Variable::operator=(const Variable &var)
     mScope = var.mScope;
     mDimensions = var.mDimensions;
     delete mValueType;
+    mValueType = nullptr;
     if (var.mValueType)
         mValueType = new ValueType(*var.mValueType);
-    else
-        mValueType = nullptr;
 
     return *this;
 }
@@ -2347,6 +2346,7 @@ void Variable::setValueType(const ValueType &valueType)
             return;
     }
     delete mValueType;
+    mValueType = nullptr;
     mValueType = new ValueType(valueType);
     if ((mValueType->pointer > 0) && (!isArray() || Token::Match(mNameToken->previous(), "( * %name% )")))
         setFlag(fIsPointer, true);

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -546,7 +546,7 @@ public:
      * @return length of dimension
      */
     MathLib::bigint dimension(nonneg int index_) const {
-        return mDimensions[index_].num;
+        return mDimensions.at(index_).num;
     }
 
     /**
@@ -554,7 +554,7 @@ public:
      * @return length of dimension known
      */
     bool dimensionKnown(nonneg int index_) const {
-        return mDimensions[index_].known;
+        return mDimensions.at(index_).known;
     }
 
     /**

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -234,14 +234,6 @@ TemplateSimplifier::TokenAndName::TokenAndName(const TokenAndName& other) :
         mToken->templateSimplifierPointer(this);
 }
 
-TemplateSimplifier::TokenAndName::TokenAndName(TokenAndName&& other) NOEXCEPT :
-    mToken(other.mToken), mScope(std::move(other.mScope)), mName(std::move(other.mName)), mFullName(std::move(other.mFullName)),
-    mNameToken(other.mNameToken), mParamEnd(other.mParamEnd), mFlags(other.mFlags)
-{
-    if (mToken)
-        mToken->templateSimplifierPointer(this);
-}
-
 TemplateSimplifier::TokenAndName::~TokenAndName()
 {
     if (mToken && mToken->templateSimplifierPointers())

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -152,7 +152,6 @@ public:
          */
         TokenAndName(Token *token, std::string scope, const Token *nameToken, const Token *paramEnd);
         TokenAndName(const TokenAndName& other);
-        TokenAndName(TokenAndName&& other) NOEXCEPT;
         ~TokenAndName();
 
         bool operator == (const TokenAndName & rhs) const {


### PR DESCRIPTION
Warnings:
```

lib/symboldatabase.h:549:27: error: Guarantee that container indices and iterators are within the valid range [premium-cert-ctr50-cpp]
        return mDimensions[index_].num;
                          ^
lib/symboldatabase.h:557:27: error: Guarantee that container indices and iterators are within the valid range [premium-cert-ctr50-cpp]
        return mDimensions[index_].known;
                          ^
lib/symboldatabase.cpp:2193:20: error: Guarantee exception safety. An exception during allocation would violate the exception safety rules. [premium-cert-err56-cpp]
        mValueType = new ValueType(*var.mValueType);
                   ^
lib/symboldatabase.cpp:2191:5: note: Deallocated mValueType
    delete mValueType;
    ^
lib/symboldatabase.cpp:2193:20: note: Reallocated mValueType
        mValueType = new ValueType(*var.mValueType);
                   ^
lib/symboldatabase.cpp:2350:16: error: Guarantee exception safety. An exception during allocation would violate the exception safety rules. [premium-cert-err56-cpp]
    mValueType = new ValueType(valueType);
               ^
lib/symboldatabase.cpp:2349:5: note: Deallocated mValueType
    delete mValueType;
    ^
lib/symboldatabase.cpp:2350:16: note: Reallocated mValueType
    mValueType = new ValueType(valueType);
               ^
lib/templatesimplifier.cpp:242:17: error: Noexcept function TokenAndName may exit with an exception. [premium-cert-err55-cpp]
        mToken->templateSimplifierPointer(this);
                ^

```