### PR TITLE
reduced `Tokenizer::isC()` usage

### DIFF
--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -241,10 +241,10 @@ static bool isAutoVariableRHS(const Token* tok) {
     return isAddressOfLocalVariable(tok) || isAutoVarArray(tok) || isLocalContainerBuffer(tok);
 }
 
-static bool hasOverloadedAssignment(const Token* tok, bool c, bool& inconclusive)
+static bool hasOverloadedAssignment(const Token* tok, bool& inconclusive)
 {
     inconclusive = false;
-    if (c)
+    if (tok->isC())
         return false;
     if (const ValueType* vt = tok->valueType()) {
         if (vt->pointer && !Token::simpleMatch(tok->astParent(), "*"))
@@ -280,13 +280,13 @@ void CheckAutoVariables::autoVariables()
             } else if (Token::Match(tok, "[;{}] * %var% =") && isPtrArg(tok->tokAt(2)) && isAutoVariableRHS(tok->tokAt(3)->astOperand2())) {
                 const Token* lhs = tok->tokAt(2);
                 bool inconclusive = false;
-                if (!hasOverloadedAssignment(lhs, mTokenizer->isC(), inconclusive) || (printInconclusive && inconclusive))
+                if (!hasOverloadedAssignment(lhs, inconclusive) || (printInconclusive && inconclusive))
                     checkAutoVariableAssignment(tok->next(), inconclusive);
                 tok = tok->tokAt(4);
             } else if (Token::Match(tok, "[;{}] %var% . %var% =") && isPtrArg(tok->next()) && isAutoVariableRHS(tok->tokAt(4)->astOperand2())) {
                 const Token* lhs = tok->tokAt(3);
                 bool inconclusive = false;
-                if (!hasOverloadedAssignment(lhs, mTokenizer->isC(), inconclusive) || (printInconclusive && inconclusive))
+                if (!hasOverloadedAssignment(lhs, inconclusive) || (printInconclusive && inconclusive))
                     checkAutoVariableAssignment(tok->next(), inconclusive);
                 tok = tok->tokAt(5);
             } else if (Token::Match(tok, "[;{}] %var% [") && Token::simpleMatch(tok->linkAt(2), "] =") &&

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1419,8 +1419,6 @@ void CheckCondition::clarifyCondition()
     if (!mSettings->severity.isEnabled(Severity::style) && !mSettings->isPremiumEnabled("clarifyCondition"))
         return;
 
-    const bool isC = mTokenizer->isC();
-
     logChecker("CheckCondition::clarifyCondition"); // style
 
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
@@ -1432,7 +1430,7 @@ void CheckCondition::clarifyCondition()
                         tok2 = tok2->link();
                     else if (tok2->isComparisonOp()) {
                         // This might be a template
-                        if (!isC && tok2->link())
+                        if (!tok2->isC() && tok2->link())
                             break;
                         if (Token::simpleMatch(tok2->astParent(), "?"))
                             break;

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -56,7 +56,7 @@ static const CWE CWE688(688U);  // Function Call With Incorrect Variable or Refe
 
 void CheckFunctions::checkProhibitedFunctions()
 {
-    const bool checkAlloca = mSettings->severity.isEnabled(Severity::warning) && ((mSettings->standards.c >= Standards::C99 && mTokenizer->isC()) || mSettings->standards.cpp >= Standards::CPP11);
+    const bool checkAlloca = mSettings->severity.isEnabled(Severity::warning) && ((mTokenizer->isC() && mSettings->standards.c >= Standards::C99) || mSettings->standards.cpp >= Standards::CPP11);
 
     logChecker("CheckFunctions::checkProhibitedFunctions");
 
@@ -67,7 +67,7 @@ void CheckFunctions::checkProhibitedFunctions()
                 continue;
             // alloca() is special as it depends on the code being C or C++, so it is not in Library
             if (checkAlloca && Token::simpleMatch(tok, "alloca (") && (!tok->function() || tok->function()->nestedIn->type == Scope::eGlobal)) {
-                if (mTokenizer->isC()) {
+                if (tok->isC()) {
                     if (mSettings->standards.c > Standards::C89)
                         reportError(tok, Severity::warning, "allocaCalled",
                                     "$symbol:alloca\n"
@@ -315,7 +315,7 @@ void CheckFunctions::checkMissingReturn()
         const Function *function = scope->function;
         if (!function || !function->hasBody())
             continue;
-        if (function->name() == "main" && !(mSettings->standards.c < Standards::C99 && mTokenizer->isC()))
+        if (function->name() == "main" && !(mTokenizer->isC() && mSettings->standards.c < Standards::C99))
             continue;
         if (function->type != Function::Type::eFunction && function->type != Function::Type::eOperatorEqual)
             continue;

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -375,7 +375,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::functionReturnType(const Function* f
         if (Token::Match(tok, "= %varid% ;", varid)) {
             return No;
         }
-        if (!mTokenizer_->isC() && Token::Match(tok, "[(,] %varid% [,)]", varid)) {
+        if (!tok->isC() && Token::Match(tok, "[(,] %varid% [,)]", varid)) {
             return No;
         }
         if (Token::Match(tok, "[(,] & %varid% [.,)]", varid)) {

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -945,7 +945,7 @@ void CheckOther::checkVariableScope()
             continue;
 
         const bool isPtrOrRef = var->isPointer() || var->isReference();
-        const bool isSimpleType = var->typeStartToken()->isStandardType() || var->typeStartToken()->isEnumType() || (mTokenizer->isC() && var->type() && var->type()->isStructType());
+        const bool isSimpleType = var->typeStartToken()->isStandardType() || var->typeStartToken()->isEnumType() || (var->typeStartToken()->isC() && var->type() && var->type()->isStructType());
         if (!isPtrOrRef && !isSimpleType && !astIsContainer(var->nameToken()))
             continue;
 

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -193,7 +193,7 @@ void CheckString::checkSuspiciousStringCompare()
                 continue;
 
             if (litTok->tokType() == Token::eString) {
-                if (mTokenizer->isC() || (varType && varType->pointer))
+                if (varTok->isC() || (varType && varType->pointer))
                     suspiciousStringCompareError(tok, varTok->expressionString(), litTok->isLong());
             } else if (litTok->tokType() == Token::eChar && varType && varType->pointer) {
                 suspiciousStringCompareError_char(tok, varTok->expressionString());

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -166,7 +166,7 @@ void CheckUninitVar::checkScope(const Scope* scope, const std::set<std::string> 
                 continue;
         }
 
-        bool stdtype = mTokenizer->isC() && arrayTypeDefs.find(var.typeStartToken()->str()) == arrayTypeDefs.end();
+        bool stdtype = var.typeStartToken()->isC() && arrayTypeDefs.find(var.typeStartToken()->str()) == arrayTypeDefs.end();
         const Token* tok = var.typeStartToken();
         for (; tok != var.nameToken() && tok->str() != "<"; tok = tok->next()) {
             if (tok->isStandardType() || tok->isEnumType())

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -167,7 +167,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                !Token::Match(tok->previous(), "new|friend|const|enum|typedef|mutable|volatile|using|)|(|<")) ||
               (Token::Match(tok, "enum class| %name% {") ||
                Token::Match(tok, "enum class| %name% : %name% {"))))
-            || (mTokenizer.isC() && tok->isKeyword() && Token::Match(tok, "struct|union|enum %name% {"))) {
+            || (tok->isC() && tok->isKeyword() && Token::Match(tok, "struct|union|enum %name% {"))) {
             const Token *tok2 = tok->tokAt(2);
 
             if (tok->strAt(1) == "::")
@@ -2116,7 +2116,7 @@ bool SymbolDatabase::isFunction(const Token *tok, const Scope* outerScope, const
     else if (Token::Match(tok, "%name% (") && !isReservedName(tok->str()) &&
              Token::simpleMatch(tok->linkAt(1), ") {") &&
              (!tok->previous() || Token::Match(tok->previous(), ";|}"))) {
-        if (mTokenizer.isC()) {
+        if (tok->isC()) {
             returnImplicitIntError(tok);
             *funcStart = tok;
             *argStart = tok->next();
@@ -6253,7 +6253,7 @@ const Type* SymbolDatabase::findType(const Token *startTok, const Scope *startSc
     if (startTok->str() == startScope->className && startScope->isClassOrStruct() && startTok->strAt(1) != "::")
         return startScope->definedType;
 
-    if (mTokenizer.isC()) {
+    if (startTok->isC()) {
         const Scope* scope = startScope;
         while (scope) {
             if (startTok->str() == scope->className && scope->isClassOrStruct())

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2753,3 +2753,8 @@ bool Token::isCpp() const
 {
     return mTokensFrontBack.list.isCPP();
 }
+
+bool Token::isC() const
+{
+    return mTokensFrontBack.list.isC();
+}

--- a/lib/token.h
+++ b/lib/token.h
@@ -1480,6 +1480,8 @@ public:
     }
 
     bool isCpp() const;
+
+    bool isC() const;
 };
 
 Token* findTypeEnd(Token* tok);


### PR DESCRIPTION
Each `Token` (should) be connected to a `TokenList`. `Tokenizer` just encapsulates that so we have no need to check the `Tokenizer` but can simply ask the `Token`.

Also if we have function calls we pass in a flag to tell it if it is C/C++ we can get rid of that flag and simply ask the `Token`.