### PR TITLE
moved `ImportProject` out of `Settings` and only store `fileSettings`

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -194,16 +194,16 @@ bool CppCheckExecutor::parseFromArgs(Settings &settings, int argc, const char* c
 #else
     const bool caseSensitive = true;
 #endif
-    if (!settings.project.fileSettings.empty() && !settings.fileFilters.empty()) {
+    if (!settings.fileSettings.empty() && !settings.fileFilters.empty()) {
         // filter only for the selected filenames from all project files
         std::list<ImportProject::FileSettings> newList;
 
-        const std::list<ImportProject::FileSettings>& fileSettings = settings.project.fileSettings;
+        const std::list<ImportProject::FileSettings>& fileSettings = settings.fileSettings;
         std::copy_if(fileSettings.cbegin(), fileSettings.cend(), std::back_inserter(newList), [&](const ImportProject::FileSettings& fs) {
             return matchglobs(settings.fileFilters, fs.filename);
         });
         if (!newList.empty())
-            settings.project.fileSettings = newList;
+            settings.fileSettings = newList;
         else {
             logger.printError("could not find any files matching the filter.");
             return false;
@@ -220,13 +220,13 @@ bool CppCheckExecutor::parseFromArgs(Settings &settings, int argc, const char* c
         }
     }
 
-    if (mFiles.empty() && settings.project.fileSettings.empty()) {
+    if (mFiles.empty() && settings.fileSettings.empty()) {
         logger.printError("could not find or open any of the paths given.");
         if (!ignored.empty())
             logger.printMessage("Maybe all paths were ignored?");
         return false;
     }
-    if (!settings.fileFilters.empty() && settings.project.fileSettings.empty()) {
+    if (!settings.fileFilters.empty() && settings.fileSettings.empty()) {
         std::map<std::string, std::size_t> newMap;
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i)
             if (matchglobs(settings.fileFilters, i->first)) {
@@ -319,7 +319,7 @@ int CppCheckExecutor::check_internal(CppCheck& cppcheck)
         std::list<std::string> fileNames;
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i)
             fileNames.emplace_back(i->first);
-        AnalyzerInformation::writeFilesTxt(settings.buildDir, fileNames, settings.userDefines, settings.project.fileSettings);
+        AnalyzerInformation::writeFilesTxt(settings.buildDir, fileNames, settings.userDefines, settings.fileSettings);
     }
 
     if (!settings.checkersReportFilename.empty())

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -237,11 +237,11 @@ unsigned int ProcessExecutor::check()
     std::map<int, std::string> pipeFile;
     std::size_t processedsize = 0;
     std::map<std::string, std::size_t>::const_iterator iFile = mFiles.cbegin();
-    std::list<ImportProject::FileSettings>::const_iterator iFileSettings = mSettings.project.fileSettings.cbegin();
+    std::list<ImportProject::FileSettings>::const_iterator iFileSettings = mSettings.fileSettings.cbegin();
     for (;;) {
         // Start a new child
         const size_t nchildren = childFile.size();
-        if ((iFile != mFiles.cend() || iFileSettings != mSettings.project.fileSettings.cend()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
+        if ((iFile != mFiles.cend() || iFileSettings != mSettings.fileSettings.cend()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
             int pipes[2];
             if (pipe(pipes) == -1) {
                 std::cerr << "#### ThreadExecutor::check, pipe() failed: "<< std::strerror(errno) << std::endl;
@@ -275,7 +275,7 @@ unsigned int ProcessExecutor::check()
                 fileChecker.settings() = mSettings;
                 unsigned int resultOfCheck = 0;
 
-                if (iFileSettings != mSettings.project.fileSettings.end()) {
+                if (iFileSettings != mSettings.fileSettings.end()) {
                     resultOfCheck = fileChecker.check(*iFileSettings);
                     if (fileChecker.settings().clangTidy)
                         fileChecker.analyseClangTidy(*iFileSettings);
@@ -291,7 +291,7 @@ unsigned int ProcessExecutor::check()
 
             close(pipes[1]);
             rpipes.push_back(pipes[0]);
-            if (iFileSettings != mSettings.project.fileSettings.end()) {
+            if (iFileSettings != mSettings.fileSettings.end()) {
                 childFile[pid] = iFileSettings->filename + ' ' + iFileSettings->cfg;
                 pipeFile[pipes[0]] = iFileSettings->filename + ' ' + iFileSettings->cfg;
                 ++iFileSettings;
@@ -334,7 +334,7 @@ unsigned int ProcessExecutor::check()
                             fileCount++;
                             processedsize += size;
                             if (!mSettings.quiet)
-                                Executor::reportStatus(fileCount, mFiles.size() + mSettings.project.fileSettings.size(), processedsize, totalfilesize);
+                                Executor::reportStatus(fileCount, mFiles.size() + mSettings.fileSettings.size(), processedsize, totalfilesize);
 
                             close(*rp);
                             rp = rpipes.erase(rp);
@@ -370,7 +370,7 @@ unsigned int ProcessExecutor::check()
                 }
             }
         }
-        if (iFile == mFiles.end() && iFileSettings == mSettings.project.fileSettings.end() && rpipes.empty() && childFile.empty()) {
+        if (iFile == mFiles.end() && iFileSettings == mSettings.fileSettings.end() && rpipes.empty() && childFile.empty()) {
             // All done
             break;
         }

--- a/cli/singleexecutor.cpp
+++ b/cli/singleexecutor.cpp
@@ -51,7 +51,7 @@ unsigned int SingleExecutor::check()
     unsigned int c = 0;
     // TODO: processes either mSettings.project.fileSettings or mFiles - process/thread implementations process both
     // TODO: thread/process implementations process fileSettings first
-    if (mSettings.project.fileSettings.empty()) {
+    if (mSettings.fileSettings.empty()) {
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i) {
             if (!mSettings.library.markupFile(i->first)
                 || !mSettings.library.processMarkupAfterCode(i->first)) {
@@ -66,13 +66,13 @@ unsigned int SingleExecutor::check()
     } else {
         // filesettings
         // check all files of the project
-        for (const ImportProject::FileSettings &fs : mSettings.project.fileSettings) {
+        for (const ImportProject::FileSettings &fs : mSettings.fileSettings) {
             if (!mSettings.library.markupFile(fs.filename)
                 || !mSettings.library.processMarkupAfterCode(fs.filename)) {
                 result += mCppcheck.check(fs);
                 ++c;
                 if (!mSettings.quiet)
-                    reportStatus(c, mSettings.project.fileSettings.size(), c, mSettings.project.fileSettings.size());
+                    reportStatus(c, mSettings.fileSettings.size(), c, mSettings.fileSettings.size());
                 if (mSettings.clangTidy)
                     mCppcheck.analyseClangTidy(fs);
             }
@@ -82,7 +82,7 @@ unsigned int SingleExecutor::check()
     // second loop to parse all markup files which may not work until all
     // c/cpp files have been parsed and checked
     // TODO: get rid of duplicated code
-    if (mSettings.project.fileSettings.empty()) {
+    if (mSettings.fileSettings.empty()) {
         for (std::map<std::string, std::size_t>::const_iterator i = mFiles.cbegin(); i != mFiles.cend(); ++i) {
             if (mSettings.library.markupFile(i->first)
                 && mSettings.library.processMarkupAfterCode(i->first)) {
@@ -96,13 +96,13 @@ unsigned int SingleExecutor::check()
         }
     }
     else {
-        for (const ImportProject::FileSettings &fs : mSettings.project.fileSettings) {
+        for (const ImportProject::FileSettings &fs : mSettings.fileSettings) {
             if (mSettings.library.markupFile(fs.filename)
                 && mSettings.library.processMarkupAfterCode(fs.filename)) {
                 result += mCppcheck.check(fs);
                 ++c;
                 if (!mSettings.quiet)
-                    reportStatus(c, mSettings.project.fileSettings.size(), c, mSettings.project.fileSettings.size());
+                    reportStatus(c, mSettings.fileSettings.size(), c, mSettings.fileSettings.size());
                 if (mSettings.clangTidy)
                     mCppcheck.analyseClangTidy(fs);
             }

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -180,7 +180,7 @@ unsigned int ThreadExecutor::check()
     std::vector<std::future<unsigned int>> threadFutures;
     threadFutures.reserve(mSettings.jobs);
 
-    ThreadData data(*this, mErrorLogger, mSettings, mFiles, mSettings.project.fileSettings, mExecuteCommand);
+    ThreadData data(*this, mErrorLogger, mSettings, mFiles, mSettings.fileSettings, mExecuteCommand);
 
     for (unsigned int i = 0; i < mSettings.jobs; ++i) {
         try {

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -600,7 +600,7 @@ void MainWindow::doAnalyzeFiles(const QStringList &files, const bool checkLibrar
         std::transform(fileNames.cbegin(), fileNames.cend(), std::back_inserter(sourcefiles), [](const QString& s) {
             return s.toStdString();
         });
-        AnalyzerInformation::writeFilesTxt(checkSettings.buildDir, sourcefiles, checkSettings.userDefines, checkSettings.project.fileSettings);
+        AnalyzerInformation::writeFilesTxt(checkSettings.buildDir, sourcefiles, checkSettings.userDefines, checkSettings.fileSettings);
     }
 
     mThread->setCheckFiles(true);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1797,7 +1797,7 @@ void CppCheck::removeCtuInfoFiles(const std::map<std::string, std::size_t> &file
             const std::string &ctuInfoFileName = getCtuInfoFileName(dumpFileName);
             std::remove(ctuInfoFileName.c_str());
         }
-        for (const auto& fs: mSettings.project.fileSettings) {
+        for (const auto& fs: mSettings.fileSettings) {
             const std::string &dumpFileName = getDumpFileName(mSettings, fs.filename);
             const std::string &ctuInfoFileName = getCtuInfoFileName(dumpFileName);
             std::remove(ctuInfoFileName.c_str());

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -205,6 +205,8 @@ public:
     /** @brief List of --file-filter for analyzing special files */
     std::vector<std::string> fileFilters;
 
+    std::list<ImportProject::FileSettings> fileSettings;
+
     /** @brief Force checking the files with "too many" configurations (--force). */
     bool force{};
 
@@ -266,8 +268,6 @@ public:
 
     /** @brief Using -E for debugging purposes */
     bool preprocessOnly{};
-
-    ImportProject project;
 
     /** @brief Is --quiet given? */
     bool quiet{};

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -2015,7 +2015,6 @@ private:
                         "</project>");
         const char * const argv[] = {"cppcheck", "--project=project.cppcheck"};
         ASSERT(parser->parseFromArgs(2, argv));
-        ASSERT_EQUALS(static_cast<int>(ImportProject::Type::CPPCHECK_GUI), static_cast<int>(settings->project.projectType));
         ASSERT_EQUALS(1, parser->getPathNames().size());
         auto it = parser->getPathNames().cbegin();
         ASSERT_EQUALS("dir", *it);

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -82,7 +82,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = std::move(f_s);
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }
@@ -93,7 +93,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = f;
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -87,7 +87,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = std::move(f_s);
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }
@@ -98,7 +98,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = f;
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -82,7 +82,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = std::move(f_s);
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }
@@ -93,7 +93,7 @@ private:
                 if (useFS) {
                     ImportProject::FileSettings fs;
                     fs.filename = f;
-                    s.project.fileSettings.emplace_back(std::move(fs));
+                    s.fileSettings.emplace_back(std::move(fs));
                 }
             }
         }


### PR DESCRIPTION
`ImportProject` is not needed outside of the command-line parsing so we do not need it inside the `Settings` at all. We only use the `fileSettings` in the executors.