### PR TITLE
pass `Settings` by reference into `Tokenizer`

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -495,7 +495,7 @@ unsigned int CppCheck::checkClang(const std::string &path)
 
     try {
         std::istringstream ast(output2);
-        Tokenizer tokenizer(&mSettings, this);
+        Tokenizer tokenizer(mSettings, this);
         tokenizer.list.appendFileIfNew(path);
         clangimport::parseClangAstDump(tokenizer, ast);
         ValueFlow::setValues(tokenizer.list,
@@ -663,7 +663,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
         }
 
         if (mSettings.library.markupFile(filename)) {
-            Tokenizer tokenizer(&mSettings, this, &preprocessor);
+            Tokenizer tokenizer(mSettings, this, &preprocessor);
             tokenizer.createTokens(std::move(tokens1));
             checkUnusedFunctions.getFileInfo(&tokenizer, &mSettings);
             return EXIT_SUCCESS;
@@ -795,7 +795,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 if (startsWith(dir.str,"#define ") || startsWith(dir.str,"#include "))
                     code += "#line " + std::to_string(dir.linenr) + " \"" + dir.file + "\"\n" + dir.str + '\n';
             }
-            Tokenizer tokenizer2(&mSettings, this);
+            Tokenizer tokenizer2(mSettings, this);
             std::istringstream istr2(code);
             tokenizer2.list.createTokens(istr2);
             executeRules("define", tokenizer2);
@@ -856,7 +856,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 continue;
             }
 
