### PR TITLE
fixed #12108 - Crash in `CTU::FileInfo::getErrorPath()` with Clang-built binary

### DIFF
--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -884,7 +884,14 @@ void CheckBufferOverrun::argumentSizeError(const Token *tok, const std::string &
 // CTU..
 //---------------------------------------------------------------------------
 
-namespace {
+// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// see https://trac.cppcheck.net/ticket/12108 for more details
+#ifdef __clang__
+inline namespace CheckBufferOverrun_internal
+#else
+namespace
+#endif
+{
     /** data for multifile checking */
     class MyFileInfo : public Check::FileInfo {
     public:

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -3402,7 +3402,14 @@ void CheckClass::unsafeClassRefMemberError(const Token *tok, const std::string &
                 CWE(0), Certainty::normal);
 }
 
-namespace {
+// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// see https://trac.cppcheck.net/ticket/12108 for more details
+#ifdef __clang__
+inline namespace CheckClass_internal
+#else
+namespace
+#endif
+{
     /* multifile checking; one definition rule violations */
     class MyFileInfo : public Check::FileInfo {
     public:

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -558,7 +558,14 @@ static bool isUnsafeUsage(const Settings *settings, const Token *vartok, MathLib
     return CheckNullPointer::isPointerDeRef(vartok, unknown, settings);
 }
 
-namespace {
+// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// see https://trac.cppcheck.net/ticket/12108 for more details
+#ifdef __clang__
+inline namespace CheckNullPointer_internal
+#else
+namespace
+#endif
+{
     /* data for multifile checking */
     class MyFileInfo : public Check::FileInfo {
     public:
@@ -572,7 +579,6 @@ namespace {
         }
     };
 }
-
 
 Check::FileInfo *CheckNullPointer::getFileInfo(const Tokenizer *tokenizer, const Settings *settings) const
 {

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1682,7 +1682,14 @@ static bool isVariableUsage(const Settings *settings, const Token *vartok, MathL
     return CheckUninitVar::isVariableUsage(vartok, settings->library, true, CheckUninitVar::Alloc::ARRAY);
 }
 
-namespace {
+// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// see https://trac.cppcheck.net/ticket/12108 for more details
+#ifdef __clang__
+inline namespace CheckUninitVar_internal
+#else
+namespace
+#endif
+{
     /* data for multifile checking */
     class MyFileInfo : public Check::FileInfo {
     public:


### PR DESCRIPTION
This is actually just a workaround as it seems the issue is an upstream Clang one.