### PR TITLE
Fix #12365 checkLibraryFunction for std::string constructor

### DIFF
--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -662,7 +662,7 @@ void CheckFunctions::checkLibraryMatchFunctions()
             continue;
 
         const Token* start = tok;
-        while (Token::Match(start->tokAt(-2), "%name% ::"))
+        while (Token::Match(start->tokAt(-2), "%name% ::") && !start->tokAt(-2)->isKeyword())
             start = start->tokAt(-2);
         if (mSettings->library.detectContainerOrIterator(start))
             continue;

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -1184,7 +1184,6 @@ void CheckLeakAutoVar::ret(const Token *tok, VarInfo &varInfo, const bool isEndO
 
             else if (used != PtrUsage::PTR && !it->second.managed() && !var->isReference()) {
                 const auto use = possibleUsage.find(varid);
-                const Token* useTok{};
                 if (use == possibleUsage.end()) {
                     leakError(tok, var->name(), it->second.type);
                 } else {

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -937,6 +937,8 @@ void CheckLeakAutoVar::functionCall(const Token *tokName, const Token *tokOpenin
     const bool isLeakIgnore = mSettings->library.isLeakIgnore(mSettings->library.getFunctionName(tokName));
     if (mSettings->library.getReallocFuncInfo(tokName))
         return;
+    if (tokName->next()->valueType() && tokName->next()->valueType()->container && tokName->next()->valueType()->container->stdStringLike)
+        return;
 
     const Token * const tokFirstArg = tokOpeningPar->next();
     if (!tokFirstArg || tokFirstArg->str() == ")") {
@@ -1182,6 +1184,7 @@ void CheckLeakAutoVar::ret(const Token *tok, VarInfo &varInfo, const bool isEndO
 
             else if (used != PtrUsage::PTR && !it->second.managed() && !var->isReference()) {
                 const auto use = possibleUsage.find(varid);
+                const Token* useTok{};
                 if (use == possibleUsage.end()) {
                     leakError(tok, var->name(), it->second.type);
                 } else {

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -2041,6 +2041,11 @@ private:
               "    if (t.at(0)) {}\n"
               "};\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
+
+        check("::std::string f(const char* c) {\n" // #12365
+              "    return ::std::string(c);\n"
+              "}\n", "test.cpp", &s);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkUseStandardLibrary1() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -1730,8 +1730,14 @@ private:
               "        auto s = new S;\n"
               "        v.push_back(std::unique_ptr<S>(s));\n"
               "    }\n"
-              "}\n", &s);
+              "}\n", /*cpp*/ true, &s);
         ASSERT_EQUALS("", errout.str()); // don't crash
+
+        check("void g(size_t len) {\n" // #12365
+              "    char* b = new char[len + 1]{};\n"
+              "    std::string str = std::string(b);\n"
+              "}", /*cpp*/ true, &s);
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory leak: b\n", errout.str());
     }
 
     void goto1() {


### PR DESCRIPTION
I wonder why both `%name%` and `%type%` match `return`.