### PR TITLE
Fix error when loading both gnu.cfg and bsd.cfg

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -245,8 +245,6 @@
       <not-null/>
     </arg>
   </function>
-  <!-- int timercmp(struct timeval *a, struct timeval *b, CMP)-->
-  <define name="timercmp(a,b,CMP)" value="(((a)-&gt;tv_sec == (b)-&gt;tv_sec) ? ((a)-&gt;tv_usec CMP (b)-&gt;tv_usec) : ((a)-&gt;tv_sec CMP (b)-&gt;tv_sec))"/>
   <!-- int __builtin_types_compatible_p (type1, type2) -->
   <function name="__builtin_types_compatible_p">
     <noreturn>false</noreturn>

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -183,38 +183,6 @@ int uninitvar_getpw(uid_t uid, char *buf)
     return getpw(someUid, buf);
 }
 
-// #9323, #9331
-void syntaxError_timercmp(struct timeval t)
-{
-    (void)timercmp(&t, &t, <);
-    (void)timercmp(&t, &t, <=);
-    (void)timercmp(&t, &t, ==);
-    (void)timercmp(&t, &t, !=);
-    (void)timercmp(&t, &t, >=);
-    (void)timercmp(&t, &t, >);
-}
-
-// False negative: #9346
-void uninitvar_timercmp(struct timeval t)
-{
-    struct timeval uninit;
-    (void)timercmp(&t, &uninit, <);
-    (void)timercmp(&uninit, &t, <=);
-    (void)timercmp(&uninit, &uninit, ==);
-}
-
-void nullPointer_timercmp(struct timeval t)
-{
-    // cppcheck-suppress constVariablePointer
-    struct timeval *p=0;
-    // cppcheck-suppress nullPointer
-    (void)timercmp(&t, p, <);
-    // cppcheck-suppress nullPointer
-    (void)timercmp(p, &t, <=);
-    // cppcheck-suppress nullPointer
-    (void)timercmp(p, p, ==);
-}
-
 // Declaration necessary because there is no specific / portable header.
 extern void *xcalloc(size_t nmemb, size_t size);
 extern void *xmalloc(size_t size);

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -70,6 +70,7 @@ private:
         TEST_CASE(container);
         TEST_CASE(version);
         TEST_CASE(loadLibErrors);
+        TEST_CASE(loadLibCombinations);
     }
 
     static bool loadxmldata(Library &lib, const char xmldata[], std::size_t len)
@@ -1064,6 +1065,13 @@ private:
 
         // comma followed by dot
         LOADLIB_ERROR_INVALID_RANGE("-10:0,.5:");
+    }
+
+    void loadLibCombinations() const {
+        {
+            const Settings s = settingsBuilder().library("std.cfg").library("gnu.cfg").library("bsd.cfg").build();
+            ASSERT_EQUALS(s.library.defines.empty(), false);
+        }
     }
 };
 


### PR DESCRIPTION
I'm not sure all libraries must work together (some legitimate clashes are to be expected), but we could test some likely combinations.