### PR TITLE
fixed checks related to `unusedFunction` check enablement

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -295,7 +295,7 @@ int CppCheckExecutor::check_internal(const Settings& settings) const
     cppcheck.analyseWholeProgram(settings.buildDir, mFiles, mFileSettings);
 
     if (settings.severity.isEnabled(Severity::information) || settings.checkConfiguration) {
-        const bool err = reportSuppressions(settings, suppressions, settings.isUnusedFunctionCheckEnabled(), mFiles, mFileSettings, stdLogger);
+        const bool err = reportSuppressions(settings, suppressions, settings.checks.isEnabled(Checks::unusedFunction), mFiles, mFileSettings, stdLogger);
         if (err && returnValue == 0)
             returnValue = settings.exitCode;
     }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -656,7 +656,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
 
     try {
         if (mSettings.library.markupFile(filename)) {
-            if (mUnusedFunctionsCheck && mSettings.isUnusedFunctionCheckEnabled() && mSettings.buildDir.empty()) {
+            if (mUnusedFunctionsCheck && mSettings.useSingleJob() && mSettings.buildDir.empty()) {
                 // this is not a real source file - we just want to tokenize it. treat it as C anyways as the language needs to be determined.
                 Tokenizer tokenizer(mSettings, this);
                 tokenizer.list.setLang(Standards::Language::C);
@@ -1044,7 +1044,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
     // In jointSuppressionReport mode, unmatched suppressions are
     // collected after all files are processed
     if (!mSettings.useSingleJob() && (mSettings.severity.isEnabled(Severity::information) || mSettings.checkConfiguration)) {
-        SuppressionList::reportUnmatchedSuppressions(mSettings.supprs.nomsg.getUnmatchedLocalSuppressions(filename, mSettings.isUnusedFunctionCheckEnabled()), *this);
+        SuppressionList::reportUnmatchedSuppressions(mSettings.supprs.nomsg.getUnmatchedLocalSuppressions(filename, (bool)mUnusedFunctionsCheck), *this);
     }
 
     mErrorList.clear();
@@ -1128,7 +1128,7 @@ void CppCheck::checkNormalTokens(const Tokenizer &tokenizer)
     if (mSettings.checks.isEnabled(Checks::unusedFunction) && !mSettings.buildDir.empty()) {
         unusedFunctionsChecker.parseTokens(tokenizer, mSettings);
     }
-    if (mUnusedFunctionsCheck && mSettings.isUnusedFunctionCheckEnabled() && mSettings.buildDir.empty()) {
+    if (mUnusedFunctionsCheck && mSettings.useSingleJob() && mSettings.buildDir.empty()) {
         mUnusedFunctionsCheck->parseTokens(tokenizer, mSettings);
     }
 

--- a/lib/settings.h
+++ b/lib/settings.h
@@ -456,13 +456,6 @@ public:
         return jobs == 1;
     }
 
-    /** Check if the user wants to check for unused functions
-     * and if it's possible at all */
-    bool isUnusedFunctionCheckEnabled() const
-    {
-        return useSingleJob() && checks.isEnabled(Checks::unusedFunction);
-    }
-
     void setCheckLevelExhaustive();
     void setCheckLevelNormal();
 


### PR DESCRIPTION
This caused the `unmatchedSuppression` for an inline `unusedFunction` suppression not to be reported with `-j2` when using `--executor=thread`.