### PR TITLE
updated Qt in CI to 6.6.0 and removed commercial-only LTS Qt versions

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        qt_ver: [5.15.2, 6.2.4, 6.5.3]
+        qt_ver: [5.15.2, 6.2.4, 6.5.3, 6.6.0]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2019, windows-2022]
-        qt_ver: [5.15.2, 6.2.4, 6.5.3, 6.6.0]
+        qt_ver: [5.15.2, 6.6.0]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      QT_VERSION: 6.5.3
+      QT_VERSION: 6.6.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      QT_VERSION: 6.5.3
+      QT_VERSION: 6.6.0
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Updates for the Qt 6.2.x and 6.5.x LTS versions are only being provided to commercial customers so the latest version is the only feasible one to use.

Builds with older 6.x versions are still being tested implicitly by using the Qt versions provided by the various distros.