### PR TITLE
fixed #12016 - ProcessExecutor: added missing invocation of clang-tidy

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -279,7 +279,8 @@ unsigned int ProcessExecutor::check()
 
                 if (iFileSettings != mSettings.project.fileSettings.end()) {
                     resultOfCheck = fileChecker.check(*iFileSettings);
-                    // TODO: call analyseClangTidy()
+                    if (fileChecker.settings().clangTidy)
+                        fileChecker.analyseClangTidy(*iFileSettings);
                 } else {
                     // Read file from a file
                     resultOfCheck = fileChecker.check(iFile->first);


### PR DESCRIPTION
No changes in tests since the intercepted invocation function in called in a forked process. The clang-tidy integration is also broken.