### PR TITLE
std.cfg: Added support for invalidFunctionArg check to tgamma().

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -737,6 +737,7 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- https://en.cppreference.com/w/cpp/numeric/math/tgamma -->
   <!-- double tgamma(double x); -->
   <function name="tgamma,std::tgamma">
     <use-retval/>
@@ -746,8 +747,11 @@
     <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <!-- If x is zero or a negative integer for which the function is asymptotic, it may cause a pole error (depending on implementation).-->
+      <valid>!0.0:</valid>
     </arg>
   </function>
+  <!-- https://en.cppreference.com/w/cpp/numeric/math/tgamma -->
   <!-- float tgammaf(float x); -->
   <function name="tgammaf,std::tgammaf">
     <use-retval/>
@@ -757,8 +761,11 @@
     <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <!-- If x is zero or a negative integer for which the function is asymptotic, it may cause a pole error (depending on implementation).-->
+      <valid>!0.0:</valid>
     </arg>
   </function>
+  <!-- https://en.cppreference.com/w/cpp/numeric/math/tgamma -->
   <!-- long double tgammal(long double x); -->
   <function name="tgammal,std::tgammal">
     <use-retval/>
@@ -768,6 +775,8 @@
     <leak-ignore/>
     <arg nr="1" direction="in">
       <not-uninit/>
+      <!-- If x is zero or a negative integer for which the function is asymptotic, it may cause a pole error (depending on implementation).-->
+      <valid>!0.0:</valid>
     </arg>
   </function>
   <!-- double trunc(double x); -->

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -2406,6 +2406,30 @@ void invalidFunctionArg_lgamma(float f, double d, long double ld)
     (void)lgammal(0.1L);
 }
 
+void invalidFunctionArg_tgamma(float f, double d, long double ld)
+{
+    (void)tgamma(d);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgamma(-0.1);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgamma(0.0);
+    (void)tgamma(0.1);
+
+    (void)tgammaf(f);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgammaf(-0.1f);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgammaf(0.0f);
+    (void)tgammaf(0.1f);
+
+    (void)tgammal(ld);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgammal(-0.1L);
+    // cppcheck-suppress invalidFunctionArg
+    (void)tgammal(0.0L);
+    (void)tgammal(0.1L);
+}
+
 void uninitvar_lgamma(void)
 {
     float f;


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/cpp/numeric/math/tgamma