### PR TITLE
Fix #12266 (Performance: valueFlowCondition slowdown)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ $(libcppdir)/errorlogger.o: lib/errorlogger.cpp externals/tinyxml2/tinyxml2.h li
 $(libcppdir)/errortypes.o: lib/errortypes.cpp lib/config.h lib/errortypes.h lib/utils.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/errortypes.cpp
 
-$(libcppdir)/forwardanalyzer.o: lib/forwardanalyzer.cpp lib/addoninfo.h lib/analyzer.h lib/astutils.h lib/config.h lib/errortypes.h lib/forwardanalyzer.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/utils.h lib/valueptr.h lib/vfvalue.h
+$(libcppdir)/forwardanalyzer.o: lib/forwardanalyzer.cpp lib/addoninfo.h lib/analyzer.h lib/astutils.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/forwardanalyzer.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenlist.h lib/utils.h lib/valueptr.h lib/vfvalue.h
 	$(CXX) ${INCLUDE_FOR_LIB} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $(libcppdir)/forwardanalyzer.cpp
 
 $(libcppdir)/fwdanalysis.o: lib/fwdanalysis.cpp lib/astutils.h lib/config.h lib/errortypes.h lib/fwdanalysis.h lib/library.h lib/mathlib.h lib/smallvector.h lib/sourcelocation.h lib/standards.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/utils.h lib/vfvalue.h

--- a/lib/forwardanalyzer.h
+++ b/lib/forwardanalyzer.h
@@ -21,15 +21,19 @@
 
 #include "analyzer.h"
 
+class ErrorLogger;
 class Settings;
 class Token;
+class TokenList;
 template<class T> class ValuePtr;
 
 Analyzer::Result valueFlowGenericForward(Token* start,
                                          const Token* end,
                                          const ValuePtr<Analyzer>& a,
+                                         const TokenList& tokenList,
+                                         ErrorLogger* const errorLogger,
                                          const Settings& settings);
 
-Analyzer::Result valueFlowGenericForward(Token* start, const ValuePtr<Analyzer>& a, const Settings& settings);
+Analyzer::Result valueFlowGenericForward(Token* start, const ValuePtr<Analyzer>& a, const TokenList& tokenList, ErrorLogger* const errorLogger, const Settings& settings);
 
 #endif

--- a/lib/reverseanalyzer.h
+++ b/lib/reverseanalyzer.h
@@ -20,11 +20,13 @@
 #define reverseanalyzerH
 
 struct Analyzer;
+class ErrorLogger;
 class Settings;
 class Token;
+class TokenList;
 template<class T>
 class ValuePtr;
 
-void valueFlowGenericReverse(Token* start, const Token* end, const ValuePtr<Analyzer>& a, const Settings& settings);
+void valueFlowGenericReverse(Token* start, const Token* end, const ValuePtr<Analyzer>& a, const TokenList& tokenlist, ErrorLogger* const errorLogger, const Settings& settings);
 
 #endif

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -243,6 +243,7 @@ void Settings::loadSummaries()
 void Settings::setCheckLevelExhaustive()
 {
     // Checking can take a little while. ~ 10 times slower than normal analysis is OK.
+    checkLevel = CheckLevel::exhaustive;
     performanceValueFlowMaxIfCount = -1;
     performanceValueFlowMaxSubFunctionArgs = 256;
 }
@@ -250,6 +251,7 @@ void Settings::setCheckLevelExhaustive()
 void Settings::setCheckLevelNormal()
 {
     // Checking should finish in reasonable time.
+    checkLevel = CheckLevel::normal;
     performanceValueFlowMaxSubFunctionArgs = 8;
     performanceValueFlowMaxIfCount = 100;
 }

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -444,6 +444,12 @@ public:
     void setCheckLevelExhaustive();
     void setCheckLevelNormal();
 
