### PR TITLE
addons/namingng.py: Improve file name checking feature.

### DIFF
--- a/addons/namingng.py
+++ b/addons/namingng.py
@@ -24,6 +24,7 @@
 
 import cppcheckdata
 import sys
+import os
 import re
 import argparse
 import json
@@ -96,10 +97,14 @@ def process(dumpfiles, configfile, debugprint=False):
 
         # Check File naming
         if "RE_FILE" in conf and conf["RE_FILE"]:
-            mockToken = DataStruct(afile[:-5], "0", afile[afile.rfind('/') + 1:-5])
-            msgType = 'File name'
-            for exp in conf["RE_FILE"]:
-                evalExpr(conf["RE_FILE"], exp, mockToken, msgType, errors)
+            for source_file in data.files:
+                basename = os.path.basename(source_file)
+                good = False
+                for exp in conf["RE_FILE"]:
+                    good |= bool(re.match(exp, source_file))
+                    good |= bool(re.match(exp, basename))
+                if not good:
+                    errors.append(reportError(source_file, 0, 'style', 'File name ' + source_file + ' violates naming convention'))
 
         # Check Namespace naming
         if "RE_NAMESPACE" in conf and conf["RE_NAMESPACE"]:


### PR DESCRIPTION
(note: comment updated after force push; initial PR was incomplete)

namingng.py attempted to derive the source filename from the name of the dumpfile. However, the dumpfile is not necessarily named according to this pattern, e.g. cppcheck will add the pid to the filename, making RE_FILE rules
fail. Taking the first item of data.files seem to be more robust.

To get the basename of the file, `os.path.basename()` is used. This solves (theoretical) issues on platforms with a different path separator.

With this patch, all filenames are checked, not just those provided on the cppcheck command line. This is useful as header files will now also be part of this check, even if not explicitly specified on the command line.

The "RE_FILE" key of the configuration JSON may contain a list of regular expressions, where any match will lead to acceptance of the filename.

Both the full path and the basename of the files are tested.

One use case for this combination of features is:

```
"RE_FILE":[
    "/.*\\.h\\Z",
    "[a-z][a-z0-9_]*[a-z0-9]\\.[ch]\\Z"
]
```
This will accept any file naming convention of the platform used (assuming platform files are all referenced using an absolute path), while enforcing a particular naming scheme for project files.
