### PR TITLE
compilerDefinitions.cmake: fixed faulty `add_compile_definitions()` value for MSVC

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -1,6 +1,6 @@
 if (MSVC)
     # Visual Studio only sets _DEBUG
-    add_compile_definitions($<$<CONFIG:Debug>:-DDEBUG>)
+    add_compile_definitions($<$<CONFIG:Debug>:DEBUG>)
 
     add_definitions(-DWIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
also fixes `<command line>(7,9): error : macro name must be an identifier` with `clang-cl` allowing the build to complete