### PR TITLE
bail out on invalid `MATCHCOMPILER` (make) and `USE_MATCHCOMPILER` (CMake) values / Makefile: removed deprecated `SRCDIR`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ ifeq ($(MATCHCOMPILER),yes)
         matchcompiler_S := $(shell $(PYTHON_INTERPRETER) tools/matchcompiler.py)
     endif
     libcppdir:=build
-else
+else ifeq ($(MATCHCOMPILER),)
     libcppdir:=lib
+else
+    $(error invalid MATCHCOMPILER value '$(MATCHCOMPILER)')
 endif
 
 ifndef CPPFLAGS

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ ifndef HAVE_RULES
     HAVE_RULES=no
 endif
 
-ifdef SRCDIR
-    $(error Usage of SRCDIR to activate match compiler has been removed. Use MATCHCOMPILER=yes instead.)
-endif
 ifndef MATCHCOMPILER
     MATCHCOMPILER=
 endif

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -22,7 +22,11 @@ option(WARNINGS_ARE_ERRORS  "Treat warnings as errors"                          
 option(EXTERNALS_AS_SYSTEM  "Treat externals as system includes"                            OFF)
 
 set(USE_MATCHCOMPILER "Auto" CACHE STRING "Usage of match compiler")
-set_property(CACHE USE_MATCHCOMPILER PROPERTY STRINGS Auto Off On Verify) 
+set(_MATCHCOMPILER_STRINGS Auto Off On Verify)
+set_property(CACHE USE_MATCHCOMPILER PROPERTY STRINGS ${_MATCHCOMPILER_STRINGS})
+if (NOT ${USE_MATCHCOMPILER} IN_LIST _MATCHCOMPILER_STRINGS)
+    message(FATAL_ERROR "Invalid USE_MATCHCOMPILER value '${USE_MATCHCOMPILER}'")
+endif()
 if (USE_MATCHCOMPILER STREQUAL "Auto")
     if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
         set(USE_MATCHCOMPILER_OPT "On")

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -22,3 +22,4 @@ Other:
 - Using Visual Studio with CMake now checks if the CMake version is at least 3.13. This was always required but was not checked explicitly.
 - Added '--template=simple'. It is expands to '{file}:{line}:{column}: {severity}:{inconclusive:inconclusive:} {message} [{id}]' without any additional location details.
 - Removed deprecated platform type 'Unspecified'. Please use 'unspecified' instead.
+- Removed deprecated 'Makefile' option 'SRCDIR'.

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -476,8 +476,10 @@ int main(int argc, char **argv)
          << "        matchcompiler_S := $(shell $(PYTHON_INTERPRETER) tools/matchcompiler.py)\n"
          << "    endif\n"
          << "    libcppdir:=build\n"
-         << "else\n"
+         << "else ifeq ($(MATCHCOMPILER),)\n"
          << "    libcppdir:=lib\n"
+         << "else\n"
+         << "    $(error invalid MATCHCOMPILER value '$(MATCHCOMPILER)')\n"
          << "endif\n\n";
 
     // avoid undefined variable

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -451,9 +451,6 @@ int main(int argc, char **argv)
     fout << "# To compile with rules, use 'make HAVE_RULES=yes'\n";
     makeConditionalVariable(fout, "HAVE_RULES", "no");
 
-    fout << "ifdef SRCDIR\n"
-         << "    $(error Usage of SRCDIR to activate match compiler has been removed. Use MATCHCOMPILER=yes instead.)\n"
-         << "endif\n";
     // avoid undefined variable
     fout << "ifndef MATCHCOMPILER\n"
          << "    MATCHCOMPILER=\n"


### PR DESCRIPTION
I accidentally specified `MATCHCOMPILER=1` and only later realized that the matchcompiler was not being used as it requires `yes` instead. So bail out on this.