### PR TITLE
Fix  #12166 debug: varid0 with reference typedef

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -891,7 +891,8 @@ namespace {
             tok->deleteThis();
 
             // Unsplit variable declarations
-            if (Token::Match(tok4->previous(), "] ; %name% = {") && tok4->isSplittedVarDeclEq()) {
+            if (tok4 && tok4->isSplittedVarDeclEq() &&
+                ((tok4->isCpp() && Token::Match(tok4->tokAt(-2), "& %name% ;")) || Token::Match(tok4->previous(), "] ; %name% = {"))) {
                 tok4->deleteNext();
                 tok4->deleteThis();
             }

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -210,6 +210,7 @@ private:
         TEST_CASE(simplifyTypedef145); // #9353
         TEST_CASE(simplifyTypedef146);
         TEST_CASE(simplifyTypedef147);
+        TEST_CASE(simplifyTypedef148);
 
         TEST_CASE(simplifyTypedefFunction1);
         TEST_CASE(simplifyTypedefFunction2); // ticket #1685
@@ -3426,6 +3427,13 @@ private:
                "}\n";
         ASSERT_EQUALS("namespace N { template < typename T > struct S { } ; } namespace N { template < typename T > struct U { S < T > operator() ( ) { return { } ; } } ; }",
                       tok(code));
+    }
+
+    void simplifyTypedef148() {
+        const char* code{};
+        code = "typedef int& R;\n" // #12166
+               "R r = i;\n";
+        ASSERT_EQUALS("int & r = i ;", tok(code));
     }
 
     void simplifyTypedefFunction1() {


### PR DESCRIPTION
Why do we even split any declarations in the first place?