### PR TITLE
Fix #12505 (cli: Add option --check-version to pin cppcheck version)

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -117,6 +117,15 @@ static bool addPathsToSet(const std::string& fileName, std::set<std::string>& se
     return true;
 }
 
+static std::string getVersion(const Settings& settings) {
+    if (!settings.cppcheckCfgProductName.empty())
+        return settings.cppcheckCfgProductName;
+    const char * const extraVersion = CppCheck::extraVersion();
+    if (*extraVersion != '\0')
+        return std::string("Cppcheck ") + CppCheck::version() + " ("+ extraVersion + ')';
+    return std::string("Cppcheck ") + CppCheck::version();
+}
+
 namespace {
     class XMLErrorMessagesLogger : public ErrorLogger
     {
@@ -356,15 +365,8 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
         if (std::strcmp(argv[i], "--version") == 0) {
             if (!loadCppcheckCfg())
                 return Result::Fail;
-            if (!mSettings.cppcheckCfgProductName.empty()) {
-                mLogger.printRaw(mSettings.cppcheckCfgProductName);
-            } else {
-                const char * const extraVersion = CppCheck::extraVersion();
-                if (*extraVersion != '\0')
-                    mLogger.printRaw(std::string("Cppcheck ") + CppCheck::version() + " ("+ extraVersion + ')');
-                else
-                    mLogger.printRaw(std::string("Cppcheck ") + CppCheck::version());
-            }
+            const std::string version = getVersion(mSettings);
+            mLogger.printRaw(version);
             return Result::Exit;
         }
     }
@@ -486,6 +488,17 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             // Check library definitions
             else if (std::strcmp(argv[i], "--check-library") == 0) {
                 mSettings.checkLibrary = true;
+            }
+
+            else if (std::strncmp(argv[i], "--check-version=", 16) == 0) {
+                if (!loadCppcheckCfg())
+                    return Result::Fail;
+                const std::string actualVersion = getVersion(mSettings);
+                const std::string wantedVersion = argv[i] + 16;
+                if (actualVersion != wantedVersion) {
+                    mLogger.printError("--check-version check failed. Aborting.");
+                    return Result::Fail;
+                }
             }
 
             else if (std::strncmp(argv[i], "--checkers-report=", 18) == 0)

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -117,15 +117,6 @@ static bool addPathsToSet(const std::string& fileName, std::set<std::string>& se
     return true;
 }
 
-static std::string getVersion(const Settings& settings) {
-    if (!settings.cppcheckCfgProductName.empty())
-        return settings.cppcheckCfgProductName;
-    const char * const extraVersion = CppCheck::extraVersion();
-    if (*extraVersion != '\0')
-        return std::string("Cppcheck ") + CppCheck::version() + " ("+ extraVersion + ')';
-    return std::string("Cppcheck ") + CppCheck::version();
-}
-
 namespace {
     class XMLErrorMessagesLogger : public ErrorLogger
     {
@@ -365,7 +356,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
         if (std::strcmp(argv[i], "--version") == 0) {
             if (!loadCppcheckCfg())
                 return Result::Fail;
-            const std::string version = getVersion(mSettings);
+            const std::string version = getVersion();
             mLogger.printRaw(version);
             return Result::Exit;
         }
@@ -493,7 +484,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             else if (std::strncmp(argv[i], "--check-version=", 16) == 0) {
                 if (!loadCppcheckCfg())
                     return Result::Fail;
-                const std::string actualVersion = getVersion(mSettings);
+                const std::string actualVersion = getVersion();
                 const std::string wantedVersion = argv[i] + 16;
                 if (actualVersion != wantedVersion) {
                     mLogger.printError("--check-version check failed. Aborting.");
@@ -1747,6 +1738,15 @@ void CmdLineParser::printHelp() const
         " * qt -- used in GUI\n";
 
     mLogger.printRaw(oss.str());
+}
+
+std::string CmdLineParser::getVersion() const {
+    if (!mSettings.cppcheckCfgProductName.empty())
+        return mSettings.cppcheckCfgProductName;
+    const char * const extraVersion = CppCheck::extraVersion();
+    if (*extraVersion != '\0')
+        return std::string("Cppcheck ") + CppCheck::version() + " ("+ extraVersion + ')';
+    return std::string("Cppcheck ") + CppCheck::version();
 }
 
 bool CmdLineParser::isCppcheckPremium() const {

--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -102,6 +102,11 @@ public:
         return mIgnoredPaths;
     }
 
+    /**
+     * Get Cppcheck version
+     */
+    std::string getVersion() const;
+
 protected:
 
     /**

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -27,3 +27,4 @@ Other:
 - Removed CMake option 'USE_THREADS' in favor of 'DISALLOW_THREAD_EXECUTOR'.
 - Fixed crash with '--rule-file=' if some data was missing.
 - '--rule-file' will now bail out if a rule could not be added or a file contains unexpected data.
+- Add option '--check-version', you can use it to pin the cppcheck version in a script.

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -475,8 +475,8 @@ private:
 
     void checkVersionCorrect() {
         REDIRECT;
-        const std::string version = parser->getVersion();
-        const std::string checkVersion = "--check-version=" + version;
+        const std::string currentVersion = parser->getVersion();
+        const std::string checkVersion = "--check-version=" + currentVersion;
         const char * const argv[] = {"cppcheck", checkVersion.c_str(), "file.cpp"};
         ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv));
     }

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -119,7 +119,8 @@ private:
         TEST_CASE(versionWithCfg);
         TEST_CASE(versionExclusive);
         TEST_CASE(versionWithInvalidCfg);
-        TEST_CASE(checkVersion);
+        TEST_CASE(checkVersionCorrect);
+        TEST_CASE(checkVersionIncorrect);
         TEST_CASE(onefile);
         TEST_CASE(onepath);
         TEST_CASE(optionwithoutfile);
@@ -472,20 +473,18 @@ private:
         ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 2 near: \n", logger->str());
     }
 
-    void checkVersion() {
+    void checkVersionCorrect() {
         REDIRECT;
-        // get version
-        const char * const argv1[] = {"cppcheck", "--version"};
-        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Exit, parser->parseFromArgs(2, argv1));
-        std::string version = logger->str();
-        version.erase(version.find('\n'));
-        const std::string checkCorrectVersion = "--check-version=" + version;
-        // check version: correct version
-        const char * const argv2[] = {"cppcheck", checkCorrectVersion.c_str(), "file.cpp"};
-        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv2));
-        // check version: incorrect version
-        const char * const argv3[] = {"cppcheck", "--check-version=Cppcheck 2.0", "file.cpp"};
-        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(3, argv3));
+        const std::string version = parser->getVersion();
+        const std::string checkVersion = "--check-version=" + version;
+        const char * const argv[] = {"cppcheck", checkVersion.c_str(), "file.cpp"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv));
+    }
+
+    void checkVersionIncorrect() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "--check-version=Cppcheck 2.0", "file.cpp"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(3, argv));
         ASSERT_EQUALS("cppcheck: error: --check-version check failed. Aborting.\n", logger->str());
     }
 

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -119,6 +119,7 @@ private:
         TEST_CASE(versionWithCfg);
         TEST_CASE(versionExclusive);
         TEST_CASE(versionWithInvalidCfg);
+        TEST_CASE(checkVersion);
         TEST_CASE(onefile);
         TEST_CASE(onepath);
         TEST_CASE(optionwithoutfile);
@@ -469,6 +470,23 @@ private:
         const char * const argv[] = {"cppcheck", "--version"};
         ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(2, argv));
         ASSERT_EQUALS("cppcheck: error: could not load cppcheck.cfg - not a valid JSON - syntax error at line 2 near: \n", logger->str());
+    }
+
+    void checkVersion() {
+        REDIRECT;
+        // get version
+        const char * const argv1[] = {"cppcheck", "--version"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Exit, parser->parseFromArgs(2, argv1));
+        std::string version = logger->str();
+        version.erase(version.find('\n'));
+        const std::string checkCorrectVersion = "--check-version=" + version;
+        // check version: correct version
+        const char * const argv2[] = {"cppcheck", checkCorrectVersion.c_str(), "file.cpp"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv2));
+        // check version: incorrect version
+        const char * const argv3[] = {"cppcheck", "--check-version=Cppcheck 2.0", "file.cpp"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(3, argv3));
+        ASSERT_EQUALS("cppcheck: error: --check-version check failed. Aborting.\n", logger->str());
     }
 
     void onefile() {


### PR DESCRIPTION
I chose to not add it in the help output. But I don't have a strong opinion it can be added there also.

This option was added for the safety certification. It could be very bad if a user runs one version of cppcheck and thinks that he runs another version. 