### PR TITLE
Settings: made `loadCppcheckCfg()` static

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1688,7 +1688,7 @@ void CmdLineParser::printHelp() const
 
 bool CmdLineParser::isCppcheckPremium() const {
     if (mSettings.cppcheckCfgProductName.empty())
-        mSettings.loadCppcheckCfg();
+        Settings::loadCppcheckCfg(mSettings, mSettings.supprs);
     return startsWith(mSettings.cppcheckCfgProductName, "Cppcheck Premium");
 }
 
@@ -1784,7 +1784,7 @@ bool CmdLineParser::loadAddons(Settings& settings)
 
 bool CmdLineParser::loadCppcheckCfg()
 {
-    const std::string cfgErr = mSettings.loadCppcheckCfg();
+    const std::string cfgErr = Settings::loadCppcheckCfg(mSettings, mSuppressions);
     if (!cfgErr.empty()) {
         mLogger.printError("could not load cppcheck.cfg - " + cfgErr);
         return false;

--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -122,7 +122,7 @@ MainWindow::MainWindow(TranslationHandler* th, QSettings* settings) :
     {
         Settings tempSettings;
         tempSettings.exename = QCoreApplication::applicationFilePath().toStdString();
-        tempSettings.loadCppcheckCfg(); // TODO: how to handle error?
+        Settings::loadCppcheckCfg(tempSettings, tempSettings.supprs); // TODO: how to handle error?
         mCppcheckCfgProductName = QString::fromStdString(tempSettings.cppcheckCfgProductName);
         mCppcheckCfgAbout = QString::fromStdString(tempSettings.cppcheckCfgAbout);
     }
@@ -978,7 +978,7 @@ QPair<bool,Settings> MainWindow::getCppcheckSettings()
     const QString pythonCmd = fromNativePath(mSettings->value(SETTINGS_PYTHON_PATH).toString());
 
     {
-        const QString cfgErr = QString::fromStdString(result.loadCppcheckCfg());
+        const QString cfgErr = QString::fromStdString(Settings::loadCppcheckCfg(result, result.supprs));
         if (!cfgErr.isEmpty()) {
             QMessageBox::critical(this, tr("Error"), tr("Failed to load %1 - %2\n\nAnalysis is aborted.").arg("cppcheck.cfg").arg(cfgErr));
             return {false, {}};

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -41,8 +41,9 @@ Settings::Settings()
     setCheckLevelNormal();
 }
 
-std::string Settings::loadCppcheckCfg()
+std::string Settings::loadCppcheckCfg(Settings& settings, Suppressions& suppressions)
 {
+    // TODO: this always needs to be run *after* the Settings has been filled
     static const std::string cfgFilename = "cppcheck.cfg";
     std::string fileName;
 #ifdef FILESDIR
@@ -51,7 +52,8 @@ std::string Settings::loadCppcheckCfg()
 #endif
     // cppcheck-suppress knownConditionTrueFalse
     if (fileName.empty()) {
-        fileName = Path::getPathFromFilename(exename) + cfgFilename;
+        // TODO: make sure that exename is set
+        fileName = Path::getPathFromFilename(settings.exename) + cfgFilename;
         if (!Path::isFile(fileName))
             return "";
     }
@@ -73,7 +75,7 @@ std::string Settings::loadCppcheckCfg()
             const auto& v = it->second;
             if (!v.is<std::string>())
                 return "'productName' is not a string";
-            cppcheckCfgProductName = v.get<std::string>();
+            settings.cppcheckCfgProductName = v.get<std::string>();
         }
     }
     {
@@ -82,7 +84,7 @@ std::string Settings::loadCppcheckCfg()
             const auto& v = it->second;
             if (!v.is<std::string>())
                 return "'about' is not a string";
-            cppcheckCfgAbout = v.get<std::string>();
+            settings.cppcheckCfgAbout = v.get<std::string>();
         }
     }
     {
@@ -97,9 +99,9 @@ std::string Settings::loadCppcheckCfg()
                     return "'addons' array entry is not a string";
                 const std::string &s = v.get<std::string>();
                 if (!Path::isAbsolute(s))
-                    addons.emplace(Path::join(Path::getPathFromFilename(fileName), s));
+                    settings.addons.emplace(Path::join(Path::getPathFromFilename(fileName), s));
                 else
-                    addons.emplace(s);
+                    settings.addons.emplace(s);
             }
         }
     }
