### PR TITLE
addons/namingng.py: Add tests for include guards, config file validation.

### DIFF
--- a/addons/namingng.config.json
+++ b/addons/namingng.config.json
@@ -2,6 +2,15 @@
     "RE_VARNAME": ["[a-z]*[a-zA-Z0-9_]*\\Z"],
     "RE_PRIVATE_MEMBER_VARIABLE": null,
     "RE_FUNCTIONNAME": ["[a-z0-9A-Z]*\\Z"],
+    "include_guard": {
+        "input": "path",
+        "prefix": "",
+        "suffix": "",
+        "case": "upper",
+        "max_linenr": 5,
+        "RE_HEADERFILE": "[^/].*\\.h\\Z",
+        "required": true
+    },
     "var_prefixes": {"uint32_t": "ui32",
                      "int*": "intp"},
     "function_prefixes": {"uint16_t": "ui16",

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -456,6 +456,87 @@ static int _invalid_static_global;
     assert lines == expect
 
 
+def test_addon_namingng_config(tmpdir):
+    addon_file = os.path.join(tmpdir, 'namingng.json')
+    addon_config_file = os.path.join(tmpdir, 'namingng.config.json')
+    with open(addon_file, 'wt') as f:
+        f.write("""
+{
+    "script": "addons/namingng.py",
+    "args": [
+        "--configfile=%s"
+    ]
+}
+                """%(addon_config_file).replace('\\','\\\\'))
+
+    with open(addon_config_file, 'wt') as f:
+        f.write("""
+{
+    "RE_FILE": "[^/]*[a-z][a-z0-9_]*[a-z0-9]\\.c\\Z",
+    "RE_NAMESPACE": false,
+    "RE_VARNAME": ["+bad pattern","[a-z]_good_pattern\\Z","(parentheses?"],
+    "RE_PRIVATE_MEMBER_VARIABLE": "[a-z][a-z0-9_]*[a-z0-9]\\Z",
+    "RE_PUBLIC_MEMBER_VARIABLE": "[a-z][a-z0-9_]*[a-z0-9]\\Z",
+    "RE_GLOBAL_VARNAME": "[a-z][a-z0-9_]*[a-z0-9]\\Z",
+    "RE_FUNCTIONNAME": "[a-z][a-z0-9_]*[a-z0-9]\\Z",
+    "RE_CLASS_NAME": "[a-z][a-z0-9_]*[a-z0-9]\\Z",
+    "_comment1": "these should all be arrays, or null, or not set",
+
+    "include_guard": true,
+    "var_prefixes": ["bad"],
+    "function_prefixes": false,
+    "_comment2": "these should all be dict",
+
+    "skip_one_char_variables": "false",
+    "_comment3": "this should be bool",
+
+    "RE_VAR_NAME": "typo"
+}
+                """.replace('\\','\\\\'))
+
+    test_file_basename = 'test.c'
+    test_file = os.path.join(tmpdir, test_file_basename)
+    with open(test_file, 'a') as f:
+        # only create the file
+        pass
+
+    args = ['--addon='+addon_file, '--verbose', '--enable=all', test_file]
+
+    exitcode, stdout, stderr = cppcheck(args)
+    assert exitcode == 0
+
+    lines = stdout.splitlines()
+    assert lines == [
+        'Checking {} ...'.format(test_file),
+        'Defines:',
+        'Undefines:',
+        'Includes:',
+        'Platform:native'
+    ]
+    lines = stderr.splitlines()
+    # ignore the first line, stating that the addon failed to run properly
+    lines.pop(0)
+    assert lines == [
+        "Output:",
+        "config error: RE_FILE must be list (not str), or not set",
+        "config error: RE_NAMESPACE must be list (not bool), or not set",
+        "config error: include_guard must be dict (not bool), or not set",
+        "config error: item '+bad pattern' of 'RE_VARNAME' is not a valid regular expression: nothing to repeat at position 0",
+        "config error: item '(parentheses?' of 'RE_VARNAME' is not a valid regular expression: missing ), unterminated subpattern at position 0",
+        "config error: var_prefixes must be dict (not list), or not set",
+        "config error: RE_PRIVATE_MEMBER_VARIABLE must be list (not str), or not set",
+        "config error: RE_PUBLIC_MEMBER_VARIABLE must be list (not str), or not set",
+        "config error: RE_GLOBAL_VARNAME must be list (not str), or not set",
+        "config error: RE_FUNCTIONNAME must be list (not str), or not set",
+        "config error: function_prefixes must be dict (not bool), or not set",
+        "config error: RE_CLASS_NAME must be list (not str), or not set",
+        "config error: skip_one_char_variables must be bool (not str), or not set",
+        "config error: unknown config key 'RE_VAR_NAME' [internalError]",
+        "",
+        "^",
+    ]
+
+
 def test_addon_findcasts(tmpdir):
     test_file = os.path.join(tmpdir, 'test.cpp')
     with open(test_file, 'wt') as f:


### PR DESCRIPTION
Include guard naming can be validated against various patterns:
- prefixes/suffixes (`_FILE_H`, `PROJECT_FILE_H`, `FILE_H_`)
- basename/full path (`FILE_H`, `SUB_DIR_INC_FILE_H`)
- upper- or lowercase (`FILE_H`, `file_h`)
- any combination of the above (`project_sub_dir_inc_file_h_`)

A regexp can be specified to match header filenames. The example matches any filename not starting with / and ending with `.h`, intended to match C header files while exluding system files.

The test is not limited to naming only; validity and presence of include guards can also be tested by setting `"required":true` in the config file.

Enabling this feature requires adding the key `"include_guard"` to the namingng config file used.

The namingng unit test is extended to test various features of the include guard test.

Also, config handling is improved, adding (superficial) validation and a unit test.