### PR TITLE
oss-fuzz/Makefile: re-added `translate` target and fixed `no-fuzz` build

### DIFF
--- a/oss-fuzz/Makefile
+++ b/oss-fuzz/Makefile
@@ -103,11 +103,14 @@ EXTOBJ =      simplecpp.o \
 oss-fuzz-client: $(EXTOBJ) $(LIBOBJ) main.o type2.o
 	${CXX} $(CPPFLAGS) ${CXXFLAGS} -o $@ $^ ${LIB_FUZZING_ENGINE}
 
-no-fuzz: $(EXTOBJ) $(LIBOBJ) main.o
-	${CXX} $(CPPFLAGS) ${CXXFLAGS} -DNO_FUZZ -o $@ $^
+no-fuzz: $(EXTOBJ) $(LIBOBJ) main_nofuzz.o type2.o
+	${CXX} $(CPPFLAGS) ${CXXFLAGS} -o $@ $^
+
+translate: translate.cpp type2.o
+	${CXX} -std=c++11 -g ${CXXFLAGS} -o $@ type2.cpp translate.cpp
 
 clean:
-	rm -f *.o build/*.o oss-fuzz-client no-fuzz
+	rm -f *.o build/*.o oss-fuzz-client no-fuzz translate
 
 simplecpp.o: ../externals/simplecpp/simplecpp.cpp ../externals/simplecpp/simplecpp.h
 	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -w -c -o $@ ../externals/simplecpp/simplecpp.cpp
@@ -308,5 +311,11 @@ $(libcppdir)/vfvalue.o: ../lib/vfvalue.cpp ../lib/config.h ../lib/errortypes.h .
 type2.o: type2.h
 	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ type2.cpp
 
+translate.o: type2.h
+	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ translate.cpp
+
 main.o: type2.h
 	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ main.cpp
+
+main_nofuzz.o: type2.h
+	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -DNO_FUZZ -c -o $@ main.cpp

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -358,11 +358,14 @@ static void write_ossfuzz_makefile(std::vector<std::string> libfiles_prio, std::
     fout << "oss-fuzz-client: $(EXTOBJ) $(LIBOBJ) main.o type2.o\n";
     fout << "\t${CXX} $(CPPFLAGS) ${CXXFLAGS} -o $@ $^ ${LIB_FUZZING_ENGINE}\n";
     fout << '\n';
-    fout << "no-fuzz: $(EXTOBJ) $(LIBOBJ) main.o\n";
-    fout << "\t${CXX} $(CPPFLAGS) ${CXXFLAGS} -DNO_FUZZ -o $@ $^\n";
+    fout << "no-fuzz: $(EXTOBJ) $(LIBOBJ) main_nofuzz.o type2.o\n";
+    fout << "\t${CXX} $(CPPFLAGS) ${CXXFLAGS} -o $@ $^\n";
+    fout << '\n';
+    fout << "translate: translate.cpp type2.o\n";
+    fout << "\t${CXX} -std=c++11 -g ${CXXFLAGS} -o $@ type2.cpp translate.cpp\n";
     fout << '\n';
     fout << "clean:\n";
-    fout << "\trm -f *.o build/*.o oss-fuzz-client no-fuzz\n";
+    fout << "\trm -f *.o build/*.o oss-fuzz-client no-fuzz translate\n";
     fout << '\n';
 
     compilefiles(fout, extfiles, "${LIB_FUZZING_ENGINE}");
@@ -372,8 +375,14 @@ static void write_ossfuzz_makefile(std::vector<std::string> libfiles_prio, std::
     fout << "type2.o: type2.h\n";
     fout << "\t$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ type2.cpp\n";
     fout << '\n';
+    fout << "translate.o: type2.h\n";
+    fout << "\t$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ translate.cpp\n";
+    fout << '\n';
     fout << "main.o: type2.h\n";
     fout << "\t$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ main.cpp\n";
+    fout << '\n';
+    fout << "main_nofuzz.o: type2.h\n";
+    fout << "\t$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -DNO_FUZZ -c -o $@ main.cpp\n";
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
I tested all builds beforehand but I worked from a branch which already removed the code generation.