### PR TITLE
removed original filenames from `TokenList` and `ErrorMessage::FileLocation` / added missing `ErrorMessage::FileLocation::mFile` normalization / some cleanups

### DIFF
--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -1632,7 +1632,6 @@ void clangimport::parseClangAstDump(Tokenizer &tokenizer, std::istream &f)
         tokenList.front()->assignIndexes();
     symbolDatabase->clangSetVariables(data.getVariableList());
     symbolDatabase->createSymbolDatabaseExprIds();
-    tokenList.clangSetOrigFiles();
     setTypes(tokenList);
     setValues(tokenizer, symbolDatabase);
 }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -404,8 +404,7 @@ static bool reportClangErrors(std::istream &is, const std::function<void(const E
         const std::string msg = line.substr(line.find(':', pos3+1) + 2);
 
         const std::string locFile = Path::toNativeSeparators(filename);
-        ErrorMessage::FileLocation loc;
-        loc.setfile(locFile);
+        ErrorMessage::FileLocation loc(locFile);
         loc.line = strToInt<int>(linenr);
         loc.column = strToInt<unsigned int>(colnr);
         ErrorMessage errmsg({std::move(loc)},
@@ -1010,8 +1009,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 msg += '\n' + s;
 
             const std::string locFile = Path::toNativeSeparators(filename);
-            ErrorMessage::FileLocation loc;
-            loc.setfile(locFile);
+            ErrorMessage::FileLocation loc(locFile);
             ErrorMessage errmsg({std::move(loc)},
                                 locFile,
                                 Severity::information,
@@ -1113,8 +1111,7 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
 
             if (maxTime > 0 && std::time(nullptr) > maxTime) {
                 if (mSettings.debugwarnings) {
-                    ErrorMessage::FileLocation loc;
-                    loc.setfile(tokenizer.list.getFiles()[0]);
+                    ErrorMessage::FileLocation loc(tokenizer.list.getFiles()[0]);
                     ErrorMessage errmsg({std::move(loc)},
                                         emptyString,
                                         Severity::debug,
@@ -1406,21 +1403,20 @@ void CppCheck::executeRules(const std::string &tokenlist, const Tokenizer &token
             pos = (int)pos2;
 
             // determine location..
-            ErrorMessage::FileLocation loc;
-            loc.setfile(tokenizer.list.getSourceFilePath());
-            loc.line = 0;
+            std::string file = tokenizer.list.getSourceFilePath();
+            int line = 0;
 
             std::size_t len = 0;
             for (const Token *tok = tokenizer.tokens(); tok; tok = tok->next()) {
                 len = len + 1U + tok->str().size();
                 if (len > pos1) {
-                    loc.setfile(tokenizer.list.getFiles().at(tok->fileIndex()));
-                    loc.line = tok->linenr();
+                    file = tokenizer.list.getFiles().at(tok->fileIndex());
+                    line = tok->linenr();
                     break;
                 }
             }
 
-            const std::list<ErrorMessage::FileLocation> callStack(1, loc);
+            ErrorMessage::FileLocation loc(file, line);
 
             // Create error message
             std::string summary;
@@ -1428,7 +1424,7 @@ void CppCheck::executeRules(const std::string &tokenlist, const Tokenizer &token
                 summary = "found '" + str.substr(pos1, pos2 - pos1) + "'";
             else
                 summary = rule.summary;
-            const ErrorMessage errmsg(callStack, tokenizer.list.getSourceFilePath(), rule.severity, summary, rule.id, Certainty::normal);
+            const ErrorMessage errmsg({std::move(loc)}, tokenizer.list.getSourceFilePath(), rule.severity, summary, rule.id, Certainty::normal);
 
             // Report error
             reportErr(errmsg);

--- a/lib/ctu.cpp
+++ b/lib/ctu.cpp
@@ -209,11 +209,11 @@ bool CTU::FileInfo::FunctionCall::loadFromXml(const tinyxml2::XMLElement *xmlEle
     for (const tinyxml2::XMLElement *e2 = xmlElement->FirstChildElement(); !error && e2; e2 = e2->NextSiblingElement()) {
         if (std::strcmp(e2->Name(), "path") != 0)
             continue;
-        ErrorMessage::FileLocation loc;
-        loc.setfile(readAttrString(e2, ATTR_LOC_FILENAME, &error));
+        ErrorMessage::FileLocation loc(readAttrString(e2, ATTR_LOC_FILENAME, &error));
         loc.line = readAttrInt(e2, ATTR_LOC_LINENR, &error);
         loc.column = readAttrInt(e2, ATTR_LOC_COLUMN, &error);
         loc.setinfo(readAttrString(e2, ATTR_INFO, &error));
+        // TODO: loc is never used
     }
     return !error;
 }
@@ -345,12 +345,10 @@ CTU::FileInfo *CTU::getFileInfo(const Tokenizer *tokenizer)
                     functionCall.callArgValue = value.intvalue;
                     functionCall.warning = !value.errorSeverity();
                     for (const ErrorPathItem &i : value.errorPath) {
-                        ErrorMessage::FileLocation loc;
-                        loc.setfile(tokenizer->list.file(i.first));
-                        loc.line = i.first->linenr();
-                        loc.column = i.first->column();
-                        loc.setinfo(i.second);
-                        functionCall.callValuePath.push_back(std::move(loc));
+                        std::string file = tokenizer->list.file(i.first);
+                        int line = i.first->linenr();
+                        int column = i.first->column();
+                        functionCall.callValuePath.emplace_back(file, i.second, line, column);
                     }
                     fileInfo->functionCalls.push_back(std::move(functionCall));
                 }

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -296,8 +296,6 @@ std::string ErrorMessage::serialize() const
         frame += '\t';
         frame += loc->getfile(false);
         frame += '\t';
-        frame += loc->getOrigFile(false);
-        frame += '\t';
         frame += loc->getinfo();
         serializeString(oss, frame);
     }
@@ -394,9 +392,9 @@ void ErrorMessage::deserialize(const std::string &data)
         }
 
         std::vector<std::string> substrings;
-        substrings.reserve(5);
-        for (std::string::size_type pos = 0; pos < temp.size() && substrings.size() < 5; ++pos) {
-            if (substrings.size() == 4) {
+        substrings.reserve(4);
+        for (std::string::size_type pos = 0; pos < temp.size() && substrings.size() < 4; ++pos) {
+            if (substrings.size() == 3) {
                 substrings.push_back(temp.substr(pos));
                 break;
             }
@@ -408,15 +406,14 @@ void ErrorMessage::deserialize(const std::string &data)
             }
             substrings.push_back(temp.substr(start, pos - start));
         }
-        if (substrings.size() < 4)
+        if (substrings.size() < 3)
             throw InternalError(nullptr, "Internal Error: Deserializing of error message failed");
 
-        // (*loc).line << '\t' << (*loc).column << '\t' << (*loc).getfile(false) << '\t' << loc->getOrigFile(false) << '\t' << loc->getinfo();
+        // (*loc).line << '\t' << (*loc).column << '\t' << (*loc).getfile(false) << '\t' << loc->getinfo();
 
-        ErrorMessage::FileLocation loc(substrings[3], strToInt<int>(substrings[0]), strToInt<unsigned int>(substrings[1]));
-        loc.setfile(std::move(substrings[2]));
-        if (substrings.size() == 5)
-            loc.setinfo(substrings[4]);
+        ErrorMessage::FileLocation loc(substrings[2], strToInt<int>(substrings[0]), strToInt<unsigned int>(substrings[1]));
+        if (substrings.size() == 4)
+            loc.setinfo(substrings[3]);
 
         callStack.push_back(std::move(loc));
 
@@ -671,7 +668,7 @@ std::string ErrorMessage::toString(bool verbose, const std::string &templateForm
                 endl = "\r\n";
             else
                 endl = "\r";
-            findAndReplace(result, "{code}", readCode(callStack.back().getOrigFile(), callStack.back().line, callStack.back().column, endl));
+            findAndReplace(result, "{code}", readCode(callStack.back().getfile(), callStack.back().line, callStack.back().column, endl));
         }
     } else {
         static const std::unordered_map<std::string, std::string> callStackSubstitutionMap =
@@ -702,7 +699,7 @@ std::string ErrorMessage::toString(bool verbose, const std::string &templateForm
                     endl = "\r\n";
                 else
                     endl = "\r";
-                findAndReplace(text, "{code}", readCode(fileLocation.getOrigFile(), fileLocation.line, fileLocation.column, endl));
+                findAndReplace(text, "{code}", readCode(fileLocation.getfile(), fileLocation.line, fileLocation.column, endl));
             }
             result += '\n' + text;
         }
@@ -723,12 +720,16 @@ std::string ErrorLogger::callStackToString(const std::list<ErrorMessage::FileLoc
 
 
 ErrorMessage::FileLocation::FileLocation(const Token* tok, const TokenList* tokenList)
-    : fileIndex(tok->fileIndex()), line(tok->linenr()), column(tok->column()), mOrigFileName(tokenList->getOrigFile(tok)), mFileName(tokenList->file(tok))
-{}
+    : fileIndex(tok->fileIndex()), line(tok->linenr()), column(tok->column())
+{
+    setfile(tokenList->file(tok));
+}
 
 ErrorMessage::FileLocation::FileLocation(const Token* tok, std::string info, const TokenList* tokenList)
-    : fileIndex(tok->fileIndex()), line(tok->linenr()), column(tok->column()), mOrigFileName(tokenList->getOrigFile(tok)), mFileName(tokenList->file(tok)), mInfo(std::move(info))
-{}
+    : fileIndex(tok->fileIndex()), line(tok->linenr()), column(tok->column()), mInfo(std::move(info))
+{
+    setfile(tokenList->file(tok));
+}
 
 std::string ErrorMessage::FileLocation::getfile(bool convert) const
 {
@@ -737,17 +738,9 @@ std::string ErrorMessage::FileLocation::getfile(bool convert) const
     return mFileName;
 }
 
-std::string ErrorMessage::FileLocation::getOrigFile(bool convert) const
-{
-    if (convert)
-        return Path::toNativeSeparators(mOrigFileName);
-    return mOrigFileName;
-}
-
 void ErrorMessage::FileLocation::setfile(std::string file)
 {
-    mFileName = Path::fromNativeSeparators(std::move(file));
-    mFileName = Path::simplifyPath(std::move(mFileName));
+    mFileName = Path::simplifyPath(Path::fromNativeSeparators(std::move(file)));
 }
 
 std::string ErrorMessage::FileLocation::stringify() const

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -52,16 +52,20 @@ public:
      * Internally paths are stored with / separator. When getting the filename
      * it is by default converted to native separators.
      */
-    class CPPCHECKLIB FileLocation {
+    class CPPCHECKLIB WARN_UNUSED FileLocation {
     public:
         FileLocation()
             : fileIndex(0), line(0), column(0) {}
 
         explicit FileLocation(const std::string &file, int line = 0, unsigned int column = 0)
-            : fileIndex(0), line(line), column(column), mOrigFileName(file), mFileName(file) {}
+            : fileIndex(0), line(line), column(column) {
+            setfile(file);
+        }
 
         FileLocation(const std::string &file, std::string info, int line, unsigned int column)
-            : fileIndex(0), line(line), column(column), mOrigFileName(file), mFileName(file), mInfo(std::move(info)) {}
+            : fileIndex(0), line(line), column(column), mInfo(std::move(info)) {
+            setfile(file);
+        }
 
         FileLocation(const Token* tok, const TokenList* tokenList);
         FileLocation(const Token* tok, std::string info, const TokenList* tokenList);
@@ -72,19 +76,6 @@ public:
          * @return filename.
          */
         std::string getfile(bool convert = true) const;
-
-        /**
-         * Filename with the whole path (no --rp)
-         * @param convert If true convert path to native separators.
-         * @return filename.
-         */
-        std::string getOrigFile(bool convert = true) const;
-
-        /**
-         * Set the filename.
-         * @param file Filename to set.
-         */
-        void setfile(std::string file);
 
         /**
          * @return the location as a string. Format: [file:line]
@@ -103,7 +94,12 @@ public:
         }
 
     private:
-        std::string mOrigFileName;
+        /**
+         * Set the filename.
+         * @param file Filename to set.
+         */
+        void setfile(std::string file);
+
         std::string mFileName;
         std::string mInfo;
     };

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3163,8 +3163,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {
-                ErrorMessage::FileLocation loc;
-                loc.setfile(mTokenList.getFiles()[0]);
+                ErrorMessage::FileLocation loc(mTokenList.getFiles()[0]);
                 ErrorMessage errmsg({std::move(loc)},
                                     emptyString,
                                     Severity::debug,
@@ -3234,8 +3233,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {
-                ErrorMessage::FileLocation loc;
-                loc.setfile(mTokenList.getFiles()[0]);
+                ErrorMessage::FileLocation loc(mTokenList.getFiles()[0]);
                 ErrorMessage errmsg({std::move(loc)},
                                     emptyString,
                                     Severity::debug,

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1150,8 +1150,7 @@ void Tokenizer::simplifyTypedefCpp()
 
         if (maxTime > 0 && std::time(nullptr) > maxTime) {
             if (mSettings.debugwarnings) {
-                ErrorMessage::FileLocation loc;
-                loc.setfile(list.getFiles()[0]);
+                ErrorMessage::FileLocation loc(list.getFiles()[0]);
                 ErrorMessage errmsg({std::move(loc)},
                                     emptyString,
                                     Severity::debug,

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -123,11 +123,6 @@ int TokenList::appendFileIfNew(std::string fileName)
     return mFiles.size() - 1;
 }
 
-void TokenList::clangSetOrigFiles()
-{
-    mOrigFiles = mFiles;
-}
-
 void TokenList::deleteTokens(Token *tok)
 {
     while (tok) {
@@ -376,7 +371,7 @@ void TokenList::createTokens(simplecpp::TokenList&& tokenList)
         // this is a copy
         // TODO: the same as TokenList.files - move that instead
         // TODO: this points to mFiles when called from createTokens(std::istream &, const std::string&)
-        mOrigFiles = mFiles = tokenList.cfront()->location.files;
+        mFiles = tokenList.cfront()->location.files;
     }
     else
         mFiles.clear();
@@ -1881,11 +1876,6 @@ void TokenList::validateAst(bool print) const
             }
         }
     }
-}
-
-std::string TokenList::getOrigFile(const Token *tok) const
-{
-    return mOrigFiles.at(tok->fileIndex());
 }
 
 const std::string& TokenList::file(const Token *tok) const

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -142,8 +142,6 @@ public:
         return mFiles;
     }
 
-    std::string getOrigFile(const Token *tok) const;
-
     /**
      * get filename for given token
      * @param tok The given token
@@ -196,8 +194,6 @@ public:
      */
     void simplifyStdType();
 
-    void clangSetOrigFiles();
-
     bool isKeyword(const std::string &str) const;
 
 private:
@@ -210,9 +206,6 @@ private:
 
     /** filenames for the tokenized source code (source + included) */
     std::vector<std::string> mFiles;
-
-    /** Original filenames for the tokenized source code (source + included) */
-    std::vector<std::string> mOrigFiles;
 
     /** settings */
     const Settings* const mSettings{};

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -9404,8 +9404,7 @@ struct ValueFlowPassRunner {
         }
         if (state.settings.debugwarnings) {
             if (n == 0 && values != getTotalValues()) {
-                ErrorMessage::FileLocation loc;
-                loc.setfile(state.tokenlist.getFiles()[0]);
+                ErrorMessage::FileLocation loc(state.tokenlist.getFiles()[0]);
                 ErrorMessage errmsg({std::move(loc)},
                                     emptyString,
                                     Severity::debug,

--- a/test/testerrorlogger.cpp
+++ b/test/testerrorlogger.cpp
@@ -39,7 +39,8 @@ private:
     void run() override {
         TEST_CASE(PatternSearchReplace);
         TEST_CASE(FileLocationDefaults);
-        TEST_CASE(FileLocationSetFile);
+        TEST_CASE(FileLocationConstruct);
+        TEST_CASE(FileLocationConstructNormalize);
         TEST_CASE(ErrorMessageConstruct);
         TEST_CASE(ErrorMessageConstructLocations);
         TEST_CASE(ErrorMessageVerbose);
@@ -105,13 +106,21 @@ private:
         ErrorMessage::FileLocation loc;
         ASSERT_EQUALS("", loc.getfile());
         ASSERT_EQUALS(0, loc.line);
+        ASSERT_EQUALS(0, loc.column);
     }
 
-    void FileLocationSetFile() const {
-        ErrorMessage::FileLocation loc;
-        loc.setfile("foo.cpp");
+    void FileLocationConstruct() const {
+        ErrorMessage::FileLocation loc("foo.cpp", 1, 2);
         ASSERT_EQUALS("foo.cpp", loc.getfile());
+        ASSERT_EQUALS(1, loc.line);
+        ASSERT_EQUALS(2, loc.column);
+    }
+
+    void FileLocationConstructNormalize() const {
+        ErrorMessage::FileLocation loc(".\\test\\test1\\..\\foo.cpp");
+        ASSERT_EQUALS("test/foo.cpp", loc.getfile());
         ASSERT_EQUALS(0, loc.line);
+        ASSERT_EQUALS(0, loc.column);
     }
 
     void ErrorMessageConstruct() const {
@@ -427,8 +436,7 @@ private:
     }
 
     void SerializeFileLocation() const {
-        ErrorMessage::FileLocation loc1(":/,;", 654, 33);
-        loc1.setfile("[]:;,()");
+        ErrorMessage::FileLocation loc1("[]:;,()", 654, 33);
         loc1.setinfo("abcd:/,");
 
         std::list<ErrorMessage::FileLocation> locs{std::move(loc1)};
@@ -445,12 +453,11 @@ private:
                       "17 Programming error"
                       "17 Programming error"
                       "1 "
-                      "27 654\t33\t[]:;,()\t:/,;\tabcd:/,", msg_str);
+                      "22 654\t33\t[]:;,()\tabcd:/,", msg_str);
 
         ErrorMessage msg2;
         ASSERT_NO_THROW(msg2.deserialize(msg_str));
         ASSERT_EQUALS("[]:;,()", msg2.callStack.front().getfile(false));
-        ASSERT_EQUALS(":/,;", msg2.callStack.front().getOrigFile(false));
         ASSERT_EQUALS(654, msg2.callStack.front().line);
         ASSERT_EQUALS(33, msg2.callStack.front().column);
         ASSERT_EQUALS("abcd:/,", msg2.callStack.front().getinfo());


### PR DESCRIPTION
The way `ErrorMessage::FileLocation` was created there was no case where the names were differed. That could only happen when those came from the `TokenList`.

The `TokenList` one could have only differed when `TokenList::clangSetOrigFiles()` was called. That copied the names over. It was only done in the Clang Import but the names were not touched afterwards so they never differed and this was completely unnecessary.

Also the way `ErrorMessage::FileLocation` was used in several cases the original name was never set at all.

The name was also no normalized in `ErrorMessage::FileLocation` when set via the constructor.