+    enum class CheckLevel {
+        exhaustive,
+        normal
+    };
+    CheckLevel checkLevel = CheckLevel::normal;
+
 private:
     static std::string parseEnabled(const std::string &str, std::tuple<SimpleEnableGroup<Severity>, SimpleEnableGroup<Checks>> &groups);
     std::string applyEnabled(const std::string &str, bool enable);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,7 @@ if (BUILD_TESTS)
                         COMMAND $<TARGET_FILE:cppcheck>
                         --library=${LIBRARY}
                         --check-library
+                        --check-level=exhaustive
                         --platform=${PLATFORM}
                         --enable=style,information
                         --inconclusive

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -27,7 +27,7 @@ CFG="$DIR"../../cfg/
 # TODO: remove missingInclude disabling when it no longer is implied by --enable=information
 # Cppcheck options
 # need to suppress unmatchedSuppression in case valueFlowBailout is not reported
-CPPCHECK_OPT='--check-library --platform=unix64 --enable=style,information --inconclusive --force --error-exitcode=-1 --disable=missingInclude --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}" --debug-warnings --suppress=valueFlowBailout --suppress=purgedConfiguration --suppress=unmatchedSuppression'
+CPPCHECK_OPT='--check-library --platform=unix64 --enable=style,information --inconclusive --force --check-level=exhaustive --error-exitcode=-1 --disable=missingInclude --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}" --debug-warnings --suppress=valueFlowBailout --suppress=purgedConfiguration --suppress=unmatchedSuppression'
 
 # Compiler settings
 CXX=g++

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -402,6 +402,8 @@ void TestFixture::reportErr(const ErrorMessage &msg)
 {
     if (msg.severity == Severity::internal)
         return;
+    if (msg.severity == Severity::information && msg.id == "normalCheckLevelMaxBranches")
+        return;
     const std::string errormessage(msg.toString(mVerbose, mTemplateFormat, mTemplateLocation));
     errout << errormessage << std::endl;
 }
@@ -420,6 +422,11 @@ void TestFixture::setTemplateFormat(const std::string &templateFormat)
         mTemplateFormat = templateFormat;
         mTemplateLocation = "";
     }
+}
+
+TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::exhaustive() {
+    settings.setCheckLevelExhaustive();
+    return *this;
 }
 
 TestFixture::SettingsBuilder& TestFixture::SettingsBuilder::library(const char lib[]) {

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -198,6 +198,8 @@ protected:
             return *this;
         }
 
+        SettingsBuilder& exhaustive();
+
         SettingsBuilder& library(const char lib[]);
 
         SettingsBuilder& libraryxml(const char xmldata[], std::size_t len);

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -142,7 +142,7 @@ private:
     }
 
     void check_(const char* file, int line, const char code[], const char* filename = "test.cpp", bool inconclusive = false) {
-        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive, inconclusive).build();
+        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive, inconclusive).exhaustive().build();
         check_(file, line, code, settings, filename);
     }
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -237,7 +237,7 @@ private:
         errout.str("");
 
         // show warnings about unhandled typedef
-        const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
+        const Settings settings = settingsBuilder(settings0).exhaustive().certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
         Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -2438,7 +2438,7 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder(pSettings ? *pSettings : settings1).debugwarnings(debug).build();
+        const Settings settings = settingsBuilder(pSettings ? *pSettings : settings1).debugwarnings(debug).exhaustive().build();
 
         // Tokenize..
         Tokenizer tokenizer(settings, this);

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -42,7 +42,7 @@ public:
     TestValueFlow() : TestFixture("TestValueFlow") {}
 
 private:
