### PR TITLE
Fixed #11807 - dump: C typedef enum not in <typedef-info>

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1211,7 +1211,7 @@ void Tokenizer::simplifyTypedefCpp()
         }
 
         /** @todo add support for union */
-        if (Token::Match(tok->next(), "enum %type% %type% ;") && tok->strAt(2) == tok->strAt(3)) {
+        if (Token::Match(tok->next(), "union %type% %type% ;") && tok->strAt(2) == tok->strAt(3)) {
             tok->deleteNext(3);
             tok->deleteThis();
             if (tok->next())


### PR DESCRIPTION
- Enum typedefs were removed from simplifyTypedefCpp "tok" list instead of unions. 

As mentioned by Daniel [here](https://sourceforge.net/p/cppcheck/discussion/general/thread/7e54b0c543/), the latest cppcheck version seems to not be affected by the [issue](https://trac.cppcheck.net/ticket/11807) anymore. But this is the fix nonetheless. 

It was tested on the newest version (no effect) and an older version (commit 579938a6ff on main). 