### PR TITLE
Addon: cppcheckdata.py Fix bug that token type was not a accacable from outside.

### DIFF
--- a/addons/cppcheckdata.py
+++ b/addons/cppcheckdata.py
@@ -336,6 +336,7 @@ class Token:
 
     typeScopeId = None
     typeScope = None
+    type = None
 
     astParentId = None
     astParent = None
@@ -355,27 +356,27 @@ class Token:
         self.previous = None
         self.scopeId = element.get('scope')
         self.scope = None
-        type = element.get('type')
-        if type == 'name':
+        self.type = element.get('type')
+        if self.type == 'name':
             self.isName = True
             if element.get('isUnsigned'):
                 self.isUnsigned = True
             if element.get('isSigned'):
                 self.isSigned = True
-        elif type == 'number':
+        elif self.type == 'number':
             self.isNumber = True
             if element.get('isInt'):
                 self.isInt = True
             elif element.get('isFloat'):
                 self.isFloat = True
-        elif type == 'string':
+        elif self.type == 'string':
             self.isString = True
             self.strlen = int(element.get('strlen'))
-        elif type == 'char':
+        elif self.type == 'char':
             self.isChar = True
-        elif type == 'boolean':
+        elif self.type == 'boolean':
             self.isBoolean = True
-        elif type == 'op':
+        elif self.type == 'op':
             self.isOp = True
             if element.get('isArithmeticalOp'):
                 self.isArithmeticalOp = True


### PR DESCRIPTION
The Token class documents that the type ("name/op/...") is accessible to the Addon which wasn't the case.

It was only read locally to set other variables.