### PR TITLE
#12254: cppcheck.cfg can't be loaded from relative paths anymore

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1629,7 +1629,7 @@ void CmdLineParser::printHelp() const
     mLogger.printRaw(oss.str());
 }
 
-bool CmdLineParser::isCppcheckPremium() const{
+bool CmdLineParser::isCppcheckPremium() const {
     if (mSettings.cppcheckCfgProductName.empty())
         mSettings.loadCppcheckCfg();
     return startsWith(mSettings.cppcheckCfgProductName, "Cppcheck Premium");

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1629,10 +1629,10 @@ void CmdLineParser::printHelp() const
     mLogger.printRaw(oss.str());
 }
 
-bool CmdLineParser::isCppcheckPremium() {
-    Settings settings;
-    settings.loadCppcheckCfg(); // TODO: how to handle errors?
-    return startsWith(settings.cppcheckCfgProductName, "Cppcheck Premium");
+bool CmdLineParser::isCppcheckPremium() const{
+    if (mSettings.cppcheckCfgProductName.empty())
+        mSettings.loadCppcheckCfg();
+    return startsWith(mSettings.cppcheckCfgProductName, "Cppcheck Premium");
 }
 
 bool CmdLineParser::tryLoadLibrary(Library& destination, const std::string& basepath, const char* filename)

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -111,7 +111,7 @@ protected:
     void printHelp() const;
 
 private:
-    static bool isCppcheckPremium();
+    bool isCppcheckPremium() const;
 
     template<typename T>
     bool parseNumberArg(const char* const arg, std::size_t offset, T& num, bool mustBePositive = false)

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -825,3 +825,25 @@ def test_file_duplicate_2(tmpdir):
         '3/3 files checked 0% done'
     ]
     assert stderr == ''
+
+
+def test_cgf_with_relative_path(tmpdir):
+
+    test_file = os.path.join(tmpdir, 'test.c')
+    with open(test_file, 'wt'):
+        pass
+
+    test_cfg = os.path.join(tmpdir, '../../cppcheck.cfg')
+    with open(test_cfg, 'wt') as f:
+        f.write("""
+                {
+                    "addons": [],
+                    "productName": "Cppcheck Premium 1.2.3.4",
+                    "about": "Cppcheck Premium 1.2.3.4"
+                }
+                """)
+
+    args = [test_file]
+
+    _, _, stderr = cppcheck(args)
+    assert stderr == ''

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -826,24 +826,3 @@ def test_file_duplicate_2(tmpdir):
     ]
     assert stderr == ''
 
-
-def test_cgf_with_relative_path(tmpdir):
-
-    test_file = os.path.join(tmpdir, 'test.c')
-    with open(test_file, 'wt'):
-        pass
-
-    test_cfg = os.path.join(tmpdir, '../../cppcheck.cfg')
-    with open(test_cfg, 'wt') as f:
-        f.write("""
-                {
-                    "addons": [],
-                    "productName": "Cppcheck Premium 1.2.3.4",
-                    "about": "Cppcheck Premium 1.2.3.4"
-                }
-                """)
-
-    args = [test_file]
-
-    _, _, stderr = cppcheck(args)
-    assert stderr == ''

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -828,7 +828,7 @@ def test_file_duplicate_2(tmpdir):
     assert stderr == ''
 
 
-def test_premium_with_relative_path(tmpdir):
+def test_premium_with_relative_path(tmpdir): #12254
 
 
     test_file = os.path.join(tmpdir, 'test.c')
@@ -838,7 +838,7 @@ def test_premium_with_relative_path(tmpdir):
     product_name = 'Cppcheck Premium ' + str(time.time())
 
     test_cfg = lookup_cppcheck_exe()
-    if(test_cfg.endswith('.exe')) :
+    if(test_cfg.endswith('.exe')):
         test_cfg = test_cfg[:-4]
     test_cfg += '.cfg'
     with open(test_cfg, 'wt') as f:
