### PR TITLE
Fix checkLibraryFunction warning when deriving from std::vector

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -972,6 +972,8 @@ std::string Library::getFunctionName(const Token *ftok, bool &error) const
         return "";
     }
     if (ftok->isName()) {
+        if (Token::simpleMatch(ftok->astParent(), "::"))
+            return ftok->str();
         for (const Scope *scope = ftok->scope(); scope; scope = scope->nestedIn) {
             if (!scope->isClassOrStruct())
                 continue;

--- a/test/testfunctions.cpp
+++ b/test/testfunctions.cpp
@@ -2046,6 +2046,12 @@ private:
               "    return ::std::string(c);\n"
               "}\n", "test.cpp", &s);
         ASSERT_EQUALS("", errout.str());
+
+        check("template <typename T>\n"
+              "struct S : public std::vector<T> {\n"
+              "    void resize(size_t n) { std::vector<T>::resize(n); }\n"
+              "};\n", "test.cpp", &s);
+        ASSERT_EQUALS("", errout.str());
     }
 
     void checkUseStandardLibrary1() {


### PR DESCRIPTION
Inspired by https://github.com/danmar/cppcheck/pull/4834