### PR TITLE
fixed tests by adjusting results for `picojson` update

### DIFF
--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -51,6 +51,8 @@ ScopedFile::ScopedFile(std::string name, const std::string &content, std::string
     , mFullPath(Path::join(mPath, mName))
 {
     if (!mPath.empty() && mPath != Path::getCurrentPath()) {
+        if (Path::isDirectory(mPath))
+            throw std::runtime_error("ScopedFile(" + mFullPath + ") - directory already exists");
 #ifdef _WIN32
         if (!CreateDirectoryA(mPath.c_str(), nullptr))
             throw std::runtime_error("ScopedFile(" + mFullPath + ") - could not create directory");
@@ -59,6 +61,9 @@ ScopedFile::ScopedFile(std::string name, const std::string &content, std::string
             throw std::runtime_error("ScopedFile(" + mFullPath + ") - could not create directory");
 #endif
     }
+
+    if (Path::isFile(mFullPath))
+        throw std::runtime_error("ScopedFile(" + mFullPath + ") - file already exists");
 
     std::ofstream of(mFullPath);
     if (!of.is_open())

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -436,7 +436,7 @@ private:
                         "{\n");
         const char * const argv[] = {"cppcheck", "--version"};
         ASSERT_EQUALS(CmdLineParser::Result::Fail, parser->parseFromArgs(2, argv));
-        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 1 near: \n", logger->str());
+        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 2 near: \n", logger->str());
     }
 
     void onefile() {
@@ -1706,7 +1706,7 @@ private:
                         "{\n");
         const char * const argv[] = {"cppcheck", "--errorlist"};
         ASSERT_EQUALS(CmdLineParser::Result::Fail, parser->parseFromArgs(2, argv));
-        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 1 near: \n", logger->str());
+        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 2 near: \n", logger->str());
     }
 
     void ignorepathsnopath() {
@@ -2310,7 +2310,7 @@ private:
                         "{\n");
         const char * const argv[] = {"cppcheck", "test.cpp"};
         ASSERT_EQUALS(CmdLineParser::Result::Fail, parser->parseFromArgs(2, argv));
-        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 1 near: \n", logger->str());
+        ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 2 near: \n", logger->str());
     }
 };
 

--- a/test/testsettings.cpp
+++ b/test/testsettings.cpp
@@ -104,7 +104,7 @@ private:
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             "{\n");
-            ASSERT_EQUALS("not a valid JSON - syntax error at line 1 near: ", s.loadCppcheckCfg());
+            ASSERT_EQUALS("not a valid JSON - syntax error at line 2 near: ", s.loadCppcheckCfg());
         }
         {
             Settings s;


### PR DESCRIPTION
The tests which are failing were in introduced in #5712. Those were not included in #5710 which updated `picojson` that resulted in the different lines being reported in the error messages.

I also added some checks to `ScopeFile` which will indicate that a temporary file already exists highlighting multi-threading issues and leftover files from previously aborted testruns. I ran into his while looking into these failing tests