### PR TITLE
Fix FP memleak with outparam allocation (f'up to #12186)

### DIFF
--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -380,6 +380,24 @@ void memleak_asprintf5(char* p) {
     // cppcheck-suppress memleak
 }
 
+void memleak_asprintf6(const char* fmt, const int arg) {
+    char* ptr;
+    if (-1 == asprintf(&ptr, fmt, arg))
+        return;
+    printf("%s", ptr);
+    free(ptr);
+}
+
+void memleak_asprintf7(const char* fmt, const int arg) {
+    char* ptr;
+    if (asprintf(&ptr, fmt, arg) != -1) {
+        printf("%s", ptr);
+        free(ptr);
+    }
+    else
+        return;
+}
+
 void memleak_xmalloc()
 {
     char *p = (char*)xmalloc(10);


### PR DESCRIPTION
I wonder if it is worth trying to get this right. We also have FPs when the return value is assigned to a variable, and that seems much harder to fix.