### PR TITLE
Fix #12406 FP containerOutOfBounds with reassigned vector

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2991,6 +2991,8 @@ struct ValueFlowAnalyzer : Analyzer {
             });
             if (value)
                 return {value->intvalue == 0};
+            if (!match(tok))
+                return {};
             ProgramMemory pm = pms.get(tok, ctx, getProgramState());
             MathLib::bigint out = 0;
             if (pm.getContainerEmptyValue(tok->exprId(), out))

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -588,7 +588,7 @@ private:
                     "}\n");
         TODO_ASSERT_EQUALS("test.cpp:7:style:Consider using std::any_of algorithm instead of a raw loop.\n",
                            "test.cpp:8:error:Out of bounds access in expression 'v[i]' because 'v' is empty.\n"
-                           "test.cpp:7 : style : Consider using std::any_of algorithm instead of a raw loop.\n",
+                           "test.cpp:7:style:Consider using std::any_of algorithm instead of a raw loop.\n",
                            errout.str());
 
         checkNormal("bool g();\n"

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -586,7 +586,10 @@ private:
                     "      return true;\n"
                     "  return false;\n"
                     "}\n");
-        ASSERT_EQUALS("test.cpp:7:style:Consider using std::any_of algorithm instead of a raw loop.\n", errout.str());
+        TODO_ASSERT_EQUALS("test.cpp:7:style:Consider using std::any_of algorithm instead of a raw loop.\n",
+                           "test.cpp:8:error:Out of bounds access in expression 'v[i]' because 'v' is empty.\n"
+                           "test.cpp:7 : style : Consider using std::any_of algorithm instead of a raw loop.\n",
+                           errout.str());
 
         checkNormal("bool g();\n"
                     "int f(int x) {\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -6857,16 +6857,16 @@ private:
         ASSERT_EQUALS(false, testValueOfXKnown(code, 9U, 1));
 
         code = "int f(std::vector<int>& v) {\n"
-          "    std::vector<int> o = v;\n"
-          "    v.clear();\n"
-          "    for (int i : o) {\n"
-          "        if (i == 1) {\n"
-          "            v.push_back(0);\n"
-          "        }\n"
-          "    }\n"
-          "    auto x = v.empty();\n"
-          "    return x;\n"
-          "}\n";
+               "    std::vector<int> o = v;\n"
+               "    v.clear();\n"
+               "    for (int i : o) {\n"
+               "        if (i == 1) {\n"
+               "            v.push_back(0);\n"
+               "        }\n"
+               "    }\n"
+               "    auto x = v.empty();\n"
+               "    return x;\n"
+               "}\n";
         ASSERT_EQUALS(false, testValueOfXKnown(code, 10U, 1));
     }
 

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -6855,6 +6855,19 @@ private:
                "    return x;\n"
                "}\n";
         ASSERT_EQUALS(false, testValueOfXKnown(code, 9U, 1));
+
+        code = "int f(std::vector<int>& v) {\n"
+          "    std::vector<int> o = v;\n"
+          "    v.clear();\n"
+          "    for (int i : o) {\n"
+          "        if (i == 1) {\n"
+          "            v.push_back(0);\n"
+          "        }\n"
+          "    }\n"
+          "    auto x = v.empty();\n"
+          "    return x;\n"
+          "}\n";
+        ASSERT_EQUALS(false, testValueOfXKnown(code, 10U, 1));
     }
 
     void valueFlowContainerElement()


### PR DESCRIPTION
Maybe trading one FP for another can be avoided somehow.
Without the `assert`, we already have an FP (tracked in https://trac.cppcheck.net/ticket/10322).