### PR TITLE
support CMAKE_UNITY_BUILD

### DIFF
--- a/gui/filelist.cpp
+++ b/gui/filelist.cpp
@@ -108,7 +108,7 @@ void FileList::addExcludeList(const QStringList &paths)
     mExcludedPaths = paths;
 }
 
-static std::vector<std::string> toStdStringList(const QStringList &stringList)
+static std::vector<std::string> toStdStringList2(const QStringList &stringList)
 {
     std::vector<std::string> ret;
     std::transform(stringList.cbegin(), stringList.cend(), std::back_inserter(ret), [](const QString& s) {
@@ -120,9 +120,9 @@ static std::vector<std::string> toStdStringList(const QStringList &stringList)
 QStringList FileList::applyExcludeList() const
 {
 #ifdef _WIN32
-    const PathMatch pathMatch(toStdStringList(mExcludedPaths), true);
+    const PathMatch pathMatch(toStdStringList2(mExcludedPaths), true);
 #else
-    const PathMatch pathMatch(toStdStringList(mExcludedPaths), false);
+    const PathMatch pathMatch(toStdStringList2(mExcludedPaths), false);
 #endif
 
     QStringList paths;

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "cppchecklibrarydata.h"
 
 #include <QObject>

--- a/gui/test/filelist/testfilelist.h
+++ b/gui/test/filelist/testfilelist.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <QObject>
 #include <QString>
 

--- a/gui/test/projectfile/testprojectfile.h
+++ b/gui/test/projectfile/testprojectfile.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <QObject>
 #include <QString>
 

--- a/gui/test/translationhandler/testtranslationhandler.h
+++ b/gui/test/translationhandler/testtranslationhandler.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <QObject>
 #include <QString>
 

--- a/gui/test/xmlreportv2/testxmlreportv2.h
+++ b/gui/test/xmlreportv2/testxmlreportv2.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include <QObject>
 #include <QString>
 

--- a/gui/xmlreport.cpp
+++ b/gui/xmlreport.cpp
@@ -29,8 +29,8 @@
 #include <QStringRef>
 #endif
 
-static constexpr char ResultElementName[] = "results";
-static constexpr char VersionAttribute[] = "version";
+static constexpr char ResultElementName2[] = "results";
+static constexpr char VersionAttribute2[] = "version";
 
 XmlReport::XmlReport(const QString &filename) :
     Report(filename)
@@ -70,10 +70,10 @@ int XmlReport::determineVersion(const QString &filename)
     while (!reader.atEnd()) {
         switch (reader.readNext()) {
         case QXmlStreamReader::StartElement:
-            if (reader.name() == QString(ResultElementName)) {
+            if (reader.name() == QString(ResultElementName2)) {
                 QXmlStreamAttributes attribs = reader.attributes();
-                if (attribs.hasAttribute(QString(VersionAttribute))) {
-                    const int ver = attribs.value(QString(), VersionAttribute).toString().toInt();
+                if (attribs.hasAttribute(QString(VersionAttribute2))) {
+                    const int ver = attribs.value(QString(), VersionAttribute2).toString().toInt();
                     return ver;
                 }
                 return 1;

--- a/lib/check64bit.cpp
+++ b/lib/check64bit.cpp
@@ -32,12 +32,10 @@
 
 //---------------------------------------------------------------------------
 
-// CWE ids used
-static const CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    Check64BitPortability instance;
+    Check64BitPortability instance64BitPortability;
 }
 
 void Check64BitPortability::pointerassignment()

--- a/lib/checkassert.cpp
+++ b/lib/checkassert.cpp
@@ -31,12 +31,10 @@
 
 //---------------------------------------------------------------------------
 
-// CWE ids used
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckAssert instance;
+    CheckAssert instanceAssert;
 }
 
 void CheckAssert::assertWithSideEffects()

--- a/lib/checkautovariables.cpp
+++ b/lib/checkautovariables.cpp
@@ -42,12 +42,9 @@
 
 // Register this check class into cppcheck by creating a static instance of it..
 namespace {
-    CheckAutoVariables instance;
+    CheckAutoVariables instanceAutoVariables;
 }
 
-static const CWE CWE398(398U);  // Indicator of Poor Code Quality
-static const CWE CWE562(562U);  // Return of Stack Variable Address
-static const CWE CWE590(590U);  // Free of Memory not on the Heap
 
 static bool isPtrArg(const Token *tok)
 {

--- a/lib/checkbool.cpp
+++ b/lib/checkbool.cpp
@@ -34,13 +34,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckBool instance;
+    CheckBool instanceBool;
 }
 
-static const CWE CWE398(398U);  // Indicator of Poor Code Quality
-static const CWE CWE571(571U);  // Expression is Always True
-static const CWE CWE587(587U);  // Assignment of a Fixed Address to a Pointer
-static const CWE CWE704(704U);  // Incorrect Type Conversion or Cast
 
 static bool isBool(const Variable* var)
 {

--- a/lib/checkboost.cpp
+++ b/lib/checkboost.cpp
@@ -26,10 +26,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckBoost instance;
+    CheckBoost instanceBoost;
 }
 
-static const CWE CWE664(664);
 
 void CheckBoost::checkBoostForeachModification()
 {

--- a/lib/checkbufferoverrun.cpp
+++ b/lib/checkbufferoverrun.cpp
@@ -48,20 +48,11 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckBufferOverrun instance;
+    CheckBufferOverrun instanceBufferOverrun;
 }
 
 //---------------------------------------------------------------------------
 
-// CWE ids used:
-static const CWE CWE131(131U);  // Incorrect Calculation of Buffer Size
-static const CWE CWE170(170U);  // Improper Null Termination
-static const CWE CWE_ARGUMENT_SIZE(398U);  // Indicator of Poor Code Quality
-static const CWE CWE_ARRAY_INDEX_THEN_CHECK(398U);  // Indicator of Poor Code Quality
-static const CWE CWE758(758U);  // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-static const CWE CWE_POINTER_ARITHMETIC_OVERFLOW(758U); // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-static const CWE CWE_BUFFER_UNDERRUN(786U);  // Access of Memory Location Before Start of Buffer
-static const CWE CWE_BUFFER_OVERRUN(788U);   // Access of Memory Location After End of Buffer
 
 //---------------------------------------------------------------------------
 
@@ -885,7 +876,7 @@ void CheckBufferOverrun::argumentSizeError(const Token *tok, const std::string &
 // CTU..
 //---------------------------------------------------------------------------
 
-// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// a Clang-built executable will crash when using the anonymous MyFileInfoBufferOverrun later on - so put it in a unique namespace for now
 // see https://trac.cppcheck.net/ticket/12108 for more details
 #ifdef __clang__
 inline namespace CheckBufferOverrun_internal
@@ -894,7 +885,7 @@ namespace
 #endif
 {
     /** data for multifile checking */
-    class MyFileInfo : public Check::FileInfo {
+    class MyFileInfoBufferOverrun : public Check::FileInfo {
     public:
         /** unsafe array index usage */
         std::list<CTU::FileInfo::UnsafeUsage> unsafeArrayIndex;
@@ -954,7 +945,7 @@ Check::FileInfo *CheckBufferOverrun::getFileInfo(const Tokenizer *tokenizer, con
     if (unsafeArrayIndex.empty() && unsafePointerArith.empty()) {
         return nullptr;
     }
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoBufferOverrun;
     fileInfo->unsafeArrayIndex = unsafeArrayIndex;
     fileInfo->unsafePointerArith = unsafePointerArith;
     return fileInfo;
@@ -966,7 +957,7 @@ Check::FileInfo * CheckBufferOverrun::loadFileInfoFromXml(const tinyxml2::XMLEle
     const std::string arrayIndex("array-index");
     const std::string pointerArith("pointer-arith");
 
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoBufferOverrun;
     for (const tinyxml2::XMLElement *e = xmlElement->FirstChildElement(); e; e = e->NextSiblingElement()) {
         if (e->Name() == arrayIndex)
             fileInfo->unsafeArrayIndex = CTU::loadUnsafeUsageListFromXml(e);
@@ -997,7 +988,7 @@ bool CheckBufferOverrun::analyseWholeProgram(const CTU::FileInfo *ctu, const std
     const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> callsMap = ctu->getCallsMap();
 
     for (const Check::FileInfo* fi1 : fileInfo) {
-        const MyFileInfo *fi = dynamic_cast<const MyFileInfo*>(fi1);
+        const MyFileInfoBufferOverrun *fi = dynamic_cast<const MyFileInfoBufferOverrun*>(fi1);
         if (!fi)
             continue;
         for (const CTU::FileInfo::UnsafeUsage &unsafeUsage : fi->unsafeArrayIndex)

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -42,17 +42,12 @@
 #include <utility>
 #include <vector>
 
-// CWE ids used
-static const CWE uncheckedErrorConditionCWE(391U);
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
-static const CWE CWE570(570U);   // Expression is Always False
-static const CWE CWE571(571U);   // Expression is Always True
 
 //---------------------------------------------------------------------------
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckCondition instance;
+    CheckCondition instanceCondition;
 }
 
 bool CheckCondition::diag(const Token* tok, bool insert)

--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -34,12 +34,9 @@
 
 // Register CheckExceptionSafety..
 namespace {
-    CheckExceptionSafety instance;
+    CheckExceptionSafety instanceExceptionSafety;
 }
 
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
-static const CWE CWE703(703U);   // Improper Check or Handling of Exceptional Conditions
-static const CWE CWE480(480U);   // Use of Incorrect Operator
 
 //---------------------------------------------------------------------------
 

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -43,16 +43,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckFunctions instance;
+    CheckFunctions instanceFunctions;
 }
 
-static const CWE CWE252(252U);  // Unchecked Return Value
-static const CWE CWE477(477U);  // Use of Obsolete Functions
-static const CWE CWE758(758U);  // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-static const CWE CWE628(628U);  // Function Call with Incorrectly Specified Arguments
-static const CWE CWE686(686U);  // Function Call With Incorrect Argument Type
-static const CWE CWE687(687U);  // Function Call With Incorrectly Specified Argument Value
-static const CWE CWE688(688U);  // Function Call With Incorrect Variable or Reference as Argument
 
 void CheckFunctions::checkProhibitedFunctions()
 {

--- a/lib/checkinternal.cpp
+++ b/lib/checkinternal.cpp
@@ -32,7 +32,7 @@
 // Register this check class (by creating a static instance of it).
 // Disabled in release builds
 namespace {
-    CheckInternal instance;
+    CheckInternal instanceInternal;
 }
 
 void CheckInternal::checkTokenMatchPatterns()

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -47,18 +47,9 @@
 
 // Register CheckIO..
 namespace {
-    CheckIO instance;
+    CheckIO instanceIO;
 }
 
-// CVE ID used:
-static const CWE CWE119(119U);  // Improper Restriction of Operations within the Bounds of a Memory Buffer
-static const CWE CWE398(398U);  // Indicator of Poor Code Quality
-static const CWE CWE664(664U);  // Improper Control of a Resource Through its Lifetime
-static const CWE CWE685(685U);  // Function Call With Incorrect Number of Arguments
-static const CWE CWE686(686U);  // Function Call With Incorrect Argument Type
-static const CWE CWE687(687U);  // Function Call With Incorrectly Specified Argument Value
-static const CWE CWE704(704U);  // Incorrect Type Conversion or Cast
-static const CWE CWE910(910U);  // Use of Expired File Descriptor
 
 //---------------------------------------------------------------------------
 //    std::cout << std::cout;

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -44,11 +44,6 @@ namespace {
     CheckMemoryLeakNoVar instance4;
 }
 
-// CWE ID used:
-static const CWE CWE398(398U);  // Indicator of Poor Code Quality
-static const CWE CWE401(401U);  // Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-static const CWE CWE771(771U);  // Missing Reference to Active Allocated Resource
-static const CWE CWE772(772U);  // Missing Release of Resource after Effective Lifetime
 
 //---------------------------------------------------------------------------
 

--- a/lib/checknullpointer.cpp
+++ b/lib/checknullpointer.cpp
@@ -40,13 +40,10 @@
 
 //---------------------------------------------------------------------------
 
-// CWE ids used:
-static const CWE CWE_NULL_POINTER_DEREFERENCE(476U);
-static const CWE CWE_INCORRECT_CALCULATION(682U);
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckNullPointer instance;
+    CheckNullPointer instanceNullPointer;
 }
 
 //---------------------------------------------------------------------------
@@ -558,7 +555,7 @@ static bool isUnsafeUsage(const Settings *settings, const Token *vartok, MathLib
     return CheckNullPointer::isPointerDeRef(vartok, unknown, settings);
 }
 
-// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// a Clang-built executable will crash when using the anonymous MyFileInfoNullPointer later on - so put it in a unique namespace for now
 // see https://trac.cppcheck.net/ticket/12108 for more details
 #ifdef __clang__
 inline namespace CheckNullPointer_internal
@@ -567,7 +564,7 @@ namespace
 #endif
 {
     /* data for multifile checking */
-    class MyFileInfo : public Check::FileInfo {
+    class MyFileInfoNullPointer : public Check::FileInfo {
     public:
         /** function arguments that are dereferenced without checking if they are null */
         std::list<CTU::FileInfo::UnsafeUsage> unsafeUsage;
@@ -586,7 +583,7 @@ Check::FileInfo *CheckNullPointer::getFileInfo(const Tokenizer *tokenizer, const
     if (unsafeUsage.empty())
         return nullptr;
 
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoNullPointer;
     fileInfo->unsafeUsage = unsafeUsage;
     return fileInfo;
 }
@@ -597,7 +594,7 @@ Check::FileInfo * CheckNullPointer::loadFileInfoFromXml(const tinyxml2::XMLEleme
     if (unsafeUsage.empty())
         return nullptr;
 
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoNullPointer;
     fileInfo->unsafeUsage = unsafeUsage;
     return fileInfo;
 }
@@ -616,7 +613,7 @@ bool CheckNullPointer::analyseWholeProgram(const CTU::FileInfo *ctu, const std::
     const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> callsMap = ctu->getCallsMap();
 
     for (const Check::FileInfo* fi1 : fileInfo) {
-        const MyFileInfo *fi = dynamic_cast<const MyFileInfo*>(fi1);
+        const MyFileInfoNullPointer *fi = dynamic_cast<const MyFileInfoNullPointer*>(fi1);
         if (!fi)
             continue;
         for (const CTU::FileInfo::UnsafeUsage &unsafeUsage : fi->unsafeUsage) {

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -48,27 +48,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckOther instance;
+    CheckOther instanceOther;
 }
 
-static const CWE CWE128(128U);   // Wrap-around Error
-static const CWE CWE131(131U);   // Incorrect Calculation of Buffer Size
-static const CWE CWE197(197U);   // Numeric Truncation Error
-static const CWE CWE362(362U);   // Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-static const CWE CWE369(369U);   // Divide By Zero
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
-static const CWE CWE475(475U);   // Undefined Behavior for Input to API
-static const CWE CWE561(561U);   // Dead Code
-static const CWE CWE563(563U);   // Assignment to Variable without Use ('Unused Variable')
-static const CWE CWE570(570U);   // Expression is Always False
-static const CWE CWE571(571U);   // Expression is Always True
-static const CWE CWE672(672U);   // Operation on a Resource after Expiration or Release
-static const CWE CWE628(628U);   // Function Call with Incorrectly Specified Arguments
-static const CWE CWE683(683U);   // Function Call With Incorrect Order of Arguments
-static const CWE CWE704(704U);   // Incorrect Type Conversion or Cast
-static const CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-static const CWE CWE768(768U);   // Incorrect Short Circuit Evaluation
-static const CWE CWE783(783U);   // Operator Precedence Logic Error
 
 //----------------------------------------------------------------------------------
 // The return value of fgetc(), getc(), ungetc(), getchar() etc. is an integer value.

--- a/lib/checkpostfixoperator.cpp
+++ b/lib/checkpostfixoperator.cpp
@@ -35,12 +35,10 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckPostfixOperator instance;
+    CheckPostfixOperator instancePostfixOperator;
 }
 
 
-// CWE ids used
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
 
 
 void CheckPostfixOperator::postfixOperator()

--- a/lib/checksizeof.cpp
+++ b/lib/checksizeof.cpp
@@ -36,12 +36,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckSizeof instance;
+    CheckSizeof instanceSizeof;
 }
 
-// CWE IDs used:
-static const CWE CWE467(467U);   // Use of sizeof() on a Pointer Type
-static const CWE CWE682(682U);   // Incorrect Calculation
 //---------------------------------------------------------------------------
 //---------------------------------------------------------------------------
 void CheckSizeof::checkSizeofForNumericParameter()

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -47,22 +47,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckStl instance;
+    CheckStl instanceStl;
 }
 
-// CWE IDs used:
-static const CWE CWE398(398U);   // Indicator of Poor Code Quality
-static const CWE CWE597(597U);   // Use of Wrong Operator in String Comparison
-static const CWE CWE628(628U);   // Function Call with Incorrectly Specified Arguments
-static const CWE CWE664(664U);   // Improper Control of a Resource Through its Lifetime
-static const CWE CWE667(667U);   // Improper Locking
-static const CWE CWE704(704U);   // Incorrect Type Conversion or Cast
-static const CWE CWE762(762U);   // Mismatched Memory Management Routines
-static const CWE CWE786(786U);   // Access of Memory Location Before Start of Buffer
-static const CWE CWE788(788U);   // Access of Memory Location After End of Buffer
-static const CWE CWE825(825U);   // Expired Pointer Dereference
-static const CWE CWE833(833U);   // Deadlock
-static const CWE CWE834(834U);   // Excessive Iteration
 
 static bool isElementAccessYield(Library::Container::Yield yield)
 {

--- a/lib/checkstring.cpp
+++ b/lib/checkstring.cpp
@@ -38,16 +38,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckString instance;
+    CheckString instanceString;
 }
 
-// CWE ids used:
-static const CWE CWE570(570U);   // Expression is Always False
-static const CWE CWE571(571U);   // Expression is Always True
-static const CWE CWE595(595U);   // Comparison of Object References Instead of Object Contents
-static const CWE CWE628(628U);   // Function Call with Incorrectly Specified Arguments
-static const CWE CWE665(665U);   // Improper Initialization
-static const CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 
 //---------------------------------------------------------------------------
 // Writing string literal is UB

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -43,7 +43,7 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckType instance;
+    CheckType instanceType;
 }
 
 //---------------------------------------------------------------------------
@@ -51,11 +51,6 @@ namespace {
 //---------------------------------------------------------------------------
 //
 
-// CWE ids used:
-static const CWE CWE195(195U);   // Signed to Unsigned Conversion Error
-static const CWE CWE197(197U);   // Numeric Truncation Error
-static const CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-static const CWE CWE190(190U);   // Integer Overflow or Wraparound
 
 
 void CheckType::checkTooBigBitwiseShift()

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -48,12 +48,10 @@ namespace tinyxml2 {
 
 //---------------------------------------------------------------------------
 
-// CWE ids used:
-static const CWE CWE_USE_OF_UNINITIALIZED_VARIABLE(457U);
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckUninitVar instance;
+    CheckUninitVar instanceUninitVar;
 }
 
 //---------------------------------------------------------------------------
@@ -1679,7 +1677,7 @@ static bool isVariableUsage(const Settings *settings, const Token *vartok, MathL
     return CheckUninitVar::isVariableUsage(vartok, settings->library, true, CheckUninitVar::Alloc::ARRAY);
 }
 
-// a Clang-built executable will crash when using the anonymous MyFileInfo later on - so put it in a unique namespace for now
+// a Clang-built executable will crash when using the anonymous MyFileInfoUninitVar later on - so put it in a unique namespace for now
 // see https://trac.cppcheck.net/ticket/12108 for more details
 #ifdef __clang__
 inline namespace CheckUninitVar_internal
@@ -1688,7 +1686,7 @@ namespace
 #endif
 {
     /* data for multifile checking */
-    class MyFileInfo : public Check::FileInfo {
+    class MyFileInfoUninitVar : public Check::FileInfo {
     public:
         /** function arguments that data are unconditionally read */
         std::list<CTU::FileInfo::UnsafeUsage> unsafeUsage;
@@ -1707,7 +1705,7 @@ Check::FileInfo *CheckUninitVar::getFileInfo(const Tokenizer *tokenizer, const S
     if (unsafeUsage.empty())
         return nullptr;
 
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoUninitVar;
     fileInfo->unsafeUsage = unsafeUsage;
     return fileInfo;
 }
@@ -1718,7 +1716,7 @@ Check::FileInfo * CheckUninitVar::loadFileInfoFromXml(const tinyxml2::XMLElement
     if (unsafeUsage.empty())
         return nullptr;
 
-    auto *fileInfo = new MyFileInfo;
+    auto *fileInfo = new MyFileInfoUninitVar;
     fileInfo->unsafeUsage = unsafeUsage;
     return fileInfo;
 }
@@ -1733,7 +1731,7 @@ bool CheckUninitVar::analyseWholeProgram(const CTU::FileInfo *ctu, const std::li
     const std::map<std::string, std::list<const CTU::FileInfo::CallBase *>> callsMap = ctu->getCallsMap();
 
     for (const Check::FileInfo* fi1 : fileInfo) {
-        const MyFileInfo *fi = dynamic_cast<const MyFileInfo*>(fi1);
+        const MyFileInfoUninitVar *fi = dynamic_cast<const MyFileInfoUninitVar*>(fi1);
         if (!fi)
             continue;
         for (const CTU::FileInfo::UnsafeUsage &unsafeUsage : fi->unsafeUsage) {

--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -45,7 +45,6 @@
 
 //---------------------------------------------------------------------------
 
-static const CWE CWE561(561U);   // Dead Code
 
 static std::string stripTemplateParameters(const std::string& funcName) {
     std::string name = funcName;
@@ -307,7 +306,7 @@ static bool isOperatorFunction(const std::string & funcName)
     return std::find(additionalOperators.cbegin(), additionalOperators.cend(), funcName.substr(operatorPrefix.length())) != additionalOperators.cend();
 }
 
-#define logChecker(id) \
+#define logChecker_macro(id) \
     do { \
         const ErrorMessage errmsg({}, nullptr, Severity::internal, "logChecker", (id), CWE(0U), Certainty::normal); \
         errorLogger.reportErr(errmsg); \
@@ -315,7 +314,7 @@ static bool isOperatorFunction(const std::string & funcName)
 
 bool CheckUnusedFunctions::check(const Settings& settings, ErrorLogger& errorLogger) const
 {
-    logChecker("CheckUnusedFunctions::check"); // unusedFunction
+    logChecker_macro("CheckUnusedFunctions::check"); // unusedFunction
 
     using ErrorParams = std::tuple<std::string, unsigned int, unsigned int, std::string>;
     std::vector<ErrorParams> errors; // ensure well-defined order

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -40,11 +40,9 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckUnusedVar instance;
+    CheckUnusedVar instanceUnusedVar;
 }
 
-static const CWE CWE563(563U);   // Assignment to Variable without Use ('Unused Variable')
-static const CWE CWE665(665U);   // Improper Initialization
 
 /** Is scope a raii class scope */
 static bool isRaiiClassScope(const Scope *classScope)

--- a/lib/checkvaarg.cpp
+++ b/lib/checkvaarg.cpp
@@ -34,7 +34,7 @@
 
 // Register this check class (by creating a static instance of it)
 namespace {
-    CheckVaarg instance;
+    CheckVaarg instanceVaarg;
 }
 
 
@@ -42,10 +42,6 @@ namespace {
 // Ensure that correct parameter is passed to va_start()
 //---------------------------------------------------------------------------
 
-// CWE ids used:
-static const CWE CWE664(664U);   // Improper Control of a Resource Through its Lifetime
-static const CWE CWE688(688U);   // Function Call With Incorrect Variable or Reference as Argument
-static const CWE CWE758(758U);   // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
 
 void CheckVaarg::va_start_argument()
 {

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -88,8 +88,6 @@ static constexpr char FILELIST[] = "cppcheck-addon-ctu-file-list";
 
 static TimerResults s_timerResults;
 
-// CWE ids used
-static const CWE CWE398(398U);  // Indicator of Poor Code Quality
 
 // File deleter
 namespace {

--- a/lib/errortypes.cpp
+++ b/lib/errortypes.cpp
@@ -96,3 +96,67 @@ Severity severityFromString(const std::string& severity)
         return Severity::internal;
     return Severity::none;
 }
+
+const CWE CWE119(119U); // Improper Restriction of Operations within the Bounds of a Memory Buffer
+const CWE CWE128(128U); // Wrap-around Error
+const CWE CWE131(131U); // Incorrect Calculation of Buffer Size
+const CWE CWE170(170U); // Improper Null Termination
+const CWE CWE190(190U); // Integer Overflow or Wraparound
+const CWE CWE195(195U); // Signed to Unsigned Conversion Error
+const CWE CWE197(197U); // Numeric Truncation Error
+const CWE CWE252(252U); // Unchecked Return Value
+const CWE CWE362(362U); // Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
+const CWE CWE369(369U); // Divide By Zero
+const CWE CWE398(398U); // Indicator of Poor Code Quality
+const CWE CWE401(401U); // Improper Release of Memory Before Removing Last Reference ('Memory Leak')
+const CWE CWE404(404U); // Improper Resource Shutdown or Release
+const CWE CWE415(415U);
+const CWE CWE467(467U); // Use of sizeof() on a Pointer Type
+const CWE CWE475(475U); // Undefined Behavior for Input to API
+const CWE CWE477(477U); // Use of Obsolete Functions
+const CWE CWE480(480U); // Use of Incorrect Operator
+const CWE CWE561(561U); // Dead Code
+const CWE CWE562(562U); // Return of Stack Variable Address
+const CWE CWE563(563U); // Assignment to Variable without Use ('Unused Variable')
+const CWE CWE570(570U); // Expression is Always False
+const CWE CWE571(571U); // Expression is Always True
+const CWE CWE587(587U); // Assignment of a Fixed Address to a Pointer
+const CWE CWE590(590U); // Free of Memory not on the Heap
+const CWE CWE595(595U); // Comparison of Object References Instead of Object Contents
+const CWE CWE597(597U); // Use of Wrong Operator in String Comparison
+const CWE CWE628(628U); // Function Call with Incorrectly Specified Arguments
+const CWE CWE664(664U); // Improper Control of a Resource Through its Lifetime
+const CWE CWE665(665U); // Improper Initialization
+const CWE CWE667(667U); // Improper Locking
+const CWE CWE672(672U); // Operation on a Resource after Expiration or Release
+const CWE CWE682(682U); // Incorrect Calculation
+const CWE CWE683(683U); // Function Call With Incorrect Order of Arguments
+const CWE CWE685(685U); // Function Call With Incorrect Number of Arguments
+const CWE CWE686(686U); // Function Call With Incorrect Argument Type
+const CWE CWE687(687U); // Function Call With Incorrectly Specified Argument Value
+const CWE CWE688(688U); // Function Call With Incorrect Variable or Reference as Argument
+const CWE CWE703(703U); // Improper Check or Handling of Exceptional Conditions
+const CWE CWE704(704U); // Incorrect Type Conversion or Cast
+const CWE CWE758(758U); // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+const CWE CWE762(762U); // Mismatched Memory Management Routines
+const CWE CWE768(768U); // Incorrect Short Circuit Evaluation
+const CWE CWE771(771U); // Missing Reference to Active Allocated Resource
+const CWE CWE772(772U); // Missing Release of Resource after Effective Lifetime
+const CWE CWE783(783U); // Operator Precedence Logic Error
+const CWE CWE786(786U); // Access of Memory Location Before Start of Buffer
+const CWE CWE788(788U); // Access of Memory Location After End of Buffer
+const CWE CWE825(825U); // Expired Pointer Dereference
+const CWE CWE833(833U); // Deadlock
+const CWE CWE834(834U); // Excessive Iteration
+const CWE CWE910(910U); // Use of Expired File Descriptor
+
+const CWE CWE_ARGUMENT_SIZE(398U);          // Indicator of Poor Code Quality
+const CWE CWE_ARRAY_INDEX_THEN_CHECK(398U); // Indicator of Poor Code Quality
+const CWE CWE_BUFFER_OVERRUN(788U);         // Access of Memory Location After End of Buffer
+const CWE CWE_BUFFER_UNDERRUN(786U);        // Access of Memory Location Before Start of Buffer
+const CWE CWE_INCORRECT_CALCULATION(682U);
+const CWE CWE_NULL_POINTER_DEREFERENCE(476U);
+const CWE CWE_ONE_DEFINITION_RULE(758U);
+const CWE CWE_POINTER_ARITHMETIC_OVERFLOW(758U); // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+const CWE CWE_USE_OF_UNINITIALIZED_VARIABLE(457U);
+const CWE uncheckedErrorConditionCWE(391U);

--- a/lib/errortypes.h
+++ b/lib/errortypes.h
@@ -126,6 +126,71 @@ struct CWE {
     unsigned short id;
 };
 
+extern const CWE CWE119; // Improper Restriction of Operations within the Bounds of a Memory Buffer
+extern const CWE CWE128; // Wrap-around Error
+extern const CWE CWE131; // Incorrect Calculation of Buffer Size
+extern const CWE CWE170; // Improper Null Termination
+extern const CWE CWE190; // Integer Overflow or Wraparound
+extern const CWE CWE195; // Signed to Unsigned Conversion Error
+extern const CWE CWE197; // Numeric Truncation Error
+extern const CWE CWE252; // Unchecked Return Value
+extern const CWE CWE362; // Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
+extern const CWE CWE369; // Divide By Zero
+extern const CWE CWE398; // Indicator of Poor Code Quality
+extern const CWE CWE401; // Improper Release of Memory Before Removing Last Reference ('Memory Leak')
+extern const CWE CWE404; // Improper Resource Shutdown or Release
+extern const CWE CWE415;
+extern const CWE CWE467; // Use of sizeof() on a Pointer Type
+extern const CWE CWE475; // Undefined Behavior for Input to API
+extern const CWE CWE477; // Use of Obsolete Functions
+extern const CWE CWE480; // Use of Incorrect Operator
+extern const CWE CWE561; // Dead Code
+extern const CWE CWE562; // Return of Stack Variable Address
+extern const CWE CWE563; // Assignment to Variable without Use ('Unused Variable')
+extern const CWE CWE570; // Expression is Always False
+extern const CWE CWE571; // Expression is Always True
+extern const CWE CWE587; // Assignment of a Fixed Address to a Pointer
+extern const CWE CWE590; // Free of Memory not on the Heap
+extern const CWE CWE595; // Comparison of Object References Instead of Object Contents
+extern const CWE CWE597; // Use of Wrong Operator in String Comparison
+extern const CWE CWE628; // Function Call with Incorrectly Specified Arguments
+extern const CWE CWE664; // Improper Control of a Resource Through its Lifetime
+extern const CWE CWE665; // Improper Initialization
+extern const CWE CWE667; // Improper Locking
+extern const CWE CWE672; // Operation on a Resource after Expiration or Release
+extern const CWE CWE682; // Incorrect Calculation
+extern const CWE CWE683; // Function Call With Incorrect Order of Arguments
+extern const CWE CWE685; // Function Call With Incorrect Number of Arguments
+extern const CWE CWE686; // Function Call With Incorrect Argument Type
+extern const CWE CWE687; // Function Call With Incorrectly Specified Argument Value
+extern const CWE CWE688; // Function Call With Incorrect Variable or Reference as Argument
+extern const CWE CWE703; // Improper Check or Handling of Exceptional Conditions
+extern const CWE CWE704; // Incorrect Type Conversion or Cast
+extern const CWE CWE758; // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+extern const CWE CWE762; // Mismatched Memory Management Routines
+extern const CWE CWE768; // Incorrect Short Circuit Evaluation
+extern const CWE CWE771; // Missing Reference to Active Allocated Resource
+extern const CWE CWE772; // Missing Release of Resource after Effective Lifetime
+extern const CWE CWE783; // Operator Precedence Logic Error
+extern const CWE CWE786; // Access of Memory Location Before Start of Buffer
+extern const CWE CWE788; // Access of Memory Location After End of Buffer
+extern const CWE CWE825; // Expired Pointer Dereference
+extern const CWE CWE833; // Deadlock
+extern const CWE CWE834; // Excessive Iteration
+extern const CWE CWE910; // Use of Expired File Descriptor
+
+extern const CWE CWE_ARGUMENT_SIZE;          // Indicator of Poor Code Quality
+extern const CWE CWE_ARRAY_INDEX_THEN_CHECK; // Indicator of Poor Code Quality
+extern const CWE CWE_BUFFER_OVERRUN;         // Access of Memory Location After End of Buffer
+extern const CWE CWE_BUFFER_UNDERRUN;        // Access of Memory Location Before Start of Buffer
+extern const CWE CWE_INCORRECT_CALCULATION;
+extern const CWE CWE_NULL_POINTER_DEREFERENCE;
+extern const CWE CWE_ONE_DEFINITION_RULE;
+extern const CWE CWE_POINTER_ARITHMETIC_OVERFLOW; // Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
+extern const CWE CWE_USE_OF_UNINITIALIZED_VARIABLE;
+extern const CWE uncheckedErrorConditionCWE;
+
+
 using ErrorPathItem = std::pair<const Token *, std::string>;
 using ErrorPath = std::list<ErrorPathItem>;
 

--- a/lib/forwardanalyzer.cpp
+++ b/lib/forwardanalyzer.cpp
@@ -43,7 +43,7 @@
 #include <utility>
 #include <vector>
 
-namespace {
+namespace forwardAnalyzer{
     struct ForwardTraversal {
         enum class Progress { Continue, Break, Skip };
         enum class Terminate { None, Bail, Inconclusive };
@@ -908,7 +908,7 @@ Analyzer::Result valueFlowGenericForward(Token* start, const Token* end, const V
 {
     if (a->invalid())
         return Analyzer::Result{Analyzer::Action::None, Analyzer::Terminate::Bail};
-    ForwardTraversal ft{a, tokenList, errorLogger, settings};
+    forwardAnalyzer::ForwardTraversal ft{a, tokenList, errorLogger, settings};
     if (start)
         ft.analyzer->updateState(start);
     ft.updateRange(start, end);
@@ -921,7 +921,7 @@ Analyzer::Result valueFlowGenericForward(Token* start, const ValuePtr<Analyzer>&
         throw TerminateException();
     if (a->invalid())
         return Analyzer::Result{Analyzer::Action::None, Analyzer::Terminate::Bail};
-    ForwardTraversal ft{a, tokenList, errorLogger, settings};
+    forwardAnalyzer::ForwardTraversal ft{a, tokenList, errorLogger, settings};
     ft.updateRecursive(start);
     return Analyzer::Result{ ft.actions, ft.terminate };
 }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -940,7 +940,7 @@ const Token* Token::nextTemplateArgument() const
     return nullptr;
 }
 
-static bool isOperator(const Token *tok)
+static bool isOperator2(const Token *tok)
 {
     if (tok->link())
         tok = tok->link();
@@ -985,7 +985,7 @@ const Token * Token::findClosingBracket() const
             return nullptr;
         // we can make some guesses for template parameters
         else if (closing->str() == "<" && closing->previous() &&
-                 (closing->previous()->isName() || Token::simpleMatch(closing->previous(), "]") || isOperator(closing->previous())) &&
+                 (closing->previous()->isName() || Token::simpleMatch(closing->previous(), "]") || isOperator2(closing->previous())) &&
                  (templateParameter ? templateParameters.find(closing->strAt(-1)) == templateParameters.end() : true))
             ++depth;
         else if (closing->str() == ">") {

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2242,7 +2242,7 @@ static const std::string& invertAssign(const std::string& assign)
     return it->second;
 }
 
-static std::string removeAssign(const std::string& assign) {
+static std::string removeAssign2(const std::string& assign) {
     return std::string{assign.cbegin(), assign.cend() - 1};
 }
 
@@ -2256,7 +2256,7 @@ static T calculateAssign(const std::string& assign, const T& x, const U& y, bool
     }
     if (assign == "=")
         return y;
-    return calculate<T, T>(removeAssign(assign), x, y, error);
+    return calculate<T, T>(removeAssign2(assign), x, y, error);
 }
 
 template<class T, class U>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,8 @@ if (BUILD_TESTS)
     endif()
 
     add_executable(testrunner ${testrunner_SOURCES})
+    # disable unity build for tests because some macros conflict with macros
+    set_target_properties(testrunner PROPERTIES UNITY_BUILD OFF)
     target_include_directories(testrunner PRIVATE ${PROJECT_SOURCE_DIR}/lib/ ${PROJECT_SOURCE_DIR}/cli/)
     if(USE_BUNDLED_TINYXML2)
         target_externals_include_directories(testrunner PRIVATE ${PROJECT_SOURCE_DIR}/externals/tinyxml2)

--- a/tools/matchcompiler.py
+++ b/tools/matchcompiler.py
@@ -206,7 +206,7 @@ class MatchCompiler:
                 arg2 = ', const int varid'
 
             ret = '// pattern: ' + pattern + '\n'
-            ret += 'static inline bool match' + \
+            ret += 'static inline bool match' + str(abs(hash(pattern))) + \
                 str(nr) + '(' + tokenType + '* tok' + arg2 + ') {\n'
             returnStatement = 'return false;\n'
 
@@ -290,7 +290,7 @@ class MatchCompiler:
             more_args += ', int varid'
 
         ret = '// pattern: ' + pattern + '\n'
-        ret += 'template<class T> static inline T * findmatch' + \
+        ret += 'template<class T> static inline T * findmatch'+ str(abs(hash(pattern))) + \
             str(findmatchnr) + '(T * start_tok' + more_args + ') {\n'
         ret += '    for (; start_tok' + endCondition + \
             '; start_tok = start_tok->next()) {\n'
@@ -432,7 +432,7 @@ class MatchCompiler:
             self._rawMatchFunctions.append(
                 self._compilePattern(pattern, patternNumber, varId))
 
-        functionName = "match"
+        functionName = "match"+ str(abs(hash(pattern)))
         if self._verifyMode:
             verifyNumber = len(self._rawMatchFunctions) + 1
             self._rawMatchFunctions.append(
@@ -572,7 +572,7 @@ class MatchCompiler:
                     endToken,
                     varId))
 
-        functionName = "findmatch"
+        functionName = "findmatch"+ str(abs(hash(pattern)))
         if self._verifyMode:
             verifyNumber = len(self._rawMatchFunctions) + 1
             self._rawMatchFunctions.append(


### PR DESCRIPTION
I noticed that `cppcheck` can not be built with a `CMAKE_UNITY_BUILD`.

The changes in the PR allow to do a `CMAKE_UNITY_BUILD`. 

Notable changes:

* move all CWE to the `errortypes.h` header as `extern` and the definition to the `errortypes.cpp`
* renamed some variables or functions in order to avoid ODR conflicts
* move code into namespaces in order to avoid ORD conflicts
* add a hash of the pattern to the generated `match` and `findMatch` functions in order to avoid ORD conflicts.

I intentionally tried to keep the initial PR small, so I did not change the indentation for the changed namespaces or do any bigger refactoring. 
