### PR TITLE
posix.cfg: Fixed FP for getdelim and array

### DIFF
--- a/cfg/posix.cfg
+++ b/cfg/posix.cfg
@@ -5259,7 +5259,7 @@ The function 'mktemp' is considered to be dangerous due to race conditions and s
       <not-uninit/>
       <valid>0:255</valid>
     </arg>
-    <arg nr="4" direction="in">
+    <arg nr="4" direction="inout">
       <not-null/>
       <not-uninit/>
     </arg>

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -913,8 +913,8 @@ typedef struct {
 } S_memalign;
 
 S_memalign* posix_memalign_memleak(size_t n) { // #12248
-    S_memalign* s = malloc(sizeof(*s));   
-    s->N = n;   
+    S_memalign* s = malloc(sizeof(*s));
+    s->N = n;
     if (0 != posix_memalign((void**)&s->data, 16, n * sizeof(int))) {
         free(s);
         return NULL;
@@ -1075,6 +1075,26 @@ void memleak_getline_array(FILE* stream) { // #12498
     size_t n;
     getline(&a[0], &n, stream);
     getline(&a[1], &n, stream);
+    free(a[0]);
+    free(a[1]);
+}
+
+void memleak_getdelim(int delim) {
+    char *line = NULL;
+    size_t size = 0;
+    getdelim(&line, &size, delim, stdin);
+    // cppcheck-suppress memleak
+    line = NULL;
+    getdelim(&line, &size, delim, stdin);
+    // cppcheck-suppress memleak
+    line = NULL;
+}
+
+void memleak_getdelim_array(FILE* stream, int delim) {
+    char* a[2] = { 0 };
+    size_t n;
+    getdelim(&a[0], &n, delim, stream);
+    getdelim(&a[1], &n, delim, stream);
     free(a[0]);
     free(a[1]);
 }


### PR DESCRIPTION
This fix is similar to https://github.com/danmar/cppcheck/pull/6108