### PR TITLE
CheckUnusedVar: fixed potential crash with incomplete code in `doAssignment()`

### DIFF
--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -474,6 +474,8 @@ static const Token* doAssignment(Variables &variables, const Token *tok, bool de
                     tok = tok->next();
 
                 tok = tok->next();
+                if (!tok)
+                    return tokOld;
                 if (tok->str() == "*")
                     tok = tok->next();
 

--- a/test/testgarbage.cpp
+++ b/test/testgarbage.cpp
@@ -252,6 +252,7 @@ private:
         TEST_CASE(garbageCode221);
         TEST_CASE(garbageCode222); // #10763
         TEST_CASE(garbageCode223); // #11639
+        TEST_CASE(garbageCode224);
 
         TEST_CASE(garbageCodeFuzzerClientMode1); // test cases created with the fuzzer client, mode 1
 
@@ -1718,6 +1719,9 @@ private:
     }
     void garbageCode223() { // #11639
         ASSERT_THROW(checkCode("struct{}*"), InternalError);  // don't crash
+    }
+    void garbageCode224() {
+        checkCode("void f(){ auto* b = dynamic_cast<const }");  // don't crash
     }
 
     void syntaxErrorFirstToken() {


### PR DESCRIPTION
Happened with the IDE integration while I was typing code.