### PR TITLE
Minor: fix msvc warning "not all control paths return a value"

### DIFF
--- a/lib/config.h
+++ b/lib/config.h
@@ -57,7 +57,12 @@
 #  define NORETURN [[noreturn]]
 #elif defined(__GNUC__)
 #  define NORETURN __attribute__((noreturn))
-#else
+#elif defined __has_cpp_attribute
+#  if __has_cpp_attribute (noreturn)
+#    define NORETURN [[noreturn]]
+#  endif
+#endif
+#if !defined(NORETURN)
 #  define NORETURN
 #endif
 

--- a/lib/config.h
+++ b/lib/config.h
@@ -58,8 +58,8 @@
 #endif
 #if !defined(NORETURN)
 #  if (defined(__GNUC__) && (__GNUC__ >= 5)) \
-      || defined(__clang__) \
-      || defined(__CPPCHECK__)
+    || defined(__clang__) \
+    || defined(__CPPCHECK__)
 #    define NORETURN [[noreturn]]
 #  elif defined(__GNUC__)
 #    define NORETURN __attribute__((noreturn))

--- a/lib/config.h
+++ b/lib/config.h
@@ -51,19 +51,21 @@
 #endif
 
 // C++11 noreturn
-#if (defined(__GNUC__) && (__GNUC__ >= 5)) \
-    || defined(__clang__) \
-    || defined(__CPPCHECK__)
-#  define NORETURN [[noreturn]]
-#elif defined(__GNUC__)
-#  define NORETURN __attribute__((noreturn))
-#elif defined __has_cpp_attribute
+#if defined __has_cpp_attribute
 #  if __has_cpp_attribute (noreturn)
 #    define NORETURN [[noreturn]]
 #  endif
 #endif
 #if !defined(NORETURN)
-#  define NORETURN
+#  if (defined(__GNUC__) && (__GNUC__ >= 5)) \
+      || defined(__clang__) \
+      || defined(__CPPCHECK__)
+#    define NORETURN [[noreturn]]
+#  elif defined(__GNUC__)
+#    define NORETURN __attribute__((noreturn))
+#  else
+#    define NORETURN
+#  endif
 #endif
 
 // fallthrough


### PR DESCRIPTION
When building with /Od - default cmake debug build for me, the __assume(false); trick does not work to get rid of the C4714 warnings

https://godbolt.org/z/a6xGnfP7d

D:\tmp\cppcheck\lib\keywords.cpp(205): warning C4715: 'Keywords::getOnly': not all control paths return a value
D:\tmp\cppcheck\lib\keywords.cpp(226): warning C4715: 'Keywords::getOnly': not all control paths return a value
D:\tmp\cppcheck\lib\keywords.cpp(168): warning C4715: 'Keywords::getAll': not all control paths return a value
D:\tmp\cppcheck\lib\keywords.cpp(188): warning C4715: 'Keywords::getAll': not all control paths return a value

Proposed fix: also define NORETURN to [[noreturn]] when according to __has_cpp_attribute [[noreturn]] is supported https://en.cppreference.com/w/cpp/feature_test

(For previous discussion see also https://github.com/danmar/cppcheck/pull/5497)