### PR TITLE
fix casing in variable name

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -830,7 +830,7 @@ class Value:
         intvalue         integer value
         tokvalue         token value
         floatvalue       float value
-        movedValue
+        movedvalue
         uninit
         containerSize    container size
         bufferSize       buffer size
@@ -900,7 +900,7 @@ class Value:
         self.symbolic = IdMap.get(self._symbolicId)
 
     def __repr__(self):
-        attrs = ["intvalue", "tokvalue", "floatvalue", "movedValue", "uninit", 
+        attrs = ["intvalue", "tokvalue", "floatvalue", "movedvalue", "uninit", 
                  "bufferSize", "containerSize", "condition", "valueKind"]
         return "{}({})".format(
             "Value",


### PR DESCRIPTION
The attribute movedValue is misspelled with an uppercase V, this leads to errors when printing token values:

```
$ python3 runaddon.py test.py test.c.dump 
Checking test.c.dump...
Checking test.c.dump, config ...
line 2 str=""lala\n""
Traceback (most recent call last):
  File "/home/eric/tools/cppcheck/addons/runaddon.py", line 11, in <module>
    cppcheck.runcheckers()
  File "/home/eric/tools/cppcheck/addons/cppcheck.py", line 39, in runcheckers
    c(cfg, data)
  File "test.py", line 9, in func
    print(f'    {value}')
  File "/home/eric/tools/cppcheck/addons/cppcheckdata.py", line 907, in __repr__
    ", ".join(("{}={}".format(a, repr(getattr(self, a))) for a in attrs))
  File "/home/eric/tools/cppcheck/addons/cppcheckdata.py", line 907, in <genexpr>
    ", ".join(("{}={}".format(a, repr(getattr(self, a))) for a in attrs))
AttributeError: 'Value' object has no attribute 'movedValue'
```