### PR TITLE
Prefer using Qt 6 over 5.

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -43,7 +43,7 @@ option(BUILD_MANPAGE        "Enable man target to build manpage"                
 
 option(BUILD_GUI            "Build the qt application"                                      OFF)
 option(WITH_QCHART          "Enable QtCharts usage in the GUI"                              OFF)
-option(USE_QT6              "Prefer Qt6 when available"                                     OFF)
+option(USE_QT6              "Prefer Qt6 when available"                                     ON)
 option(REGISTER_GUI_TESTS   "Register GUI tests in CTest"                                   ON)
 
 option(HAVE_RULES           "Usage of rules (needs PCRE library and headers)"               OFF)


### PR DESCRIPTION
Both Qt 5 and Cppcheck's support for it are deprecated.
This is the first step towards removing Qt 5 support.

Additional things related to this pull request:
1. Adjust continuous testing workflows accordingly.
2. Remove Cppcheck's deprecated support for qmake, as Qt 6 no longer uses it.
If wished, I can work on these two aspects.