### PR TITLE
CI: add coverity scan scheduled

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,38 @@
+
+name: Coverity
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'danmar' }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install missing software on ubuntu
+      run: |
+        sudo apt-get update
+        sudo apt-get install qtbase5-dev qttools5-dev libqt5charts5-dev libboost-container-dev
+    - name: Download Coverity build tool
+      run: |
+        wget -c -N https://scan.coverity.com/download/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=cppcheck" -O coverity_tool.tar.gz
+        mkdir coverity_tool
+        tar xzf coverity_tool.tar.gz --strip 1 -C coverity_tool
+    - name: Build with Coverity build tool
+      run: |
+        export PATH=`pwd`/coverity_tool/bin:$PATH
+        cov-build --dir cov-int make 
+    - name: Submit build result to Coverity Scan
+      run: |
+        tar czvf cov.tar.gz cov-int
+        curl --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+          --form email=daniel.marjamaki@gmail.com \
+          --form file=@cov.tar.gz \
+          --form version="Commit $GITHUB_SHA" \
+          --form description="Development" \
+          https://scan.coverity.com/builds?project=cppcheck


### PR DESCRIPTION
this  requires adding a variable `COVERITY_SCAN_TOKEN` to [settings](https://github.com/danmar/cppcheck/settings/secrets/actions/new)

also, I'd suggest issue new token since current one (or is it fake ?) exposed in   https://github.com/danmar/cppcheck/blob/eed9c4d0b4c1e9f08ea2a20e57758fd290ddbe3b/tools/run-coverity.sh#L15