### PR TITLE
made all suppressions in `cfg` tests inline / added TODOs

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,7 +115,6 @@ if (BUILD_TESTS)
             else()
                 # TODO: remove missingInclude disabling when it no longer is implied by --enable=information
                 # TODO: add syntax check
-                # need to suppress unmatchedSuppression in case valueFlowBailout is not reported
                 add_test(NAME cfg-${TEST_NAME}
                         COMMAND $<TARGET_FILE:cppcheck>
                         --library=${LIBRARY}
@@ -129,9 +128,6 @@ if (BUILD_TESTS)
                         --disable=missingInclude
                         --inline-suppr
                         --debug-warnings
-                        --suppress=valueFlowBailout
-                        --suppress=purgedConfiguration
-                        --suppress=unmatchedSuppression
                         --suppress=checkersReport
                         ${CMAKE_CURRENT_SOURCE_DIR}/cfg/${CFG_TEST}
                 )

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <boost/config.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/endian/conversion.hpp>

--- a/test/cfg/bsd.c
+++ b/test/cfg/bsd.c
@@ -6,6 +6,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -6,6 +6,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <cppunit/TestAssert.h>
 
 void cppunit_assert_equal(int x, double y)

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <gmock/gmock-generated-matchers.h>
 #include <gtest/gtest.h>
 

--- a/test/cfg/libcurl.c
+++ b/test/cfg/libcurl.c
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <curl/curl.h>
 #include <stdio.h>
 

--- a/test/cfg/opencv2.cpp
+++ b/test/cfg/opencv2.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <iostream>
 #include <opencv2/opencv.hpp>
 

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file [valueFlowBailout,purgedConfiguration]
+
 #define _BSD_SOURCE
 
 #include <aio.h>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <QObject>
 #include <QString>
 #include <QVector>
@@ -576,7 +578,7 @@ void validCode(int * pIntPtr, QString & qstrArg, double d)
 
     printf(QT_TR_NOOP("Hi"));
 
-    // cppcheck-suppress [checkLibraryFunction,valueFlowBailoutIncompleteVar]
+    // cppcheck-suppress valueFlowBailoutIncompleteVar
     Q_DECLARE_LOGGING_CATEGORY(logging_category_test);
     QT_FORWARD_DECLARE_CLASS(forwardDeclaredClass);
     QT_FORWARD_DECLARE_STRUCT(forwardDeclaredStruct);

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -27,7 +27,7 @@ CFG="$DIR"../../cfg/
 # TODO: remove missingInclude disabling when it no longer is implied by --enable=information
 # Cppcheck options
 # need to suppress unmatchedSuppression in case valueFlowBailout is not reported
-CPPCHECK_OPT='--check-library --platform=unix64 --enable=style,information --inconclusive --force --check-level=exhaustive --error-exitcode=-1 --disable=missingInclude --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}" --debug-warnings --suppress=valueFlowBailout --suppress=purgedConfiguration --suppress=unmatchedSuppression --suppress=checkersReport'
+CPPCHECK_OPT='--check-library --platform=unix64 --enable=style,information --inconclusive --force --check-level=exhaustive --error-exitcode=-1 --disable=missingInclude --inline-suppr --template="{file}:{line}:{severity}:{id}:{message}" --debug-warnings --suppress=checkersReport'
 
 # Compiler settings
 CXX=g++

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <algorithm>
 #include <bitset>
 #include <cassert>
@@ -2472,21 +2474,21 @@ void uninitvar_ldexp(void)
 void invalidFunctionArg_lgamma(float f, double d, long double ld)
 {
     (void)lgamma(d);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)lgamma(-0.1);
     // cppcheck-suppress invalidFunctionArg
     (void)lgamma(0.0);
     (void)lgamma(0.1);
 
     (void)lgammaf(f);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)lgammaf(-0.1f);
     // cppcheck-suppress invalidFunctionArg
     (void)lgammaf(0.0f);
     (void)lgammaf(0.1f);
 
     (void)lgammal(ld);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)lgammal(-0.1L);
     // cppcheck-suppress invalidFunctionArg
     (void)lgammal(0.0L);
@@ -2496,21 +2498,21 @@ void invalidFunctionArg_lgamma(float f, double d, long double ld)
 void invalidFunctionArg_tgamma(float f, double d, long double ld)
 {
     (void)tgamma(d);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)tgamma(-0.1);
     // cppcheck-suppress invalidFunctionArg
     (void)tgamma(0.0);
     (void)tgamma(0.1);
 
     (void)tgammaf(f);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)tgammaf(-0.1f);
     // cppcheck-suppress invalidFunctionArg
     (void)tgammaf(0.0f);
     (void)tgammaf(0.1f);
 
     (void)tgammal(ld);
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     (void)tgammal(-0.1L);
     // cppcheck-suppress invalidFunctionArg
     (void)tgammal(0.0L);
@@ -4969,7 +4971,7 @@ void memleak_std_realloc(void* block, size_t newsize)
 
 void unusedAllocatedMemory_std_free()
 {
-    //cppcheck-suppress unusedAllocatedMemory
+    // TODO cppcheck-suppress unusedAllocatedMemory
     void* p = std::malloc(1);
     std::free(p);
 }

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file [valueFlowBailout,purgedConfiguration]
+
 #include <Windows.h>
 #include <WinCon.h>
 #include <cstdio>
@@ -355,7 +357,7 @@ void validCode()
     WSACleanup();
 
     wordInit = MAKEWORD(1, 2);
-    // cppcheck-suppress redundantAssignment
+    // TODO cppcheck-suppress redundantAssignment
     dwordInit = MAKELONG(1, 2);
     // cppcheck-suppress redundantAssignment
     wordInit = LOWORD(dwordInit);
@@ -789,7 +791,7 @@ void invalidFunctionArg()
     CloseHandle(hMutex);
 
     //Incorrect: 2. parameter to LoadLibraryEx() must be NULL
-    // cppcheck-suppress invalidFunctionArg
+    // TODO cppcheck-suppress invalidFunctionArg
     HINSTANCE hInstLib = LoadLibraryEx(L"My.dll", HANDLE(1), 0);
     FreeLibrary(hInstLib);
 
@@ -814,7 +816,7 @@ void uninitvar()
     // cppcheck-suppress uninitvar
     lstrcat(buf, _T("test"));
     buf[0] = _T('\0');
-    // cppcheck-suppress constVariable
+    // TODO cppcheck-suppress constVariable
     TCHAR buf2[2];
     // cppcheck-suppress lstrcatCalled
     // cppcheck-suppress uninitvar

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -7,6 +7,8 @@
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //
 
+// cppcheck-suppress-file valueFlowBailout
+
 #include <wx/wx.h>
 #include <wx/accel.h>
 #include <wx/app.h>


### PR DESCRIPTION
`unmatchedSuppression` was suppressed globally which obviously has the effect that we got no feedback when an expected warning was not being reported.