### PR TITLE
CI-unixish-docker.yml: fixate `hendrikmuhs/ccache-action` on `1.2.11` to fix older images

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -53,8 +53,10 @@ jobs:
       # needs to be called after the package installation since
       # - it doesn't call "apt-get update"
       # - it doesn't support centos
+      #
+      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ matrix.image }}
 
@@ -110,8 +112,10 @@ jobs:
       # needs to be called after the package installation since
       # - it doesn't call "apt-get update"
       # - it doesn't support centos
+      #
+      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ matrix.image }}
 


### PR DESCRIPTION
See
https://github.com/danmar/cppcheck/actions/runs/7677304162/job/20926809147?pr=5917
https://github.com/hendrikmuhs/ccache-action/issues/178