@@ -850,7 +850,7 @@ def test_premium_with_relative_path(tmpdir):
                 }
                 """.replace('NAME', product_name))
 
-    if os.path.isfile('cppcheck') :
+    if os.path.isfile('cppcheck'):
         os.chdir('test/cli')
 
     args = ['--premium=misra-c++-2008', test_file]
@@ -862,3 +862,5 @@ def test_premium_with_relative_path(tmpdir):
     _, stdout, stderr = cppcheck(['--version'])
     assert stdout == product_name + '\n'
     assert stderr == ''
+
+    os.remove(test_cfg)

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -42,7 +42,7 @@ def create_gui_project_file(project_file, root_path=None, import_project=None, p
     f.close()
 
 
-def __lookup_cppcheck_exe():
+def lookup_cppcheck_exe():
     # path the script is located in
     script_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -63,7 +63,7 @@ def __lookup_cppcheck_exe():
 
 # Run Cppcheck with args
 def cppcheck(args, env=None):
-    exe = __lookup_cppcheck_exe()
+    exe = lookup_cppcheck_exe()
     assert exe is not None, 'no cppcheck binary found'
 
     logging.info(exe + ' ' + ' '.join(args))

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -124,6 +124,7 @@ private:
         TEST_CASE(helplongExclusive);
         TEST_CASE(version);
         TEST_CASE(versionWithCfg);
+        TEST_CASE(versionSwitchWithCfg);
         TEST_CASE(versionExclusive);
         TEST_CASE(versionWithInvalidCfg);
         TEST_CASE(onefile);
@@ -419,6 +420,19 @@ private:
         ASSERT_EQUALS(CmdLineParser::Result::Exit, parser->parseFromArgs(2, argv));
         // TODO: somehow the config is not loaded on some systems
         (void)logger->str(); //ASSERT_EQUALS("The Product\n", logger->str()); // TODO: include version?
+    }
+
+    void versionSwitchWithCfg() {
+        REDIRECT;
+        ScopedFile file(Path::join(Path::getPathFromFilename(Path::getCurrentExecutablePath("")), "cppcheck.cfg"),
+                        "{\n"
+                        "\"productName\": \"Cppcheck Premium 1.2.3.4\""
+                        "}\n");
+        const char * const argv[] = {"cppcheck", "--premium=misra-c++-2008", "--version", "file.cpp"};
+        // --premium=misra-c++-2008 should be recognized from cfg
+        ASSERT_EQUALS(CmdLineParser::Result::Exit, parser->parseFromArgs(4, argv));
+        // TODO: somehow the config is not loaded on some systems
+        ASSERT_EQUALS("Cppcheck Premium 1.2.3.4\n", logger->str());
     }
 
     // TODO: test --version with extraVersion

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -124,7 +124,6 @@ private:
         TEST_CASE(helplongExclusive);
         TEST_CASE(version);
         TEST_CASE(versionWithCfg);
-        TEST_CASE(versionSwitchWithCfg);
         TEST_CASE(versionExclusive);
         TEST_CASE(versionWithInvalidCfg);
         TEST_CASE(onefile);
@@ -420,19 +419,6 @@ private:
         ASSERT_EQUALS(CmdLineParser::Result::Exit, parser->parseFromArgs(2, argv));
         // TODO: somehow the config is not loaded on some systems
         (void)logger->str(); //ASSERT_EQUALS("The Product\n", logger->str()); // TODO: include version?
-    }
-
-    void versionSwitchWithCfg() {
-        REDIRECT;
-        ScopedFile file(Path::join(Path::getPathFromFilename(Path::getCurrentExecutablePath("")), "cppcheck.cfg"),
-                        "{\n"
-                        "\"productName\": \"Cppcheck Premium 1.2.3.4\""
-                        "}\n");
-        const char * const argv[] = {"cppcheck", "--premium=misra-c++-2008", "--version", "file.cpp"};
-        // --premium=misra-c++-2008 should be recognized from cfg
-        ASSERT_EQUALS(CmdLineParser::Result::Exit, parser->parseFromArgs(4, argv));
-        // TODO: somehow the config is not loaded on some systems
-        ASSERT_EQUALS("Cppcheck Premium 1.2.3.4\n", logger->str());
     }
 
     // TODO: test --version with extraVersion


### PR DESCRIPTION
Hot fix