### PR TITLE
addons/namingng.py: Backward compatibility with addons/naming.py

### DIFF
--- a/.selfcheck_suppressions
+++ b/.selfcheck_suppressions
@@ -3,13 +3,13 @@ missingIncludeSystem
 # temporary suppressions - fix the warnings!
 simplifyUsing:lib/valueptr.h
 varid0:gui/projectfile.cpp
-naming-privateMemberVariable:gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+naming-namingConvention:gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
 symbolDatabaseWarning:*/moc_*.cpp
 simplifyUsing:*/moc_*.cpp
 
 # warnings in Qt generated code we cannot fix
 funcArgNamesDifferent:*/moc_*.cpp
-naming-varname:*/ui_*.h
+naming-namingConvention:*/ui_*.h
 functionStatic:*/ui_fileview.h
 
 # --debug-warnings suppressions
@@ -17,12 +17,11 @@ valueFlowBailout
 valueFlowBailoutIncompleteVar
 autoNoType
 
-naming-varname:externals/simplecpp/simplecpp.h
-naming-privateMemberVariable:externals/simplecpp/simplecpp.h
+naming-namingConvention:externals/simplecpp/simplecpp.h
 
 # these warnings need to be addressed upstream
 uninitMemberVar:externals/tinyxml2/tinyxml2.h
 noExplicitConstructor:externals/tinyxml2/tinyxml2.h
 missingOverride:externals/tinyxml2/tinyxml2.h
 invalidPrintfArgType_sint:externals/tinyxml2/tinyxml2.h
-naming-privateMemberVariable:externals/tinyxml2/tinyxml2.h
+naming-namingConvention:externals/tinyxml2/tinyxml2.h

--- a/addons/naming.py
+++ b/addons/naming.py
@@ -2,90 +2,11 @@
 #
 # cppcheck addon for naming conventions
 #
-# Example usage (variable name must start with lowercase, function name must start with uppercase):
-# $ cppcheck --dump path-to-src/
-# $ python addons/naming.py --var='[a-z].*' --function='[A-Z].*' path-to-src/*.dump
-#
+# namingng.py was made backward compatible with naming.py; call through.
 
-import cppcheckdata
 import sys
-import re
+import cppcheckdata
+import namingng
 
-
-def validate_regex(expr):
-    try:
-        re.compile(expr)
-    except re.error:
-        print('Error: "{}" is not a valid regular expression.'.format(expr))
-        exit(1)
-
-
-RE_VARNAME = None
-RE_CONSTNAME = None
-RE_PRIVATE_MEMBER_VARIABLE = None
-RE_FUNCTIONNAME = None
-for arg in sys.argv[1:]:
-    if arg[:6] == '--var=':
-        RE_VARNAME = arg[6:]
-        validate_regex(RE_VARNAME)
-    elif arg.startswith('--const='):
-        RE_CONSTNAME = arg[arg.find('=')+1:]
-        validate_regex(RE_CONSTNAME)
-    elif arg.startswith('--private-member-variable='):
-        RE_PRIVATE_MEMBER_VARIABLE = arg[arg.find('=')+1:]
-        validate_regex(RE_PRIVATE_MEMBER_VARIABLE)
-    elif arg[:11] == '--function=':
-        RE_FUNCTIONNAME = arg[11:]
-        validate_regex(RE_FUNCTIONNAME)
-
-
-def reportError(token, severity, msg, errorId):
-    cppcheckdata.reportError(token, severity, msg, 'naming', errorId)
-
-
-for arg in sys.argv[1:]:
-    if not arg.endswith('.dump'):
-        continue
-    print('Checking ' + arg + '...')
-    data = cppcheckdata.CppcheckData(arg)
-
-    for cfg in data.iterconfigurations():
-        print('Checking %s, config %s...' % (arg, cfg.name))
-        if RE_VARNAME:
-            for var in cfg.variables:
-                if var.access == 'Private':
-                    continue
-                if var.nameToken and not var.isConst:
-                    res = re.match(RE_VARNAME, var.nameToken.str)
-                    if not res:
-                        reportError(var.typeStartToken, 'style', 'Variable ' +
-                                    var.nameToken.str + ' violates naming convention', 'varname')
-        if RE_CONSTNAME:
-            for var in cfg.variables:
-                if var.access == 'Private':
-                    continue
-                if var.nameToken and var.isConst:
-                    res = re.match(RE_CONSTNAME, var.nameToken.str)
-                    if not res:
-                        reportError(var.typeStartToken, 'style', 'Constant ' +
-                                    var.nameToken.str + ' violates naming convention', 'constname')
-        if RE_PRIVATE_MEMBER_VARIABLE:
-            for var in cfg.variables:
-                if (var.access is None) or var.access != 'Private':
-                    continue
-                res = re.match(RE_PRIVATE_MEMBER_VARIABLE, var.nameToken.str)
-                if not res:
-                    reportError(var.typeStartToken, 'style', 'Private member variable ' +
-                                var.nameToken.str + ' violates naming convention', 'privateMemberVariable')
-        if RE_FUNCTIONNAME:
-            for scope in cfg.scopes:
-                if scope.type == 'Function':
-                    function = scope.function
-                    if function is not None and function.type in ('Constructor', 'Destructor', 'CopyConstructor', 'MoveConstructor'):
-                        continue
-                    res = re.match(RE_FUNCTIONNAME, scope.className)
-                    if not res:
-                        reportError(
-                            scope.bodyStart, 'style', 'Function ' + scope.className + ' violates naming convention', 'functionName')
-
+namingng.main()
 sys.exit(cppcheckdata.EXIT_CODE)

