### PR TITLE
windows.cfg: Added support for _utime-functions

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -1877,6 +1877,26 @@
       <strz/>
     </arg>
   </function>
+  <!-- int _utime(const char *filename, struct _utimbuf *times); -->
+  <!-- int _utime32(const char *filename, struct __utimbuf32 *times); -->
+  <!-- int _utime64(const char *filename, struct __utimbuf64 *times); -->
+  <!-- int _wutime(const wchar_t *filename, struct _utimbuf *times); -->
+  <!-- int _wutime32(const wchar_t *filename, struct __utimbuf32 *times); -->
+  <!-- int _wutime64(const wchar_t *filename, struct __utimbuf64 *times); -->
+  <function name="_utime,_utime32,_utime64,_wutime,_wutime32,_wutime64">
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <returnValue type="int"/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+      <strz/>
+    </arg>
+    <arg nr="2" direction="out">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
   <!-- BOOL GetCommState(HANDLE hFile, LPDCB  lpDCB); -->
   <function name="GetCommState">
     <noreturn>false</noreturn>


### PR DESCRIPTION
Reference: https://learn.microsoft.com/de-de/cpp/c-runtime-library/reference/utime-utime32-utime64-wutime-wutime32-wutime64?view=msvc-170