### PR TITLE
reduced `Tokenizer::isCPP()` usage / SymbolDatabase: removed `mIsCpp` and `isCPP()`

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -409,22 +409,22 @@ bool isStlStringType(const Token* tok)
            (Token::simpleMatch(tok, "std :: basic_string <") && !Token::simpleMatch(tok->linkAt(3), "> ::"));
 }
 
-bool isTemporary(bool cpp, const Token* tok, const Library* library, bool unknown)
+bool isTemporary(const Token* tok, const Library* library, bool unknown)
 {
     if (!tok)
         return false;
     if (Token::simpleMatch(tok, "."))
-        return (tok->originalName() != "->" && isTemporary(cpp, tok->astOperand1(), library)) ||
-               isTemporary(cpp, tok->astOperand2(), library);
+        return (tok->originalName() != "->" && isTemporary(tok->astOperand1(), library)) ||
+               isTemporary(tok->astOperand2(), library);
     if (Token::Match(tok, ",|::"))
-        return isTemporary(cpp, tok->astOperand2(), library);
-    if (tok->isCast() || (cpp && isCPPCast(tok)))
-        return isTemporary(cpp, tok->astOperand2(), library);
+        return isTemporary(tok->astOperand2(), library);
+    if (tok->isCast() || (tok->isCpp() && isCPPCast(tok)))
+        return isTemporary(tok->astOperand2(), library);
     if (Token::Match(tok, ".|[|++|--|%name%|%assign%"))
         return false;
     if (tok->isUnaryOp("*"))
         return false;
-    if (Token::Match(tok, "&|<<|>>") && isLikelyStream(cpp, tok->astOperand1()))
+    if (Token::Match(tok, "&|<<|>>") && isLikelyStream(tok->astOperand1()))
         return false;
     if (Token::simpleMatch(tok, "?")) {
         const Token* branchTok = tok->astOperand2();
@@ -473,7 +473,7 @@ bool isTemporary(bool cpp, const Token* tok, const Library* library, bool unknow
         return unknown;
     if (Token::simpleMatch(tok, "{") && Token::simpleMatch(tok->astParent(), "return") && tok->astOperand1() &&
         !tok->astOperand2())
-        return isTemporary(cpp, tok->astOperand1(), library);
+        return isTemporary(tok->astOperand1(), library);
     return true;
 }
 
@@ -629,7 +629,7 @@ static std::vector<const Token*> getParentMembers(const Token* tok)
     return result;
 }
 
-const Token* getParentLifetime(bool cpp, const Token* tok, const Library* library)
+const Token* getParentLifetime(const Token* tok, const Library* library)
 {
     std::vector<const Token*> members = getParentMembers(tok);
     if (members.size() < 2)
@@ -639,7 +639,7 @@ const Token* getParentLifetime(bool cpp, const Token* tok, const Library* librar
         const Variable* var = tok2->variable();
         if (var)
             return var->isLocal() || var->isArgument();
-        return isTemporary(cpp, tok2, library);
+        return isTemporary(tok2, library);
     });
     if (it == members.rend())
         return tok;
@@ -1137,7 +1137,7 @@ bool isStructuredBindingVariable(const Variable* var)
 /// This takes a token that refers to a variable and it will return the token
 /// to the expression that the variable is assigned to. If its not valid to
 /// make such substitution then it will return the original token.
-static const Token * followVariableExpression(const Token * tok, bool cpp, const Token * end = nullptr)
+static const Token * followVariableExpression(const Token * tok, const Token * end = nullptr)
 {
     if (!tok)
         return tok;
@@ -1175,7 +1175,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
     const Token * lastTok = precedes(tok, end) ? end : tok;
     // If this is in a loop then check if variables are modified in the entire scope
     const Token * endToken = (isInLoopCondition(tok) || isInLoopCondition(varTok) || var->scope() != tok->scope()) ? var->scope()->bodyEnd : lastTok;
-    if (!var->isConst() && (!precedes(varTok, endToken) || isVariableChanged(varTok, endToken, tok->varId(), false, nullptr, cpp)))
+    if (!var->isConst() && (!precedes(varTok, endToken) || isVariableChanged(varTok, endToken, tok->varId(), false, nullptr)))
         return tok;
     if (precedes(varTok, endToken) && isAliased(varTok, endToken, tok->varId()))
         return tok;
@@ -1187,7 +1187,7 @@ static const Token * followVariableExpression(const Token * tok, bool cpp, const
             return tok;
     } else if (!precedes(startToken, endToken)) {
         return tok;
-    } else if (findExpressionChanged(varTok, startToken, endToken, nullptr, cpp)) {
+    } else if (findExpressionChanged(varTok, startToken, endToken, nullptr)) {
         return tok;
     }
     return varTok;
@@ -1250,7 +1250,7 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
                     return {};
                 errors.emplace_back(varDeclEndToken, "Assigned to reference.");
                 const Token *vartok = varDeclEndToken->astOperand2();
-                if (vartok == tok || (!temporary && isTemporary(true, vartok, nullptr, true) &&
+                if (vartok == tok || (!temporary && isTemporary(vartok, nullptr, true) &&
                                       (var->isConst() || var->isRValueReference()))) {
                     SmallVector<ReferenceToken> refs_result;
                     refs_result.push_back({tok, std::move(errors)});
@@ -1527,13 +1527,14 @@ static bool astIsBoolLike(const Token* tok)
     return astIsBool(tok) || isUsedAsBool(tok);
 }
 
-bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
+bool isSameExpression(bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
 {
     if (tok1 == nullptr && tok2 == nullptr)
         return true;
     if (tok1 == nullptr || tok2 == nullptr)
         return false;
-    if (cpp) {
+    // tokens needs to be from the same TokenList so no need check standard on both of them
+    if (tok1->isCpp()) {
         if (tok1->str() == "." && tok1->astOperand1() && tok1->astOperand1()->str() == "this")
             tok1 = tok1->astOperand2();
         if (tok2->str() == "." && tok2->astOperand1() && tok2->astOperand1()->str() == "this")
@@ -1541,10 +1542,10 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
     }
     // Skip double not
     if (Token::simpleMatch(tok1, "!") && Token::simpleMatch(tok1->astOperand1(), "!") && !Token::simpleMatch(tok1->astParent(), "=") && astIsBoolLike(tok2)) {
-        return isSameExpression(cpp, macro, tok1->astOperand1()->astOperand1(), tok2, library, pure, followVar, errors);
+        return isSameExpression(macro, tok1->astOperand1()->astOperand1(), tok2, library, pure, followVar, errors);
     }
     if (Token::simpleMatch(tok2, "!") && Token::simpleMatch(tok2->astOperand1(), "!") && !Token::simpleMatch(tok2->astParent(), "=") && astIsBoolLike(tok1)) {
-        return isSameExpression(cpp, macro, tok1, tok2->astOperand1()->astOperand1(), library, pure, followVar, errors);
+        return isSameExpression(macro, tok1, tok2->astOperand1()->astOperand1(), library, pure, followVar, errors);
     }
     const bool tok_str_eq = tok1->str() == tok2->str();
     if (!tok_str_eq && isDifferentKnownValues(tok1, tok2))
@@ -1560,20 +1561,20 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
 
     // Follow variable
     if (followVar && !tok_str_eq && (followTok1->varId() || followTok2->varId() || followTok1->enumerator() || followTok2->enumerator())) {
-        const Token * varTok1 = followVariableExpression(followTok1, cpp, followTok2);
+        const Token * varTok1 = followVariableExpression(followTok1, followTok2);
         if ((varTok1->str() == followTok2->str()) || isSameConstantValue(macro, varTok1, followTok2)) {
             followVariableExpressionError(followTok1, varTok1, errors);
-            return isSameExpression(cpp, macro, varTok1, followTok2, library, true, followVar, errors);
+            return isSameExpression(macro, varTok1, followTok2, library, true, followVar, errors);
         }
-        const Token * varTok2 = followVariableExpression(followTok2, cpp, followTok1);
+        const Token * varTok2 = followVariableExpression(followTok2, followTok1);
         if ((followTok1->str() == varTok2->str()) || isSameConstantValue(macro, followTok1, varTok2)) {
             followVariableExpressionError(followTok2, varTok2, errors);
-            return isSameExpression(cpp, macro, followTok1, varTok2, library, true, followVar, errors);
+            return isSameExpression(macro, followTok1, varTok2, library, true, followVar, errors);
         }
         if ((varTok1->str() == varTok2->str()) || isSameConstantValue(macro, varTok1, varTok2)) {
             followVariableExpressionError(tok1, varTok1, errors);
             followVariableExpressionError(tok2, varTok2, errors);
-            return isSameExpression(cpp, macro, varTok1, varTok2, library, true, followVar, errors);
+            return isSameExpression(macro, varTok1, varTok2, library, true, followVar, errors);
         }
     }
     // Follow references
@@ -1585,17 +1586,17 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
                 const Token *start = refTok1, *end = refTok2;
                 if (!precedes(start, end))
                     std::swap(start, end);
-                if (findExpressionChanged(start, start, end, nullptr, cpp))
+                if (findExpressionChanged(start, start, end, nullptr))
                     return false;
             }
-            return isSameExpression(cpp, macro, refTok1, refTok2, library, pure, followVar, errors);
+            return isSameExpression(macro, refTok1, refTok2, library, pure, followVar, errors);
         }
     }
     if (tok1->varId() != tok2->varId() || !tok_str_eq || tok1->originalName() != tok2->originalName()) {
         if ((Token::Match(tok1,"<|>") && Token::Match(tok2,"<|>")) ||
             (Token::Match(tok1,"<=|>=") && Token::Match(tok2,"<=|>="))) {
-            return isSameExpression(cpp, macro, tok1->astOperand1(), tok2->astOperand2(), library, pure, followVar, errors) &&
-                   isSameExpression(cpp, macro, tok1->astOperand2(), tok2->astOperand1(), library, pure, followVar, errors);
+            return isSameExpression(macro, tok1->astOperand1(), tok2->astOperand2(), library, pure, followVar, errors) &&
+                   isSameExpression(macro, tok1->astOperand2(), tok2->astOperand1(), library, pure, followVar, errors);
         }
         const Token* condTok = nullptr;
         const Token* exprTok = nullptr;
@@ -1633,7 +1634,7 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
                 }
             }
             if (compare && astIsBoolLike(varTok1) && astIsBoolLike(varTok2))
-                return isSameExpression(cpp, macro, varTok1, varTok2, library, pure, followVar, errors);
+                return isSameExpression(macro, varTok1, varTok2, library, pure, followVar, errors);
 
         }
         return false;
@@ -1714,15 +1715,15 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
             return false;
     }
     bool noncommutativeEquals =
-        isSameExpression(cpp, macro, tok1->astOperand1(), tok2->astOperand1(), library, pure, followVar, errors);
+        isSameExpression(macro, tok1->astOperand1(), tok2->astOperand1(), library, pure, followVar, errors);
     noncommutativeEquals = noncommutativeEquals &&
-                           isSameExpression(cpp, macro, tok1->astOperand2(), tok2->astOperand2(), library, pure, followVar, errors);
+                           isSameExpression(macro, tok1->astOperand2(), tok2->astOperand2(), library, pure, followVar, errors);
 
     if (noncommutativeEquals)
         return true;
 
     // in c++, a+b might be different to b+a, depending on the type of a and b
-    if (cpp && tok1->str() == "+" && tok1->isBinaryOp()) {
+    if (tok1->isCpp() && tok1->str() == "+" && tok1->isBinaryOp()) {
         const ValueType* vt1 = tok1->astOperand1()->valueType();
         const ValueType* vt2 = tok1->astOperand2()->valueType();
         if (!(vt1 && (vt1->type >= ValueType::VOID || vt1->pointer) && vt2 && (vt2->type >= ValueType::VOID || vt2->pointer)))
@@ -1731,9 +1732,9 @@ bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2
 
     const bool commutative = tok1->isBinaryOp() && Token::Match(tok1, "%or%|%oror%|+|*|&|&&|^|==|!=");
     bool commutativeEquals = commutative &&
-                             isSameExpression(cpp, macro, tok1->astOperand2(), tok2->astOperand1(), library, pure, followVar, errors);
+                             isSameExpression(macro, tok1->astOperand2(), tok2->astOperand1(), library, pure, followVar, errors);
     commutativeEquals = commutativeEquals &&
-                        isSameExpression(cpp, macro, tok1->astOperand1(), tok2->astOperand2(), library, pure, followVar, errors);
+                        isSameExpression(macro, tok1->astOperand1(), tok2->astOperand2(), library, pure, followVar, errors);
 
 
     return commutativeEquals;
@@ -1757,12 +1758,12 @@ static bool isZeroBoundCond(const Token * const cond)
     return false;
 }
 
-bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
+bool isOppositeCond(bool isNot, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
 {
     if (!cond1 || !cond2)
         return false;
 
-    if (isSameExpression(cpp, true, cond1, cond2, library, pure, followVar, errors))
+    if (isSameExpression(true, cond1, cond2, library, pure, followVar, errors))
         return false;
 
     if (!isNot && cond1->str() == "&&" && cond2->str() == "&&") {
@@ -1772,8 +1773,8 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
             for (const Token* tok2: {
                 cond2->astOperand1(), cond2->astOperand2()
             }) {
-                if (isSameExpression(cpp, true, tok1, tok2, library, pure, followVar, errors)) {
-                    if (isOppositeCond(isNot, cpp, tok1->astSibling(), tok2->astSibling(), library, pure, followVar, errors))
+                if (isSameExpression(true, tok1, tok2, library, pure, followVar, errors)) {
+                    if (isOppositeCond(isNot, tok1->astSibling(), tok2->astSibling(), library, pure, followVar, errors))
                         return true;
                 }
             }
@@ -1791,37 +1792,36 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
             orCond = cond2;
             otherCond = cond1;
         }
-        return isOppositeCond(isNot, cpp, orCond->astOperand1(), otherCond, library, pure, followVar, errors) &&
-               isOppositeCond(isNot, cpp, orCond->astOperand2(), otherCond, library, pure, followVar, errors);
+        return isOppositeCond(isNot, orCond->astOperand1(), otherCond, library, pure, followVar, errors) &&
+               isOppositeCond(isNot, orCond->astOperand2(), otherCond, library, pure, followVar, errors);
     }
 
     if (cond1->str() == "!") {
         if (cond2->str() == "!=") {
             if (cond2->astOperand1() && cond2->astOperand1()->str() == "0")
-                return isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand2(), library, pure, followVar, errors);
+                return isSameExpression(true, cond1->astOperand1(), cond2->astOperand2(), library, pure, followVar, errors);
             if (cond2->astOperand2() && cond2->astOperand2()->str() == "0")
-                return isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors);
+                return isSameExpression(true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors);
         }
         if (!isUsedAsBool(cond2))
             return false;
-        return isSameExpression(cpp, true, cond1->astOperand1(), cond2, library, pure, followVar, errors);
+        return isSameExpression(true, cond1->astOperand1(), cond2, library, pure, followVar, errors);
     }
 
     if (cond2->str() == "!")
-        return isOppositeCond(isNot, cpp, cond2, cond1, library, pure, followVar, errors);
+        return isOppositeCond(isNot, cond2, cond1, library, pure, followVar, errors);
 
     if (!isNot) {
         if (cond1->str() == "==" && cond2->str() == "==") {
-            if (isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors))
+            if (isSameExpression(true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors))
                 return isDifferentKnownValues(cond1->astOperand2(), cond2->astOperand2());
-            if (isSameExpression(cpp, true, cond1->astOperand2(), cond2->astOperand2(), library, pure, followVar, errors))
+            if (isSameExpression(true, cond1->astOperand2(), cond2->astOperand2(), library, pure, followVar, errors))
                 return isDifferentKnownValues(cond1->astOperand1(), cond2->astOperand1());
         }
         // TODO: Handle reverse conditions
         if (Library::isContainerYield(cond1, Library::Container::Yield::EMPTY, "empty") &&
             Library::isContainerYield(cond2->astOperand1(), Library::Container::Yield::SIZE, "size") &&
-            isSameExpression(cpp,
-                             true,
+            isSameExpression(true,
                              cond1->astOperand1()->astOperand1(),
                              cond2->astOperand1()->astOperand1()->astOperand1(),
                              library,
@@ -1833,8 +1833,7 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
 
         if (Library::isContainerYield(cond2, Library::Container::Yield::EMPTY, "empty") &&
             Library::isContainerYield(cond1->astOperand1(), Library::Container::Yield::SIZE, "size") &&
-            isSameExpression(cpp,
-                             true,
+            isSameExpression(true,
                              cond2->astOperand1()->astOperand1(),
                              cond1->astOperand1()->astOperand1()->astOperand1(),
                              library,
@@ -1853,11 +1852,11 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
 
     // condition found .. get comparator
     std::string comp2;
-    if (isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors) &&
-        isSameExpression(cpp, true, cond1->astOperand2(), cond2->astOperand2(), library, pure, followVar, errors)) {
+    if (isSameExpression(true, cond1->astOperand1(), cond2->astOperand1(), library, pure, followVar, errors) &&
+        isSameExpression(true, cond1->astOperand2(), cond2->astOperand2(), library, pure, followVar, errors)) {
         comp2 = cond2->str();
-    } else if (isSameExpression(cpp, true, cond1->astOperand1(), cond2->astOperand2(), library, pure, followVar, errors) &&
-               isSameExpression(cpp, true, cond1->astOperand2(), cond2->astOperand1(), library, pure, followVar, errors)) {
+    } else if (isSameExpression(true, cond1->astOperand1(), cond2->astOperand2(), library, pure, followVar, errors) &&
+               isSameExpression(true, cond1->astOperand2(), cond2->astOperand1(), library, pure, followVar, errors)) {
         comp2 = cond2->str();
         if (comp2[0] == '>')
             comp2[0] = '<';
@@ -1893,7 +1892,7 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
         if (!expr1 || !value1 || !expr2 || !value2) {
             return false;
         }
-        if (!isSameExpression(cpp, true, expr1, expr2, library, pure, followVar, errors))
+        if (!isSameExpression(true, expr1, expr2, library, pure, followVar, errors))
             return false;
 
         const ValueFlow::Value &rhsValue1 = value1->values().front();
@@ -1921,16 +1920,16 @@ bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token
                         )));
 }
 
-bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * const tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
+bool isOppositeExpression(const Token * const tok1, const Token * const tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors)
 {
     if (!tok1 || !tok2)
         return false;
-    if (isOppositeCond(true, cpp, tok1, tok2, library, pure, followVar, errors))
+    if (isOppositeCond(true, tok1, tok2, library, pure, followVar, errors))
         return true;
     if (tok1->isUnaryOp("-") && !(tok2->astParent() && tok2->astParent()->tokType() == Token::eBitOp))
-        return isSameExpression(cpp, true, tok1->astOperand1(), tok2, library, pure, followVar, errors);
+        return isSameExpression(true, tok1->astOperand1(), tok2, library, pure, followVar, errors);
     if (tok2->isUnaryOp("-") && !(tok2->astParent() && tok2->astParent()->tokType() == Token::eBitOp))
-        return isSameExpression(cpp, true, tok2->astOperand1(), tok1, library, pure, followVar, errors);
+        return isSameExpression(true, tok2->astOperand1(), tok1, library, pure, followVar, errors);
     return false;
 }
 
@@ -2023,7 +2022,7 @@ bool isConstFunctionCall(const Token* ftok, const Library& library)
     return true;
 }
 
-bool isConstExpression(const Token *tok, const Library& library, bool cpp)
+bool isConstExpression(const Token *tok, const Library& library)
 {
     if (!tok)
         return true;
@@ -2037,17 +2036,19 @@ bool isConstExpression(const Token *tok, const Library& library, bool cpp)
         return false;
     if (tok->isAssignmentOp())
         return false;
-    if (isLikelyStreamRead(cpp, tok))
+    if (isLikelyStreamRead(tok))
         return false;
     // bailout when we see ({..})
     if (tok->str() == "{")
         return false;
-    return isConstExpression(tok->astOperand1(), library, cpp) && isConstExpression(tok->astOperand2(), library, cpp);
+    return isConstExpression(tok->astOperand1(), library) && isConstExpression(tok->astOperand2(), library);
 }
 
-bool isWithoutSideEffects(bool cpp, const Token* tok, bool checkArrayAccess, bool checkReference)
+bool isWithoutSideEffects(const Token* tok, bool checkArrayAccess, bool checkReference)
 {
-    if (!cpp)
+    if (!tok)
+        return true;
+    if (!tok->isCpp())
         return true;
 
     while (tok && tok->astOperand2() && tok->astOperand2()->str() != "(")
@@ -2520,7 +2521,7 @@ bool isVariableChangedByFunctionCall(const Token *tok, int indirect, const Setti
     return false;
 }
 
-bool isVariableChanged(const Token *tok, int indirect, const Settings *settings, bool cpp, int depth)
+bool isVariableChanged(const Token *tok, int indirect, const Settings *settings, int depth)
 {
     if (!tok)
         return false;
@@ -2577,7 +2578,7 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
         const Variable * var = getLHSVariable(tok2->astParent());
         if (var && var->isReference() && !var->isConst() &&
             ((var->nameToken() && var->nameToken()->next() == tok2->astParent()) || var->isPointer())) {
-            if (!var->isLocal() || isVariableChanged(var, settings, cpp, depth - 1))
+            if (!var->isLocal() || isVariableChanged(var, settings, depth - 1))
                 return true;
         }
     }
@@ -2586,7 +2587,7 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
 
     // Check addressof
     if (tok2->astParent() && tok2->astParent()->isUnaryOp("&")) {
-        if (isVariableChanged(tok2->astParent(), indirect + 1, settings, cpp, depth - 1))
+        if (isVariableChanged(tok2->astParent(), indirect + 1, settings, depth - 1))
             return true;
     } else {
         // If its already const then it cant be modified
@@ -2594,10 +2595,10 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
             return false;
     }
 
-    if (cpp && Token::Match(tok2->astParent(), ">>|&") && astIsRHS(tok2) && isLikelyStreamRead(cpp, tok2->astParent()))
+    if (tok2->isCpp() && Token::Match(tok2->astParent(), ">>|&") && astIsRHS(tok2) && isLikelyStreamRead(tok2->astParent()))
         return true;
 
-    if (isLikelyStream(cpp, tok2))
+    if (isLikelyStream(tok2))
         return true;
 
     // Member function call
@@ -2626,14 +2627,14 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
             const Library::Container::Yield yield = c->getYield(ftok->str());
             // If accessing element check if the element is changed
             if (contains({Library::Container::Yield::ITEM, Library::Container::Yield::AT_INDEX}, yield))
-                return isVariableChanged(ftok->next(), indirect, settings, cpp, depth - 1);
+                return isVariableChanged(ftok->next(), indirect, settings, depth - 1);
 
             if (contains({Library::Container::Yield::BUFFER,
                           Library::Container::Yield::BUFFER_NT,
                           Library::Container::Yield::START_ITERATOR,
                           Library::Container::Yield::ITERATOR},
                          yield)) {
-                return isVariableChanged(ftok->next(), indirect + 1, settings, cpp, depth - 1);
+                return isVariableChanged(ftok->next(), indirect + 1, settings, depth - 1);
             }
             if (contains({Library::Container::Yield::SIZE,
                           Library::Container::Yield::EMPTY,
@@ -2716,7 +2717,7 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
         const Variable * loopVar = varTok->variable();
         if (!loopVar)
             return false;
-        if (!loopVar->isConst() && loopVar->isReference() && isVariableChanged(loopVar, settings, cpp, depth - 1))
+        if (!loopVar->isConst() && loopVar->isReference() && isVariableChanged(loopVar, settings, depth - 1))
             return true;
         return false;
     }
@@ -2738,14 +2739,14 @@ bool isVariableChanged(const Token *tok, int indirect, const Settings *settings,
     return false;
 }
 
-bool isVariableChanged(const Token *start, const Token *end, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth)
+bool isVariableChanged(const Token *start, const Token *end, const nonneg int exprid, bool globalvar, const Settings *settings, int depth)
 {
-    return findVariableChanged(start, end, 0, exprid, globalvar, settings, cpp, depth) != nullptr;
+    return findVariableChanged(start, end, 0, exprid, globalvar, settings, depth) != nullptr;
 }
 
-bool isVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth)
+bool isVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth)
 {
-    return findVariableChanged(start, end, indirect, exprid, globalvar, settings, cpp, depth) != nullptr;
+    return findVariableChanged(start, end, indirect, exprid, globalvar, settings, depth) != nullptr;
 }
 
 const Token* findExpression(const Token* start, const nonneg int exprid)
@@ -2788,7 +2789,6 @@ static bool isExpressionChangedAt(const F& getExprTok,
                                   const nonneg int exprid,
                                   bool globalvar,
                                   const Settings* settings,
-                                  bool cpp,
                                   int depth)
 {
     if (depth < 0)
@@ -2809,14 +2809,14 @@ static bool isExpressionChangedAt(const F& getExprTok,
             aliased = isAliasOf(tok, expr, &i);
         if (!aliased)
             return false;
-        if (isVariableChanged(tok, indirect + i, settings, cpp, depth))
+        if (isVariableChanged(tok, indirect + i, settings, depth))
             return true;
         // TODO: Try to traverse the lambda function
         if (Token::Match(tok, "%var% ("))
             return true;
         return false;
     }
-    return (isVariableChanged(tok, indirect, settings, cpp, depth));
+    return (isVariableChanged(tok, indirect, settings, depth));
 }
 
 bool isExpressionChangedAt(const Token* expr,
@@ -2824,15 +2824,14 @@ bool isExpressionChangedAt(const Token* expr,
                            int indirect,
                            bool globalvar,
                            const Settings* settings,
-                           bool cpp,
                            int depth)
 {
     return isExpressionChangedAt([&] {
         return expr;
-    }, tok, indirect, expr->exprId(), globalvar, settings, cpp, depth);
+    }, tok, indirect, expr->exprId(), globalvar, settings, depth);
 }
 
-Token* findVariableChanged(Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth)
+Token* findVariableChanged(Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth)
 {
     if (!precedes(start, end))
         return nullptr;
@@ -2842,18 +2841,18 @@ Token* findVariableChanged(Token *start, const Token *end, int indirect, const n
         return findExpression(start, exprid);
     });
     for (Token *tok = start; tok != end; tok = tok->next()) {
-        if (isExpressionChangedAt(getExprTok, tok, indirect, exprid, globalvar, settings, cpp, depth))
+        if (isExpressionChangedAt(getExprTok, tok, indirect, exprid, globalvar, settings, depth))
             return tok;
     }
     return nullptr;
 }
 
-const Token* findVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth)
+const Token* findVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth)
 {
-    return findVariableChanged(const_cast<Token*>(start), end, indirect, exprid, globalvar, settings, cpp, depth);
+    return findVariableChanged(const_cast<Token*>(start), end, indirect, exprid, globalvar, settings, depth);
 }
 
-bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp, int depth)
+bool isVariableChanged(const Variable * var, const Settings *settings, int depth)
 {
     if (!var)
         return false;
@@ -2869,15 +2868,14 @@ bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp,
         if (next)
             start = next;
     }
