### PR TITLE
do not explicitly load `windows.cfg` during command-line parsing

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -713,11 +713,7 @@ bool CmdLineParser::parseFromArgs(int argc, const char* const argv[])
                 if (projType == ImportProject::Type::VS_SLN || projType == ImportProject::Type::VS_VCXPROJ) {
                     if (project.guiProject.analyzeAllVsConfigs == "false")
                         project.selectOneVsConfig(mSettings.platform.type);
-                    if (!CppCheckExecutor::tryLoadLibrary(mSettings.library, argv[0], "windows.cfg")) {
-                        // This shouldn't happen normally.
-                        mLogger.printError("failed to load 'windows.cfg'. Your Cppcheck installation is broken. Please re-install.");
-                        return false;
-                    }
+                    mSettings.libraries.emplace_back("windows");
                 }
                 if (projType == ImportProject::Type::MISSING) {
                     mLogger.printError("failed to open project '" + projectFile + "'. The file does not exist.");

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -97,13 +97,13 @@ public:
      */
     static FILE* getExceptionOutput();
 
+private:
+
     /**
      * Tries to load a library and prints warning/error messages
      * @return false, if an error occurred (except unknown XML elements)
      */
     static bool tryLoadLibrary(Library& destination, const std::string& basepath, const char* filename);
-
-private:
 
     /**
      * Execute a shell command and read the output from it. Returns exitcode of the executed command,.

--- a/cli/cppcheckexecutor.h
+++ b/cli/cppcheckexecutor.h
@@ -71,6 +71,8 @@ public:
      */
     int check(int argc, const char* const argv[]);
 
+private:
+
     /**
      * Information about progress is directed here. This should be
      * called by the CppCheck class only.
@@ -83,6 +85,8 @@ public:
     void reportErr(const ErrorMessage &msg) override;
 
     void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override;
+
+public:
 
     /**
      * @param exceptionOutput Output file
@@ -99,12 +103,12 @@ public:
      */
     static bool tryLoadLibrary(Library& destination, const std::string& basepath, const char* filename);
 
+private:
+
     /**
      * Execute a shell command and read the output from it. Returns exitcode of the executed command,.
      */
     static int executeCommand(std::string exe, std::vector<std::string> args, std::string redirect, std::string &output_);
-
-protected:
 
     /**
      * Helper function to print out errors. Appends a line change.
@@ -122,8 +126,6 @@ protected:
      * @return false when errors are found in the input
      */
     bool parseFromArgs(Settings &settings, int argc, const char* const argv[]);
-
-private:
 
     static bool reportSuppressions(const Settings &settings, bool unusedFunctionCheckEnabled, const std::map<std::string, std::size_t> &files, ErrorLogger& errorLogger);
 


### PR DESCRIPTION
As we now fail early on loading of all libraries we no longer need to explicitly bail out on mandatory ones. This would have also caused `libraries` and `library` to go out-of-sync and possibly lead to duplicated loading of the library. It also allows for a `CppCheckExecutor` to be made private.