### PR TITLE
Fix syntaxError with using namespace ::std (f'up to #8454)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2844,6 +2844,9 @@ bool Tokenizer::simplifyUsing()
     for (Token* tok = list.front(); tok; tok = tok->next()) {
         if (!Token::Match(tok, "using ::| %name% ::"))
             continue;
+        const Token* ns = tok->tokAt(tok->strAt(1) == "::" ? 2 : 1);
+        if (ns->isKeyword())
+            continue;
         Token* end = tok->tokAt(3);
         while (end && !Token::Match(end, "[;,]")) {
             if (end->str() == "<" && end->link()) // skip template args

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -724,6 +724,18 @@ private:
             ASSERT_EQUALS(expected, tok(code, Platform::Type::Native, /*debugwarnings*/ true));
             ASSERT_EQUALS("", errout.str());
         }
+        {
+            const char code[] = "using namespace ::std;\n"
+                                "void f(const char* c) {\n"
+                                "    cout << std::string(c) << \"abc\";\n"
+                                "}\n";
+            const char expected[] = "using namespace :: std ; " // TODO: simplify cout?
+                                    "void f ( const char * c ) { "
+                                    "cout << std :: string ( c ) << \"abc\" ; "
+                                    "}";
+            ASSERT_EQUALS(expected, tok(code, Platform::Type::Native, /*debugwarnings*/ true));
+            ASSERT_EQUALS("", errout.str());
+        }
     }
 
     void simplifyUsing8970() {


### PR DESCRIPTION
Why do `%type%` and `%name%` match keywords?