-    Settings settings = settingsBuilder().library("std.cfg").build();
+    Settings settings = settingsBuilder().library("std.cfg").exhaustive().build();
 
     void run() override {
         // strcpy, abort cfg
@@ -485,7 +485,7 @@ private:
 
 #define bailout(...) bailout_(__FILE__, __LINE__, __VA_ARGS__)
     void bailout_(const char* file, int line, const char code[]) {
-        const Settings s = settingsBuilder().debugwarnings().build();
+        const Settings s = settingsBuilder().debugwarnings().exhaustive().build();
         errout.str("");
 
         std::vector<std::string> files(1, "test.cpp");
@@ -6867,7 +6867,7 @@ private:
     void valueFlowSafeFunctionParameterValues() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s = settingsBuilder().exhaustive().library("std.cfg").build();
         s.safeChecks.classes = s.safeChecks.externalFunctions = s.safeChecks.internalFunctions = true;
 
         code = "short f(short x) {\n"
@@ -6918,7 +6918,7 @@ private:
     void valueFlowUnknownFunctionReturn() {
         const char *code;
         std::list<ValueFlow::Value> values;
-        Settings s = settingsBuilder().library("std.cfg").build();
+        Settings s = settingsBuilder().exhaustive().library("std.cfg").build();
         s.checkUnknownFunctionReturn.insert("rand");
 
         code = "x = rand();";


### PR DESCRIPTION
I have executed test-my-pr.py on 532 packages


number of "main" warnings: 
```
egrep -v valueFlow my_check_diff.log | egrep "^main " | wc -l
277
```

number of "your" warnings (genomicepidemiology-kma timed out without these changes): 
```
egrep -v valueFlow my_check_diff.log | egrep "^your " | egrep -v genomicepidemiology-kma | wc -l
90
```

=> There are some false negatives. But it's rougly  ~ 190 in 532 packages.. so it's not a major problem imho.

I can see a speedup. For the packages that took more than 1 second to analyze the timing factor was:
```
$ egrep -v " 0.[0-9][0-9] " my_check_diff_timing.log | sed 's/.* //' | egrep -v Factor | sort
0.04
0.08
0.10
0.10
0.13
0.18
0.19
0.20
0.21
0.21
0.23
0.24
0.25
0.26
0.26
0.27
0.28
0.28
0.29
0.31
0.31
0.31
0.31
0.31
0.32
0.33
0.34
0.35
0.35
0.35
0.37
0.37
0.38
0.39
0.39
0.40
0.42
0.42
0.43
0.43
0.44
0.44
0.44
0.45
0.46
0.46
0.46
0.46
0.46
0.47
0.48
0.49
0.49
0.50
0.50
0.50
0.50
0.50
0.51
0.51
0.51
0.52
0.52
0.52
0.52
0.54
0.54
0.54
0.54
0.54
0.55
0.56
0.56
0.56
0.56
0.56
0.57
0.57
0.57
0.57
0.58
0.58
0.58
0.59
0.59
0.59
0.60
0.61
0.61
0.61
0.62
0.62
0.62
0.62
0.63
0.63
0.63
0.63
0.63
0.64
0.65
0.65
0.65
0.65
0.65
0.65
0.65
0.65
0.65
0.65
0.66
0.66
0.66
0.67
0.67
0.67
0.67
0.68
0.68
0.69
0.69
0.69
0.69
0.69
0.70
0.70
0.70
0.70
0.70
0.71
0.71
0.71
0.72
0.73
0.73
0.73
0.73
0.73
0.73
0.73
0.74
0.75
0.75
0.75
0.75
0.75
0.75
0.75
0.75
0.75
0.75
0.76
0.76
0.76
0.76
0.76
0.77
0.77
0.77
0.77
0.78
0.78
0.78
0.78
0.79
0.79
0.79
0.80
0.80
0.80
0.80
0.80
0.80
0.80
0.80
0.81
0.81
0.82
0.82
0.82
0.82
0.82
0.83
0.83
0.83
0.84
0.84
0.84
0.84
0.85
0.85
0.85
0.85
0.86
0.86
0.86
0.86
0.86
0.86
0.86
0.86
0.87
0.88
0.88
0.88
0.89
0.89
0.89
0.90
0.90
0.90
0.90
0.90
0.90
0.90
0.90
0.91
0.91
0.92
0.92
0.92
0.93
0.93
0.93
0.93
0.94
0.94
0.95
0.95
0.96
0.96
0.96
0.96
0.97
0.97
0.97
0.97
0.99
0.99
0.99
1.00
1.00
1.00
1.01
```