### PR TITLE
improved handling/testing of XMLs without a a root node / added some TODOs

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1040,11 +1040,13 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             // Rule file
             else if (std::strncmp(argv[i], "--rule-file=", 12) == 0) {
 #ifdef HAVE_RULES
+                // TODO: improved error handling - unknown elements, wrong root node, etc.
                 const std::string ruleFile = argv[i] + 12;
                 tinyxml2::XMLDocument doc;
                 const tinyxml2::XMLError err = doc.LoadFile(ruleFile.c_str());
                 if (err == tinyxml2::XML_SUCCESS) {
-                    tinyxml2::XMLElement *node = doc.FirstChildElement();
+                    const tinyxml2::XMLElement *node = doc.FirstChildElement();
+                    // TODO: this looks like legacy handling - deprecate it
                     if (node && strcmp(node->Value(), "rules") == 0)
                         node = node->FirstChildElement("rule");
                     for (; node && strcmp(node->Value(), "rule") == 0; node = node->NextSiblingElement()) {
@@ -1059,7 +1061,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                             rule.pattern = pattern->GetText();
                         }
 
-                        tinyxml2::XMLElement *message = node->FirstChildElement("message");
+                        const tinyxml2::XMLElement *message = node->FirstChildElement("message");
                         if (message) {
                             const tinyxml2::XMLElement *severity = message->FirstChildElement("severity");
                             if (severity)

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -103,15 +103,16 @@ std::string SuppressionList::parseXmlFile(const char *filename)
 {
     tinyxml2::XMLDocument doc;
     const tinyxml2::XMLError error = doc.LoadFile(filename);
-    if (error == tinyxml2::XML_ERROR_FILE_NOT_FOUND)
-        return "File not found";
     if (error != tinyxml2::XML_SUCCESS)
-        return "Failed to parse XML file";
+        return std::string("failed to load suppressions XML '") + filename + "' (" + tinyxml2::XMLDocument::ErrorIDToName(error) + ").";
 
     const tinyxml2::XMLElement * const rootnode = doc.FirstChildElement();
+    if (!rootnode)
+        return std::string("failed to load suppressions XML '") + filename + "' (no root node found).";
+    // TODO: check for proper root node 'suppressions'
     for (const tinyxml2::XMLElement * e = rootnode->FirstChildElement(); e; e = e->NextSiblingElement()) {
         if (std::strcmp(e->Name(), "suppress") != 0)
-            return "Invalid suppression xml file format, expected <suppress> element but got a \"" + std::string(e->Name()) + '\"';
+            return std::string("invalid suppression xml file '") + filename + "', expected 'suppress' element but got a '" + e->Name() + "'.";
 
         Suppression s;
         for (const tinyxml2::XMLElement * e2 = e->FirstChildElement(); e2; e2 = e2->NextSiblingElement()) {
@@ -127,7 +128,7 @@ std::string SuppressionList::parseXmlFile(const char *filename)
             else if (*text && std::strcmp(e2->Name(), "hash") == 0)
                 s.hash = strToInt<std::size_t>(text);
             else
-                return "Unknown suppression element \"" + std::string(e2->Name()) + "\", expected id/fileName/lineNumber/symbolName/hash";
+                return std::string("unknown element '") + e2->Name() + "' in suppressions XML '" + filename + "', expected id/fileName/lineNumber/symbolName/hash.";
         }
 
         const std::string err = addSuppression(std::move(s));

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -279,6 +279,8 @@ private:
                                "</error>";
         tinyxml2::XMLDocument doc;
         ASSERT(doc.Parse(xmldata, sizeof(xmldata)) == tinyxml2::XML_SUCCESS);
+        const auto * const rootnode = doc.FirstChildElement();
+        ASSERT(rootnode);
         ErrorMessage msg(doc.FirstChildElement());
         ASSERT_EQUALS("errorId", msg.id);
         ASSERT_EQUALS_ENUM(Severity::error, msg.severity);

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -984,6 +984,9 @@ private:
 
     void loadLibErrors() const {
 
+        LOADLIBERROR("<?xml version=\"1.0\"?>",
+                     Library::ErrorCode::BAD_XML);
+
         LOADLIBERROR("<?xml version=\"1.0\"?>\n"
                      "<def>\n"
                      "   <X name=\"uint8_t,std::uint8_t\" size=\"1\"/>\n"

--- a/test/testplatform.cpp
+++ b/test/testplatform.cpp
@@ -46,6 +46,8 @@ private:
         TEST_CASE(default_platform);
         TEST_CASE(limitsDefines);
         TEST_CASE(charMinMax);
+        TEST_CASE(no_root_node);
+        TEST_CASE(wrong_root_node);
     }
 
     static bool readPlatform(Platform& platform, const char* xmldata) {
@@ -416,6 +418,19 @@ private:
         ASSERT_EQUALS(255, platform.unsignedCharMax());
         ASSERT_EQUALS(127, platform.signedCharMax());
         ASSERT_EQUALS(-128, platform.signedCharMin());
+    }
+
+    void no_root_node() const {
+        constexpr char xmldata[] = "<?xml version=\"1.0\"?>";
+        Platform platform;
+        ASSERT(!readPlatform(platform, xmldata));
+    }
+
+    void wrong_root_node() const {
+        constexpr char xmldata[] = "<?xml version=\"1.0\"?>\n"
+                                   "<platforms/>";
+        Platform platform;
+        ASSERT(!readPlatform(platform, xmldata));
     }
 };
 

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -1465,7 +1465,7 @@ private:
         ASSERT_EQUALS("[a.c:10]: (information) Unmatched suppression: abc\n", errout.str());
     }
 
-    void suppressionsParseXmlFile() {
+    void suppressionsParseXmlFile() const {
         {
             ScopedFile file("suppressparsexml.xml",
                             "<suppressions>\n"

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -97,6 +97,8 @@ private:
         TEST_CASE(suppressLocal);
 
         TEST_CASE(suppressUnmatchedSuppressions);
+
+        TEST_CASE(suppressionsParseXmlFile);
     }
 
     void suppressionsBadId1() const {
@@ -1461,6 +1463,82 @@ private:
         suppressions.emplace_back("unmatchedSuppression", "a.c", 1U);
         ASSERT_EQUALS(true, SuppressionList::reportUnmatchedSuppressions(suppressions, *this));
         ASSERT_EQUALS("[a.c:10]: (information) Unmatched suppression: abc\n", errout.str());
+    }
+
+    void suppressionsParseXmlFile() {
+        {
+            ScopedFile file("suppressparsexml.xml",
+                            "<suppressions>\n"
+                            "<suppress>\n"
+                            "<id>uninitvar</id>\n"
+                            "<fileName>file.c</fileName>\n"
+                            "<lineNumber>10</lineNumber>\n"
+                            "<symbolName>sym</symbolName>\n"
+                            "</suppress>\n"
+                            "</suppressions>");
+
+            SuppressionList supprList;
+            ASSERT_EQUALS("", supprList.parseXmlFile(file.path().c_str()));
+            const auto& supprs = supprList.getSuppressions();
+            ASSERT_EQUALS(1, supprs.size());
+            const auto& suppr = *supprs.cbegin();
+            ASSERT_EQUALS("uninitvar", suppr.errorId);
+            ASSERT_EQUALS("file.c", suppr.fileName);
+            ASSERT_EQUALS(10, suppr.lineNumber);
+            ASSERT_EQUALS("sym", suppr.symbolName);
+        }
+
+        // no file specified
+        {
+            SuppressionList supprList;
+            ASSERT_EQUALS("failed to load suppressions XML '' (XML_ERROR_FILE_NOT_FOUND).", supprList.parseXmlFile(""));
+        }
+
+        // missing file
+        {
+            SuppressionList supprList;
+            ASSERT_EQUALS("failed to load suppressions XML 'suppressparsexml.xml' (XML_ERROR_FILE_NOT_FOUND).", supprList.parseXmlFile("suppressparsexml.xml"));
+        }
+
+        // empty file
+        {
+            ScopedFile file("suppressparsexml.xml",
+                            "");
+
+            SuppressionList supprList;
+            ASSERT_EQUALS("failed to load suppressions XML 'suppressparsexml.xml' (XML_ERROR_EMPTY_DOCUMENT).", supprList.parseXmlFile(file.path().c_str()));
+        }
+
+        // wrong root node
+        {
+            ScopedFile file("suppressparsexml.xml",
+                            "<suppress/>\n");
+
+            SuppressionList supprList;
+            ASSERT_EQUALS("", supprList.parseXmlFile(file.path().c_str()));
+        }
+
+        // no root node
+        {
+            ScopedFile file("suppressparsexml.xml",
+                            "<?xml version=\"1.0\"?>\n");
+
+            SuppressionList supprList;
+            ASSERT_EQUALS("failed to load suppressions XML 'suppressparsexml.xml' (no root node found).", supprList.parseXmlFile(file.path().c_str()));
+        }
+
+        // unknown element
+        {
+            ScopedFile file("suppressparsexml.xml",
+                            "<suppressions>\n"
+                            "<suppress>\n"
+                            "<eid>uninitvar</eid>\n"
+                            "</suppress>\n"
+                            "</suppressions>");
+
+            SuppressionList supprList;
+            ASSERT_EQUALS("unknown element 'eid' in suppressions XML 'suppressparsexml.xml', expected id/fileName/lineNumber/symbolName/hash.", supprList.parseXmlFile(file.path().c_str()));
+        }
     }
 };
 


### PR DESCRIPTION
This is based on a Coverity finding in `SuppressionList::parseXmlFile()`. `--suppress-xml` was actually crashing when a XML without a root node was provided.