### PR TITLE
fixed #12063 - use less heavy code in executor tests

### DIFF
--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -161,7 +161,7 @@ private:
         oss << "int main()\n"
             << "{\n";
         for (int i = 0; i < 500; i++)
-            oss << "  {char *a = malloc(10);}\n";
+            oss << "  {int i = *((int*)0);}\n";
 
         oss << "  return 0;\n"
             << "}\n";
@@ -173,7 +173,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}");
     }
@@ -184,7 +184,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY));
     }
@@ -196,7 +196,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.plistOutput = plistOutput.c_str()));
     }
@@ -229,7 +229,7 @@ private:
         check(2, 1, 1,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -238,7 +238,7 @@ private:
         check(2, 20, 20,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -256,7 +256,7 @@ private:
         check(2, 4, 2,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}",
               dinit(CheckOptions,

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -163,7 +163,7 @@ private:
         check(100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions,
                          $.quiet = false));
@@ -180,7 +180,7 @@ private:
         check(100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY));
     }
@@ -192,7 +192,7 @@ private:
         check(100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.plistOutput = plistOutput.c_str()));
     }
@@ -225,7 +225,7 @@ private:
         check(1, 1,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -234,7 +234,7 @@ private:
         check(20, 20,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -252,7 +252,7 @@ private:
         check(4, 2,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}",
               dinit(CheckOptions,

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -160,7 +160,7 @@ private:
         oss << "int main()\n"
             << "{\n";
         for (int i = 0; i < 500; i++)
-            oss << "  {char *a = malloc(10);}\n";
+            oss << "  {int i = *((int*)0);}\n";
 
         oss << "  return 0;\n"
             << "}\n";
@@ -172,7 +172,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}");
     }
@@ -183,7 +183,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.showtime = SHOWTIME_MODES::SHOWTIME_SUMMARY));
     }
@@ -195,7 +195,7 @@ private:
         check(16, 100, 100,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}", dinit(CheckOptions, $.plistOutput = plistOutput.c_str()));
     }
@@ -228,7 +228,7 @@ private:
         check(2, 1, 1,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -237,7 +237,7 @@ private:
         check(2, 20, 20,
               "int main()\n"
               "{\n"
-              "  {char *a = malloc(10);}\n"
+              "  {int i = *((int*)0);}\n"
               "  return 0;\n"
               "}");
     }
@@ -255,7 +255,7 @@ private:
         check(2, 4, 2,
               "int main()\n"
               "{\n"
-              "  char *a = malloc(10);\n"
+              "  int i = *((int*)0);\n"
               "  return 0;\n"
               "}",
               dinit(CheckOptions,


### PR DESCRIPTION
The allocation invokes some heavy ValueFlow computations. We just want to generate an unconditional error from the analysis so use some lighter code which does the same.

`TestThreadExecutorFiles::deadlock_with_many_errors`

Before:
```
real    0m23.517s
user    0m33.453s
sys     0m2.297s
```

After:
```
real    0m5.051s
user    0m6.234s
sys     0m0.422s
```