### PR TITLE
Fix #12431 (Style warnings are reported when only --enable=warning is used)

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2891,6 +2891,9 @@ void CheckClass::virtualFunctionCallInConstructorError(
     const std::list<const Token *> & tokStack,
     const std::string &funcname)
 {
+    if (scopeFunction && !mSettings->severity.isEnabled(Severity::style) && !mSettings->isPremiumEnabled("virtualCallInConstructor"))
+        return;
+
     const char * scopeFunctionTypeName = scopeFunction ? getFunctionTypeName(scopeFunction->type) : "constructor";
 
     ErrorPath errorPath;

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2403,17 +2403,17 @@ namespace {
 void CheckOther::checkDuplicateExpression()
 {
     {
-    const bool styleEnabled = mSettings->severity.isEnabled(Severity::style);
-    const bool premiumEnabled = mSettings->isPremiumEnabled("oppositeExpression") ||
-                                mSettings->isPremiumEnabled("duplicateExpression") ||
-                                mSettings->isPremiumEnabled("duplicateAssignExpression") ||
-                                mSettings->isPremiumEnabled("duplicateExpressionTernary") ||
-                                mSettings->isPremiumEnabled("duplicateValueTernary") ||
-                                mSettings->isPremiumEnabled("selfAssignment") ||
-                                mSettings->isPremiumEnabled("knownConditionTrueFalse");
+        const bool styleEnabled = mSettings->severity.isEnabled(Severity::style);
+        const bool premiumEnabled = mSettings->isPremiumEnabled("oppositeExpression") ||
+                                    mSettings->isPremiumEnabled("duplicateExpression") ||
+                                    mSettings->isPremiumEnabled("duplicateAssignExpression") ||
+                                    mSettings->isPremiumEnabled("duplicateExpressionTernary") ||
+                                    mSettings->isPremiumEnabled("duplicateValueTernary") ||
+                                    mSettings->isPremiumEnabled("selfAssignment") ||
+                                    mSettings->isPremiumEnabled("knownConditionTrueFalse");
 
-    if (!styleEnabled && !premiumEnabled)
-        return;
+        if (!styleEnabled && !premiumEnabled)
+            return;
     }
 
     logChecker("CheckOther::checkDuplicateExpression"); // style,warning

--- a/test/testclass.cpp
+++ b/test/testclass.cpp
@@ -8027,7 +8027,7 @@ private:
         errout.str("");
 
         // Check..
-        const Settings settings = settingsBuilder().severity(Severity::warning).certainty(Certainty::inconclusive, inconclusive).build();
+        const Settings settings = settingsBuilder().severity(Severity::warning).severity(Severity::style).certainty(Certainty::inconclusive, inconclusive).build();
 
         Preprocessor preprocessor(settings);
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -5467,26 +5467,26 @@ private:
               "    x = x;\n"
               "    return 0;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4]: (warning) Redundant assignment of 'x' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Redundant assignment of 'x' to itself.\n", errout.str());
 
         check("void foo()\n"
               "{\n"
               "    int x = x;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (warning) Redundant assignment of 'x' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Redundant assignment of 'x' to itself.\n", errout.str());
 
         check("struct A { int b; };\n"
               "void foo(A* a1, A* a2) {\n"
               "    a1->b = a1->b;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (warning) Redundant assignment of 'a1->b' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Redundant assignment of 'a1->b' to itself.\n", errout.str());
 
         check("int x;\n"
               "void f()\n"
               "{\n"
               "    x = x = 3;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4]: (warning) Redundant assignment of 'x' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Redundant assignment of 'x' to itself.\n", errout.str());
 
         // #4073 (segmentation fault)
         check("void Foo::myFunc( int a )\n"
@@ -5514,7 +5514,7 @@ private:
               "    BAR *x = getx();\n"
               "    x = x;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (warning) Redundant assignment of 'x' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Redundant assignment of 'x' to itself.\n", errout.str());
 
         // #2502 - non-primitive type -> there might be some side effects
         check("void foo()\n"
@@ -5546,7 +5546,7 @@ private:
               "void f() {\n"
               "    i = i;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:3]: (warning) Redundant assignment of 'i' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3]: (style) Redundant assignment of 'i' to itself.\n", errout.str());
 
         // #4291 - id for variables accessed through 'this'
         check("class Foo {\n"
@@ -5556,7 +5556,7 @@ private:
               "void Foo::func() {\n"
               "    this->var = var;\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:6]: (warning) Redundant assignment of 'this->var' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:6]: (style) Redundant assignment of 'this->var' to itself.\n", errout.str());
 
         check("class Foo {\n"
               "    int var;\n"
@@ -5575,7 +5575,7 @@ private:
               "void f() {\n"
               "    struct callbacks ops = { .s = ops.s };\n"
               "}");
-        TODO_ASSERT_EQUALS("[test.cpp:6]: (warning) Redundant assignment of 'something' to itself.\n", "", errout.str());
+        TODO_ASSERT_EQUALS("[test.cpp:6]: (style) Redundant assignment of 'something' to itself.\n", "", errout.str());
 
         check("class V\n"
               "{\n"
@@ -5590,9 +5590,9 @@ private:
               "    }\n"
               "    double x, y, z;\n"
               "};");
-        ASSERT_EQUALS("[test.cpp:10]: (warning) Redundant assignment of 'x' to itself.\n"
-                      "[test.cpp:10]: (warning) Redundant assignment of 'y' to itself.\n"
-                      "[test.cpp:10]: (warning) Redundant assignment of 'z' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:10]: (style) Redundant assignment of 'x' to itself.\n"
+                      "[test.cpp:10]: (style) Redundant assignment of 'y' to itself.\n"
+                      "[test.cpp:10]: (style) Redundant assignment of 'z' to itself.\n", errout.str());
 
         check("void f(int i) { i = !!i; }");
         ASSERT_EQUALS("", errout.str());
@@ -5602,7 +5602,7 @@ private:
               "    int &ref = x;\n"
               "    ref = x;\n"
               "}\n");
-        ASSERT_EQUALS("[test.cpp:4]: (warning) Redundant assignment of 'ref' to itself.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:4]: (style) Redundant assignment of 'ref' to itself.\n", errout.str());
 
         check("class Foo {\n" // #9850
               "    int i{};\n"
@@ -7057,7 +7057,7 @@ private:
               "        int var = buffer[index - 1];\n"
               "        return buffer[index - 1] - var;\n"  // <<
               "}");
-        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (style) Same expression on both sides of '-'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (style) Same expression on both sides of '-' because 'buffer[index-1]' and 'var' represent the same value.\n", errout.str());
     }
 
     void duplicateExpression13() { //#7899
@@ -10750,8 +10750,8 @@ private:
               "  int x = x = y + 1;\n"
               "}", "test.c");
         ASSERT_EQUALS(
-            "[test.c:2]: (warning) Redundant assignment of 'x' to itself.\n"
-            "[test.c:2]: (warning) Redundant assignment of 'x' to itself.\n",   // duplicate
+            "[test.c:2]: (style) Redundant assignment of 'x' to itself.\n"
+            "[test.c:2]: (style) Redundant assignment of 'x' to itself.\n",   // duplicate
             errout.str());
     }
 


### PR DESCRIPTION
work in progress...
* change selfAssignment from warning to style => it's not about undefined behavior
* don't claim that code such as `a = b|c;`  is a condition.