### PR TITLE
Fix #12131: No warning for missing override specifier for virtual function with different default argument

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2874,7 +2874,7 @@ bool Function::argsMatch(const Scope *scope, const Token *first, const Token *se
             if (second)
                 second = second->tokAt(-2);
             if (!second) { // End of argument list (second)
-                return false;
+                return !first->nextArgument();
             }
         }
 

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -8413,6 +8413,16 @@ private:
                       "};\n");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:8]: (style) The function 'operator->' overrides a function in a base class but is not marked with a 'override' specifier.\n",
                       errout.str());
+
+        checkOverride("class Base {\n" // #12131
+                      "    virtual int Calculate(int arg) = 0;\n"
+                      "};\n"
+                      "class Derived : public Base {\n"
+                      "    int Calculate(int arg = 0) {\n"
+                      "        return arg * 2;\n"
+                      "    }\n"
+                      "};\n");
+        ASSERT_EQUALS("[test.cpp:2] -> [test.cpp:5]: (style) The function 'Calculate' overrides a function in a base class but is not marked with a 'override' specifier.\n", errout.str());
     }
 
     void overrideCVRefQualifiers() {


### PR DESCRIPTION
added check for the end off both functions parameter lists during compare