### PR TITLE
Tokenizer: removed some wrapper functions

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -893,7 +893,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 {
                     Timer timer("Tokenizer::createTokens", mSettings.showtime, &s_timerResults);
                     simplecpp::TokenList tokensP = preprocessor.preprocess(tokens1, mCurrentConfig, files, true);
-                    tokenizer.createTokens(std::move(tokensP));
+                    tokenizer.list.createTokens(std::move(tokensP));
                 }
                 hasValidConfig = true;
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -3345,17 +3345,6 @@ void Tokenizer::simplifyUsingError(const Token* usingStart, const Token* usingEn
     }
 }
 
-bool Tokenizer::createTokens(std::istream &code,
-                             const std::string& FileName)
-{
-    return list.createTokens(code, FileName);
-}
-
-void Tokenizer::createTokens(simplecpp::TokenList&& tokenList)
-{
-    list.createTokens(std::move(tokenList));
-}
-
 bool Tokenizer::simplifyTokens1(const std::string &configuration)
 {
     // Fill the map mTypeSize..
@@ -3441,7 +3430,7 @@ bool Tokenizer::tokenize(std::istream &code,
                          const char FileName[],
                          const std::string &configuration)
 {
-    if (!createTokens(code, FileName))
+    if (!list.createTokens(code, FileName))
         return false;
 
     return simplifyTokens1(configuration);

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -39,10 +39,6 @@ class ErrorLogger;
 class Preprocessor;
 enum class Severity;
 
-namespace simplecpp {
-    class TokenList;
-}
-
 /// @addtogroup Core
 /// @{
 
@@ -82,9 +78,6 @@ public:
      * \return true if scope ends with a function call that might be 'noreturn'
      */
     bool isScopeNoReturn(const Token *endScopeToken, bool *unknown = nullptr) const;
-
-    bool createTokens(std::istream &code, const std::string& FileName);
-    void createTokens(simplecpp::TokenList&& tokenList);
 
     bool simplifyTokens1(const std::string &configuration);
     /**

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -155,7 +155,7 @@ void PreprocessorHelper::preprocess(const char code[], std::vector<std::string> 
     simplecpp::preprocess(tokens2, tokens1, files, filedata, simplecpp::DUI());
 
     // Tokenizer..
-    tokenizer.createTokens(std::move(tokens2));
+    tokenizer.list.createTokens(std::move(tokens2));
 }
 
 void PreprocessorHelper::preprocess(Preprocessor &preprocessor, const char code[], std::vector<std::string> &files, Tokenizer& tokenizer)
@@ -174,7 +174,7 @@ void PreprocessorHelper::preprocess(Preprocessor &preprocessor, const char code[
     simplecpp::preprocess(tokens2, tokens1, files, filedata, dui);
 
     // Tokenizer..
-    tokenizer.createTokens(std::move(tokens2));
+    tokenizer.list.createTokens(std::move(tokens2));
 
     preprocessor.setDirectives(tokens1);
 }

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -5290,7 +5290,7 @@ private:
         Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
-        tokenizer.createTokens(istr, "test.cpp");
+        tokenizer.list.createTokens(istr, "test.cpp");
         tokenizer.createLinks();
         tokenizer.splitTemplateRightAngleBrackets(false);
 
@@ -5357,7 +5357,7 @@ private:
         Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
-        tokenizer.createTokens(istr, "test.cpp");
+        tokenizer.list.createTokens(istr, "test.cpp");
         tokenizer.createLinks();
         tokenizer.splitTemplateRightAngleBrackets(false);
 
@@ -5427,7 +5427,7 @@ private:
         Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
-        tokenizer.createTokens(istr, "test.cpp");
+        tokenizer.list.createTokens(istr, "test.cpp");
         tokenizer.createLinks();
         tokenizer.splitTemplateRightAngleBrackets(false);
 
@@ -5456,7 +5456,7 @@ private:
         Tokenizer tokenizer(settings, this);
 
         std::istringstream istr(code);
-        tokenizer.createTokens(istr, "test.cpp");
+        tokenizer.list.createTokens(istr, "test.cpp");
         tokenizer.createLinks();
         tokenizer.splitTemplateRightAngleBrackets(false);
 


### PR DESCRIPTION
These were used inconsistently. Also `Tokenizer::list` is public and used directly across the code already.