-            Tokenizer tokenizer(&mSettings, this, &preprocessor);
+            Tokenizer tokenizer(mSettings, this, &preprocessor);
             if (mSettings.showtime != SHOWTIME_MODES::SHOWTIME_NONE)
                 tokenizer.setTimerResults(&s_timerResults);
 

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -563,7 +563,7 @@ namespace {
             // TODO : Better evaluation
             Settings s;
             std::istringstream istr(c);
-            Tokenizer tokenizer(&s);
+            Tokenizer tokenizer(s);
             tokenizer.tokenize(istr,"vcxproj");
             for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
                 if (tok->str() == "(" && tok->astOperand1() && tok->astOperand2()) {

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -274,7 +274,7 @@ bool TemplateSimplifier::TokenAndName::isAliasToken(const Token *tok) const
 }
 
 TemplateSimplifier::TemplateSimplifier(Tokenizer &tokenizer)
-    : mTokenizer(tokenizer), mTokenList(mTokenizer.list), mSettings(*mTokenizer.mSettings),
+    : mTokenizer(tokenizer), mTokenList(mTokenizer.list), mSettings(*mTokenizer.getSettings()),
     mErrorLogger(mTokenizer.mErrorLogger)
 {}
 

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -59,7 +59,7 @@ class CPPCHECKLIB Tokenizer {
     friend class TemplateSimplifier;
 
 public:
-    explicit Tokenizer(const Settings * settings, ErrorLogger *errorLogger = nullptr, const Preprocessor *preprocessor = nullptr);
+    explicit Tokenizer(const Settings & settings, ErrorLogger *errorLogger = nullptr, const Preprocessor *preprocessor = nullptr);
     ~Tokenizer();
 
     void setTimerResults(TimerResults *tr) {
@@ -640,8 +640,9 @@ public:
      */
     static const Token * startOfExecutableScope(const Token * tok);
 
+    // TODO: return reference
     const Settings *getSettings() const {
-        return mSettings;
+        return &mSettings;
     }
 
     void calculateScopes();
@@ -668,7 +669,7 @@ private:
     void setPodTypes();
 
     /** settings */
-    const Settings * const mSettings;
+    const Settings & mSettings;
 
     /** errorlogger */
     ErrorLogger* const mErrorLogger;

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -42,7 +42,7 @@ private:
 
 public:
     explicit givenACodeSampleToTokenize(const char sample[], bool createOnly = false, bool cpp = true)
-        : tokenizer(&settings, nullptr) {
+        : tokenizer(settings, nullptr) {
         std::istringstream iss(sample);
         if (createOnly)
             tokenizer.list.createTokens(iss, cpp ? "test.cpp" : "test.c");

--- a/test/test64bit.cpp
+++ b/test/test64bit.cpp
@@ -48,7 +48,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testassert.cpp
+++ b/test/testassert.cpp
@@ -39,7 +39,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -51,7 +51,7 @@ private:
 #define findLambdaEndToken(...) findLambdaEndToken_(__FILE__, __LINE__, __VA_ARGS__)
     bool findLambdaEndToken_(const char* file, int line, const char code[], const char pattern[] = nullptr, bool checkNext = true) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token* const tokStart = pattern ? Token::findsimplematch(tokenizer.tokens(), pattern, strlen(pattern)) : tokenizer.tokens();
@@ -90,7 +90,7 @@ private:
 #define findLambdaStartToken(code) findLambdaStartToken_(code, __FILE__, __LINE__)
     bool findLambdaStartToken_(const char code[], const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const tokStart = (::findLambdaStartToken)(tokenizer.list.back());
@@ -123,7 +123,7 @@ private:
 #define isNullOperand(code) isNullOperand_(code, __FILE__, __LINE__)
     bool isNullOperand_(const char code[], const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         return (::isNullOperand)(tokenizer.tokens());
@@ -145,7 +145,7 @@ private:
 #define isReturnScope(code, offset) isReturnScope_(code, offset, __FILE__, __LINE__)
     bool isReturnScope_(const char code[], int offset, const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const tok = (offset < 0)
@@ -177,7 +177,7 @@ private:
     bool isSameExpression_(const char* file, int line, const char code[], const char tokStr1[], const char tokStr2[]) {
         const Settings settings;
         Library library;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const tok1 = Token::findsimplematch(tokenizer.tokens(), tokStr1, strlen(tokStr1));
@@ -215,7 +215,7 @@ private:
 #define isVariableChanged(code, startPattern, endPattern) isVariableChanged_(code, startPattern, endPattern, __FILE__, __LINE__)
     bool isVariableChanged_(const char code[], const char startPattern[], const char endPattern[], const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const tok1 = Token::findsimplematch(tokenizer.tokens(), startPattern, strlen(startPattern));
@@ -250,7 +250,7 @@ private:
 #define isVariableChangedByFunctionCall(code, pattern, inconclusive) isVariableChangedByFunctionCall_(code, pattern, inconclusive, __FILE__, __LINE__)
     bool isVariableChangedByFunctionCall_(const char code[], const char pattern[], bool *inconclusive, const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * const argtok = Token::findmatch(tokenizer.tokens(), pattern);
@@ -393,7 +393,7 @@ private:
                               int line)
     {
         const Settings settings = settingsBuilder().library("std.cfg").build();
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token* const start = Token::findsimplematch(tokenizer.tokens(), startPattern, strlen(startPattern));
@@ -425,7 +425,7 @@ private:
 #define nextAfterAstRightmostLeaf(code, parentPattern, rightPattern) nextAfterAstRightmostLeaf_(code, parentPattern, rightPattern, __FILE__, __LINE__)
     bool nextAfterAstRightmostLeaf_(const char code[], const char parentPattern[], const char rightPattern[], const char* file, int line) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
         const Token * tok = Token::findsimplematch(tokenizer.tokens(), parentPattern, strlen(parentPattern));
@@ -450,7 +450,7 @@ private:
 
     Result isUsedAsBool(const char code[], const char pattern[]) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         if (!tokenizer.tokenize(istr, "test.cpp"))
             return Result::Fail;

--- a/test/testautovariables.cpp
+++ b/test/testautovariables.cpp
@@ -40,7 +40,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testbool.cpp
+++ b/test/testbool.cpp
@@ -82,7 +82,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testboost.cpp
+++ b/test/testboost.cpp
@@ -42,7 +42,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testbufferoverrun.cpp
+++ b/test/testbufferoverrun.cpp
@@ -48,7 +48,7 @@ private:
         const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -57,7 +57,7 @@ private:
     }
 
     void check_(const char* file, int line, const char code[], const Settings &settings, const char filename[] = "test.cpp") {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -78,7 +78,7 @@ private:
                                   .c(Standards::CLatest).cpp(Standards::CPPLatest).certainty(Certainty::inconclusive).build();
 
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenizer..
@@ -5175,7 +5175,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testcharvar.cpp
+++ b/test/testcharvar.cpp
@@ -45,7 +45,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testclangimport.cpp
+++ b/test/testclangimport.cpp
@@ -140,7 +140,7 @@ private:
 
     std::string parse(const char clang[]) {
         const Settings settings = settingsBuilder().clang().build();
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(clang);
         clangimport::parseClangAstDump(tokenizer, istr);
         if (!tokenizer.tokens()) {
@@ -1054,7 +1054,7 @@ private:
 
 #define GET_SYMBOL_DB(AST) \
     const Settings settings = settingsBuilder().clang().platform(Platform::Type::Unix64).build(); \
-    Tokenizer tokenizer(&settings, this); \
+    Tokenizer tokenizer(settings, this); \
     { \
         std::istringstream istr(AST); \
         clangimport::parseClangAstDump(tokenizer, istr); \

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -252,7 +252,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -358,7 +358,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -512,7 +512,7 @@ private:
         Preprocessor preprocessor(settings1);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -723,7 +723,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -1172,7 +1172,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -1648,7 +1648,7 @@ private:
         Preprocessor preprocessor(settings1);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -2613,7 +2613,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -2955,7 +2955,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -3586,7 +3586,7 @@ private:
         Preprocessor preprocessor(settings1);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -3623,7 +3623,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -7548,7 +7548,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -7682,7 +7682,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -7896,7 +7896,7 @@ private:
         Preprocessor preprocessor(settings0);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this, &preprocessor);
+        Tokenizer tokenizer(settings0, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -8012,7 +8012,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -8361,7 +8361,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -8547,7 +8547,7 @@ private:
         const Settings settings = settingsBuilder().severity(Severity::style).build();
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         ASSERT_LOC(tokenizer.simplifyTokens1(""), file, line);
@@ -8723,7 +8723,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -8746,7 +8746,7 @@ private:
         Preprocessor preprocessor(settings1);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -8903,7 +8903,7 @@ private:
         // getFileInfo
         std::list<Check::FileInfo*> fileInfo;
         for (const std::string& c: code) {
-            Tokenizer tokenizer(&settings, this);
+            Tokenizer tokenizer(settings, this);
             std::istringstream istr(c);
             ASSERT(tokenizer.tokenize(istr, (std::to_string(fileInfo.size()) + ".cpp").c_str()));
             fileInfo.push_back(check.getFileInfo(&tokenizer, &settings));
@@ -8951,7 +8951,7 @@ private:
         Preprocessor preprocessor(settings1);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -131,7 +131,7 @@ private:
 
         Preprocessor preprocessor(settings);
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer);
 
         // Tokenizer..
@@ -547,7 +547,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -42,7 +42,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -56,7 +56,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(s, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -66,7 +66,7 @@ private:
         const Settings settings1 = settingsBuilder(s ? *s : settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -113,7 +113,7 @@ private:
             settings_ = &settings;
 
         // Tokenize..
-        Tokenizer tokenizer(settings_, this);
+        Tokenizer tokenizer(*settings_, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -289,7 +289,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -303,7 +303,7 @@ private:
 
 #define getSyntaxError(code) getSyntaxError_(code, __FILE__, __LINE__)
     std::string getSyntaxError_(const char code[], const char* file, int line) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         try {
             ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -321,7 +321,7 @@ private:
         const char code[] = "class __declspec(dllexport) x final { };";
         {
             errout.str("");
-            Tokenizer tokenizer(&settings, this);
+            Tokenizer tokenizer(settings, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT_EQUALS("", errout.str());
@@ -368,7 +368,7 @@ private:
                             " )\n"
                             "}";
 
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         try {
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
@@ -403,14 +403,14 @@ private:
 
         {
             errout.str("");
-            Tokenizer tokenizer(&settings, this);
+            Tokenizer tokenizer(settings, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.c"));
             ASSERT_EQUALS("", errout.str());
         }
         {
             errout.str("");
-            Tokenizer tokenizer(&settings, this);
+            Tokenizer tokenizer(settings, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT_EQUALS("[test.cpp:1]: (information) The code 'class x y {' is not handled. You can use -I or --include to add handling of this code.\n", errout.str());

--- a/test/testincompletestatement.cpp
+++ b/test/testincompletestatement.cpp
@@ -42,7 +42,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..

--- a/test/testinternal.cpp
+++ b/test/testinternal.cpp
@@ -54,7 +54,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -96,7 +96,7 @@ private:
         PLATFORM(settings1.platform, platform);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         const std::string file_in = cpp ? "test.cpp" : "test.c";
         ASSERT_LOC(tokenizer.tokenize(istr, file_in.c_str()), file, line);

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -239,7 +239,7 @@ private:
         const Settings settings1 = settingsBuilder(s ? *s : settings).checkLibrary().build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, cpp ? "test.cpp" : "test.c"), file, line);
 
@@ -254,7 +254,7 @@ private:
         const Settings settings0 = settingsBuilder(s).checkLibrary().build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -2994,7 +2994,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, cpp?"test.cpp":"test.c");
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenizer..
@@ -3045,7 +3045,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -3130,7 +3130,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.c"), file, line);
 

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -580,14 +580,14 @@ private:
         ASSERT_EQUALS(library.functions.size(), 1U);
 
         {
-            Tokenizer tokenizer(&settings, nullptr);
+            Tokenizer tokenizer(settings, nullptr);
             std::istringstream istr("CString str; str.Format();");
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(library.isnotnoreturn(Token::findsimplematch(tokenizer.tokens(), "Format")));
         }
 
         {
-            Tokenizer tokenizer(&settings, nullptr);
+            Tokenizer tokenizer(settings, nullptr);
             std::istringstream istr("HardDrive hd; hd.Format();");
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(!library.isnotnoreturn(Token::findsimplematch(tokenizer.tokens(), "Format")));
@@ -606,14 +606,14 @@ private:
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
         {
-            Tokenizer tokenizer(&settings, nullptr);
+            Tokenizer tokenizer(settings, nullptr);
             std::istringstream istr("struct X : public Base { void dostuff() { f(0); } };");
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(library.isnullargbad(Token::findsimplematch(tokenizer.tokens(), "f"),1));
         }
 
         {
-            Tokenizer tokenizer(&settings, nullptr);
+            Tokenizer tokenizer(settings, nullptr);
             std::istringstream istr("struct X : public Base { void dostuff() { f(1,2); } };");
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(!library.isnullargbad(Token::findsimplematch(tokenizer.tokens(), "f"),1));

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -50,7 +50,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -102,7 +102,7 @@ private:
         // Clear the error buffer..
         errout.str("");
 
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -132,7 +132,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -471,7 +471,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -1678,7 +1678,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, isCPP ? "test.cpp" : "test.c"), file, line);
 
@@ -2291,7 +2291,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -184,7 +184,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -200,7 +200,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, false).build();
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenizer..
@@ -4148,7 +4148,7 @@ private:
 
     void functioncalllibrary() {
         const Settings settings1;
-        Tokenizer tokenizer(&settings1,this);
+        Tokenizer tokenizer(settings1,this);
         std::istringstream code("void f() { int a,b,c; x(a,b,c); }");
         ASSERT_EQUALS(true, tokenizer.tokenize(code, "test.c"));
         const Token *xtok = Token::findsimplematch(tokenizer.tokens(), "x");
@@ -4492,7 +4492,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -314,7 +314,7 @@ private:
         Preprocessor preprocessor(*settings);
 
         // Tokenize..
-        Tokenizer tokenizer(settings, this, &preprocessor);
+        Tokenizer tokenizer(*settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename ? filename : "test.cpp"), file, line);
 
@@ -344,7 +344,7 @@ private:
 
         Preprocessor preprocessor(*settings);
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(settings, this, &preprocessor);
+        Tokenizer tokenizer(*settings, this, &preprocessor);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer);
 
         // Tokenizer..
@@ -1709,7 +1709,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizerCpp(&settings, this, &preprocessor);
+        Tokenizer tokenizerCpp(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizerCpp.tokenize(istr, "test.cpp"), file, line);
 
@@ -1911,7 +1911,7 @@ private:
         Preprocessor preprocessor(settings);
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testpostfixoperator.cpp
+++ b/test/testpostfixoperator.cpp
@@ -38,7 +38,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -312,7 +312,7 @@ private:
         errout.str("");
 
         const Settings settings1 = settingsBuilder(settings).library("std.cfg").debugwarnings(debugwarnings).platform(type).build();
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -5287,7 +5287,7 @@ private:
     }
 
     unsigned int templateParameters(const char code[]) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         tokenizer.createTokens(istr, "test.cpp");
@@ -5354,7 +5354,7 @@ private:
 
     // Helper function to unit test TemplateSimplifier::getTemplateNamePosition
     int templateNamePositionHelper(const char code[], unsigned offset = 0) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         tokenizer.createTokens(istr, "test.cpp");
@@ -5424,7 +5424,7 @@ private:
 
     // Helper function to unit test TemplateSimplifier::findTemplateDeclarationEnd
     bool findTemplateDeclarationEndHelper(const char code[], const char pattern[], unsigned offset = 0) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         tokenizer.createTokens(istr, "test.cpp");
@@ -5453,7 +5453,7 @@ private:
 
     // Helper function to unit test TemplateSimplifier::getTemplateParametersInDeclaration
     bool getTemplateParametersInDeclarationHelper(const char code[], const std::vector<std::string> & params) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         tokenizer.createTokens(istr, "test.cpp");
@@ -5756,7 +5756,7 @@ private:
 
 #define instantiateMatch(code, numberOfArguments, patternAfter) instantiateMatch_(code, numberOfArguments, patternAfter, __FILE__, __LINE__)
     bool instantiateMatch_(const char code[], const std::size_t numberOfArguments, const char patternAfter[], const char* file, int line) {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp", ""), file, line);

--- a/test/testsimplifytokens.cpp
+++ b/test/testsimplifytokens.cpp
@@ -167,7 +167,7 @@ private:
         errout.str("");
 
         const Settings settings = settingsBuilder(settings0).platform(type).build();
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -178,7 +178,7 @@ private:
     std::string tok_(const char* file, int line, const char code[], const char filename[], bool simplify = true) {
         errout.str("");
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
@@ -195,7 +195,7 @@ private:
         const Settings settings = settingsBuilder(settings1).debugwarnings().platform(platform).cpp(cpp11 ? Standards::CPP11 : Standards::CPP03).build();
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 
@@ -221,7 +221,7 @@ private:
     std::string tokenizeDebugListing_(const char* file, int line, const char code[], bool simplify = false, const char filename[] = "test.cpp") {
         errout.str("");
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -264,7 +264,7 @@ private:
 
         const char expected[] =  "a = L\"hello world\" ;";
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -276,7 +276,7 @@ private:
 
         const char expected[] =  "abcd = u\"abcd\" ;";
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -288,7 +288,7 @@ private:
 
         const char expected[] =  "abcd = U\"abcd\" ;";
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -300,7 +300,7 @@ private:
 
         const char expected[] =  "abcd = u8\"abcd\" ;";
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -312,7 +312,7 @@ private:
 
         const char expected[] =  "abcdef = L\"abcdef\" ;";
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -1492,7 +1492,7 @@ private:
     std::string simplifyKnownVariables_(const char code[], const char* file, int line) {
         errout.str("");
 
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -238,7 +238,7 @@ private:
 
         // show warnings about unhandled typedef
         const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -249,7 +249,7 @@ private:
     std::string simplifyTypedef(const char code[]) {
         errout.str("");
 
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
 
         std::istringstream istr(code);
         tokenizer.list.createTokens(istr);
@@ -265,7 +265,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..
@@ -281,7 +281,7 @@ private:
         // Tokenize..
         // show warnings about unhandled typedef
         const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings().build();
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
     }
@@ -290,7 +290,7 @@ private:
     std::string simplifyTypedefC(const char code[]) {
         errout.str("");
 
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
 
         std::istringstream istr(code);
         tokenizer.list.createTokens(istr, "file.c");

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -99,7 +99,7 @@ private:
 
         const Settings settings = settingsBuilder(settings0).certainty(Certainty::inconclusive).debugwarnings(debugwarnings).platform(type).build();
 
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
 
         if (preprocess) {
             std::vector<std::string> files(1, "test.cpp");

--- a/test/testsizeof.cpp
+++ b/test/testsizeof.cpp
@@ -54,7 +54,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -68,7 +68,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -183,7 +183,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).certainty(Certainty::inconclusive, inconclusive).cpp(cppstandard).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
 
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -201,7 +201,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/teststring.cpp
+++ b/test/teststring.cpp
@@ -68,7 +68,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..

--- a/test/testsummaries.cpp
+++ b/test/testsummaries.cpp
@@ -45,7 +45,7 @@ private:
 
         // tokenize..
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
         return Summaries::create(&tokenizer, "");

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -45,20 +45,20 @@
 class TestSymbolDatabase;
 
 #define GET_SYMBOL_DB_STD(code) \
-    Tokenizer tokenizer(&settings1, this); \
+    Tokenizer tokenizer(settings1, this); \
     LOAD_LIB_2(settings1.library, "std.cfg"); \
     const SymbolDatabase *db = getSymbolDB_inner(tokenizer, code, "test.cpp"); \
     ASSERT(db); \
     do {} while (false)
 
 #define GET_SYMBOL_DB(code) \
-    Tokenizer tokenizer(&settings1, this); \
+    Tokenizer tokenizer(settings1, this); \
     const SymbolDatabase *db = getSymbolDB_inner(tokenizer, code, "test.cpp"); \
     ASSERT(db); \
     do {} while (false)
 
 #define GET_SYMBOL_DB_C(code) \
-    Tokenizer tokenizer(&settings1, this); \
+    Tokenizer tokenizer(settings1, this); \
     const SymbolDatabase *db = getSymbolDB_inner(tokenizer, code, "test.c"); \
     do {} while (false)
 
@@ -105,7 +105,7 @@ private:
                                 unsigned int exprline2,
                                 SourceLocation loc = SourceLocation::current())
     {
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), loc.file_name(), loc.line());
 
@@ -2447,7 +2447,7 @@ private:
         const Settings settings = settingsBuilder(pSettings ? *pSettings : settings1).debugwarnings(debug).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -8450,7 +8450,7 @@ private:
     }
 #define typeOf(...) typeOf_(__FILE__, __LINE__, __VA_ARGS__)
     std::string typeOf_(const char* file, int line, const char code[], const char pattern[], const char filename[] = "test.cpp", const Settings *settings = nullptr) {
-        Tokenizer tokenizer(settings ? settings : &settings2, this);
+        Tokenizer tokenizer(settings ? *settings : settings2, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
         const Token* tok;

--- a/test/testtoken.cpp
+++ b/test/testtoken.cpp
@@ -137,7 +137,7 @@ private:
 #define MatchCheck(...) MatchCheck_(__FILE__, __LINE__, __VA_ARGS__)
     bool MatchCheck_(const char* file, int line, const std::string& code, const std::string& pattern, unsigned int varid = 0) {
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(";" + code + ";");
         try {
             ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -457,7 +457,7 @@ private:
         const Settings settings = settingsBuilder(settings1).debugwarnings().cpp(std).platform(platform).build();
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 
@@ -484,7 +484,7 @@ private:
         const Settings settings = settingsBuilder(settings_windows).debugwarnings().cpp(cpp11 ? Standards::CPP11 : Standards::CPP03).platform(platform).build();
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, linenr);
 
@@ -507,7 +507,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
         if (!tokenizer.tokens())
@@ -521,7 +521,7 @@ private:
 
         const Settings settings = settingsBuilder(settings0).c(Standards::C89).cpp(Standards::CPP03).build();
 
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -1552,7 +1552,7 @@ private:
         {
             const char code[] = "extern \"C\" int foo();";
             // tokenize..
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             // Expected result..
@@ -1562,7 +1562,7 @@ private:
         {
             const char code[] = "extern \"C\" { int foo(); }";
             // tokenize..
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             // Expected result..
@@ -1572,7 +1572,7 @@ private:
         {
             const char code[] = "extern \"C++\" int foo();";
             // tokenize..
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             // Expected result..
@@ -1582,7 +1582,7 @@ private:
         {
             const char code[] = "extern \"C++\" { int foo(); }";
             // tokenize..
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             // Expected result..
@@ -2909,7 +2909,7 @@ private:
                                 " void f() {}\n"
                                 "};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -2934,7 +2934,7 @@ private:
                                 " char *b ; b = new char[a[0]];\n"
                                 "};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -2958,7 +2958,7 @@ private:
                                 " foo(g());\n"
                                 "};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -2978,7 +2978,7 @@ private:
                                 "    return(a<b && b>f);\n"
                                 "}";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3006,7 +3006,7 @@ private:
                                 "    return static_cast<bar>(a);\n"
                                 "}";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3023,7 +3023,7 @@ private:
                                 "    nvwa<(x > y)> ERROR_nnn;\n"
                                 "}";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3039,7 +3039,7 @@ private:
             // #4860
             const char code[] = "class A : public B<int> {};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3055,7 +3055,7 @@ private:
             // #4860
             const char code[] = "Bar<Typelist< int, Typelist< int, Typelist< int, FooNullType>>>>::set(1, 2, 3);";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3072,7 +3072,7 @@ private:
             // #5627
             const char code[] = "new Foo<Bar>[10];";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3088,7 +3088,7 @@ private:
             // #6242
             const char code[] = "func = integral_<uchar, int, double>;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3103,7 +3103,7 @@ private:
             // if (a < b || c > d) { }
             const char code[] = "{ if (a < b || c > d); }";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3115,7 +3115,7 @@ private:
             // bool f = a < b || c > d
             const char code[] = "bool f = a < b || c > d;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3127,7 +3127,7 @@ private:
             // template
             const char code[] = "a < b || c > d;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3139,7 +3139,7 @@ private:
             // if (a < ... > d) { }
             const char code[] = "{ if (a < b || c == 3 || d > e); }";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3151,7 +3151,7 @@ private:
             // template
             const char code[] = "a<b==3 || c> d;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3162,7 +3162,7 @@ private:
             // template
             const char code[] = "a<b || c==4> d;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3172,7 +3172,7 @@ private:
         {
             const char code[] = "template < f = b || c > struct S;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3183,7 +3183,7 @@ private:
         {
             const char code[] = "struct A : B<c&&d> {};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3194,7 +3194,7 @@ private:
         {
             const char code[] = "Data<T&&>;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3206,7 +3206,7 @@ private:
             // #6601
             const char code[] = "template<class R> struct FuncType<R(&)()> : FuncType<R()> { };";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = tokenizer.tokens();
@@ -3226,7 +3226,7 @@ private:
             // #7158
             const char code[] = "enum { value = boost::mpl::at_c<B, C> };";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok = Token::findsimplematch(tokenizer.tokens(), "<");
@@ -3240,7 +3240,7 @@ private:
                                 "struct CheckedDivOp< T, U, typename std::enable_if<std::is_floating_point<T>::value || std::is_floating_point<U>::value>::type> {\n"
                                 "};\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok1 = Token::findsimplematch(tokenizer.tokens(), "struct")->tokAt(2);
@@ -3253,7 +3253,7 @@ private:
             // #7975
             const char code[] = "template <class C> X<Y&&Z, C*> copy() {};\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok1 = Token::findsimplematch(tokenizer.tokens(), "< Y");
@@ -3266,7 +3266,7 @@ private:
             // #8006
             const char code[] = "C<int> && a = b;";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok1 = tokenizer.tokens()->next();
@@ -3279,7 +3279,7 @@ private:
             // #8115
             const char code[] = "void Test(C<int> && c);";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok1 = Token::findsimplematch(tokenizer.tokens(), "<");
@@ -3292,7 +3292,7 @@ private:
             const char code[] = "template<int N> struct A {}; "
                                 "template<int... Ns> struct foo : A<Ns>... {};";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *A = Token::findsimplematch(tokenizer.tokens(), "A <");
@@ -3303,7 +3303,7 @@ private:
             const char code[] = "template<typename std::enable_if<!(std::value1) && std::value2>::type>"
                                 "void basic_json() {}";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT_EQUALS(true, Token::simpleMatch(tokenizer.tokens()->next()->link(), "> void"));
@@ -3312,7 +3312,7 @@ private:
         {
             // #9094 - template usage or comparison?
             const char code[] = "a = f(x%x<--a==x>x);";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr == Token::findsimplematch(tokenizer.tokens(), "<")->link());
@@ -3323,7 +3323,7 @@ private:
             const char code[] = "using std::same_as;\n"
                                 "template<same_as<int> T>\n"
                                 "void f();";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token *tok1 = Token::findsimplematch(tokenizer.tokens(), "template <");
@@ -3335,7 +3335,7 @@ private:
         {
             // #9131 - template usage or comparison?
             const char code[] = "using std::list; list<t *> l;";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "<")->link());
@@ -3347,7 +3347,7 @@ private:
                                 "{\n"
                                 "    for (set<ParticleSource*>::iterator i = sources.begin(); i != sources.end(); ++i) {}\n"
                                 "}";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "<")->link());
@@ -3359,7 +3359,7 @@ private:
                                 "  a<> b;\n"
                                 "  b.a<>::c();\n"
                                 "}\n";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> ::")->link());
@@ -3371,7 +3371,7 @@ private:
                                 "template <char... b> struct c {\n"
                                 "  void d() { a<b...>[0]; }\n"
                                 "};\n";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> [")->link());
@@ -3384,7 +3384,7 @@ private:
                                 "template <typename e> using f = c<e() && sizeof(int), int>;\n"
                                 "template <typename e, typename = f<e>> struct g {};\n"
                                 "template <typename e> using baz = g<e>;\n";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> ;")->link());
@@ -3399,7 +3399,7 @@ private:
                                 "template <int> using c = a;\n"
                                 "template <int d> c<d> e;\n"
                                 "auto f = -e<1> == 0;\n";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> ==")->link());
@@ -3418,7 +3418,7 @@ private:
                                 "constexpr void b<a, d>::operator()(c &&) const {\n"
                                 "  i<3>.f([] {});\n"
                                 "}\n";
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             ASSERT(nullptr != Token::findsimplematch(tokenizer.tokens(), "> . f (")->link());
@@ -3428,7 +3428,7 @@ private:
             // #10491
             const char code[] = "template <template <class> class> struct a;\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< class");
@@ -3441,7 +3441,7 @@ private:
             // #10491
             const char code[] = "template <template <class> class> struct a;\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< template");
@@ -3454,7 +3454,7 @@ private:
             // #10552
             const char code[] = "v.value<QPair<int, int>>()\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< QPair");
@@ -3467,7 +3467,7 @@ private:
             // #10552
             const char code[] = "v.value<QPair<int, int>>()\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< int");
@@ -3480,7 +3480,7 @@ private:
             // #10615
             const char code[] = "struct A : public B<__is_constructible()>{};\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< >");
@@ -3493,7 +3493,7 @@ private:
             // #10664
             const char code[] = "class C1 : public T1<D2<C2>const> {};\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< C2");
@@ -3510,7 +3510,7 @@ private:
                                 "    if (a<int>[0]) {}\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< int");
@@ -3526,7 +3526,7 @@ private:
                                 "    if (b[idx<1>]) {}\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< 1");
@@ -3540,7 +3540,7 @@ private:
                                 "    []<typename T>() {};\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< T");
@@ -3554,7 +3554,7 @@ private:
                                 "    auto g = [] <typename A, typename B> (A a, B&& b) { return a < b; };\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< A");
@@ -3570,7 +3570,7 @@ private:
                                 "    };\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< T");
@@ -3589,7 +3589,7 @@ private:
                                 "    s.operator()<int, int>(1);\n"
                                 "}\n";
             errout.str("");
-            Tokenizer tokenizer(&settings0, this);
+            Tokenizer tokenizer(settings0, this);
             std::istringstream istr(code);
             ASSERT(tokenizer.tokenize(istr, "test.cpp"));
             const Token* tok1 = Token::findsimplematch(tokenizer.tokens(), "< int");
@@ -3601,7 +3601,7 @@ private:
 
     void simplifyString() {
         errout.str("");
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         ASSERT_EQUALS("\"abc\"", tokenizer.simplifyString("\"abc\""));
         ASSERT_EQUALS("\"\n\"", tokenizer.simplifyString("\"\\xa\""));
         ASSERT_EQUALS("\"3\"", tokenizer.simplifyString("\"\\x33\""));
@@ -3827,7 +3827,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -3856,7 +3856,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
         ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
@@ -3872,7 +3872,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
         ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
@@ -3888,7 +3888,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
         ASSERT_EQUALS(expected, tokenizer.tokens()->stringifyList(nullptr, false));
@@ -3904,7 +3904,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -3927,7 +3927,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -3957,7 +3957,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -3983,7 +3983,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -4024,7 +4024,7 @@ private:
         errout.str("");
 
         // tokenize..
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -4679,7 +4679,7 @@ private:
         const char code[] = "struct A { unsigned int x : 1; };";
 
         errout.str("");
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
         const Token *x = Token::findsimplematch(tokenizer.tokens(), "x");
@@ -5958,43 +5958,43 @@ private:
 
     std::string testAst(const char code[], AstStyle style = AstStyle::Simple) const {
         // tokenize given code..
-        Tokenizer tokenList(&settings0, nullptr);
+        Tokenizer tokenizer(settings0, nullptr);
         std::istringstream istr(code);
-        if (!tokenList.list.createTokens(istr,"test.cpp"))
+        if (!tokenizer.list.createTokens(istr,"test.cpp"))
             return "ERROR";
 
-        tokenList.combineStringAndCharLiterals();
-        tokenList.combineOperators();
-        tokenList.simplifySpaceshipOperator();
-        tokenList.createLinks();
-        tokenList.createLinks2();
-        tokenList.list.front()->assignIndexes();
+        tokenizer.combineStringAndCharLiterals();
+        tokenizer.combineOperators();
+        tokenizer.simplifySpaceshipOperator();
+        tokenizer.createLinks();
+        tokenizer.createLinks2();
+        tokenizer.list.front()->assignIndexes();
 
         // set varid..
-        for (Token *tok = tokenList.list.front(); tok; tok = tok->next()) {
+        for (Token *tok = tokenizer.list.front(); tok; tok = tok->next()) {
             if (tok->str() == "var")
                 tok->varId(1);
         }
 
         // Create AST..
-        tokenList.prepareTernaryOpForAST();
-        tokenList.list.createAst();
+        tokenizer.prepareTernaryOpForAST();
+        tokenizer.list.createAst();
 
-        tokenList.list.validateAst(false);
+        tokenizer.list.validateAst(false);
 
         // Basic AST validation
-        for (const Token *tok = tokenList.list.front(); tok; tok = tok->next()) {
+        for (const Token *tok = tokenizer.list.front(); tok; tok = tok->next()) {
             if (tok->astOperand2() && !tok->astOperand1() && tok->str() != ";" && tok->str() != ":")
                 return "Op2 but no Op1 for token: " + tok->str();
         }
 
         // Return stringified AST
         if (style == AstStyle::Z3)
-            return tokenList.list.front()->astTop()->astStringZ3();
+            return tokenizer.list.front()->astTop()->astStringZ3();
 
         std::string ret;
         std::set<const Token *> astTop;
-        for (const Token *tok = tokenList.list.front(); tok; tok = tok->next()) {
+        for (const Token *tok = tokenizer.list.front(); tok; tok = tok->next()) {
             if (tok->astOperand1() && astTop.find(tok->astTop()) == astTop.end()) {
                 astTop.insert(tok->astTop());
                 if (!ret.empty())
@@ -6875,7 +6875,7 @@ private:
 
 #define isStartOfExecutableScope(offset, code) isStartOfExecutableScope_(offset, code, __FILE__, __LINE__)
     bool isStartOfExecutableScope_(int offset, const char code[], const char* file, int line) {
-        Tokenizer tokenizer(&settings0, this);
+        Tokenizer tokenizer(settings0, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -7620,7 +7620,7 @@ private:
         const Settings s = settingsBuilder().checkConfiguration().build();
 
         // tokenize..
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(s, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
     }
@@ -7643,7 +7643,7 @@ private:
                       "V::Type value;";
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -7663,7 +7663,7 @@ private:
                             "a = static_cast<int>(x);\n";
 
         const Settings settings;
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT(tokenizer.tokenize(istr, "test.cpp"));
 
@@ -7681,7 +7681,7 @@ private:
 
         Preprocessor preprocessor(settings0);
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer);
 
         // Tokenizer..
@@ -7802,7 +7802,7 @@ private:
         #define testIsCpp11init(...) testIsCpp11init_(__FILE__, __LINE__, __VA_ARGS__)
         auto testIsCpp11init_ = [this](const char* file, int line, const char* code, const char* find, TokenImpl::Cpp11init expected) {
             const Settings settings;
-            Tokenizer tokenizer(&settings, this);
+            Tokenizer tokenizer(settings, this);
             std::istringstream istr(code);
             ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testtokenrange.cpp
+++ b/test/testtokenrange.cpp
@@ -102,7 +102,7 @@ private:
 
     void scopeExample() const {
         const Settings settings;
-        Tokenizer tokenizer{ &settings, nullptr };
+        Tokenizer tokenizer(settings);
         std::istringstream sample("void a(){} void main(){ if(true){a();} }");
         ASSERT(tokenizer.tokenize(sample, "test.cpp"));
 

--- a/test/testtype.cpp
+++ b/test/testtype.cpp
@@ -58,7 +58,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).severity(Severity::warning).severity(Severity::portability).cpp(standard).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 
@@ -75,7 +75,7 @@ private:
 
         Preprocessor preprocessor(settings1);
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings1, this, &preprocessor);
+        Tokenizer tokenizer(settings1, this, &preprocessor);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer, dui);
 
         // Tokenizer..

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -113,7 +113,7 @@ private:
         const Settings settings1 = settingsBuilder(s ? *s : settings).debugwarnings(debugwarnings).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, fname), file, line);
 
@@ -5380,7 +5380,7 @@ private:
         // Tokenize..
         const Settings s = settingsBuilder(settings).debugwarnings(false).build();
 
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(s, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, fname), file, line);
 
@@ -7593,7 +7593,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -90,7 +90,7 @@ private:
         const Settings settings1 = settingsBuilder(s ? *s : settings).platform(platform).build();
 
         // Tokenize..
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -537,7 +537,7 @@ private:
     }
 
     void multipleFiles() {
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         CheckUnusedFunctions c(&tokenizer, &settings, nullptr);
 
         // Clear the error buffer..
@@ -552,7 +552,7 @@ private:
             // Clear the error buffer..
             errout.str("");
 
-            Tokenizer tokenizer2(&settings, this);
+            Tokenizer tokenizer2(settings, this);
             std::istringstream istr(code);
             ASSERT(tokenizer2.tokenize(istr, fname.str().c_str()));
 

--- a/test/testunusedprivfunc.cpp
+++ b/test/testunusedprivfunc.cpp
@@ -94,7 +94,7 @@ private:
         const Settings settings1 = settingsBuilder(settings).platform(platform).build();
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&settings1, this);
+        Tokenizer tokenizer(settings1, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..

--- a/test/testunusedvar.cpp
+++ b/test/testunusedvar.cpp
@@ -268,7 +268,7 @@ private:
         const Settings *settings1 = s ? s : &settings;
 
         // Tokenize..
-        Tokenizer tokenizer(settings1, this, &preprocessor);
+        Tokenizer tokenizer(*settings1, this, &preprocessor);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -284,7 +284,7 @@ private:
 
         std::vector<std::string> files(1, "test.cpp");
         Preprocessor preprocessor(settings);
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer);
 
         // Tokenizer..
@@ -302,7 +302,7 @@ private:
 
         Preprocessor preprocessor(settings);
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings, this, &preprocessor);
+        Tokenizer tokenizer(settings, this, &preprocessor);
         PreprocessorHelper::preprocess(preprocessor, code, files, tokenizer);
 
         // Tokenizer..
@@ -2003,7 +2003,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, filename), file, line);
 

--- a/test/testvaarg.cpp
+++ b/test/testvaarg.cpp
@@ -38,7 +38,7 @@ private:
         errout.str("");
 
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -195,7 +195,7 @@ private:
 #define testValueOfXKnown(...) testValueOfXKnown_(__FILE__, __LINE__, __VA_ARGS__)
     bool testValueOfXKnown_(const char* file, int line, const char code[], unsigned int linenr, int value) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -217,7 +217,7 @@ private:
 
     bool testValueOfXKnown_(const char* file, int line, const char code[], unsigned int linenr, const std::string& expr, int value) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -240,7 +240,7 @@ private:
 #define testValueOfXImpossible(...) testValueOfXImpossible_(__FILE__, __LINE__, __VA_ARGS__)
     bool testValueOfXImpossible_(const char* file, int line, const char code[], unsigned int linenr, int value) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -263,7 +263,7 @@ private:
     bool testValueOfXImpossible_(const char* file, int line, const char code[], unsigned int linenr, const std::string& expr, int value)
     {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -286,7 +286,7 @@ private:
 #define testValueOfXInconclusive(code, linenr, value) testValueOfXInconclusive_(code, linenr, value, __FILE__, __LINE__)
     bool testValueOfXInconclusive_(const char code[], unsigned int linenr, int value, const char* file, int line) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -311,7 +311,7 @@ private:
         const Settings *settings1 = s ? s : &settings;
 
         // Tokenize..
-        Tokenizer tokenizer(settings1, this);
+        Tokenizer tokenizer(*settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -330,7 +330,7 @@ private:
     bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, const std::string& expr, int value)
     {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -348,7 +348,7 @@ private:
 
     bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, double value, double diff) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -367,7 +367,7 @@ private:
 #define getErrorPathForX(code, linenr) getErrorPathForX_(code, linenr, __FILE__, __LINE__)
     std::string getErrorPathForX_(const char code[], unsigned int linenr, const char* file, int line) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -391,7 +391,7 @@ private:
 
     bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, const char value[], ValueFlow::Value::ValueType type) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -411,7 +411,7 @@ private:
 #define testLifetimeOfX(...) testLifetimeOfX_(__FILE__, __LINE__, __VA_ARGS__)
     bool testLifetimeOfX_(const char* file, int line, const char code[], unsigned int linenr, const char value[], ValueFlow::Value::LifetimeScope lifetimeScope = ValueFlow::Value::LifetimeScope::Local) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -430,7 +430,7 @@ private:
 
     bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, int value, ValueFlow::Value::ValueType type) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -448,7 +448,7 @@ private:
 
     bool testValueOfX_(const char* file, int line, const char code[], unsigned int linenr, ValueFlow::Value::MoveKind moveKind) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -467,7 +467,7 @@ private:
 #define testConditionalValueOfX(code, linenr, value) testConditionalValueOfX_(code, linenr, value, __FILE__, __LINE__)
     bool testConditionalValueOfX_(const char code[], unsigned int linenr, int value, const char* file, int line) {
         // Tokenize..
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
 
@@ -489,7 +489,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, "test.cpp");
-        Tokenizer tokenizer(&s, this);
+        Tokenizer tokenizer(s, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         // Tokenize..
@@ -498,7 +498,7 @@ private:
 
 #define tokenValues(...) tokenValues_(__FILE__, __LINE__, __VA_ARGS__)
     std::list<ValueFlow::Value> tokenValues_(const char* file, int line, const char code[], const char tokstr[], const Settings *s = nullptr) {
-        Tokenizer tokenizer(s ? s : &settings, this);
+        Tokenizer tokenizer(s ? *s : settings, this);
         std::istringstream istr(code);
         errout.str("");
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);
@@ -517,7 +517,7 @@ private:
 #define lifetimeValues(...) lifetimeValues_(__FILE__, __LINE__, __VA_ARGS__)
     std::vector<std::string> lifetimeValues_(const char* file, int line, const char code[], const char tokstr[], const Settings *s = nullptr) {
         std::vector<std::string> result;
-        Tokenizer tokenizer(s ? s : &settings, this);
+        Tokenizer tokenizer(s ? *s : settings, this);
         std::istringstream istr(code);
         errout.str("");
         ASSERT_LOC(tokenizer.tokenize(istr, "test.cpp"), file, line);

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -254,7 +254,7 @@ private:
 
         const Settings *settings1 = s ? s : &settings;
 
-        Tokenizer tokenizer(settings1, this);
+        Tokenizer tokenizer(*settings1, this);
         std::istringstream istr(code);
         ASSERT_LOC((tokenizer.tokenize)(istr, filename), file, line);
 
@@ -269,7 +269,7 @@ private:
         errout.str("");
 
         std::vector<std::string> files(1, filename);
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         PreprocessorHelper::preprocess(code, files, tokenizer);
 
         ASSERT_LOC(tokenizer.simplifyTokens1(""), file, line);
@@ -284,7 +284,7 @@ private:
     std::string compareVaridsForVariable_(const char* file, int line, const char code[], const char varname[], const char filename[] = "test.cpp") {
         errout.str("");
 
-        Tokenizer tokenizer(&settings, this);
+        Tokenizer tokenizer(settings, this);
         std::istringstream istr(code);
         ASSERT_LOC((tokenizer.tokenize)(istr, filename), file, line);
 


### PR DESCRIPTION
We already were enforcing that it is provided via an assert. Back when I added that I did not change it yet because of all the files affected.