### PR TITLE
#12263: Constant Error 'missingInclude'

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -553,7 +553,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     mLogger.printError(errmsg);
                     return Result::Fail;
                 }
-                if(std::string(argv[i] + 10).find("missingInclude") != std::string::npos) {
+                if (std::string(argv[i] + 10).find("missingInclude") != std::string::npos) {
                     --logMissingInclude;
                 }
             }
@@ -579,8 +579,8 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     ++logMissingInclude;
                     mSettings.addEnabled("missingInclude");
                 }
-                if(enable_arg.find("missingInclude") != std::string::npos) {
-                    --logMissingInclude ;
+                if (enable_arg.find("missingInclude") != std::string::npos) {
+                    --logMissingInclude;
                 }
             }
 

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -376,6 +376,8 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
 
     ImportProject project;
 
+    int8_t logMissingInclude{0};
+
     for (int i = 1; i < argc; i++) {
         if (argv[i][0] == '-') {
             // User define
@@ -551,6 +553,9 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     mLogger.printError(errmsg);
                     return Result::Fail;
                 }
+                if(std::string(argv[i] + 10).find("missingInclude") != std::string::npos) {
+                    --logMissingInclude;
+                }
             }
 
             // dump cppcheck data
@@ -570,9 +575,12 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     mSettings.addEnabled("performance");
                     mSettings.addEnabled("portability");
                 }
-                if (enable_arg.find("information") != std::string::npos) {
+                if (enable_arg.find("information") != std::string::npos && logMissingInclude == 0) {
+                    ++logMissingInclude;
                     mSettings.addEnabled("missingInclude");
-                    mLogger.printMessage("'--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.");
+                }
+                if(enable_arg.find("missingInclude") != std::string::npos) {
+                    --logMissingInclude ;
                 }
             }
 
@@ -1233,6 +1241,9 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             mPathNames.emplace_back(Path::fromNativeSeparators(Path::removeQuotationMarks(argv[i])));
         }
     }
+
+    if (logMissingInclude == 1)
+        mLogger.printMessage("'--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.");
 
     if (!loadCppcheckCfg())
         return Result::Fail;

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -173,6 +173,8 @@ private:
         TEST_CASE(enabledUnusedFunction);
         TEST_CASE(enabledMissingInclude);
         TEST_CASE(disabledMissingIncludeWithInformation);
+        TEST_CASE(enabledMissingIncludeWithInformation);
+        TEST_CASE(enabledMissingIncludeWithInformationReverseOrder);
 #ifdef CHECK_INTERNAL
         TEST_CASE(enabledInternal);
 #endif
@@ -846,6 +848,24 @@ private:
         ASSERT_EQUALS(CmdLineParser::Result::Success, parser->parseFromArgs(4, argv));
         ASSERT(settings->severity.isEnabled(Severity::information));
         ASSERT(!settings->checks.isEnabled(Checks::missingInclude));
+        ASSERT_EQUALS("", logger->str());
+    }
+
+    void enabledMissingIncludeWithInformation() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--enable=information", "--enable=missingInclude", "file.cpp"};
+        ASSERT_EQUALS(CmdLineParser::Result::Success, parser->parseFromArgs(4, argv));
+        ASSERT(settings->severity.isEnabled(Severity::information));
+        ASSERT(settings->checks.isEnabled(Checks::missingInclude));
+        ASSERT_EQUALS("", logger->str());
+    }
+
+    void enabledMissingIncludeWithInformationReverseOrder() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--enable=missingInclude", "--enable=information", "file.cpp"};
+        ASSERT_EQUALS(CmdLineParser::Result::Success, parser->parseFromArgs(4, argv));
+        ASSERT(settings->severity.isEnabled(Severity::information));
+        ASSERT(settings->checks.isEnabled(Checks::missingInclude));
         ASSERT_EQUALS("", logger->str());
     }
 

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -172,6 +172,7 @@ private:
         TEST_CASE(enabledInformation);
         TEST_CASE(enabledUnusedFunction);
         TEST_CASE(enabledMissingInclude);
+        TEST_CASE(disabledMissingIncludeWithInformation);
 #ifdef CHECK_INTERNAL
         TEST_CASE(enabledInternal);
 #endif
@@ -839,6 +840,15 @@ private:
         ASSERT(settings->checks.isEnabled(Checks::missingInclude));
     }
 
+    void disabledMissingIncludeWithInformation() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--disable=missingInclude", "--enable=information", "file.cpp"};
+        ASSERT_EQUALS(CmdLineParser::Result::Success, parser->parseFromArgs(4, argv));
+        ASSERT(settings->severity.isEnabled(Severity::information));
+        ASSERT(!settings->checks.isEnabled(Checks::missingInclude));
+        ASSERT_EQUALS("", logger->str());
+    }
+
 #ifdef CHECK_INTERNAL
     void enabledInternal() {
         REDIRECT;
@@ -940,7 +950,7 @@ private:
         ASSERT_EQUALS(CmdLineParser::Result::Success, parser->parseFromArgs(4, argv));
         ASSERT(settings->severity.isEnabled(Severity::information));
         ASSERT(!settings->checks.isEnabled(Checks::missingInclude));
-        ASSERT_EQUALS("cppcheck: '--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.\n", logger->str());
+        ASSERT_EQUALS("", logger->str());
     }
 
     void disableInformationPartial2() {


### PR DESCRIPTION
Small adjustment of the log of the error.

- printed only when there was `--enabled=information` and no mentioning of `missingInclude`