### PR TITLE
avoid some unnecessary copies

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -93,8 +93,8 @@ static bool addIncludePathsToList(const std::string& fileList, std::list<std::st
         // cppcheck-suppress accessMoved - FP
         while (std::getline(files, pathName)) { // next line
             if (!pathName.empty()) {
-                pathName = Path::removeQuotationMarks(pathName);
-                pathName = Path::fromNativeSeparators(pathName);
+                pathName = Path::removeQuotationMarks(std::move(pathName));
+                pathName = Path::fromNativeSeparators(std::move(pathName));
 
                 // If path doesn't end with / or \, add it
                 if (!endsWith(pathName, '/'))
@@ -433,8 +433,8 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                 else {
                     path = 2 + argv[i];
                 }
-                path = Path::removeQuotationMarks(path);
-                path = Path::fromNativeSeparators(path);
+                path = Path::removeQuotationMarks(std::move(path));
+                path = Path::fromNativeSeparators(std::move(path));
 
                 // If path doesn't end with / or \, add it
                 if (!endsWith(path,'/'))
@@ -676,9 +676,9 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                 }
 
                 if (!path.empty()) {
-                    path = Path::removeQuotationMarks(path);
-                    path = Path::fromNativeSeparators(path);
-                    path = Path::simplifyPath(path);
+                    path = Path::removeQuotationMarks(std::move(path));
+                    path = Path::fromNativeSeparators(std::move(path));
+                    path = Path::simplifyPath(std::move(path));
 
                     if (Path::isDirectory(path)) {
                         // If directory name doesn't end with / or \, add it

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -1282,7 +1282,7 @@ void MainWindow::reAnalyzeSelected(const QStringList& files)
     QDateTime saveCheckStartTime = mThread->getCheckStartTime();
     mThread->check(checkSettings);
     mUI->mResults->setCheckSettings(checkSettings);
-    mThread->setCheckStartTime(saveCheckStartTime);
+    mThread->setCheckStartTime(std::move(saveCheckStartTime));
 }
 
 void MainWindow::reAnalyze(bool all)

--- a/gui/projectfiledialog.cpp
+++ b/gui/projectfiledialog.cpp
@@ -485,7 +485,7 @@ void ProjectFileDialog::saveToProjectFile(ProjectFile *projectFile) const
         codingStandards << CODING_STANDARD_MISRA_CPP_2008;
     if (mUI->mAutosar->isChecked())
         codingStandards << CODING_STANDARD_AUTOSAR;
-    projectFile->setCodingStandards(codingStandards);
+    projectFile->setCodingStandards(std::move(codingStandards));
     projectFile->setCertIntPrecision(mUI->mEditCertIntPrecision->text().toInt());
     projectFile->setBughunting(mUI->mBughunting->isChecked());
     projectFile->setClangAnalyzer(mUI->mToolClangAnalyzer->isChecked());

--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -972,7 +972,7 @@ void ResultsTree::recheckSelectedFiles()
                 selectedItems<<fileNameWithCheckPath;
         }
     }
-    emit checkSelected(selectedItems);
+    emit checkSelected(std::move(selectedItems));
 }
 
 void ResultsTree::hideAllIdResult()

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -3225,7 +3225,7 @@ bool isCPPCast(const Token* tok)
     return tok && Token::simpleMatch(tok->previous(), "> (") && tok->astOperand2() && tok->astOperand1() && isCPPCastKeyword(tok->astOperand1());
 }
 
