### PR TITLE
enabled some clang-tidy warnings for non-GUI code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -61,7 +61,6 @@ Checks: >
         -readability-braces-around-statements,
         -readability-const-return-type,
         -readability-container-data-pointer,
-        -readability-convert-member-functions-to-static,
         -readability-function-cognitive-complexity,
         -readability-function-size,
         -readability-identifier-length,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,7 +68,6 @@ Checks: >
         -readability-implicit-bool-conversion,
         -readability-isolate-declaration,
         -readability-magic-numbers,
-        -readability-redundant-access-specifiers,
         -readability-suspicious-call-argument,
         -readability-uppercase-literal-suffix
 WarningsAsErrors: '*'

--- a/clang-tidy.md
+++ b/clang-tidy.md
@@ -71,10 +71,6 @@ These might change the behavior of code which might not be intended (need to fil
 
 This leads to a mismatch of raw string literals and regular ones and does reduce the readability.
 
-`readability-convert-member-functions-to-static`<br/>
-
-Disabled because of false positives with Qt `slot` methods (see https://github.com/llvm/llvm-project/issues/57520).
-
 `-clang-analyzer-*`<br/>
 
 Disabled because of false positives (needs to file an upstream bug report).
@@ -197,3 +193,9 @@ This is the most expensive check for several files and it is providing much in t
 `modernize-use-nullptr`
 
 This is already covered by the `-Wzero-as-null-pointer-constant` compiler warning so there is no need for an additional check.
+
+### Disabled for GUI only
+
+`readability-convert-member-functions-to-static`<br/>
+
+Disabled because of false positives with Qt `slot` methods (see https://github.com/llvm/llvm-project/issues/57520).

--- a/clang-tidy.md
+++ b/clang-tidy.md
@@ -108,10 +108,6 @@ Produces a lot of false positives since it is too vague in its analysis.
 
 Produces warnings which might be considered false positives starting with C++11 - see https://github.com/llvm/llvm-project/issues/54526.
 
-`readability-redundant-access-specifiers`<br/>
-
-Reports warning with the Qt `<access-specifier> slots:` syntax in class declarations - see https://github.com/llvm/llvm-project/issues/60055.
-
 `modernize-avoid-c-arrays`<br/>
 
 Produces warnings when `const char[]` is being used which is quite common in our code. Does not make sense to enable before C++17 when `std::string_view` becomes available.
@@ -199,3 +195,7 @@ This is already covered by the `-Wzero-as-null-pointer-constant` compiler warnin
 `readability-convert-member-functions-to-static`<br/>
 
 Disabled because of false positives with Qt `slot` methods (see https://github.com/llvm/llvm-project/issues/57520).
+
+`readability-redundant-access-specifiers`<br/>
+
+Reports warning with the Qt `<access-specifier> slots:` syntax in class declarations - see https://github.com/llvm/llvm-project/issues/60055.

--- a/gui/.clang-tidy
+++ b/gui/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: >
+        -readability-convert-member-functions-to-static
+InheritParentConfig: true

--- a/gui/.clang-tidy
+++ b/gui/.clang-tidy
@@ -1,4 +1,5 @@
 ---
 Checks: >
-        -readability-convert-member-functions-to-static
+        -readability-convert-member-functions-to-static,
+        -readability-redundant-access-specifiers
 InheritParentConfig: true

--- a/tools/triage/.clang-tidy
+++ b/tools/triage/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks: >
+        -readability-convert-member-functions-to-static,
+        -readability-redundant-access-specifiers
+InheritParentConfig: true


### PR DESCRIPTION
There are some clang-tidy warnings which cannot properly handle the extensions used in the Qt code so the produce lots of false positives and were previously enabled. With clang-tidy now offering the possibility to inherit the parent configuration we can enable these across the project and simply disable them for the GUI code.

No additional warnings were found as they were already fixed in earlier commits without enabling the checks in question.