### PR TITLE
donate-cpu: some small improvements

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -182,6 +182,9 @@ while True:
         if ver == 'head':
             ver = 'main'
         current_cppcheck_dir = os.path.join(work_path, 'tree-'+ver)
+        if ver != 'main' and lib.has_binary(current_cppcheck_dir):
+            print('No need to check Cppcheck-{} for changes - binary already exists'.format(ver))
+            continue
         print('Checking Cppcheck-{} for changes..'.format(ver))
         try:
             has_changes = lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)

--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -182,14 +182,14 @@ while True:
         if ver == 'head':
             ver = 'main'
         current_cppcheck_dir = os.path.join(work_path, 'tree-'+ver)
-        print('Fetching Cppcheck-{}..'.format(ver))
+        print('Checking Cppcheck-{} for changes..'.format(ver))
         try:
             has_changes = lib.try_retry(lib.checkout_cppcheck_version, fargs=(repo_path, ver, current_cppcheck_dir), max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
         except KeyboardInterrupt as e:
             # Passthrough for user abort
             raise e
         except Exception as e:
-            print('Failed to update Cppcheck ({}), retry later'.format(e))
+            print('Failed to update Cppcheck-{} ({}), retry later'.format(ver, e))
             sys.exit(1)
         if ver == 'main':
             if (has_changes or not lib.has_binary(current_cppcheck_dir)) and not lib.compile_cppcheck(current_cppcheck_dir):

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -16,7 +16,7 @@ import copy
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.50"
+CLIENT_VERSION = "1.3.51"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -506,7 +506,7 @@ def scan_package(cppcheck_path, source_path, libraries, capture_callstack=True):
                 sig_num = int(ie_line[sig_start_pos:ie_line.find(' ', sig_start_pos)])
             # break on the first signalled file for now
             break
-    print('cppcheck finished with ' + str(returncode) + ('' if sig_num == -1 else ' (signal ' + str(sig_num) + ')'))
+    print('cppcheck finished with ' + str(returncode) + ('' if sig_num == -1 else ' (signal ' + str(sig_num) + ')') + ' in {:.1f}s'.format(elapsed_time))
 
     options_j = options + ' ' + __jobs
 


### PR DESCRIPTION
- added timing information to "finished" log message in `scan_package()`
- adjusted some log messages
- avoid unnecessary `git checkout` invocation if non-`main` binary already exists