### PR TITLE
Additional fix for #12298: Rule 9.3: Allow only { 0 } form of initializer

### DIFF
--- a/addons/misra_9.py
+++ b/addons/misra_9.py
@@ -311,7 +311,7 @@ class InitializerParser:
                 if self.ed and self.ed.isValue:
                     if not isDesignated and len(self.rootStack) > 0 and self.rootStack[-1][1] == self.root:
                         self.rootStack[-1][0].markStuctureViolation(self.token)
-                    if isFirstElement and self.token.isInt and self.token.getKnownIntValue() == 0 and self.token.next.str == '}':
+                    if isFirstElement and self.token.str == '0' and self.token.next.str == '}':
                         # Zero initializer causes recursive initialization
                         self.root.initializeChildren()
                     elif self.token.isString and self.ed.valueType and self.ed.valueType.pointer > 0:

--- a/addons/test/misra/misra-test.c
+++ b/addons/test/misra/misra-test.c
@@ -441,7 +441,10 @@ static void misra_9_empty_or_zero_initializers(void) {
     int e[2][2] = { { 1 , 2 }, {} };           // 9.2
 
     int f[5]    = { 0 };
-    int f1[5]   = { 0u };                     // no-warning  #11298
+    int f1[5]   = { 0u };                     // 9.3
+    unsigned int f1[ 3 ][ 2 ] = { 0U };       // 9.3 9.2
+    unsigned int f2[ 3 ] = { 0U };            // 9.3
+    float f3[ 3 ][ 2 ]  = { 0.0F };           // 9.3 9.2
     int g[5][2] = { 0 };
     int h[2][2] = { { 0 } };                   // 9.3
     int i[2][2] = { { 0 }, { 0 } };


### PR DESCRIPTION
Revert changes made for [#12298](https://trac.cppcheck.net/ticket/12298)