-bool isConstVarExpression(const Token *tok, std::function<bool(const Token*)> skipPredicate)
+bool isConstVarExpression(const Token *tok, const std::function<bool(const Token*)>& skipPredicate)
 {
     if (!tok)
         return false;
@@ -3255,7 +3255,7 @@ bool isConstVarExpression(const Token *tok, std::function<bool(const Token*)> sk
     if (Token::Match(tok, "%cop%|[|.")) {
         if (tok->astOperand1() && !isConstVarExpression(tok->astOperand1(), skipPredicate))
             return false;
-        if (tok->astOperand2() && !isConstVarExpression(tok->astOperand2(), std::move(skipPredicate)))
+        if (tok->astOperand2() && !isConstVarExpression(tok->astOperand2(), skipPredicate))
             return false;
         return true;
     }

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -437,7 +437,7 @@ bool isLikelyStreamRead(bool cpp, const Token *op);
 
 bool isCPPCast(const Token* tok);
 
-bool isConstVarExpression(const Token* tok, std::function<bool(const Token*)> skipPredicate = nullptr);
+bool isConstVarExpression(const Token* tok, const std::function<bool(const Token*)>& skipPredicate = nullptr);
 
 bool isLeafDot(const Token* tok);
 

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -388,7 +388,7 @@ static std::string arrayIndexMessage(const Token* tok,
     auto add_dim = [](const std::string &s, const Dimension &dim) {
         return s + "[" + std::to_string(dim.num) + "]";
     };
-    const std::string array = std::accumulate(dimensions.cbegin(), dimensions.cend(), tok->astOperand1()->expressionString(), add_dim);
+    const std::string array = std::accumulate(dimensions.cbegin(), dimensions.cend(), tok->astOperand1()->expressionString(), std::move(add_dim));
 
     std::ostringstream errmsg;
     if (condition)

--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -116,7 +116,7 @@ namespace {
         }
 
         template<class T, class F, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-        Progress traverseTok(T* tok, F f, bool traverseUnknown, T** out = nullptr) {
+        Progress traverseTok(T* tok, const F &f, bool traverseUnknown, T** out = nullptr) {
             if (Token::Match(tok, "asm|goto"))
                 return Break(Analyzer::Terminate::Bail);
             if (Token::Match(tok, "setjmp|longjmp (")) {
@@ -166,7 +166,7 @@ namespace {
         }
 
         template<class T, class F, REQUIRES("T must be a Token class", std::is_convertible<T*, const Token*> )>
-        Progress traverseRecursive(T* tok, F f, bool traverseUnknown, unsigned int recursion=0) {
+        Progress traverseRecursive(T* tok, const F &f, bool traverseUnknown, unsigned int recursion=0) {
             if (!tok)
                 return Progress::Continue;
             if (recursion > 10000)

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -137,7 +137,7 @@ static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std:
     }
     if (s.find("$(") != std::string::npos)
         return false;
-    s = Path::simplifyPath(Path::fromNativeSeparators(s));
+    s = Path::simplifyPath(Path::fromNativeSeparators(std::move(s)));
     return true;
 }
 

--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -87,7 +87,7 @@ PathAnalysis::Progress PathAnalysis::forwardRange(const Token* startToken, const
         if (Token::Match(tok, "asm|goto|break|continue"))
             return Progress::Break;
         if (Token::Match(tok, "return|throw")) {
-            forwardRecursive(tok, info, f);
+            forwardRecursive(tok, std::move(info), f);
             return Progress::Break;
             // Evaluate RHS of assignment before LHS
         }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -6469,7 +6469,7 @@ static const Token* parsedecl(const Token* type,
                               bool isCpp,
                               SourceLocation loc = SourceLocation::current());
 
-void SymbolDatabase::setValueType(Token* tok, const Variable& var, SourceLocation loc)
+void SymbolDatabase::setValueType(Token* tok, const Variable& var, const SourceLocation &loc)
 {
     ValueType valuetype;
     if (mSettings.debugnormal || mSettings.debugwarnings)
@@ -6502,7 +6502,7 @@ void SymbolDatabase::setValueType(Token* tok, const Variable& var, SourceLocatio
 
 static ValueType::Type getEnumType(const Scope* scope, const Platform& platform);
 
-void SymbolDatabase::setValueType(Token* tok, const Enumerator& enumerator, SourceLocation loc)
+void SymbolDatabase::setValueType(Token* tok, const Enumerator& enumerator, const SourceLocation &loc)
 {
     ValueType valuetype;
     if (mSettings.debugnormal || mSettings.debugwarnings)
@@ -6551,7 +6551,7 @@ static bool isContainerYieldPointer(Library::Container::Yield yield)
     return yield == Library::Container::Yield::BUFFER || yield == Library::Container::Yield::BUFFER_NT;
 }
 
-void SymbolDatabase::setValueType(Token* tok, const ValueType& valuetype, SourceLocation loc)
+void SymbolDatabase::setValueType(Token* tok, const ValueType& valuetype, const SourceLocation &loc)
 {
     auto* valuetypePtr = new ValueType(valuetype);
     if (mSettings.debugnormal || mSettings.debugwarnings)
@@ -8138,7 +8138,7 @@ std::string ValueType::str() const
     return ret.substr(1);
 }
 
-void ValueType::setDebugPath(const Token* tok, SourceLocation ctx, SourceLocation local)
+void ValueType::setDebugPath(const Token* tok, SourceLocation ctx, const SourceLocation &local)
 {
     std::string file = ctx.file_name();
     if (file.empty())

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -1312,7 +1312,7 @@ public:
     std::string str() const;
     std::string dump() const;
 
-    void setDebugPath(const Token* tok, SourceLocation ctx, SourceLocation local = SourceLocation::current());
+    void setDebugPath(const Token* tok, SourceLocation ctx, const SourceLocation &local = SourceLocation::current());
 };
 
 
@@ -1463,9 +1463,9 @@ private:
 
     const Enumerator * findEnumerator(const Token * tok, std::set<std::string>& tokensThatAreNotEnumeratorValues) const;
 
-    void setValueType(Token* tok, const ValueType& valuetype, SourceLocation loc = SourceLocation::current());
-    void setValueType(Token* tok, const Variable& var, SourceLocation loc = SourceLocation::current());
-    void setValueType(Token* tok, const Enumerator& enumerator, SourceLocation loc = SourceLocation::current());
+    void setValueType(Token* tok, const ValueType& valuetype, const SourceLocation &loc = SourceLocation::current());
+    void setValueType(Token* tok, const Variable& var, const SourceLocation &loc = SourceLocation::current());
+    void setValueType(Token* tok, const Enumerator& enumerator, const SourceLocation &loc = SourceLocation::current());
 
     Tokenizer& mTokenizer;
     const Settings &mSettings;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -771,7 +771,7 @@ static void setTokenValue(Token* tok,
     }
 
     else if (parent->str() == ":") {
-        setTokenValue(parent,value,settings);
+        setTokenValue(parent,std::move(value),settings);
     }
 
     else if (parent->str() == "?" && tok->str() == ":" && tok == parent->astOperand2() && parent->astOperand1()) {
@@ -807,7 +807,7 @@ static void setTokenValue(Token* tok,
             if (ret)
                 return;
 
-            ValueFlow::Value v(value);
+            ValueFlow::Value v(std::move(value));
             v.conditional = true;
             v.changeKnownToPossible();
 
@@ -1053,7 +1053,7 @@ static void setTokenValue(Token* tok,
     }
 
     else if (Token::Match(parent, ":: %name%") && parent->astOperand2() == tok) {
-        setTokenValue(parent, value, settings);
+        setTokenValue(parent, std::move(value), settings);
     }
     // Calling std::size or std::empty on an array
     else if (value.isTokValue() && Token::simpleMatch(value.tokvalue, "{") && tok->variable() &&
@@ -1061,12 +1061,12 @@ static void setTokenValue(Token* tok,
         std::vector<const Token*> args = getArguments(value.tokvalue);
         if (const Library::Function* f = settings.library.getFunction(parent->previous())) {
             if (f->containerYield == Library::Container::Yield::SIZE) {
-                ValueFlow::Value v(value);
+                ValueFlow::Value v(std::move(value));
                 v.valueType = ValueFlow::Value::ValueType::INT;
                 v.intvalue = args.size();
                 setTokenValue(parent, std::move(v), settings);
             } else if (f->containerYield == Library::Container::Yield::EMPTY) {
-                ValueFlow::Value v(value);
+                ValueFlow::Value v(std::move(value));
                 v.intvalue = args.empty();
                 v.valueType = ValueFlow::Value::ValueType::INT;
                 setTokenValue(parent, std::move(v), settings);
@@ -4009,7 +4009,7 @@ static void valueFlowForwardLifetime(Token * tok, TokenList &tokenlist, ErrorLog
                 const Token* parentLifetime =
                     getParentLifetime(tokenlist.isCPP(), parent->astOperand1()->astOperand2(), &settings.library);
                 if (parentLifetime && parentLifetime->exprId() > 0) {
-                    valueFlowForward(nextExpression, endOfVarScope, parentLifetime, values, tokenlist, errorLogger, settings);
+                    valueFlowForward(nextExpression, endOfVarScope, parentLifetime, std::move(values), tokenlist, errorLogger, settings);
                 }
             }
         }

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -115,7 +115,7 @@ private:
 
     void ErrorMessageConstruct() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.", "errorId", Certainty::normal);
         ASSERT_EQUALS(1, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Programming error.", msg.verboseMessage());
@@ -125,7 +125,7 @@ private:
 
     void ErrorMessageConstructLocations() const {
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.", "errorId", Certainty::normal);
         ASSERT_EQUALS(2, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Programming error.", msg.verboseMessage());
@@ -135,7 +135,7 @@ private:
 
     void ErrorMessageVerbose() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         ASSERT_EQUALS(1, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
@@ -145,7 +145,7 @@ private:
 
     void ErrorMessageVerboseLocations() const {
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         ASSERT_EQUALS(2, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
@@ -185,7 +185,7 @@ private:
 
     void CustomFormat() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         ASSERT_EQUALS(1, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
@@ -195,7 +195,7 @@ private:
 
     void CustomFormat2() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         ASSERT_EQUALS(1, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
@@ -206,7 +206,7 @@ private:
     void CustomFormatLocations() const {
         // Check that first location from location stack is used in template
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         ASSERT_EQUALS(2, msg.callStack.size());
         ASSERT_EQUALS("Programming error.", msg.shortMessage());
         ASSERT_EQUALS("Verbose error", msg.verboseMessage());
@@ -216,7 +216,7 @@ private:
 
     void ToXmlV2() const {
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         std::string header("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<results version=\"2\">\n");
         header += "    <cppcheck version=\"";
         header += CppCheck::version();
@@ -232,7 +232,7 @@ private:
     void ToXmlV2Locations() const {
         std::list<ErrorMessage::FileLocation> locs = { fooCpp5, barCpp8 };
         locs.back().setinfo("ä");
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nVerbose error", "errorId", Certainty::normal);
         std::string header("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<results version=\"2\">\n");
         header += "    <cppcheck version=\"";
         header += CppCheck::version();
@@ -249,17 +249,16 @@ private:
     void ToXmlV2Encoding() const {
         {
             std::list<ErrorMessage::FileLocation> locs;
-            ErrorMessage msg(locs, emptyString, Severity::error, "Programming error.\nComparing \"\203\" with \"\003\"", "errorId", Certainty::normal);
+            ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error.\nComparing \"\203\" with \"\003\"", "errorId", Certainty::normal);
             const std::string expected("        <error id=\"errorId\" severity=\"error\" msg=\"Programming error.\" verbose=\"Comparing &quot;\\203&quot; with &quot;\\003&quot;\"/>");
             ASSERT_EQUALS(expected, msg.toXML());
         }
         {
             const char code1[]="äöü";
             const char code2[]="\x12\x00\x00\x01";
-            std::list<ErrorMessage::FileLocation> locs;
-            ErrorMessage msg1(locs, emptyString, Severity::error, std::string("Programming error.\nReading \"")+code1+"\"", "errorId", Certainty::normal);
+            ErrorMessage msg1({}, emptyString, Severity::error, std::string("Programming error.\nReading \"")+code1+"\"", "errorId", Certainty::normal);
             ASSERT_EQUALS("        <error id=\"errorId\" severity=\"error\" msg=\"Programming error.\" verbose=\"Reading &quot;\\303\\244\\303\\266\\303\\274&quot;\"/>", msg1.toXML());
-            ErrorMessage msg2(locs, emptyString, Severity::error, std::string("Programming error.\nReading \"")+code2+"\"", "errorId", Certainty::normal);
+            ErrorMessage msg2({}, emptyString, Severity::error, std::string("Programming error.\nReading \"")+code2+"\"", "errorId", Certainty::normal);
             ASSERT_EQUALS("        <error id=\"errorId\" severity=\"error\" msg=\"Programming error.\" verbose=\"Reading &quot;\\022&quot;\"/>", msg2.toXML());
         }
     }
@@ -301,7 +300,7 @@ private:
         std::list<ErrorMessage::FileLocation> locs(1, fooCpp5);
 
         // Inconclusive error message
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
 
         // xml version 2 error message
         ASSERT_EQUALS("        <error id=\"errorId\" severity=\"error\" msg=\"Programming error\" verbose=\"Programming error\" inconclusive=\"true\">\n"
@@ -313,7 +312,7 @@ private:
     void SerializeInconclusiveMessage() const {
         // Inconclusive error message
         std::list<ErrorMessage::FileLocation> locs;
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
         msg.file0 = "test.cpp";
 
         const std::string msg_str = msg.serialize();
@@ -402,7 +401,7 @@ private:
 
     void SerializeSanitize() const {
         std::list<ErrorMessage::FileLocation> locs;
-        ErrorMessage msg(locs, emptyString, Severity::error, std::string("Illegal character in \"foo\001bar\""), "errorId", Certainty::normal);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, std::string("Illegal character in \"foo\001bar\""), "errorId", Certainty::normal);
         msg.file0 = "1.c";
 
         const std::string msg_str = msg.serialize();
@@ -429,9 +428,9 @@ private:
         loc1.setfile("[]:;,()");
         loc1.setinfo("abcd:/,");
 
-        std::list<ErrorMessage::FileLocation> locs{loc1};
+        std::list<ErrorMessage::FileLocation> locs{std::move(loc1)};
 
-        ErrorMessage msg(locs, emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
+        ErrorMessage msg(std::move(locs), emptyString, Severity::error, "Programming error", "errorId", Certainty::inconclusive);
 
         const std::string msg_str = msg.serialize();
         ASSERT_EQUALS("7 errorId"

--- a/test/testfilelister.cpp
+++ b/test/testfilelister.cpp
@@ -60,7 +60,7 @@ private:
         // Recursively add add files..
         std::list<std::pair<std::string, std::size_t>> files;
         std::vector<std::string> masks;
-        PathMatch matcher(masks);
+        PathMatch matcher(std::move(masks));
         std::string err = FileLister::recursiveAddFiles(files, adddir, matcher);
         ASSERT_EQUALS("", err);
 

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -374,7 +374,7 @@ private:
         fs1.filename = "foo/bar";
         fs2.filename = "qwe/rty";
         TestImporter project;
-        project.fileSettings = {fs1, fs2};
+        project.fileSettings = {std::move(fs1), std::move(fs2)};
 
         project.ignorePaths({"*foo", "bar*"});
         ASSERT_EQUALS(2, project.fileSettings.size());

--- a/test/testpathmatch.cpp
+++ b/test/testpathmatch.cpp
@@ -92,7 +92,7 @@ private:
 
     void onemasksamepathdifferentcase() const {
         std::vector<std::string> masks(1, "sRc/");
-        PathMatch match(masks, false);
+        PathMatch match(std::move(masks), false);
         ASSERT(match.match("srC/"));
     }
 
@@ -139,25 +139,25 @@ private:
 
     void twomasklongerpath1() const {
         std::vector<std::string> masks = { "src/", "module/" };
-        PathMatch match(masks);
+        PathMatch match(std::move(masks));
         ASSERT(!match.match("project/"));
     }
 
     void twomasklongerpath2() const {
         std::vector<std::string> masks = { "src/", "module/" };
-        PathMatch match(masks);
+        PathMatch match(std::move(masks));
         ASSERT(match.match("project/src/"));
     }
 
     void twomasklongerpath3() const {
         std::vector<std::string> masks = { "src/", "module/" };
-        PathMatch match(masks);
+        PathMatch match(std::move(masks));
         ASSERT(match.match("project/module/"));
     }
 
     void twomasklongerpath4() const {
         std::vector<std::string> masks = { "src/", "module/" };
-        PathMatch match(masks);
+        PathMatch match(std::move(masks));
         ASSERT(match.match("project/src/module/"));
     }
 
@@ -168,7 +168,7 @@ private:
 
     void filemaskdifferentcase() const {
         std::vector<std::string> masks(1, "foo.cPp");
-        PathMatch match(masks, false);
+        PathMatch match(std::move(masks), false);
         ASSERT(match.match("fOo.cpp"));
     }
 


### PR DESCRIPTION
this is mainly based on the warnings of the unfinished `performance-unnecessary-copy-on-last-use` clang-tidy check (see https://github.com/llvm/llvm-project/issues/53489). it also includes some fixes spotted by review as well as some adjustments to the previous Coverity fixes