### PR TITLE
Fix #12443 FP mismatchingContainers with container in namespace

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -690,6 +690,8 @@ static std::vector<const Token*> getAddressContainer(const Token* tok)
 {
     if (Token::simpleMatch(tok, "[") && tok->astOperand1())
         return { tok->astOperand1() };
+    while (Token::simpleMatch(tok, "::") && tok->astOperand2())
+        tok = tok->astOperand2();
     std::vector<ValueFlow::Value> values = ValueFlow::getLifetimeObjValues(tok, /*inconclusive*/ false);
     std::vector<const Token*> res;
     for (const auto& v : values) {

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -2204,6 +2204,16 @@ private:
               "    a.erase(*it);\n"
               "}\n");
         ASSERT_EQUALS("", errout.str());
+
+        check("namespace N {\n" // #12443
+              "    std::vector<int> v;\n"
+              "}\n"
+              "using namespace N;\n"
+              "void f() {\n"
+              "    auto it = std::find(v.begin(), v.end(), 0);\n"
+              "    if (it != N::v.end()) {}\n"
+              "}\n");
+        ASSERT_EQUALS("", errout.str());
     }
 
     void eraseIteratorOutOfBounds() {


### PR DESCRIPTION
Or should this be fixed elsewhere?
If `::` represents the container, `isSameExpression()` should handle that.
If `::` is not the container, then it shouldn't be set as `tokvalue`.