-    return findExpressionChanged(var->nameToken(), start->next(), var->scope()->bodyEnd, settings, cpp, depth);
+    return findExpressionChanged(var->nameToken(), start->next(), var->scope()->bodyEnd, settings, depth);
 }
 
 bool isVariablesChanged(const Token* start,
                         const Token* end,
                         int indirect,
                         const std::vector<const Variable*> &vars,
-                        const Settings* settings,
-                        bool cpp)
+                        const Settings* settings)
 {
     std::set<int> varids;
     std::transform(vars.cbegin(), vars.cend(), std::inserter(varids, varids.begin()), [](const Variable* var) {
@@ -2893,13 +2891,13 @@ bool isVariablesChanged(const Token* start,
                 return true;
             continue;
         }
-        if (isVariableChanged(tok, indirect, settings, cpp))
+        if (isVariableChanged(tok, indirect, settings))
             return true;
     }
     return false;
 }
 
-bool isThisChanged(const Token* tok, int indirect, const Settings* settings, bool cpp)
+bool isThisChanged(const Token* tok, int indirect, const Settings* settings)
 {
     if ((Token::Match(tok->previous(), "%name% (") && !Token::simpleMatch(tok->astOperand1(), ".")) ||
         Token::Match(tok->tokAt(-3), "this . %name% (")) {
@@ -2910,19 +2908,19 @@ bool isThisChanged(const Token* tok, int indirect, const Settings* settings, boo
             return true;
         }
     }
-    if (isVariableChanged(tok, indirect, settings, cpp))
+    if (isVariableChanged(tok, indirect, settings))
         return true;
     return false;
 }
 
-const Token* findThisChanged(const Token* start, const Token* end, int indirect, const Settings* settings, bool cpp)
+const Token* findThisChanged(const Token* start, const Token* end, int indirect, const Settings* settings)
 {
     if (!precedes(start, end))
         return nullptr;
     for (const Token* tok = start; tok != end; tok = tok->next()) {
         if (!exprDependsOnThis(tok))
             continue;
-        if (isThisChanged(tok, indirect, settings, cpp))
+        if (isThisChanged(tok, indirect, settings))
             return tok;
     }
     return nullptr;
@@ -2933,7 +2931,6 @@ static const Token* findExpressionChangedImpl(const Token* expr,
                                               const Token* start,
                                               const Token* end,
                                               const Settings* settings,
-                                              bool cpp,
                                               int depth,
                                               Find find)
 {
@@ -2944,7 +2941,7 @@ static const Token* findExpressionChangedImpl(const Token* expr,
     const Token* result = nullptr;
     findAstNode(expr, [&](const Token* tok) {
         if (exprDependsOnThis(tok)) {
-            result = findThisChanged(start, end, /*indirect*/ 0, settings, cpp);
+            result = findThisChanged(start, end, /*indirect*/ 0, settings);
             if (result)
                 return true;
         }
@@ -2967,7 +2964,7 @@ static const Token* findExpressionChangedImpl(const Token* expr,
                         ++indirect;
                 }
                 for (int i = 0; i <= indirect; ++i)
-                    if (isExpressionChangedAt(tok, tok2, i, global, settings, cpp, depth))
+                    if (isExpressionChangedAt(tok, tok2, i, global, settings, depth))
                         return true;
                 return false;
             });
@@ -3009,22 +3006,20 @@ const Token* findExpressionChanged(const Token* expr,
                                    const Token* start,
                                    const Token* end,
                                    const Settings* settings,
-                                   bool cpp,
                                    int depth)
 {
-    return findExpressionChangedImpl(expr, start, end, settings, cpp, depth, ExpressionChangedSimpleFind{});
+    return findExpressionChangedImpl(expr, start, end, settings, depth, ExpressionChangedSimpleFind{});
 }
 
 const Token* findExpressionChangedSkipDeadCode(const Token* expr,
                                                const Token* start,
                                                const Token* end,
                                                const Settings* settings,
-                                               bool cpp,
                                                const std::function<std::vector<MathLib::bigint>(const Token* tok)>& evaluate,
                                                int depth)
 {
     return findExpressionChangedImpl(
-        expr, start, end, settings, cpp, depth, ExpressionChangedSkipDeadCode{&settings->library, evaluate});
+        expr, start, end, settings, depth, ExpressionChangedSkipDeadCode{&settings->library, evaluate});
 }
 
 const Token* getArgumentStart(const Token* ftok)
@@ -3183,12 +3178,12 @@ Token* findLambdaEndToken(Token* first)
     return findLambdaEndTokenGeneric(first);
 }
 
-bool isLikelyStream(bool cpp, const Token *stream)
+bool isLikelyStream(const Token *stream)
 {
-    if (!cpp)
+    if (!stream)
         return false;
 
-    if (!stream)
+    if (!stream->isCpp())
         return false;
 
     if (!Token::Match(stream->astParent(), "&|<<|>>") || !stream->astParent()->isBinaryOp())
@@ -3200,9 +3195,12 @@ bool isLikelyStream(bool cpp, const Token *stream)
     return !astIsIntegral(stream, false);
 }
 
-bool isLikelyStreamRead(bool cpp, const Token *op)
+bool isLikelyStreamRead(const Token *op)
 {
-    if (!cpp)
+    if (!op)
+        return false;
+
+    if (!op->isCpp())
         return false;
 
     if (!Token::Match(op, "&|>>") || !op->isBinaryOp())
@@ -3324,7 +3322,7 @@ bool isLeafDot(const Token* tok)
     return isLeafDot(parent);
 }
 
-ExprUsage getExprUsage(const Token* tok, int indirect, const Settings* settings, bool cpp)
+ExprUsage getExprUsage(const Token* tok, int indirect, const Settings* settings)
 {
     const Token* parent = tok->astParent();
     if (indirect > 0 && parent) {
@@ -3339,12 +3337,12 @@ ExprUsage getExprUsage(const Token* tok, int indirect, const Settings* settings,
         if (parent->isCast())
             return ExprUsage::NotUsed;
         if (Token::simpleMatch(parent, ":") && Token::simpleMatch(parent->astParent(), "?"))
-            return getExprUsage(parent->astParent(), indirect, settings, cpp);
+            return getExprUsage(parent->astParent(), indirect, settings);
     }
     if (indirect == 0) {
         if (Token::Match(parent, "%cop%|%assign%|++|--") && parent->str() != "=" &&
             !parent->isUnaryOp("&") &&
-            !(astIsRHS(tok) && isLikelyStreamRead(cpp, parent)))
+            !(astIsRHS(tok) && isLikelyStreamRead(parent)))
             return ExprUsage::Used;
         if (isLeafDot(tok)) {
             const Token* op = parent->astParent();
@@ -3478,7 +3476,7 @@ bool isNullOperand(const Token *expr)
     return Token::Match(castOp, "NULL|nullptr") || (MathLib::isInt(castOp->str()) && MathLib::isNullValue(castOp->str()));
 }
 
-bool isGlobalData(const Token *expr, bool cpp)
+bool isGlobalData(const Token *expr)
 {
     // function call that returns reference => assume global data
     if (expr && expr->str() == "(" && expr->valueType() && expr->valueType()->reference != Reference::None) {
@@ -3491,7 +3489,7 @@ bool isGlobalData(const Token *expr, bool cpp)
     bool globalData = false;
     bool var = false;
     visitAstNodes(expr,
-                  [expr, cpp, &globalData, &var](const Token *tok) {
+                  [expr, &globalData, &var](const Token *tok) {
         if (tok->varId())
             var = true;
         if (tok->varId() && !tok->variable()) {
@@ -3549,7 +3547,7 @@ bool isGlobalData(const Token *expr, bool cpp)
             }
         }
         // Unknown argument type => it might be some reference type..
-        if (cpp && tok->str() == "." && tok->astOperand1() && tok->astOperand1()->variable() && !tok->astOperand1()->valueType()) {
+        if (tok->isCpp() && tok->str() == "." && tok->astOperand1() && tok->astOperand1()->variable() && !tok->astOperand1()->valueType()) {
             globalData = true;
             return ChildrenToVisit::none;
         }

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -194,7 +194,7 @@ const Token * astIsVariableComparison(const Token *tok, const std::string &comp,
 bool isVariableDecl(const Token* tok);
 bool isStlStringType(const Token* tok);
 
-bool isTemporary(bool cpp, const Token* tok, const Library* library, bool unknown = false);
+bool isTemporary(const Token* tok, const Library* library, bool unknown = false);
 
 const Token* previousBeforeAstLeftmostLeaf(const Token* tok);
 Token* previousBeforeAstLeftmostLeaf(Token* tok);
@@ -208,7 +208,7 @@ const Token* astParentSkipParens(const Token* tok);
 const Token* getParentMember(const Token * tok);
 
 const Token* getParentLifetime(const Token* tok);
-const Token* getParentLifetime(bool cpp, const Token* tok, const Library* library);
+const Token* getParentLifetime(const Token* tok, const Library* library);
 
 std::vector<ValueType> getParentValueTypes(const Token* tok,
                                            const Settings* settings = nullptr,
@@ -261,7 +261,7 @@ SmallVector<ReferenceToken> followAllReferences(const Token* tok,
                                                 int depth = 20);
 const Token* followReferences(const Token* tok, ErrorPath* errors = nullptr);
 
-CPPCHECKLIB bool isSameExpression(bool cpp, bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
+CPPCHECKLIB bool isSameExpression(bool macro, const Token *tok1, const Token *tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 
 bool isEqualKnownValue(const Token * const tok1, const Token * const tok2);
 
@@ -282,21 +282,20 @@ bool compareTokenFlags(const Token* tok1, const Token* tok2, bool macro);
 /**
  * Are two conditions opposite
  * @param isNot  do you want to know if cond1 is !cond2 or if cond1 and cond2 are non-overlapping. true: cond1==!cond2  false: cond1==true => cond2==false
- * @param cpp    c++ file
  * @param cond1  condition1
  * @param cond2  condition2
  * @param library files data
  * @param pure boolean
  */
-bool isOppositeCond(bool isNot, bool cpp, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
+bool isOppositeCond(bool isNot, const Token * const cond1, const Token * const cond2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 
-bool isOppositeExpression(bool cpp, const Token * const tok1, const Token * const tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
+bool isOppositeExpression(const Token * const tok1, const Token * const tok2, const Library& library, bool pure, bool followVar, ErrorPath* errors=nullptr);
 
 bool isConstFunctionCall(const Token* ftok, const Library& library);
 
-bool isConstExpression(const Token *tok, const Library& library, bool cpp);
+bool isConstExpression(const Token *tok, const Library& library);
 
-bool isWithoutSideEffects(bool cpp, const Token* tok, bool checkArrayAccess = false, bool checkReference = true);
+bool isWithoutSideEffects(const Token* tok, bool checkArrayAccess = false, bool checkReference = true);
 
 bool isUniqueExpression(const Token* tok);
 
@@ -341,38 +340,35 @@ bool isVariableChangedByFunctionCall(const Token *tok, int indirect, nonneg int 
 CPPCHECKLIB bool isVariableChangedByFunctionCall(const Token *tok, int indirect, const Settings *settings, bool *inconclusive);
 
 /** Is variable changed in block of code? */
-CPPCHECKLIB bool isVariableChanged(const Token *start, const Token *end, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth = 20);
-bool isVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth = 20);
+CPPCHECKLIB bool isVariableChanged(const Token *start, const Token *end, const nonneg int exprid, bool globalvar, const Settings *settings, int depth = 20);
+bool isVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth = 20);
 
-bool isVariableChanged(const Token *tok, int indirect, const Settings *settings, bool cpp, int depth = 20);
+bool isVariableChanged(const Token *tok, int indirect, const Settings *settings, int depth = 20);
 
-bool isVariableChanged(const Variable * var, const Settings *settings, bool cpp, int depth = 20);
+bool isVariableChanged(const Variable * var, const Settings *settings, int depth = 20);
 
 bool isVariablesChanged(const Token* start,
                         const Token* end,
                         int indirect,
                         const std::vector<const Variable*> &vars,
-                        const Settings* settings,
-                        bool cpp);
+                        const Settings* settings);
 
-bool isThisChanged(const Token* tok, int indirect, const Settings* settings, bool cpp);
-const Token* findThisChanged(const Token* start, const Token* end, int indirect, const Settings* settings, bool cpp);
+bool isThisChanged(const Token* tok, int indirect, const Settings* settings);
+const Token* findThisChanged(const Token* start, const Token* end, int indirect, const Settings* settings);
 
-const Token* findVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth = 20);
-Token* findVariableChanged(Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, bool cpp, int depth = 20);
+const Token* findVariableChanged(const Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth = 20);
+Token* findVariableChanged(Token *start, const Token *end, int indirect, const nonneg int exprid, bool globalvar, const Settings *settings, int depth = 20);
 
 CPPCHECKLIB const Token* findExpressionChanged(const Token* expr,
                                                const Token* start,
                                                const Token* end,
                                                const Settings* settings,
-                                               bool cpp,
                                                int depth = 20);
 
 const Token* findExpressionChangedSkipDeadCode(const Token* expr,
                                                const Token* start,
                                                const Token* end,
                                                const Settings* settings,
-                                               bool cpp,
                                                const std::function<std::vector<MathLib::bigint>(const Token* tok)>& evaluate,
                                                int depth = 20);
 
@@ -381,7 +377,6 @@ bool isExpressionChangedAt(const Token* expr,
                            int indirect,
                            bool globalvar,
                            const Settings* settings,
-                           bool cpp,
                            int depth = 20);
 
 /// If token is an alias if another variable
@@ -426,14 +421,14 @@ CPPCHECKLIB const Token *findLambdaStartToken(const Token *last);
 CPPCHECKLIB const Token *findLambdaEndToken(const Token *first);
 CPPCHECKLIB Token* findLambdaEndToken(Token* first);
 
-bool isLikelyStream(bool cpp, const Token *stream);
+bool isLikelyStream(const Token *stream);
 
 /**
  * do we see a likely write of rhs through overloaded operator
  *   s >> x;
  *   a & x;
  */
-bool isLikelyStreamRead(bool cpp, const Token *op);
+bool isLikelyStreamRead(const Token *op);
 
 bool isCPPCast(const Token* tok);
 
@@ -443,7 +438,7 @@ bool isLeafDot(const Token* tok);
 
 enum class ExprUsage { None, NotUsed, PassedByReference, Used, Inconclusive };
 
-ExprUsage getExprUsage(const Token* tok, int indirect, const Settings* settings, bool cpp);
+ExprUsage getExprUsage(const Token* tok, int indirect, const Settings* settings);
 
 const Variable *getLHSVariable(const Token *tok);
 
@@ -458,7 +453,7 @@ bool isScopeBracket(const Token* tok);
 
 CPPCHECKLIB bool isNullOperand(const Token *expr);
 
-bool isGlobalData(const Token *expr, bool cpp);
+bool isGlobalData(const Token *expr);
 
 bool isUnevaluated(const Token *tok);
 

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -122,7 +122,7 @@ void CheckBool::checkBitwiseOnBoolean()
                 if (tok->str() == "|" && !isConvertedToBool(tok) && !(isBoolOp1 && isBoolOp2))
                     continue;
                 // first operand will always be evaluated
-                if (!isConstExpression(tok->astOperand2(), mSettings->library, mTokenizer->isCPP()))
+                if (!isConstExpression(tok->astOperand2(), mSettings->library))
                     continue;
                 if (tok->astOperand2()->variable() && tok->astOperand2()->variable()->nameToken() == tok->astOperand2())
                     continue;

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -327,7 +327,7 @@ void CheckBufferOverrun::arrayIndex()
             const Token* changeTok = var->scope()->bodyStart;
             bool isChanged = false;
             while ((changeTok = findVariableChanged(changeTok->next(), var->scope()->bodyEnd, /*indirect*/ 0, var->declarationId(),
-                                                    /*globalvar*/ false, mSettings, mTokenizer->isCPP()))) {
+                                                    /*globalvar*/ false, mSettings))) {
                 if (!Token::simpleMatch(changeTok->astParent(), "[")) {
                     isChanged = true;
                     break;
@@ -793,7 +793,7 @@ void CheckBufferOverrun::stringNotZeroTerminated()
                 const Token *rhs = tok2->next()->astOperand2();
                 if (!rhs || !rhs->hasKnownIntValue() || rhs->getKnownIntValue() != 0)
                     continue;
-                if (isSameExpression(mTokenizer->isCPP(), false, args[0], tok2->link()->astOperand1(), mSettings->library, false, false))
+                if (isSameExpression(false, args[0], tok2->link()->astOperand1(), mSettings->library, false, false))
                     isZeroTerminated = true;
             }
             if (isZeroTerminated)
@@ -1090,7 +1090,7 @@ void CheckBufferOverrun::objectIndex()
                     if (var->valueType()->pointer > obj->valueType()->pointer)
                         continue;
                 }
-                if (obj->valueType() && var->valueType() && (obj->isCast() || (mTokenizer->isCPP() && isCPPCast(obj)) || obj->valueType()->pointer)) { // allow cast to a different type
+                if (obj->valueType() && var->valueType() && (obj->isCast() || (obj->isCpp() && isCPPCast(obj)) || obj->valueType()->pointer)) { // allow cast to a different type
                     const auto varSize = var->valueType()->typeSize(mSettings->platform);
                     if (varSize == 0)
                         continue;

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -503,7 +503,7 @@ void CheckClass::copyconstructors()
                 }
             }
             for (tok = func.functionScope->bodyStart; tok != func.functionScope->bodyEnd; tok = tok->next()) {
-                if ((mTokenizer->isCPP() && Token::Match(tok, "%var% = new")) ||
+                if ((tok->isCpp() && Token::Match(tok, "%var% = new")) ||
                     (Token::Match(tok, "%var% = %name% (") && (mSettings->library.getAllocFuncInfo(tok->tokAt(2)) || mSettings->library.getReallocFuncInfo(tok->tokAt(2))))) {
                     allocatedVars.erase(tok->varId());
                 } else if (Token::Match(tok, "%var% = %name% . %name% ;") && allocatedVars.find(tok->varId()) != allocatedVars.end()) {
@@ -817,7 +817,7 @@ void CheckClass::initializeVarList(const Function &func, std::list<const Functio
             continue;
 
         // Variable getting value from stream?
-        if (Token::Match(ftok, ">>|& %name%") && isLikelyStreamRead(true, ftok)) {
+        if (Token::Match(ftok, ">>|& %name%") && isLikelyStreamRead(ftok)) {
             assignVar(usage, ftok->next()->varId());
         }
 
@@ -1771,7 +1771,7 @@ bool CheckClass::hasAllocation(const Function *func, const Scope* scope, const T
     if (!end)
         end = func->functionScope->bodyEnd;
     for (const Token *tok = start; tok && (tok != end); tok = tok->next()) {
-        if (((mTokenizer->isCPP() && Token::Match(tok, "%var% = new")) ||
+        if (((tok->isCpp() && Token::Match(tok, "%var% = new")) ||
              (Token::Match(tok, "%var% = %name% (") && mSettings->library.getAllocFuncInfo(tok->tokAt(2)))) &&
             isMemberVar(scope, tok))
             return true;
@@ -1780,9 +1780,9 @@ bool CheckClass::hasAllocation(const Function *func, const Scope* scope, const T
         const Token *var;
         if (Token::Match(tok, "%name% ( %var%") && mSettings->library.getDeallocFuncInfo(tok))
             var = tok->tokAt(2);
-        else if (mTokenizer->isCPP() && Token::Match(tok, "delete [ ] %var%"))
+        else if (tok->isCpp() && Token::Match(tok, "delete [ ] %var%"))
             var = tok->tokAt(3);
-        else if (mTokenizer->isCPP() && Token::Match(tok, "delete %var%"))
+        else if (tok->isCpp() && Token::Match(tok, "delete %var%"))
             var = tok->next();
         else
             continue;
@@ -2552,7 +2552,7 @@ bool CheckClass::checkConstFunc(const Scope *scope, const Function *func, Member
             // Streaming
             else if (end->strAt(1) == "<<" && tok1->strAt(-1) != "<<")
                 return false;
-            else if (isLikelyStreamRead(true, tok1->previous()))
+            else if (isLikelyStreamRead(tok1->previous()))
                 return false;
 
             // ++/--
@@ -2581,7 +2581,7 @@ bool CheckClass::checkConstFunc(const Scope *scope, const Function *func, Member
         }
 
         // streaming: >> *this
-        else if (Token::simpleMatch(tok1, ">> * this") && isLikelyStreamRead(true, tok1)) {
+        else if (Token::simpleMatch(tok1, ">> * this") && isLikelyStreamRead(tok1)) {
             return false;
         }
 

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -148,7 +148,7 @@ void CheckFunctions::invalidFunctionUsage()
                     // Is non-null terminated local variable of type char (e.g. char buf[] = {'x'};) ?
                     if (variable && variable->isLocal()
                         && valueType && (valueType->type == ValueType::Type::CHAR || valueType->type == ValueType::Type::WCHAR_T)
-                        && !isVariablesChanged(variable->declEndToken(), functionToken, 0 /*indirect*/, { variable }, mSettings, mTokenizer->isCPP())) {
+                        && !isVariablesChanged(variable->declEndToken(), functionToken, 0 /*indirect*/, { variable }, mSettings)) {
                         const Token* varTok = variable->declEndToken();
                         auto count = -1; // Find out explicitly set count, e.g.: char buf[3] = {...}. Variable 'count' is set to 3 then.
                         if (varTok && Token::simpleMatch(varTok->astOperand1(), "["))
@@ -756,10 +756,10 @@ void CheckFunctions::useStandardLibrary()
 
         const auto& secondOp = condToken->str();
         const bool isLess = "<" == secondOp &&
-                            isConstExpression(condToken->astOperand2(), mSettings->library, mTokenizer->isCPP()) &&
+                            isConstExpression(condToken->astOperand2(), mSettings->library) &&
                             condToken->astOperand1()->varId() == idxVarId;
         const bool isMore = ">" == secondOp &&
-                            isConstExpression(condToken->astOperand1(), mSettings->library, mTokenizer->isCPP()) &&
+                            isConstExpression(condToken->astOperand1(), mSettings->library) &&
                             condToken->astOperand2()->varId() == idxVarId;
 
         if (!(isLess || isMore))
@@ -776,7 +776,7 @@ void CheckFunctions::useStandardLibrary()
         // technically using void* here is not correct but some compilers could allow it
 
         const Token *tok = scope.bodyStart;
-        const std::string memcpyName = mTokenizer->isCPP() ? "std::memcpy" : "memcpy";
+        const std::string memcpyName = tok->isCpp() ? "std::memcpy" : "memcpy";
         // (reinterpret_cast<uint8_t*>(dest))[i] = (reinterpret_cast<const uint8_t*>(src))[i];
         if (Token::Match(tok, "{ (| reinterpret_cast < uint8_t|int8_t|char|void * > ( %var% ) )| [ %varid% ] = "
                          "(| reinterpret_cast < const| uint8_t|int8_t|char|void * > ( %var% ) )| [ %varid% ] ; }", idxVarId)) {
@@ -792,7 +792,7 @@ void CheckFunctions::useStandardLibrary()
         }
 
 
-        const static std::string memsetName = mTokenizer->isCPP() ? "std::memset" : "memset";
+        const static std::string memsetName = tok->isCpp() ? "std::memset" : "memset";
         // ((char*)dst)[i] = 0;
         if (Token::Match(tok, "{ ( ( uint8_t|int8_t|char|void * ) (| %var% ) )| [ %varid% ] = %char%|%num% ; }", idxVarId)) {
             useStandardLibraryError(tok->next(), memsetName);

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -254,7 +254,7 @@ static bool isPointerReleased(const Token *startToken, const Token *endToken, no
     return false;
 }
 
-static bool isLocalVarNoAutoDealloc(const Token *varTok, const bool isCpp)
+static bool isLocalVarNoAutoDealloc(const Token *varTok)
 {
     // not a local variable nor argument?
     const Variable *var = varTok->variable();
@@ -268,7 +268,7 @@ static bool isLocalVarNoAutoDealloc(const Token *varTok, const bool isCpp)
         return false;
 
     // non-pod variable
-    if (isCpp) {
+    if (varTok->isCpp()) {
         // Possibly automatically deallocated memory
         if (isAutoDealloc(var) && Token::Match(varTok, "%var% [=({] new"))
             return false;
@@ -432,7 +432,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 leakIfAllocated(varTok, varInfo);
             varInfo.erase(varTok->varId());
 
-            if (!isLocalVarNoAutoDealloc(varTok, mTokenizer->isCPP()))
+            if (!isLocalVarNoAutoDealloc(varTok))
                 continue;
 
             // allocation?
@@ -447,7 +447,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 }
 
                 changeAllocStatusIfRealloc(alloctype, fTok, varTok);
-            } else if (mTokenizer->isCPP() && Token::Match(varTok->tokAt(2), "new !!(")) {
+            } else if (varTok->isCpp() && Token::Match(varTok->tokAt(2), "new !!(")) {
                 const Token* tok2 = varTok->tokAt(2)->astOperand1();
                 const bool arrayNew = (tok2 && (tok2->str() == "[" || (Token::Match(tok2, "(|{") && tok2->astOperand1() && tok2->astOperand1()->str() == "[")));
                 VarInfo::AllocInfo& varAlloc = alloctype[varTok->varId()];
@@ -481,7 +481,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                 if (!openingPar)
                     checkTokenInsideExpression(innerTok, varInfo);
 
-                if (!isLocalVarNoAutoDealloc(innerTok, mTokenizer->isCPP()))
+                if (!isLocalVarNoAutoDealloc(innerTok))
                     continue;
 
                 // Check assignments in the if-statement. Skip multiple assignments since we don't track those
@@ -505,7 +505,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                             alloctype.erase(innerTok->varId());
                         }
                         changeAllocStatusIfRealloc(alloctype, fTok, varTok);
-                    } else if (mTokenizer->isCPP() && Token::Match(innerTok->tokAt(2), "new !!(")) {
+                    } else if (innerTok->isCpp() && Token::Match(innerTok->tokAt(2), "new !!(")) {
                         const Token* tok2 = innerTok->tokAt(2)->astOperand1();
                         const bool arrayNew = (tok2 && (tok2->str() == "[" || (tok2->str() == "(" && tok2->astOperand1() && tok2->astOperand1()->str() == "[")));
                         VarInfo::AllocInfo& varAlloc = alloctype[innerTok->varId()];
@@ -656,7 +656,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
         }
 
         // throw
-        else if (mTokenizer->isCPP() && tok->str() == "throw") {
+        else if (tok->isCpp() && tok->str() == "throw") {
             bool tryFound = false;
             const Scope* scope = tok->scope();
             while (scope && scope->isExecutable()) {
@@ -671,7 +671,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
         }
 
         // delete
-        else if (mTokenizer->isCPP() && tok->str() == "delete") {
+        else if (tok->isCpp() && tok->str() == "delete") {
             const Token * delTok = tok;
             if (Token::simpleMatch(delTok->astOperand1(), "."))
                 continue;
@@ -962,7 +962,7 @@ void CheckLeakAutoVar::functionCall(const Token *tokName, const Token *tokOpenin
     int argNr = 1;
     for (const Token *funcArg = tokFirstArg; funcArg; funcArg = funcArg->nextArgument()) {
         const Token* arg = funcArg;
-        if (mTokenizer->isCPP()) {
+        if (arg->isCpp()) {
             int tokAdvance = 0;
             if (arg->str() == "new")
                 tokAdvance = 1;

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -76,7 +76,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::getAllocationType(const Token *tok2,
         if (reallocType != No)
             return reallocType;
 
-        if (mTokenizer_->isCPP() && tok2->str() == "new") {
+        if (tok2->isCpp() && tok2->str() == "new") {
             if (tok2->strAt(1) == "(" && !Token::Match(tok2->next(),"( std| ::| nothrow )"))
                 return No;
             if (tok2->astOperand1() && (tok2->astOperand1()->str() == "[" || (tok2->astOperand1()->astOperand1() && tok2->astOperand1()->astOperand1()->str() == "[")))
@@ -187,7 +187,7 @@ CheckMemoryLeak::AllocType CheckMemoryLeak::getReallocationType(const Token *tok
 
 CheckMemoryLeak::AllocType CheckMemoryLeak::getDeallocationType(const Token *tok, nonneg int varid) const
 {
-    if (mTokenizer_->isCPP() && tok->str() == "delete" && tok->astOperand1()) {
+    if (tok->isCpp() && tok->str() == "delete" && tok->astOperand1()) {
         const Token* vartok = tok->astOperand1();
         if (Token::Match(vartok, ".|::"))
             vartok = vartok->astOperand2();
@@ -973,7 +973,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
             continue;
 
         const std::string& functionName = tok->str();
-        if ((mTokenizer->isCPP() && functionName == "delete") ||
+        if ((tok->isCpp() && functionName == "delete") ||
             functionName == "return")
             continue;
 
@@ -989,7 +989,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
             if (arg->isOp() && !(tok->isKeyword() && arg->str() == "*")) // e.g. switch (*new int)
                 continue;
             while (arg->astOperand1()) {
-                if (mTokenizer->isCPP() && Token::simpleMatch(arg, "new"))
+                if (arg->isCpp() && Token::simpleMatch(arg, "new"))
                     break;
                 arg = arg->astOperand1();
             }
@@ -1031,7 +1031,7 @@ void CheckMemoryLeakNoVar::checkForUnreleasedInputArgument(const Scope *scope)
 void CheckMemoryLeakNoVar::checkForUnusedReturnValue(const Scope *scope)
 {
     for (const Token *tok = scope->bodyStart; tok != scope->bodyEnd; tok = tok->next()) {
-        const bool isNew = mTokenizer->isCPP() && tok->str() == "new";
+        const bool isNew = tok->isCpp() && tok->str() == "new";
         if (!isNew && !Token::Match(tok, "%name% ("))
             continue;
 

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -92,7 +92,7 @@ void CheckOther::checkCastIntToCharAndBack()
     const SymbolDatabase *symbolDatabase = mTokenizer->getSymbolDatabase();
     for (const Scope * scope : symbolDatabase->functionScopes) {
         std::map<int, std::string> vars;
-        for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
+        for (const Token* tok = scope->bodyStart->next(); tok && tok != scope->bodyEnd; tok = tok->next()) {
             // Quick check to see if any of the matches below have any chances
             if (!Token::Match(tok, "%var%|EOF %comp%|="))
                 continue;
@@ -107,13 +107,13 @@ void CheckOther::checkCastIntToCharAndBack()
                 if (var && var->typeEndToken()->str() == "char" && !var->typeEndToken()->isSigned()) {
                     checkCastIntToCharAndBackError(tok, tok->strAt(2));
                 }
-            } else if (mTokenizer->isCPP() && (Token::Match(tok, "EOF %comp% ( %var% = std :: cin . get (") || Token::Match(tok, "EOF %comp% ( %var% = cin . get ("))) {
+            } else if (tok->isCpp() && (Token::Match(tok, "EOF %comp% ( %var% = std :: cin . get (") || Token::Match(tok, "EOF %comp% ( %var% = cin . get ("))) {
                 tok = tok->tokAt(3);
                 const Variable *var = tok->variable();
                 if (var && var->typeEndToken()->str() == "char" && !var->typeEndToken()->isSigned()) {
                     checkCastIntToCharAndBackError(tok, "cin.get");
                 }
-            } else if (mTokenizer->isCPP() && (Token::Match(tok, "%var% = std :: cin . get (") || Token::Match(tok, "%var% = cin . get ("))) {
+            } else if (tok->isCpp() && (Token::Match(tok, "%var% = std :: cin . get (") || Token::Match(tok, "%var% = cin . get ("))) {
                 const Variable *var = tok->variable();
                 if (var && var->typeEndToken()->str() == "char" && !var->typeEndToken()->isSigned()) {
                     vars[tok->varId()] = "cin.get";
@@ -482,7 +482,7 @@ void CheckOther::checkRedundantAssignment()
                     continue;
 
                 bool inconclusive = false;
-                if (mTokenizer->isCPP() && tok->astOperand1()->valueType()) {
+                if (tok->isCpp() && tok->astOperand1()->valueType()) {
                     // If there is a custom assignment operator => this is inconclusive
                     if (tok->astOperand1()->valueType()->typeScope) {
                         const std::string op = "operator" + tok->str();
@@ -498,7 +498,7 @@ void CheckOther::checkRedundantAssignment()
                 if (inconclusive && !mSettings->certainty.isEnabled(Certainty::inconclusive))
                     continue;
 
-                FwdAnalysis fwdAnalysis(mTokenizer->isCPP(), mSettings->library);
+                FwdAnalysis fwdAnalysis(mSettings->library);
                 if (fwdAnalysis.hasOperand(tok->astOperand2(), tok->astOperand1()))
                     continue;
 
@@ -917,7 +917,7 @@ static bool isSimpleExpr(const Token* tok, const Variable* var, const Settings* 
             ((ftok->function() && ftok->function()->isConst()) || settings->library.isFunctionConst(ftok->str(), /*pure*/ true)))
             needsCheck = true;
     }
-    return (needsCheck && !findExpressionChanged(tok, tok->astParent(), var->scope()->bodyEnd, settings, true));
+    return (needsCheck && !findExpressionChanged(tok, tok->astParent(), var->scope()->bodyEnd, settings));
 }
 
 //---------------------------------------------------------------------------
@@ -1305,7 +1305,7 @@ void CheckOther::checkPassByReference()
         if (!isRangeBasedFor && (!var->scope() || var->scope()->function->isImplicitlyVirtual()))
             continue;
 
-        if (!isVariableChanged(var, mSettings, mTokenizer->isCPP())) {
+        if (!isVariableChanged(var, mSettings)) {
             passedByValueError(var, inconclusive, isRangeBasedFor);
         }
     }
@@ -1421,7 +1421,7 @@ void CheckOther::checkConstVariable()
             continue;
         if (isStructuredBindingVariable(var)) // TODO: check all bound variables
             continue;
-        if (isVariableChanged(var, mSettings, mTokenizer->isCPP()))
+        if (isVariableChanged(var, mSettings))
             continue;
         const bool hasFunction = function != nullptr;
         if (!hasFunction) {
@@ -1630,7 +1630,7 @@ void CheckOther::checkConstPointer()
         if (std::find(nonConstPointers.cbegin(), nonConstPointers.cend(), p) == nonConstPointers.cend()) {
             const Token *start = getVariableChangedStart(p);
             const int indirect = p->isArray() ? p->dimensions().size() : 1;
-            if (isVariableChanged(start, p->scope()->bodyEnd, indirect, p->declarationId(), false, mSettings, mTokenizer->isCPP()))
+            if (isVariableChanged(start, p->scope()->bodyEnd, indirect, p->declarationId(), false, mSettings))
                 continue;
             if (p->typeStartToken() && p->typeStartToken()->isSimplifiedTypedef() && !(Token::simpleMatch(p->typeEndToken(), "*") && !p->typeEndToken()->isSimplifiedTypedef()))
                 continue;
@@ -1809,7 +1809,7 @@ static bool isConstant(const Token* tok) {
     return tok && (tok->isEnumerator() || Token::Match(tok, "%bool%|%num%|%str%|%char%|nullptr|NULL"));
 }
 
-static bool isConstStatement(const Token *tok, bool cpp)
+static bool isConstStatement(const Token *tok)
 {
     if (!tok)
         return false;
@@ -1831,7 +1831,7 @@ static bool isConstStatement(const Token *tok, bool cpp)
         tok2 = tok2->astParent();
     }
     if (Token::Match(tok, "&&|%oror%"))
-        return isConstStatement(tok->astOperand1(), cpp) && isConstStatement(tok->astOperand2(), cpp);
+        return isConstStatement(tok->astOperand1()) && isConstStatement(tok->astOperand2());
     if (Token::Match(tok, "!|~|%cop%") && (tok->astOperand1() || tok->astOperand2()))
         return true;
     if (Token::simpleMatch(tok->previous(), "sizeof ("))
@@ -1839,15 +1839,15 @@ static bool isConstStatement(const Token *tok, bool cpp)
     if (isCPPCast(tok)) {
         if (Token::simpleMatch(tok->astOperand1(), "dynamic_cast") && Token::simpleMatch(tok->astOperand1()->linkAt(1)->previous(), "& >"))
             return false;
-        return isWithoutSideEffects(cpp, tok) && isConstStatement(tok->astOperand2(), cpp);
+        return isWithoutSideEffects(tok) && isConstStatement(tok->astOperand2());
     }
     if (tok->isCast() && tok->next() && tok->next()->isStandardType())
-        return isWithoutSideEffects(cpp, tok->astOperand1()) && isConstStatement(tok->astOperand1(), cpp);
+        return isWithoutSideEffects(tok->astOperand1()) && isConstStatement(tok->astOperand1());
     if (Token::simpleMatch(tok, "."))
-        return isConstStatement(tok->astOperand2(), cpp);
+        return isConstStatement(tok->astOperand2());
     if (Token::simpleMatch(tok, ",")) {
         if (tok->astParent()) // warn about const statement on rhs at the top level
-            return isConstStatement(tok->astOperand1(), cpp) && isConstStatement(tok->astOperand2(), cpp);
+            return isConstStatement(tok->astOperand1()) && isConstStatement(tok->astOperand2());
 
         const Token* lml = previousBeforeAstLeftmostLeaf(tok); // don't warn about matrix/vector assignment (e.g. Eigen)
         if (lml)
@@ -1855,14 +1855,14 @@ static bool isConstStatement(const Token *tok, bool cpp)
         const Token* stream = lml;
         while (stream && Token::Match(stream->astParent(), ".|[|(|*"))
             stream = stream->astParent();
-        return (!stream || !isLikelyStream(cpp, stream)) && isConstStatement(tok->astOperand2(), cpp);
+        return (!stream || !isLikelyStream(stream)) && isConstStatement(tok->astOperand2());
     }
     if (Token::simpleMatch(tok, "?") && Token::simpleMatch(tok->astOperand2(), ":")) // ternary operator
-        return isConstStatement(tok->astOperand1(), cpp) && isConstStatement(tok->astOperand2()->astOperand1(), cpp) && isConstStatement(tok->astOperand2()->astOperand2(), cpp);
-    if (isBracketAccess(tok) && isWithoutSideEffects(cpp, tok->astOperand1(), /*checkArrayAccess*/ true, /*checkReference*/ false)) {
+        return isConstStatement(tok->astOperand1()) && isConstStatement(tok->astOperand2()->astOperand1()) && isConstStatement(tok->astOperand2()->astOperand2());
+    if (isBracketAccess(tok) && isWithoutSideEffects(tok->astOperand1(), /*checkArrayAccess*/ true, /*checkReference*/ false)) {
         if (Token::simpleMatch(tok->astParent(), "["))
-            return isConstStatement(tok->astOperand2(), cpp) && isConstStatement(tok->astParent(), cpp);
-        return isConstStatement(tok->astOperand2(), cpp);
+            return isConstStatement(tok->astOperand2()) && isConstStatement(tok->astParent());
+        return isConstStatement(tok->astOperand2());
     }
     return false;
 }
@@ -1946,7 +1946,7 @@ void CheckOther::checkIncompleteStatement()
         const Token *rtok = nextAfterAstRightmostLeaf(tok);
         if (!Token::simpleMatch(tok->astParent(), ";") && !Token::simpleMatch(rtok, ";") &&
             !Token::Match(tok->previous(), ";|}|{ %any% ;") &&
-            !(mTokenizer->isCPP() && tok->isCast() && !tok->astParent()) &&
+            !(tok->isCpp() && tok->isCast() && !tok->astParent()) &&
             !Token::simpleMatch(tok->tokAt(-2), "for (") &&
             !Token::Match(tok->tokAt(-1), "%var% [") &&
             !(tok->str() == "," && tok->astParent() && tok->astParent()->isAssignmentOp()))
@@ -1954,11 +1954,11 @@ void CheckOther::checkIncompleteStatement()
         // Skip statement expressions
         if (Token::simpleMatch(rtok, "; } )"))
             continue;
-        if (!isConstStatement(tok, mTokenizer->isCPP()))
+        if (!isConstStatement(tok))
             continue;
         if (isVoidStmt(tok))
             continue;
-        if (mTokenizer->isCPP() && tok->str() == "&" && !(tok->astOperand1() && tok->astOperand1()->valueType() && tok->astOperand1()->valueType()->isIntegral()))
+        if (tok->isCpp() && tok->str() == "&" && !(tok->astOperand1() && tok->astOperand1()->valueType() && tok->astOperand1()->valueType()->isIntegral()))
             // Possible archive
             continue;
         const bool inconclusive = tok->isConstOp();
@@ -2143,7 +2143,7 @@ void CheckOther::checkMisusedScopedObject()
                 if (Token::simpleMatch(parTok, "<") && parTok->link())
                     parTok = parTok->link()->next();
                 if (const Token* arg = parTok->astOperand2()) {
-                    if (!isConstStatement(arg, mTokenizer->isCPP()))
+                    if (!isConstStatement(arg))
                         continue;
                     if (parTok->str() == "(") {
                         if (arg->varId() && !(arg->variable() && arg->variable()->nameToken() != arg))
@@ -2266,8 +2266,8 @@ void CheckOther::checkDuplicateBranch()
             if (branchTop1->str() != branchTop2->str())
                 continue;
             ErrorPath errorPath;
-            if (isSameExpression(mTokenizer->isCPP(), false, branchTop1->astOperand1(), branchTop2->astOperand1(), mSettings->library, true, true, &errorPath) &&
-                isSameExpression(mTokenizer->isCPP(), false, branchTop1->astOperand2(), branchTop2->astOperand2(), mSettings->library, true, true, &errorPath))
+            if (isSameExpression(false, branchTop1->astOperand1(), branchTop2->astOperand1(), mSettings->library, true, true, &errorPath) &&
+                isSameExpression(false, branchTop1->astOperand2(), branchTop2->astOperand2(), mSettings->library, true, true, &errorPath))
                 duplicateBranchError(scope.classDef, scope.bodyEnd->next(), std::move(errorPath));
         }
     }
@@ -2300,10 +2300,10 @@ void CheckOther::checkInvalidFree()
     const bool printInconclusive = mSettings->certainty.isEnabled(Certainty::inconclusive);
     const SymbolDatabase* symbolDatabase = mTokenizer->getSymbolDatabase();
     for (const Scope * scope : symbolDatabase->functionScopes) {
-        for (const Token* tok = scope->bodyStart->next(); tok != scope->bodyEnd; tok = tok->next()) {
+        for (const Token* tok = scope->bodyStart->next(); tok && tok != scope->bodyEnd; tok = tok->next()) {
 
             // Keep track of which variables were assigned addresses to newly-allocated memory
-            if ((mTokenizer->isCPP() && Token::Match(tok, "%var% = new")) ||
+            if ((tok->isCpp() && Token::Match(tok, "%var% = new")) ||
                 (Token::Match(tok, "%var% = %name% (") && mSettings->library.getAllocFuncInfo(tok->tokAt(2)))) {
                 allocation.insert(std::make_pair(tok->varId(), tok->strAt(2)));
                 inconclusive.insert(std::make_pair(tok->varId(), false));
@@ -2431,8 +2431,6 @@ void CheckOther::checkDuplicateExpression()
     std::list<const Function*> constFunctions;
     getConstFunctions(symbolDatabase, constFunctions);
 
-    const bool cpp = mTokenizer->isCPP();
-
     for (const Scope *scope : symbolDatabase->functionScopes) {
         for (const Token *tok = scope->bodyStart; tok != scope->bodyEnd; tok = tok->next()) {
             if (tok->str() == "=" && Token::Match(tok->astOperand1(), "%var%")) {
@@ -2457,8 +2455,8 @@ void CheckOther::checkDuplicateExpression()
                             Token::Match(tok->astOperand2()->previous(), "%name% (")
                             ) &&
                         tok->next()->tokType() != Token::eType &&
-                        isSameExpression(cpp, true, tok->next(), nextAssign->next(), mSettings->library, true, false) &&
-                        isSameExpression(cpp, true, tok->astOperand2(), nextAssign->astOperand2(), mSettings->library, true, false) &&
+                        isSameExpression(true, tok->next(), nextAssign->next(), mSettings->library, true, false) &&
+                        isSameExpression(true, tok->astOperand2(), nextAssign->astOperand2(), mSettings->library, true, false) &&
                         tok->astOperand2()->expressionString() == nextAssign->astOperand2()->expressionString()) {
                         bool differentDomain = false;
                         const Scope * varScope = var1->scope() ? var1->scope() : scope;
@@ -2472,8 +2470,7 @@ void CheckOther::checkDuplicateExpression()
 
                             if (assignTok->astOperand1()->varId() != var1->varId() &&
                                 assignTok->astOperand1()->varId() != var2->varId() &&
-                                !isSameExpression(cpp,
-                                                  true,
+                                !isSameExpression(true,
                                                   tok->astOperand2(),
                                                   assignTok->astOperand1(),
                                                   mSettings->library,
@@ -2482,8 +2479,7 @@ void CheckOther::checkDuplicateExpression()
                                 continue;
                             if (assignTok->astOperand2()->varId() != var1->varId() &&
                                 assignTok->astOperand2()->varId() != var2->varId() &&
-                                !isSameExpression(cpp,
-                                                  true,
+                                !isSameExpression(true,
                                                   tok->astOperand2(),
                                                   assignTok->astOperand2(),
                                                   mSettings->library,
@@ -2513,24 +2509,23 @@ void CheckOther::checkDuplicateExpression()
                 const bool pointerDereference = (tok->astOperand1() && tok->astOperand1()->isUnaryOp("*")) ||
                                                 (tok->astOperand2() && tok->astOperand2()->isUnaryOp("*"));
                 const bool followVar = (!isConstVarExpression(tok) || Token::Match(tok, "%comp%|%oror%|&&")) && !pointerDereference;
-                if (isSameExpression(cpp,
-                                     true,
+                if (isSameExpression(true,
                                      tok->astOperand1(),
                                      tok->astOperand2(),
                                      mSettings->library,
                                      true,
                                      followVar,
                                      &errorPath)) {
-                    if (isWithoutSideEffects(cpp, tok->astOperand1())) {
+                    if (isWithoutSideEffects(tok->astOperand1())) {
                         const Token* loopTok = isInLoopCondition(tok);
                         if (!loopTok ||
-                            !findExpressionChanged(tok, tok, loopTok->link()->next()->link(), mSettings, cpp)) {
+                            !findExpressionChanged(tok, tok, loopTok->link()->next()->link(), mSettings)) {
                             const bool isEnum = tok->scope()->type == Scope::eEnum;
                             const bool assignment = !isEnum && tok->str() == "=";
                             if (assignment)
                                 selfAssignmentError(tok, tok->astOperand1()->expressionString());
                             else if (!isEnum) {
-                                if (cpp && mSettings->standards.cpp >= Standards::CPP11 && tok->str() == "==") {
+                                if (tok->isCpp() && mSettings->standards.cpp >= Standards::CPP11 && tok->str() == "==") {
                                     const Token* parent = tok->astParent();
                                     while (parent && parent->astParent()) {
                                         parent = parent->astParent();
@@ -2544,43 +2539,40 @@ void CheckOther::checkDuplicateExpression()
                         }
                     }
                 } else if (tok->str() == "=" && Token::simpleMatch(tok->astOperand2(), "=") &&
-                           isSameExpression(cpp,
-                                            false,
+                           isSameExpression(false,
                                             tok->astOperand1(),
                                             tok->astOperand2()->astOperand1(),
                                             mSettings->library,
                                             true,
                                             false)) {
-                    if (isWithoutSideEffects(cpp, tok->astOperand1())) {
+                    if (isWithoutSideEffects(tok->astOperand1())) {
                         selfAssignmentError(tok, tok->astOperand1()->expressionString());
                     }
-                } else if (isOppositeExpression(cpp,
-                                                tok->astOperand1(),
+                } else if (isOppositeExpression(tok->astOperand1(),
                                                 tok->astOperand2(),
                                                 mSettings->library,
                                                 false,
                                                 true,
                                                 &errorPath) &&
                            !Token::Match(tok, "=|-|-=|/|/=") &&
-                           isWithoutSideEffects(cpp, tok->astOperand1())) {
+                           isWithoutSideEffects(tok->astOperand1())) {
                     oppositeExpressionError(tok, std::move(errorPath));
                 } else if (!Token::Match(tok, "[-/%]")) { // These operators are not associative
                     if (tok->astOperand2() && tok->str() == tok->astOperand1()->str() &&
-                        isSameExpression(cpp,
-                                         true,
+                        isSameExpression(true,
                                          tok->astOperand2(),
                                          tok->astOperand1()->astOperand2(),
                                          mSettings->library,
                                          true,
                                          followVar,
                                          &errorPath) &&
-                        isWithoutSideEffects(cpp, tok->astOperand2()))
+                        isWithoutSideEffects(tok->astOperand2()))
                         duplicateExpressionError(tok->astOperand2(), tok->astOperand1()->astOperand2(), tok, errorPath);
-                    else if (tok->astOperand2() && isConstExpression(tok->astOperand1(), mSettings->library, cpp)) {
+                    else if (tok->astOperand2() && isConstExpression(tok->astOperand1(), mSettings->library)) {
                         auto checkDuplicate = [&](const Token* exp1, const Token* exp2, const Token* ast1) {
-                            if (isSameExpression(cpp, true, exp1, exp2, mSettings->library, true, true, &errorPath) &&
-                                isWithoutSideEffects(cpp, exp1) &&
-                                isWithoutSideEffects(cpp, ast1->astOperand2()))
+                            if (isSameExpression(true, exp1, exp2, mSettings->library, true, true, &errorPath) &&
+                                isWithoutSideEffects(exp1) &&
+                                isWithoutSideEffects(ast1->astOperand2()))
                                 duplicateExpressionError(exp1, exp2, tok, errorPath, /*hasMultipleExpr*/ true);
                         };
                         const Token *ast1 = tok->astOperand1();
@@ -2594,10 +2586,10 @@ void CheckOther::checkDuplicateExpression()
                 }
             } else if (tok->astOperand1() && tok->astOperand2() && tok->str() == ":" && tok->astParent() && tok->astParent()->str() == "?") {
                 if (!tok->astOperand1()->values().empty() && !tok->astOperand2()->values().empty() && isEqualKnownValue(tok->astOperand1(), tok->astOperand2()) &&
-                    !isVariableChanged(tok->astParent(), /*indirect*/ 0, mSettings, cpp) &&
-                    isConstStatement(tok->astOperand1(), cpp) && isConstStatement(tok->astOperand2(), cpp))
+                    !isVariableChanged(tok->astParent(), /*indirect*/ 0, mSettings) &&
+                    isConstStatement(tok->astOperand1()) && isConstStatement(tok->astOperand2()))
                     duplicateValueTernaryError(tok);
-                else if (isSameExpression(cpp, true, tok->astOperand1(), tok->astOperand2(), mSettings->library, false, true, &errorPath))
+                else if (isSameExpression(true, tok->astOperand1(), tok->astOperand2(), mSettings->library, false, true, &errorPath))
                     duplicateExpressionTernaryError(tok, std::move(errorPath));
             }
         }
@@ -2874,7 +2866,7 @@ void CheckOther::checkRedundantCopy()
     for (const Variable* var : symbolDatabase->variableList()) {
         if (!var || var->isReference() || var->isPointer() ||
             (!var->type() && !var->isStlType()) || // bailout if var is of standard type, if it is a pointer or non-const
-            (!var->isConst() && isVariableChanged(var, mSettings, mTokenizer->isCPP())))
+            (!var->isConst() && isVariableChanged(var, mSettings)))
             continue;
 
         const Token* startTok = var->nameToken();
@@ -2899,9 +2891,9 @@ void CheckOther::checkRedundantCopy()
 
         const Token* dot = tok->astOperand1();
         if (Token::simpleMatch(dot, ".")) {
-            if (dot->astOperand1() && isVariableChanged(dot->astOperand1()->variable(), mSettings, mTokenizer->isCPP()))
+            if (dot->astOperand1() && isVariableChanged(dot->astOperand1()->variable(), mSettings))
                 continue;
-            if (isTemporary(/*cpp*/ true, dot, &mSettings->library, /*unknown*/ true))
+            if (isTemporary(dot, &mSettings->library, /*unknown*/ true))
                 continue;
         }
         if (exprDependsOnThis(tok->previous()))
@@ -2955,7 +2947,7 @@ void CheckOther::checkNegativeBitwiseShift()
             continue;
 
         // don't warn if lhs is a class. this is an overloaded operator then
-        if (mTokenizer->isCPP()) {
+        if (tok->isCpp()) {
             const ValueType * lhsType = tok->astOperand1()->valueType();
             if (!lhsType || !lhsType->isIntegral())
                 continue;
@@ -3333,9 +3325,9 @@ void CheckOther::checkEvaluationOrder()
                 if (tok2 == tok &&
                     tok->str() == "=" &&
                     parent->str() == "=" &&
-                    isSameExpression(mTokenizer->isCPP(), false, tok->astOperand1(), parent->astOperand1(), mSettings->library, true, false)) {
+                    isSameExpression(false, tok->astOperand1(), parent->astOperand1(), mSettings->library, true, false)) {
                     if (mSettings->severity.isEnabled(Severity::warning) &&
-                        isSameExpression(mTokenizer->isCPP(), true, tok->astOperand1(), parent->astOperand1(), mSettings->library, true, false))
+                        isSameExpression(true, tok->astOperand1(), parent->astOperand1(), mSettings->library, true, false))
                         selfAssignmentError(parent, tok->astOperand1()->expressionString());
                     break;
                 }
@@ -3348,7 +3340,7 @@ void CheckOther::checkEvaluationOrder()
                         return ChildrenToVisit::none; // don't handle address-of for now
                     if (tok3->str() == "(" && Token::simpleMatch(tok3->previous(), "sizeof"))
                         return ChildrenToVisit::none; // don't care about sizeof usage
-                    if (isSameExpression(mTokenizer->isCPP(), false, tok->astOperand1(), tok3, mSettings->library, true, false))
+                    if (isSameExpression(false, tok->astOperand1(), tok3, mSettings->library, true, false))
                         foundError = true;
                     return foundError ? ChildrenToVisit::done : ChildrenToVisit::op1_and_op2;
                 });
@@ -3399,7 +3391,7 @@ void CheckOther::checkAccessOfMovedVariable()
                 else
                     inconclusive = true;
             } else {
-                const ExprUsage usage = getExprUsage(tok, 0, mSettings, mTokenizer->isCPP());
+                const ExprUsage usage = getExprUsage(tok, 0, mSettings);
                 if (usage == ExprUsage::Used)
                     accessOfMoved = true;
                 if (usage == ExprUsage::PassedByReference)
@@ -3705,7 +3697,7 @@ void CheckOther::checkKnownArgument()
                 continue;
             if (tok->isComparisonOp() &&
                 isSameExpression(
-                    mTokenizer->isCPP(), true, tok->astOperand1(), tok->astOperand2(), mSettings->library, true, true))
+                    true, tok->astOperand1(), tok->astOperand2(), mSettings->library, true, true))
                 continue;
             // ensure that there is a integer variable in expression with unknown value
             const Token* vartok = nullptr;
@@ -3838,10 +3830,10 @@ void CheckOther::checkComparePointers()
                 continue;
             if (var1->isRValueReference() || var2->isRValueReference())
                 continue;
-            if (const Token* parent2 = getParentLifetime(mTokenizer->isCPP(), v2.tokvalue, &mSettings->library))
+            if (const Token* parent2 = getParentLifetime(v2.tokvalue, &mSettings->library))
                 if (var1 == parent2->variable())
                     continue;
-            if (const Token* parent1 = getParentLifetime(mTokenizer->isCPP(), v1.tokvalue, &mSettings->library))
+            if (const Token* parent1 = getParentLifetime(v1.tokvalue, &mSettings->library))
                 if (var2 == parent1->variable())
                     continue;
             comparePointersError(tok, &v1, &v2);
@@ -3998,7 +3990,7 @@ void CheckOther::checkOverlappingWrite()
                         constexpr bool macro = true;
                         constexpr bool pure = true;
                         constexpr bool follow = true;
-                        if (!isSameExpression(mTokenizer->isCPP(), macro, ptr1, ptr2, mSettings->library, pure, follow, &errorPath))
+                        if (!isSameExpression(macro, ptr1, ptr2, mSettings->library, pure, follow, &errorPath))
                             continue;
                         overlappingWriteFunction(tok);
                     }
@@ -4023,7 +4015,7 @@ void CheckOther::checkOverlappingWrite()
                 constexpr bool macro = true;
                 constexpr bool pure = true;
                 constexpr bool follow = true;
-                if (!isSameExpression(mTokenizer->isCPP(), macro, buf1, buf2, mSettings->library, pure, follow, &errorPath))
+                if (!isSameExpression(macro, buf1, buf2, mSettings->library, pure, follow, &errorPath))
                     continue;
                 overlappingWriteFunction(tok);
             }

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -189,7 +189,7 @@ void CheckString::checkSuspiciousStringCompare()
                 continue;
 
             const ValueType* varType = varTok->valueType();
-            if (mTokenizer->isCPP() && (!varType || !varType->isIntegral()))
+            if (varTok->isCpp() && (!varType || !varType->isIntegral()))
                 continue;
 
             if (litTok->tokType() == Token::eString) {
@@ -396,7 +396,7 @@ void CheckString::overlappingStrcmp()
                     if (args1[1]->isLiteral() &&
                         args2[1]->isLiteral() &&
                         args1[1]->str() != args2[1]->str() &&
-                        isSameExpression(mTokenizer->isCPP(), true, args1[0], args2[0], mSettings->library, true, false))
+                        isSameExpression(true, args1[0], args2[0], mSettings->library, true, false))
                         overlappingStrcmpError(eq0, ne0);
                 }
             }
@@ -444,8 +444,7 @@ void CheckString::sprintfOverlappingData()
                 while (arg->isCast())
                     arg = arg->astOperand2() ? arg->astOperand2() : arg->astOperand1();
 
-                const bool same = isSameExpression(mTokenizer->isCPP(),
-                                                   false,
+                const bool same = isSameExpression(false,
                                                    dest,
                                                    arg,
                                                    mSettings->library,

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -68,7 +68,7 @@ void CheckType::checkTooBigBitwiseShift()
 
     for (const Token *tok = mTokenizer->tokens(); tok; tok = tok->next()) {
         // C++ and macro: OUT(x<<y)
-        if (mTokenizer->isCPP() && Token::Match(tok, "[;{}] %name% (") && Token::simpleMatch(tok->linkAt(2), ") ;") && tok->next()->isUpperCaseName() && !tok->next()->function())
+        if (tok->isCpp() && Token::Match(tok, "[;{}] %name% (") && Token::simpleMatch(tok->linkAt(2), ") ;") && tok->next()->isUpperCaseName() && !tok->next()->function())
             tok = tok->linkAt(2);
 
         if (!tok->astOperand1() || !tok->astOperand2())

--- a/lib/checkvaarg.cpp
+++ b/lib/checkvaarg.cpp
@@ -150,7 +150,7 @@ void CheckVaarg::va_list_usage()
                 tok = findNextTokenFromBreak(tok);
                 if (!tok)
                     return;
-            } else if (tok->str() == "goto" || (mTokenizer->isCPP() && tok->str() == "try")) {
+            } else if (tok->str() == "goto" || (tok->isCpp() && tok->str() == "try")) {
                 open = false;
                 break;
             } else if (!open && tok->varId() == var->declarationId())

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -436,7 +436,7 @@ CTU::FileInfo *CTU::getFileInfo(const Tokenizer *tokenizer)
     return fileInfo;
 }
 
-static std::list<std::pair<const Token *, MathLib::bigint>> getUnsafeFunction(const Tokenizer *tokenizer, const Settings *settings, const Scope *scope, int argnr, bool (*isUnsafeUsage)(const Settings *settings, const Token *argtok, MathLib::bigint *value))
+static std::list<std::pair<const Token *, MathLib::bigint>> getUnsafeFunction(const Settings *settings, const Scope *scope, int argnr, bool (*isUnsafeUsage)(const Settings *settings, const Token *argtok, MathLib::bigint *value))
 {
     std::list<std::pair<const Token *, MathLib::bigint>> ret;
     const Variable * const argvar = scope->function->getArgumentVar(argnr);
@@ -450,7 +450,7 @@ static std::list<std::pair<const Token *, MathLib::bigint>> getUnsafeFunction(co
             int indirect = 0;
             if (argvar->valueType())
                 indirect = argvar->valueType()->pointer;
-            if (isVariableChanged(tok2->link(), tok2, indirect, argvar->declarationId(), false, settings, tokenizer->isCPP()))
+            if (isVariableChanged(tok2->link(), tok2, indirect, argvar->declarationId(), false, settings))
                 return ret;
         }
         if (Token::Match(tok2, "%oror%|&&|?")) {
@@ -482,7 +482,7 @@ std::list<CTU::FileInfo::UnsafeUsage> CTU::getUnsafeUsage(const Tokenizer *token
 
         // "Unsafe" functions unconditionally reads data before it is written..
         for (int argnr = 0; argnr < function->argCount(); ++argnr) {
-            for (const std::pair<const Token *, MathLib::bigint> &v : getUnsafeFunction(tokenizer, settings, &scope, argnr, isUnsafeUsage)) {
+            for (const std::pair<const Token *, MathLib::bigint> &v : getUnsafeFunction(settings, &scope, argnr, isUnsafeUsage)) {
                 const Token *tok = v.first;
                 const MathLib::bigint val = v.second;
                 unsafeUsage.emplace_back(CTU::getFunctionId(tokenizer, function), argnr+1, tok->str(), CTU::FileInfo::Location(tokenizer,tok), val);

--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -383,13 +383,13 @@ namespace {
                 std::pair<const Token*, const Token*> exprToks = stepTok->findExpressionStartEndTokens();
                 if (exprToks.first != nullptr && exprToks.second != nullptr)
                     stepChangesCond |=
-                        findExpressionChanged(condTok, exprToks.first, exprToks.second->next(), &settings, true) != nullptr;
+                        findExpressionChanged(condTok, exprToks.first, exprToks.second->next(), &settings) != nullptr;
             }
-            const bool bodyChangesCond = findExpressionChanged(condTok, endBlock->link(), endBlock, &settings, true);
+            const bool bodyChangesCond = findExpressionChanged(condTok, endBlock->link(), endBlock, &settings);
             // Check for mutation in the condition
             const bool condChanged =
                 nullptr != findAstNode(condTok, [&](const Token* tok) {
-                return isVariableChanged(tok, 0, &settings, true);
+                return isVariableChanged(tok, 0, &settings);
             });
             const bool changed = stepChangesCond || bodyChangesCond || condChanged;
             if (!changed)

--- a/lib/fwdanalysis.cpp
+++ b/lib/fwdanalysis.cpp
@@ -272,12 +272,12 @@ FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const Token *
         if (exprVarIds.find(tok->varId()) != exprVarIds.end()) {
             const Token *parent = tok;
             bool other = false;
-            bool same = tok->astParent() && isSameExpression(mCpp, false, expr, tok, mLibrary, true, false, nullptr);
+            bool same = tok->astParent() && isSameExpression(false, expr, tok, mLibrary, true, false, nullptr);
             while (!same && Token::Match(parent->astParent(), "*|.|::|[|(|%cop%")) {
                 parent = parent->astParent();
                 if (parent->str() == "(" && !parent->isCast())
                     break;
-                if (isSameExpression(mCpp, false, expr, parent, mLibrary, true, false, nullptr)) {
+                if (isSameExpression(false, expr, parent, mLibrary, true, false, nullptr)) {
                     same = true;
                     if (mWhat == What::ValueFlow) {
                         KnownAndToken v;
@@ -287,7 +287,7 @@ FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const Token *
                     }
                 }
                 if (Token::Match(parent, ". %var%") && parent->next()->varId() && exprVarIds.find(parent->next()->varId()) == exprVarIds.end() &&
-                    isSameExpression(mCpp, false, expr->astOperand1(), parent->astOperand1(), mLibrary, true, false, nullptr)) {
+                    isSameExpression(false, expr->astOperand1(), parent->astOperand1(), mLibrary, true, false, nullptr)) {
                     other = true;
                     break;
                 }
@@ -317,7 +317,7 @@ FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const Token *
                 if (hasGccCompoundStatement(parent->astParent()->astOperand2()))
                     return Result(Result::Type::BAILOUT);
                 // cppcheck-suppress shadowFunction - TODO: fix this
-                const bool reassign = isSameExpression(mCpp, false, expr, parent, mLibrary, false, false, nullptr);
+                const bool reassign = isSameExpression(false, expr, parent, mLibrary, false, false, nullptr);
                 if (reassign)
                     return Result(Result::Type::WRITE, parent->astParent());
                 return Result(Result::Type::READ);
@@ -395,11 +395,6 @@ FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const Token *
     return Result(Result::Type::NONE);
 }
 
-bool FwdAnalysis::isGlobalData(const Token *expr) const
-{
-    return ::isGlobalData(expr, mCpp);
-}
-
 std::set<nonneg int> FwdAnalysis::getExprVarIds(const Token* expr, bool* localOut, bool* unknownVarIdOut) const
 {
     // all variable ids in expr.
@@ -469,7 +464,7 @@ bool FwdAnalysis::hasOperand(const Token *tok, const Token *lhs) const
 {
     if (!tok)
         return false;
-    if (isSameExpression(mCpp, false, tok, lhs, mLibrary, false, false, nullptr))
+    if (isSameExpression(false, tok, lhs, mLibrary, false, false, nullptr))
         return true;
     return hasOperand(tok->astOperand1(), lhs) || hasOperand(tok->astOperand2(), lhs);
 }
@@ -517,7 +512,7 @@ bool FwdAnalysis::possiblyAliased(const Token *expr, const Token *startToken) co
                 if (tok->function() && tok->function()->getArgumentVar(argnr) && !tok->function()->getArgumentVar(argnr)->isReference() && !tok->function()->isConst())
                     continue;
                 for (const Token *subexpr = expr; subexpr; subexpr = subexpr->astOperand1()) {
-                    if (isSameExpression(mCpp, macro, subexpr, args[argnr], mLibrary, pure, followVar)) {
+                    if (isSameExpression(macro, subexpr, args[argnr], mLibrary, pure, followVar)) {
                         const Scope* scope = expr->scope(); // if there is no other variable, assume no aliasing
                         if (scope->varlist.size() > 1)
                             return true;
@@ -542,7 +537,7 @@ bool FwdAnalysis::possiblyAliased(const Token *expr, const Token *startToken) co
             continue;
 
         for (const Token *subexpr = expr; subexpr; subexpr = subexpr->astOperand1()) {
-            if (subexpr != addrOf && isSameExpression(mCpp, macro, subexpr, addrOf, mLibrary, pure, followVar))
+            if (subexpr != addrOf && isSameExpression(macro, subexpr, addrOf, mLibrary, pure, followVar))
                 return true;
         }
     }

--- a/lib/fwdanalysis.h
+++ b/lib/fwdanalysis.h
@@ -37,7 +37,7 @@ class Library;
  */
 class FwdAnalysis {
 public:
-    FwdAnalysis(bool cpp, const Library &library) : mCpp(cpp), mLibrary(library) {}
+    FwdAnalysis(const Library &library) : mLibrary(library) {}
 
     bool hasOperand(const Token *tok, const Token *lhs) const;
 
@@ -82,10 +82,6 @@ private:
     Result check(const Token *expr, const Token *startToken, const Token *endToken);
     Result checkRecursive(const Token *expr, const Token *startToken, const Token *endToken, const std::set<nonneg int> &exprVarIds, bool local, bool inInnerClass, int depth=0);
 
-    // Is expression a l-value global data?
-    bool isGlobalData(const Token *expr) const;
-
-    const bool mCpp;
     const Library &mLibrary;
     enum class What { Reassign, UnusedValue, ValueFlow } mWhat = What::Reassign;
     std::vector<KnownAndToken> mValueFlow;

--- a/lib/fwdanalysis.h
+++ b/lib/fwdanalysis.h
@@ -37,7 +37,7 @@ class Library;
  */
 class FwdAnalysis {
 public:
-    FwdAnalysis(const Library &library) : mLibrary(library) {}
+    explicit FwdAnalysis(const Library &library) : mLibrary(library) {}
 
     bool hasOperand(const Token *tok, const Token *lhs) const;
 

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -295,7 +295,7 @@ void programMemoryParseCondition(ProgramMemory& pm, const Token* tok, const Toke
             return;
         if (!truevalue.isIntValue())
             return;
-        if (endTok && findExpressionChanged(vartok, tok->next(), endTok, settings, true))
+        if (endTok && findExpressionChanged(vartok, tok->next(), endTok, settings))
             return;
         const bool impossible = (tok->str() == "==" && !then) || (tok->str() == "!=" && then);
         const ValueFlow::Value& v = then ? truevalue : falsevalue;
@@ -323,7 +323,7 @@ void programMemoryParseCondition(ProgramMemory& pm, const Token* tok, const Toke
                 pm.setIntValue(tok, 0, then);
         }
     } else if (tok && tok->exprId() > 0) {
-        if (endTok && findExpressionChanged(tok, tok->next(), endTok, settings, true))
+        if (endTok && findExpressionChanged(tok, tok->next(), endTok, settings))
             return;
         pm.setIntValue(tok, 0, then);
         assert(settings);
@@ -381,7 +381,7 @@ static void fillProgramMemoryFromAssignments(ProgramMemory& pm, const Token* tok
                 }
             }
         } else if (tok2->exprId() > 0 && Token::Match(tok2, ".|(|[|*|%var%") && !pm.hasValue(tok2->exprId()) &&
-                   isVariableChanged(tok2, 0, settings, true)) {
+                   isVariableChanged(tok2, 0, settings)) {
             pm.setUnknown(tok2);
         }
 
@@ -421,7 +421,7 @@ static void fillProgramMemoryFromAssignments(ProgramMemory& pm, const Token* tok
 static void removeModifiedVars(ProgramMemory& pm, const Token* tok, const Token* origin)
 {
     pm.erase_if([&](const ExprIdToken& e) {
-        return isVariableChanged(origin, tok, e.getExpressionId(), false, nullptr, true);
+        return isVariableChanged(origin, tok, e.getExpressionId(), false, nullptr);
     });
 }
 
@@ -508,7 +508,7 @@ void ProgramMemoryState::removeModifiedVars(const Token* tok)
     state.erase_if([&](const ExprIdToken& e) {
         const Token* start = origins[e.getExpressionId()];
         const Token* expr = e.tok;
-        if (!expr || findExpressionChangedSkipDeadCode(expr, start, tok, settings, true, eval)) {
+        if (!expr || findExpressionChangedSkipDeadCode(expr, start, tok, settings, eval)) {
             origins.erase(e.getExpressionId());
             return true;
         }
@@ -1610,7 +1610,7 @@ namespace {
                             if (ValueFlow::isContainerSizeChanged(child, v.indirect, *settings))
                                 v = unknown();
                         } else if (v.valueType != ValueFlow::Value::ValueType::UNINIT) {
-                            if (isVariableChanged(child, v.indirect, settings, true))
+                            if (isVariableChanged(child, v.indirect, settings))
                                 v = unknown();
                         }
                     }

--- a/lib/reverseanalyzer.cpp
+++ b/lib/reverseanalyzer.cpp
@@ -248,7 +248,7 @@ namespace {
                             // Assignment to
                         } else if (lhsAction.matches() && !assignTok->astOperand2()->hasKnownIntValue() &&
                                    assignTok->astOperand2()->exprId() > 0 &&
-                                   isConstExpression(assignTok->astOperand2(), settings.library, true)) {
+                                   isConstExpression(assignTok->astOperand2(), settings.library)) {
                             const std::string info = "Assignment to '" + assignTok->expressionString() + "'";
                             ValuePtr<Analyzer> a = analyzer->reanalyze(assignTok->astOperand2(), info);
                             if (a) {

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -6451,7 +6451,7 @@ Function * SymbolDatabase::findFunctionInScope(const Token *func, const Scope *n
 
 //---------------------------------------------------------------------------
 
-bool SymbolDatabase::isReservedName(const Token* tok) const
+bool SymbolDatabase::isReservedName(const Token* tok)
 {
     const std::string& iName = tok->str();
     if (tok->isCpp()) {

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1176,7 +1176,7 @@ public:
      */
     const Variable *getVariable(const std::string &varname) const;
 
-    const Token * addEnum(const Token * tok, bool isCpp);
+    const Token * addEnum(const Token * tok);
 
     const Scope *findRecordInBase(const std::string &name) const;
 
@@ -1387,8 +1387,6 @@ public:
     void printVariable(const Variable *var, const char *indent) const;
     void printXml(std::ostream &out) const;
 
-    bool isCPP() const;
-
     /*
      * @brief Do a sanity check
      */
@@ -1458,8 +1456,8 @@ private:
 
     void fixVarId(VarIdMap & varIds, const Token * vartok, Token * membertok, const Variable * membervar);
 
-    /** Whether iName is a keyword as defined in http://en.cppreference.com/w/c/keyword and http://en.cppreference.com/w/cpp/keyword*/
-    bool isReservedName(const std::string& iName) const;
+    /** Whether the token is a keyword as defined in http://en.cppreference.com/w/c/keyword and http://en.cppreference.com/w/cpp/keyword*/
+    bool isReservedName(const Token* tok) const;
 
     const Enumerator * findEnumerator(const Token * tok, std::set<std::string>& tokensThatAreNotEnumeratorValues) const;
 
@@ -1477,7 +1475,6 @@ private:
     /** list for missing types */
     std::list<Type> mBlankTypes;
 
-    bool mIsCpp;
     ValueType::Sign mDefaultSignedness;
 };
 

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1457,7 +1457,7 @@ private:
     void fixVarId(VarIdMap & varIds, const Token * vartok, Token * membertok, const Variable * membervar);
 
     /** Whether the token is a keyword as defined in http://en.cppreference.com/w/c/keyword and http://en.cppreference.com/w/cpp/keyword*/
-    bool isReservedName(const Token* tok) const;
+    static bool isReservedName(const Token* tok);
 
     const Enumerator * findEnumerator(const Token * tok, std::set<std::string>& tokensThatAreNotEnumeratorValues) const;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -313,7 +313,7 @@ bool Tokenizer::duplicateTypedef(Token **tokPtr, const Token *name, const Token 
                             return false;
                         } else if (tok->previous()->str() == "union") {
                             return tok->next()->str() != ";";
-                        } else if (isCPP() && tok->previous()->str() == "class") {
+                        } else if (tok->isCpp() && tok->previous()->str() == "class") {
                             return tok->next()->str() != ";";
                         }
                         if (tok)
@@ -1697,7 +1697,7 @@ void Tokenizer::simplifyTypedefCpp()
                     }
 
                     // check for member functions
-                    else if (isCPP() && tok2->str() == "(" && isFunctionHead(tok2, "{:")) {
+                    else if (tok2->isCpp() && tok2->str() == "(" && isFunctionHead(tok2, "{:")) {
                         const Token *func = tok2->previous();
 
                         /** @todo add support for multi-token operators */
@@ -1724,7 +1724,7 @@ void Tokenizer::simplifyTypedefCpp()
                     // check for entering a new scope
                     else if (tok2->str() == "{") {
                         // check for entering a new namespace
-                        if (isCPP()) {
+                        if (tok2->isCpp()) {
                             if (tok2->strAt(-2) == "namespace") {
                                 if (classLevel < spaceInfo.size() &&
                                     spaceInfo[classLevel].isNamespace &&
@@ -1753,7 +1753,7 @@ void Tokenizer::simplifyTypedefCpp()
 
                 // check for operator typedef
                 /** @todo add support for multi-token operators */
-                else if (isCPP() &&
+                else if (tok2->isCpp() &&
                          tok2->str() == "operator" &&
                          tok2->next() &&
                          tok2->next()->str() == typeName->str() &&
@@ -4528,7 +4528,7 @@ void Tokenizer::setVarIdPass1()
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         if (tok->isOp())
             continue;
-        if (isCPP() && Token::simpleMatch(tok, "template <")) {
+        if (tok->isCpp() && Token::simpleMatch(tok, "template <")) {
             Token* closingBracket = tok->next()->findClosingBracket();
             if (closingBracket)
                 tok = closingBracket;
@@ -4722,7 +4722,7 @@ void Tokenizer::setVarIdPass1()
                     ;
                 else if (Token::Match(prev2, "%type% ( !!)") && Token::simpleMatch(tok2->link(), ") ;")) {
                     // In C++ , a variable can't be called operator+ or something like that.
-                    if (isCPP() &&
+                    if (prev2->isCpp() &&
                         prev2->isOperatorKeyword())
                         continue;
 
@@ -4804,7 +4804,7 @@ void Tokenizer::setVarIdPass1()
 
         if (tok->isName() && !tok->isKeyword() && !tok->isStandardType()) {
             // don't set variable id after a struct|enum|union
-            if (Token::Match(tok->previous(), "struct|enum|union") || (isCPP() && tok->strAt(-1) == "class"))
+            if (Token::Match(tok->previous(), "struct|enum|union") || (tok->isCpp() && tok->strAt(-1) == "class"))
                 continue;
 
             bool globalNamespace = false;
@@ -6153,7 +6153,7 @@ void Tokenizer::simplifyHeadersAndUnusedTemplates()
     // functions and types to keep
     std::set<std::string> keep;
     for (const Token *tok = list.front(); tok; tok = tok->next()) {
-        if (isCPP() && Token::simpleMatch(tok, "template <")) {
+        if (tok->isCpp() && Token::simpleMatch(tok, "template <")) {
             const Token *closingBracket = tok->next()->findClosingBracket();
             if (Token::Match(closingBracket, "> class|struct %name% {"))
                 tok = closingBracket->linkAt(3);
@@ -6884,7 +6884,7 @@ void Tokenizer::simplifyFunctionPointers()
             Token::Match(tok, "static_cast < %type% %type%| *| *| ( * ) (")) {
             Token *tok1 = tok;
 
-            if (isCPP() && tok1->str() == "static_cast")
+            if (tok1->isCpp() && tok1->str() == "static_cast")
                 tok1 = tok1->next();
 
             tok1 = tok1->next();
@@ -7085,7 +7085,7 @@ void Tokenizer::simplifyVarDecl(Token * tokBegin, const Token * const tokEnd, co
             continue;
         if (isCPP11 && type0->str() == "using")
             continue;
-        if (isCPP() && type0->str() == "namespace")
+        if (type0->isCpp() && type0->str() == "namespace")
             continue;
 
         bool isconst = false;
@@ -7744,7 +7744,7 @@ bool Tokenizer::simplifyRedundantParentheses()
         if (tok->str() != "(")
             continue;
 
-        if (isCPP() && Token::simpleMatch(tok->previous(), "} (")) {
+        if (tok->isCpp() && Token::simpleMatch(tok->previous(), "} (")) {
             const Token* plp = tok->previous()->link()->previous();
             if (Token::Match(plp, "%name%|>|] {") || (Token::simpleMatch(plp, ")") && Token::simpleMatch(plp->link()->previous(), "]")))
                 continue;

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -1424,7 +1424,7 @@ const Token* findLambdaEndTokenWithoutAST(const Token* tok) {
     return tok->link()->next();
 }
 
-static Token * createAstAtToken(Token *tok, bool cpp);
+static Token * createAstAtToken(Token *tok);
 
 // Compile inner expressions inside inner ({..}) and lambda bodies
 static void createAstAtTokenInner(Token * const tok1, const Token *endToken, bool cpp)
@@ -1445,7 +1445,7 @@ static void createAstAtTokenInner(Token * const tok1, const Token *endToken, boo
             }
             if (!hasAst) {
                 for (; tok && tok != endToken && tok != endToken2; tok = tok ? tok->next() : nullptr)
-                    tok = createAstAtToken(tok, cpp);
+                    tok = createAstAtToken(tok);
             }
         } else if (cpp && tok->str() == "[") {
             if (isLambdaCaptureList(tok)) {
@@ -1455,7 +1455,7 @@ static void createAstAtTokenInner(Token * const tok1, const Token *endToken, boo
                 const Token * const endToken2 = tok->link();
                 tok = tok->next();
                 for (; tok && tok != endToken && tok != endToken2; tok = tok ? tok->next() : nullptr)
-                    tok = createAstAtToken(tok, cpp);
+                    tok = createAstAtToken(tok);
             }
         }
         else if (Token::simpleMatch(tok, "( * ) [")) {
@@ -1497,8 +1497,9 @@ static Token * findAstTop(Token *tok1, const Token *tok2)
     return nullptr;
 }
 
-static Token * createAstAtToken(Token *tok, bool cpp)
+static Token * createAstAtToken(Token *tok)
 {
+    const bool cpp = tok->isCpp();
     // skip function pointer declaration
     if (Token::Match(tok, "%type% %type%") && !Token::Match(tok, "return|throw|new|delete")) {
         Token* tok2 = tok->tokAt(2);
@@ -1754,7 +1755,7 @@ static Token * createAstAtToken(Token *tok, bool cpp)
 void TokenList::createAst() const
 {
     for (Token *tok = mTokensFrontBack.front; tok; tok = tok ? tok->next() : nullptr) {
-        tok = createAstAtToken(tok, isCPP());
+        tok = createAstAtToken(tok);
     }
 }
 

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -181,7 +181,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, cpp ? "test.cpp" : "test.c"), file, line);
         const Token * const tok1 = Token::findsimplematch(tokenizer.tokens(), tokStr1, strlen(tokStr1));
         const Token * const tok2 = Token::findsimplematch(tok1->next(), tokStr2, strlen(tokStr2));
-        return (isSameExpression)(cpp, false, tok1, tok2, library, false, true, nullptr);
+        return (isSameExpression)(false, tok1, tok2, library, false, true, nullptr);
     }
 
     void isSameExpressionTestInternal(bool cpp) {
@@ -229,7 +229,7 @@ private:
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const tok1 = Token::findsimplematch(tokenizer.tokens(), startPattern, strlen(startPattern));
         const Token * const tok2 = Token::findsimplematch(tokenizer.tokens(), endPattern, strlen(endPattern));
-        return (isVariableChanged)(tok1, tok2, 1, false, &settingsDefault, /*cpp*/ true);
+        return (isVariableChanged)(tok1, tok2, 1, false, &settingsDefault);
     }
 
     void isVariableChangedTest() {
@@ -407,7 +407,7 @@ private:
         const Token* const start = Token::findsimplematch(tokenizer.tokens(), startPattern, strlen(startPattern));
         const Token* const end = Token::findsimplematch(start, endPattern, strlen(endPattern));
         const Token* const expr = Token::findsimplematch(tokenizer.tokens(), var, strlen(var));
-        return (findExpressionChanged)(expr, start, end, &settings, /*cpp*/ true);
+        return (findExpressionChanged)(expr, start, end, &settings);
     }
 
     void isExpressionChangedTest()


### PR DESCRIPTION
Each `Token` (should) be connected to a `TokenList`. `Tokenizer` just encapsulates that so we have no need to check the `Tokenizer` but can simply ask the `Token`.

Also if we have function calls we pass in a flag to tell it if it is C/C++ we can get rid of that flag and simply ask the `Token`. In several cases we were only passing that flag to be used in some underlying calls making it completely unnecessary in the top call.