### PR TITLE
std.cfg: added `EXIT_SUCCESS` and `EXIT_FAILURE`

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -1271,6 +1271,8 @@
       <not-uninit/>
     </arg>
   </function>
+  <define name="EXIT_SUCCESS" value="0"/>
+  <define name="EXIT_FAILURE" value="1"/>
   <!-- double erf(double x); -->
   <function name="erf,std::erf">
     <use-retval/>


### PR DESCRIPTION
Although the values are implementation dependent and thus not documented, they reflect the common values of 0 and positive non-0 for success/failure. For the analysis it is also not important that these are correct but that they are being consistent across the code.

https://en.cppreference.com/w/cpp/utility/program/EXIT_status