### PR TITLE
Add BUILD_TESTS Flag to Readme for CMake [skip ci]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,9 @@ For rules support (requires pcre) use the flag.
 For release builds it is recommended that you use:
 -DUSE_MATCHCOMPILER=ON
 
+For building the tests use the flag.
+-DBUILD_TESTS=ON
+
 Using cmake you can generate project files for Visual Studio,XCode,etc.
 
 #### Building a specific configuration


### PR DESCRIPTION
See title as i was developing on Linux didn't found the option for building the test binary. With some feedback and examination of the Actions i found that the BUILD_TESTS flag should be enabled. Added that to Readme. 