### PR TITLE
fixated all usages of `hendrikmuhs/ccache-action` to `v1.2.11` for now

### DIFF
--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -43,7 +43,7 @@ jobs:
             mingw-w64-x86_64-ccache
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -272,7 +272,7 @@ jobs:
           brew link qt@5 --force
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -462,7 +462,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install libboost-container-dev
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1.2.11
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 


### PR DESCRIPTION
As the work on https://github.com/hendrikmuhs/ccache-action/issues/178 and https://github.com/hendrikmuhs/ccache-action/issues/179 has stalled roll back all usages to the previous version for now. This prevents the steps from running into a 2 minutes timeout.