@@ -114,7 +116,7 @@ std::string Settings::loadCppcheckCfg()
                 if (!v.is<std::string>())
                     return "'suppressions' array entry is not a string";
                 const std::string &s = v.get<std::string>();
-                const std::string err = supprs.nomsg.addSuppressionLine(s);
+                const std::string err = suppressions.nomsg.addSuppressionLine(s);
                 if (!err.empty())
                     return "could not parse suppression '" + s + "' - " + err;
             }
@@ -126,7 +128,7 @@ std::string Settings::loadCppcheckCfg()
             const auto& v = it->second;
             if (!v.is<bool>())
                 return "'safety' is not a bool";
-            safety = safety || v.get<bool>();
+            settings.safety = settings.safety || v.get<bool>();
         }
     }
 

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -99,7 +99,7 @@ private:
 public:
     Settings();
 
-    std::string loadCppcheckCfg();
+    static std::string loadCppcheckCfg(Settings& settings, Suppressions& suppressions);
 
     static std::pair<std::string, std::string> getNameAndVersion(const std::string& productName);
 

--- a/test/testsettings.cpp
+++ b/test/testsettings.cpp
@@ -95,78 +95,78 @@ private:
     {
         {
             Settings s;
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             "{}\n");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             "{\n");
-            ASSERT_EQUALS("not a valid JSON - syntax error at line 2 near: ", s.loadCppcheckCfg());
+            ASSERT_EQUALS("not a valid JSON - syntax error at line 2 near: ", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"productName": ""}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS("", s.cppcheckCfgProductName);
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"productName": "product"}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS("product", s.cppcheckCfgProductName);
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"productName": 1}\n)");
-            ASSERT_EQUALS("'productName' is not a string", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'productName' is not a string", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"about": ""}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS("", s.cppcheckCfgAbout);
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"about": "about"}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS("about", s.cppcheckCfgAbout);
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"about": 1}\n)");
-            ASSERT_EQUALS("'about' is not a string", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'about' is not a string", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"addons": []}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(0, s.addons.size());
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"addons": 1}\n)");
-            ASSERT_EQUALS("'addons' is not an array", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'addons' is not an array", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"addons": ["addon"]}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(1, s.addons.size());
             ASSERT_EQUALS("addon", *s.addons.cbegin());
         }
@@ -174,26 +174,26 @@ private:
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"addons": [1]}\n)");
-            ASSERT_EQUALS("'addons' array entry is not a string", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'addons' array entry is not a string", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"addons": []}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(0, s.addons.size());
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"suppressions": 1}\n)");
-            ASSERT_EQUALS("'suppressions' is not an array", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'suppressions' is not an array", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"suppressions": ["id"]}\n)");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(1, s.supprs.nomsg.getSuppressions().size());
             ASSERT_EQUALS("id", s.supprs.nomsg.getSuppressions().cbegin()->errorId);
         }
@@ -201,13 +201,13 @@ private:
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"suppressions": [""]}\n)");
-            ASSERT_EQUALS("could not parse suppression '' - Failed to add suppression. No id.", s.loadCppcheckCfg());
+            ASSERT_EQUALS("could not parse suppression '' - Failed to add suppression. No id.", Settings::loadCppcheckCfg(s, s.supprs));
         }
         {
             Settings s;
             ScopedFile file("cppcheck.cfg",
                             R"({"suppressions": [1]}\n)");
-            ASSERT_EQUALS("'suppressions' array entry is not a string", s.loadCppcheckCfg());
+            ASSERT_EQUALS("'suppressions' array entry is not a string", Settings::loadCppcheckCfg(s, s.supprs));
         }
 
         // TODO: test with FILESDIR
@@ -220,7 +220,7 @@ private:
             Settings s;
             s.safety = false;
             ScopedFile file("cppcheck.cfg", "{}");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(false, s.safety);
         }
 
@@ -228,7 +228,7 @@ private:
             Settings s;
             s.safety = true;
             ScopedFile file("cppcheck.cfg", "{\"safety\": false}");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(true, s.safety);
         }
 
@@ -236,7 +236,7 @@ private:
             Settings s;
             s.safety = false;
             ScopedFile file("cppcheck.cfg", "{\"safety\": true}");
-            ASSERT_EQUALS("", s.loadCppcheckCfg());
+            ASSERT_EQUALS("", Settings::loadCppcheckCfg(s, s.supprs));
             ASSERT_EQUALS(true, s.safety);
         }
     }


### PR DESCRIPTION
This is a prerequisite for splitting `Suppressions` from `Settings` so the latter can be made immutable.