### PR TITLE
gtk.cfg: Add more definitions for assert macros

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -178,11 +178,14 @@
   <define name="g_assert(expr)" value="assert(expr)"/>
   <define name="g_assert_not_reached()" value="assert(NULL)"/>
   <define name="g_assert_true(expr)" value="g_assert(expr)"/>
+  <define name="g_assert_false(expr)" value="g_assert(!(expr))"/>
   <define name="g_assert_cmpstr(s1, cmp, s2)" value="g_assert_true(g_strcmp0 ((s1), (s2)) cmp 0)"/>
   <define name="g_assert_cmpint(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
   <define name="g_assert_cmpuint(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
   <define name="g_assert_cmphex(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
   <define name="g_assert_cmpfloat(n1, cmp, n2)" value="g_assert_true((n1) cmp (n2))"/>
+  <define name="g_assert_null(expr)" value="g_assert_true((expr) == NULL)"/>
+  <define name="g_assert_nonnull(expr)" value="g_assert_true((expr) != NULL)"/>
   <define name="g_signal_connect(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, (GConnectFlags) 0)"/>
   <define name="g_signal_connect_after(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, G_CONNECT_AFTER)"/>
   <define name="g_signal_connect_swapped(instance, detailed_signal, c_handler, data)" value="g_signal_connect_data ((instance), (detailed_signal), (c_handler), (data), NULL, G_CONNECT_SWAPPED)"/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -230,6 +230,25 @@ void g_assert_test()
     g_assert(a = 5);
 }
 
+void g_assert_true_false_test()
+{
+    gboolean t = TRUE;
+    gboolean f = FALSE;
+    g_assert_true(t);
+    // cppcheck-suppress checkLibraryNoReturn
+    g_assert_false(f);
+}
+
+void g_assert_null_nonnull_test()
+{
+    char * gpt = g_malloc(1);
+    g_assert_nonnull(gpt);
+    gpt[0] = 0;
+    g_free(gpt);
+    // cppcheck-suppress checkLibraryNoReturn
+    g_assert_null(NULL);
+}
+
 void g_print_test()
 {
     // cppcheck-suppress invalidPrintfArgType_uint

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -2,7 +2,7 @@
 // Test library configuration for gtk.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=gtk --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr --library=gtk test/cfg/gtk.cpp
+// $ cppcheck --check-library --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr --library=gtk test/cfg/gtk.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //


### PR DESCRIPTION
In particular, the missing definition of `g_assert_nonnull()` can cause false positives because it's not recognized as `assert(expr != NULL)` by cppcheck.