--- a/gui/codeeditorstyle.cpp
+++ b/gui/codeeditorstyle.cpp
@@ -23,23 +23,23 @@
 #include <QVariant>
 
 CodeEditorStyle::CodeEditorStyle(
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor CtrlFGColor, QColor CtrlBGColor,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor HiLiBGColor,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor LnNumFGColor, QColor LnNumBGColor,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor KeyWdFGColor, QFont::Weight KeyWdWeight,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor ClsFGColor, QFont::Weight ClsWeight,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor QteFGColor, QFont::Weight QteWeight,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor CmtFGColor, QFont::Weight CmtWeight,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QColor SymbFGColor, QColor SymbBGColor,
-    // cppcheck-suppress naming-varname - TODO: fix this
+    // cppcheck-suppress naming-namingConvention - TODO: fix this
     QFont::Weight SymbWeight) :
     widgetFGColor(CtrlFGColor),
     widgetBGColor(CtrlBGColor),

--- a/gui/codeeditorstyle.h
+++ b/gui/codeeditorstyle.h
@@ -51,23 +51,23 @@ class QSettings;
 class CodeEditorStyle {
 public:
     explicit CodeEditorStyle(
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor CtrlFGColor, QColor CtrlBGColor,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor HiLiBGColor,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor LnNumFGColor, QColor LnNumBGColor,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor KeyWdFGColor, QFont::Weight KeyWdWeight,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor ClsFGColor, QFont::Weight ClsWeight,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor QteFGColor, QFont::Weight QteWeight,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor CmtFGColor, QFont::Weight CmtWeight,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QColor SymbFGColor, QColor SymbBGColor,
-        // cppcheck-suppress naming-varname - TODO: fix this
+        // cppcheck-suppress naming-namingConvention - TODO: fix this
         QFont::Weight SymbWeight);
 
     bool operator==(const CodeEditorStyle& rhs) const;

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -306,7 +306,7 @@ int Var;
     assert lines == [
         'Checking {} ...'.format(test_file)
     ]
-    assert stderr == '{}:2:1: style: Variable Var violates naming convention [naming-varname]\n'.format(test_file)
+    assert stderr == '{}:2:5: style: Global variable Var violates naming convention [naming-namingConvention]\n'.format(test_file)
 
 
 def test_addon_namingng(tmpdir):
@@ -331,6 +331,7 @@ def test_addon_namingng(tmpdir):
     "RE_CLASS_NAME": ["[a-z][a-z0-9_]*[a-z0-9]\\Z"],
     "RE_NAMESPACE": ["[a-z][a-z0-9_]*[a-z0-9]\\Z"],
     "RE_VARNAME": ["[a-z][a-z0-9_]*[a-z0-9]\\Z"],
+    "RE_CONST": ["const_[a-z][a-z0-9_]*[a-z0-9]\\Z"],
     "RE_PUBLIC_MEMBER_VARIABLE": ["[a-z][a-z0-9_]*[a-z0-9]\\Z"],
     "RE_PRIVATE_MEMBER_VARIABLE": {
         ".*_tmp\\Z":[true,"illegal suffix _tmp"],
@@ -400,9 +401,11 @@ class _clz {
 public:
     _clz() : _invalid_public(0), _invalid_private(0), priv_good(0), priv_bad_tmp(0) { }
     int _invalid_public;
+    const int random_number = 4;
+    const int const_zero = 0;
 private:
     char _invalid_private;
-    int priv_good;
+    int priv_good = random_number*const_zero;
     int priv_bad_tmp;
 };
 
@@ -475,13 +478,16 @@ namespace _invalid_namespace { }
         '{}:21:9: style: Public member variable _invalid_public violates naming convention [namingng-namingConvention]'.format(test_file),
         '    int _invalid_public;',
         '        ^',
-        '{}:23:10: style: Private member variable _invalid_private violates naming convention: required prefix priv_ missing [namingng-namingConvention]'.format(test_file),
+        '{}:22:15: style: Constant random_number violates naming convention [namingng-namingConvention]'.format(test_file),
+        '    const int random_number = 4;',
+        '              ^',
+        '{}:25:10: style: Private member variable _invalid_private violates naming convention: required prefix priv_ missing [namingng-namingConvention]'.format(test_file),
         '    char _invalid_private;',
         '         ^',
-        '{}:25:9: style: Private member variable priv_bad_tmp violates naming convention: illegal suffix _tmp [namingng-namingConvention]'.format(test_file),
+        '{}:27:9: style: Private member variable priv_bad_tmp violates naming convention: illegal suffix _tmp [namingng-namingConvention]'.format(test_file),
         '    int priv_bad_tmp;',
         '        ^',
-        '{}:28:11: style: Namespace _invalid_namespace violates naming convention [namingng-namingConvention]'.format(test_file),
+        '{}:30:11: style: Namespace _invalid_namespace violates naming convention [namingng-namingConvention]'.format(test_file),
         'namespace _invalid_namespace { }',
         '          ^',
     ]


### PR DESCRIPTION
In case `naming.py` cannot be simply removed, due to it being in active use, this PR suggests a path forward, merging `namingng.py` and `naming.py`, with little risk.

A next step could be to drop `namingng.py` and `s/namingng/naming/g` throughout the project.