### PR TITLE
test/cli/test-other.py: Fix test_showtime_top5_file.

### DIFF
--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -781,7 +781,12 @@ def test_showtime_top5_file(tmpdir):
     assert len(lines) == 7
     assert lines[0] == ''
     for i in range(1, 5):
-        assert lines[i].endswith(' - 1 result(s))')
+        if lines[i].startswith('valueFlowLifetime'):
+            assert lines[i].endswith(' - 2 result(s))')
+        elif lines[i].startswith('valueFlowEnumValue'):
+            assert lines[i].endswith(' - 2 result(s))')
+        else:
+            assert lines[i].endswith(' - 1 result(s))')
     assert lines[6].startswith('Overall time:')
     assert stderr == ''
 


### PR DESCRIPTION
test_showtime_top5_file() assumes that all reported elements, of which the "top 5" are validated, end with the string "- 1 result(s))".

This is clearly not the case when viewing the entire list:

```bash
$ cppcheck --showtime=summary --quiet empty.c  |grep "2 result"
valueFlowLifetime(tokenlist, errorLogger, settings): 3.4e-05s (avg. 1.7e-05s - 2 result(s))
valueFlowEnumValue(symboldatabase, settings): 3e-06s (avg. 1.5e-06s - 2 result(s))
```

As the order of items is non-deterministic, this test makes CI workflows randomly fail.

This patch addresses the issue by adjusting the expected string to the reported item.