### PR TITLE
Include sys/wait.h for WIF* macros

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -64,6 +64,10 @@
 #include <windows.h>
 #endif
 
+#if !defined(WIN32) && !defined(__MINGW32__)
+#include <sys/wait.h> // WIFEXITED and friends
+#endif
+
 namespace {
     class CmdLineLoggerStd : public CmdLineLogger
     {


### PR DESCRIPTION
This fixes build on FreeBSD. Not sure if preprocessor condition is 100% correct though.