### PR TITLE
added environment variable `TEST_CPPCHECK_INJECT_CLANG` to inject `--clang` into the cppcheck invocation of Python tests

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -405,6 +405,15 @@ jobs:
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
+      # do not use pushd in this step since we go below the working directory
+      - name: Run test/cli (--clang)
+        if: false
+        run: |
+          cd test/cli
+          python3 -m pytest -Werror --strict-markers -vv
+        env:
+          TEST_CPPCHECK_INJECT_CLANG: clang
+
       - name: Run cfg tests
         if: matrix.os != 'ubuntu-22.04'
         run: |

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -182,6 +182,15 @@ jobs:
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
+      # TODO: install clang
+      - name: Run test/cli (--clang)
+        if: false # matrix.config == 'release'
+        run: |
+          cd test/cli || exit /b !errorlevel!
+          python -m pytest -Werror --strict-markers -vv || exit /b !errorlevel!
+        env:
+          TEST_CPPCHECK_INJECT_CLANG: clang
+
       - name: Test addons
         if: matrix.config == 'release'
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -108,6 +108,15 @@ jobs:
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
+      - name: Run test/cli (--clang)
+        if: false
+        run: |
+          pwd=$(pwd)
+          cd test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv
+        env:
+          TEST_CPPCHECK_INJECT_CLANG: clang
+
       - name: Generate dependencies
         if: false
         run: |

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -107,6 +107,15 @@ jobs:
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
+      - name: Run test/cli (--clang)
+        if: false
+        run: |
+          pwd=$(pwd)
+          cd test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv
+        env:
+          TEST_CPPCHECK_INJECT_CLANG: clang
+
       - name: Generate dependencies
         if: false
         run: |

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -107,6 +107,15 @@ jobs:
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
+      - name: Run test/cli (--clang)
+        if: false
+        run: |
+          pwd=$(pwd)
+          cd test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv
+        env:
+          TEST_CPPCHECK_INJECT_CLANG: clang
+
       - name: Generate dependencies
         run: |
           # make sure auto-generated GUI files exist

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -470,9 +470,17 @@ unsigned int CppCheck::checkClang(const std::string &path)
     }
 
     std::string output2;
-    if (mExecuteCommand(exe,split(args2),redirect2,output2) != EXIT_SUCCESS || output2.find("TranslationUnitDecl") == std::string::npos) {
-        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "'" << std::endl;
-        return 0;
+    const int exitcode = mExecuteCommand(exe,split(args2),redirect2,output2);
+    if (exitcode != EXIT_SUCCESS) {
+        // TODO: report as proper error
+        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (exitcode: " << exitcode << " / output: " << output2 << ")" << std::endl;
+        return 0; // TODO: report as failure?
+    }
+
+    if (output2.find("TranslationUnitDecl") == std::string::npos) {
+        // TODO: report as proper error
+        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (no TranslationUnitDecl in output)" << std::endl;
+        return 0; // TODO: report as failure?
     }
 
     // Ensure there are not syntax errors...

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -559,7 +559,7 @@ unsigned int CppCheck::checkClang(const std::string &path)
 unsigned int CppCheck::check(const std::string &path)
 {
     if (mSettings.clang)
-        return checkClang(path);
+        return checkClang(Path::simplifyPath(path));
 
     return checkFile(Path::simplifyPath(path), emptyString);
 }

--- a/test/cli/helloworld/main.c
+++ b/test/cli/helloworld/main.c
@@ -2,7 +2,7 @@
 
 int main(void) {
     (void)printf("Hello world!\n");
-    x = 3 / 0; // ERROR
+    int x = 3 / 0; (void)x; // ERROR
     return 0;
 }
 

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -87,6 +87,16 @@ def cppcheck(args, env=None, remove_checkers_report=True, cwd=None, cppcheck_exe
             arg_j = '-j' + str(os.environ['TEST_CPPCHECK_INJECT_J'])
             args.append(arg_j)
 
+    if 'TEST_CPPCHECK_INJECT_CLANG' in os.environ:
+        found_clang = False
+        for arg in args:
+            if arg.startswith('--clang'):
+                found_clang = True
+                break
+        if not found_clang:
+            arg_clang = '--clang=' + str(os.environ['TEST_CPPCHECK_INJECT_CLANG'])
+            args.append(arg_clang)
+
     logging.info(exe + ' ' + ' '.join(args))
     p = subprocess.Popen([exe] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, cwd=cwd)
     try:


### PR DESCRIPTION
This is currently disabled since a lot of tests still fail. I did fix some low hanging fruits though.