### PR TITLE
iwyu.yml: fixed `include-what-you-use` job / cleaned up includes

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -83,7 +83,7 @@ jobs:
       - name: iwyu_tool
         run: |
           PWD=$(pwd)
-          iwyu_tool -p cmake.output -j $(nproc) -- -w -Xiwyu --max_line_length=1024 -Xiwyu --comment_style=long -Xiwyu --quoted_includes_first -Xiwyu --update_comments -Xiwyu --mapping_file=$PWD/qt5.imp > iwyu.log
+          iwyu_tool -p cmake.output -j $(nproc) -- -w -Xiwyu --max_line_length=1024 -Xiwyu --comment_style=long -Xiwyu --quoted_includes_first -Xiwyu --update_comments -Xiwyu --mapping_file=$PWD/qt5.imp -I/usr/lib/clang/17/include > iwyu.log
 
       - uses: actions/upload-artifact@v3
         if: success() || failure()

--- a/cli/singleexecutor.cpp
+++ b/cli/singleexecutor.cpp
@@ -20,7 +20,6 @@
 
 #include "cppcheck.h"
 #include "filesettings.h"
-#include "library.h"
 #include "settings.h"
 #include "timer.h"
 

--- a/test/testprocessexecutor.cpp
+++ b/test/testprocessexecutor.cpp
@@ -23,14 +23,11 @@
 #include "fixture.h"
 #include "helpers.h"
 #include "timer.h"
-#include "library.h"
 
 #include <algorithm>
 #include <cstdlib>
 #include <list>
-#include <map>
 #include <memory>
-#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/test/testsingleexecutor.cpp
+++ b/test/testsingleexecutor.cpp
@@ -21,7 +21,6 @@
 #include "fixture.h"
 #include "helpers.h"
 #include "redirect.h"
-#include "library.h"
 #include "settings.h"
 #include "singleexecutor.h"
 #include "timer.h"
@@ -29,9 +28,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <list>
-#include <map>
 #include <memory>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/testthreadexecutor.cpp
+++ b/test/testthreadexecutor.cpp
@@ -21,16 +21,13 @@
 #include "filesettings.h"
 #include "fixture.h"
 #include "helpers.h"
-#include "library.h"
 #include "threadexecutor.h"
 #include "timer.h"
 
 #include <algorithm>
 #include <cstdlib>
 #include <list>
-#include <map>
 #include <memory>
-#include <set>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/test/testtokenlist.cpp
+++ b/test/testtokenlist.cpp
@@ -19,6 +19,7 @@
 #include "settings.h"
 #include "fixture.h"
 #include "platform.h"
+#include "standards.h"
 #include "token.h"
 #include "tokenlist.h"
 


### PR DESCRIPTION
As usual when the base clang version of a distro changes iwyu ends up broken and needs additional packages and/or options applied to work again.