### PR TITLE
enabled and mitigated `performance-avoid-endl` clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -55,7 +55,6 @@ Checks: >
         -modernize-use-nodiscard,
         -modernize-use-scoped-lock,
         -modernize-use-trailing-return-type,
-        -performance-avoid-endl,
         -performance-inefficient-string-concatenation,
         -performance-no-automatic-move,
         -portability-avoid-pragma-once,

--- a/clang-tidy.md
+++ b/clang-tidy.md
@@ -123,7 +123,6 @@ Does not improve the readability.
 `bugprone-signed-char-misuse`<br/>
 `concurrency-mt-unsafe`<br/>
 `misc-use-anonymous-namespace`<br/>
-`performance-avoid-endl`<br/>
 `bugprone-switch-missing-default-case`<br/>
 `bugprone-empty-catch`<br/>
 `readability-avoid-nested-conditional-operator`<br/>

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -120,7 +120,7 @@ namespace {
     {
         void reportOut(const std::string & outmsg, Color /*c*/ = Color::Reset) override
         {
-            std::cout << outmsg << std::endl;
+            std::cout << outmsg << '\n';
         }
 
         void reportErr(const ErrorMessage &msg) override
@@ -179,7 +179,7 @@ bool CmdLineParser::fillSettingsFromArgs(int argc, const char* const argv[])
                 // TODO: this bypasses the template format and other settings
                 // If the include path is not found, warn user and remove the non-existing path from the list.
                 if (mSettings.severity.isEnabled(Severity::information))
-                    std::cout << "(information) Couldn't find path given by -I '" << path << '\'' << std::endl;
+                    std::cout << "(information) Couldn't find path given by -I '" << path << '\'' << '\n';
                 iter = mSettings.includePaths.erase(iter);
             }
         }
@@ -377,7 +377,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                 XMLErrorMessagesLogger xmlLogger;
                 std::cout << ErrorMessage::getXMLHeader(mSettings.cppcheckCfgProductName, 2);
                 CppCheck::getErrorMessages(xmlLogger);
-                std::cout << ErrorMessage::getXMLFooter(2) << std::endl;
+                std::cout << ErrorMessage::getXMLFooter(2) << '\n';
             }
             return Result::Exit;
         }

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -97,7 +97,7 @@ namespace {
 
         void printRaw(const std::string &message) override
         {
-            std::cout << message << std::endl; // TODO: should not append newline
+            std::cout << message << '\n'; // TODO: should not append newline
         }
     };
 
@@ -592,18 +592,18 @@ static inline std::string ansiToOEM(const std::string &msg, bool doConvert)
 void StdLogger::reportErr(const std::string &errmsg)
 {
     if (mErrorOutput)
-        *mErrorOutput << errmsg << std::endl;
+        *mErrorOutput << errmsg << '\n';
     else {
-        std::cerr << ansiToOEM(errmsg, mSettings.outputFormat != Settings::OutputFormat::xml) << std::endl;
+        std::cerr << ansiToOEM(errmsg, mSettings.outputFormat != Settings::OutputFormat::xml) << '\n';
     }
 }
 
 void StdLogger::reportOut(const std::string &outmsg, Color c)
 {
     if (c == Color::Reset)
-        std::cout << ansiToOEM(outmsg, true) << std::endl;
+        std::cout << ansiToOEM(outmsg, true) << '\n';
     else
-        std::cout << c << ansiToOEM(outmsg, true) << Color::Reset << std::endl;
+        std::cout << c << ansiToOEM(outmsg, true) << Color::Reset << '\n';
 }
 
 // TODO: remove filename parameter?
@@ -710,11 +710,11 @@ int CppCheckExecutor::executeCommand(std::string exe, std::vector<std::string> a
 #else
     FILE *p = popen(cmd.c_str(), "r");
 #endif
-    //std::cout << "invoking command '" << cmd << "'" << std::endl;
+    //std::cout << "invoking command '" << cmd << "'" << '\n';
     if (!p) {
         // TODO: how to provide to caller?
         //const int err = errno;
-        //std::cout << "popen() errno " << std::to_string(err) << std::endl;
+        //std::cout << "popen() errno " << std::to_string(err) << '\n';
         return -1;
     }
     char buffer[1024];
@@ -732,7 +732,7 @@ int CppCheckExecutor::executeCommand(std::string exe, std::vector<std::string> a
     if (res == -1) { // error occurred
         // TODO: how to provide to caller?
         //const int err = errno;
-        //std::cout << "pclose() errno " << std::to_string(err) << std::endl;
+        //std::cout << "pclose() errno " << std::to_string(err) << '\n';
         return res;
     }
 #if !defined(_WIN32) && !defined(__MINGW32__)

--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -141,12 +141,12 @@ namespace {
             const ssize_t bytes_written = write(mWpipe, data, to_write);
             if (bytes_written <= 0) {
                 const int err = errno;
-                std::cerr << "#### ThreadExecutor::writeToPipeInternal() error for type " << static_cast<unsigned char>(type) << ": " << std::strerror(err) << std::endl;
+                std::cerr << "#### ThreadExecutor::writeToPipeInternal() error for type " << static_cast<unsigned char>(type) << ": " << std::strerror(err) << '\n';
                 std::exit(EXIT_FAILURE);
             }
             // TODO: write until everything is written
             if (bytes_written != to_write) {
-                std::cerr << "#### ThreadExecutor::writeToPipeInternal() error for type " << static_cast<unsigned char>(type) << ": insufficient data written (expected: " << to_write << " / got: " << bytes_written << ")" << std::endl;
+                std::cerr << "#### ThreadExecutor::writeToPipeInternal() error for type " << static_cast<unsigned char>(type) << ": insufficient data written (expected: " << to_write << " / got: " << bytes_written << ")" << '\n';
                 std::exit(EXIT_FAILURE);
             }
         }
@@ -191,7 +191,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
         return false;
     }
     if (bytes_read != bytes_to_read) {
-        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (type): insufficient data read (expected: " << bytes_to_read << " / got: " << bytes_read << ")" << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (type): insufficient data read (expected: " << bytes_to_read << " / got: " << bytes_read << ")" << '\n';
         std::exit(EXIT_FAILURE);
     }
 
@@ -202,7 +202,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
         type != PipeWriter::CHILD_END &&
         type != PipeWriter::REPORT_METRIC &&
         type != PipeWriter::REPORT_TIMER) {
-        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") invalid type " << int(type) << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") invalid type " << int(type) << '\n';
         std::exit(EXIT_FAILURE);
     }
 
@@ -211,11 +211,11 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
     bytes_read = read(rpipe, &len, bytes_to_read);
     if (bytes_read <= 0) {
         const int err = errno;
-        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (len) for type " << int(type) << ": " << std::strerror(err) << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (len) for type " << int(type) << ": " << std::strerror(err) << '\n';
         std::exit(EXIT_FAILURE);
     }
     if (bytes_read != bytes_to_read) {
-        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (len) for type" << int(type) << ": insufficient data read (expected: " << bytes_to_read << " / got: " << bytes_read << ")"  << std::endl;
+        std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (len) for type" << int(type) << ": insufficient data read (expected: " << bytes_to_read << " / got: " << bytes_read << ")"  << '\n';
         std::exit(EXIT_FAILURE);
     }
 
@@ -227,7 +227,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
             bytes_read = read(rpipe, data_start, bytes_to_read);
             if (bytes_read <= 0) {
                 const int err = errno;
-                std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (buf) for type" << int(type) << ": " << std::strerror(err) << std::endl;
+                std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") error (buf) for type" << int(type) << ": " << std::strerror(err) << '\n';
                 std::exit(EXIT_FAILURE);
             }
             bytes_to_read -= bytes_read;
@@ -246,7 +246,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
         try {
             msg.deserialize(buf);
         } catch (const InternalError& e) {
-            std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") internal error: " << e.errorMessage << std::endl;
+            std::cerr << "#### ThreadExecutor::handleRead(" << filename << ") internal error: " << e.errorMessage << '\n';
             std::exit(EXIT_FAILURE);
         }
 
@@ -347,25 +347,25 @@ unsigned int ProcessExecutor::check()
         if ((iFile != mFiles.cend() || iFileSettings != mFileSettings.cend()) && nchildren < mSettings.jobs && checkLoadAverage(nchildren)) {
             int pipes[2];
             if (pipe(pipes) == -1) {
-                std::cerr << "#### ThreadExecutor::check, pipe() failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, pipe() failed: "<< std::strerror(errno) << '\n';
                 std::exit(EXIT_FAILURE);
             }
 
             const int flags = fcntl(pipes[0], F_GETFL, 0);
             if (flags < 0) {
-                std::cerr << "#### ThreadExecutor::check, fcntl(F_GETFL) failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, fcntl(F_GETFL) failed: "<< std::strerror(errno) << '\n';
                 std::exit(EXIT_FAILURE);
             }
 
             if (fcntl(pipes[0], F_SETFL, flags) < 0) {
-                std::cerr << "#### ThreadExecutor::check, fcntl(F_SETFL) failed: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, fcntl(F_SETFL) failed: "<< std::strerror(errno) << '\n';
                 std::exit(EXIT_FAILURE);
             }
 
             const pid_t pid = fork();
             if (pid < 0) {
                 // Error
-                std::cerr << "#### ThreadExecutor::check, Failed to create child process: "<< std::strerror(errno) << std::endl;
+                std::cerr << "#### ThreadExecutor::check, Failed to create child process: "<< std::strerror(errno) << '\n';
                 std::exit(EXIT_FAILURE);
             } else if (pid == 0) {
 #if defined(__linux__)

--- a/cli/threadexecutor.cpp
+++ b/cli/threadexecutor.cpp
@@ -207,7 +207,7 @@ unsigned int ThreadExecutor::check()
             threadFutures.emplace_back(std::async(std::launch::async, &threadProc, &data));
         }
         catch (const std::system_error &e) {
-            std::cerr << "#### ThreadExecutor::check exception :" << e.what() << std::endl;
+            std::cerr << "#### ThreadExecutor::check exception :" << e.what() << '\n';
             exit(EXIT_FAILURE);
         }
     }

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -118,7 +118,7 @@ static void ShowUsage()
                        );
     (void)msgBox.exec();
 #else
-    std::cout << helpMessage.toStdString() << std::endl;
+    std::cout << helpMessage.toStdString() << '\n';
 #endif
 }
 
@@ -136,6 +136,6 @@ static void ShowVersion()
     if (*extraVersion != 0)
         versionMessage += std::string(" (") + extraVersion + ")";
 
-    std::cout << versionMessage << std::endl;
+    std::cout << versionMessage << '\n';
 #endif
 }

--- a/lib/analyzerinfo.cpp
+++ b/lib/analyzerinfo.cpp
@@ -71,7 +71,7 @@ std::string AnalyzerInformation::getFilesTxt(const std::list<std::string> &sourc
     for (const FileSettings &fs : fileSettings) {
         const std::string afile = getFilename(fs.filename());
         const std::string id = fs.file.fsFileId() > 0 ? std::to_string(fs.file.fsFileId()) : "";
-        ret << afile << ".a" << (++fileCount[afile]) << sep << fs.cfg << sep << id << sep << Path::simplifyPath(fs.filename()) << std::endl;
+        ret << afile << ".a" << (++fileCount[afile]) << sep << fs.cfg << sep << id << sep << Path::simplifyPath(fs.filename()) << '\n';
     }
 
     return ret.str();

--- a/lib/check.cpp
+++ b/lib/check.cpp
@@ -57,7 +57,7 @@ Check::Check(const std::string &aname)
 
 void Check::writeToErrorList(const ErrorMessage &errmsg)
 {
-    std::cout << errmsg.toXML() << std::endl;
+    std::cout << errmsg.toXML() << '\n';
 }
 
 

--- a/lib/checkersreport.cpp
+++ b/lib/checkersreport.cpp
@@ -160,23 +160,23 @@ std::string CheckersReport::getReport(const std::string& criticalErrors) const
 {
     std::ostringstream fout;
 
-    fout << "Critical errors" << std::endl;
-    fout << "---------------" << std::endl;
+    fout << "Critical errors" << '\n';
+    fout << "---------------" << '\n';
     if (!criticalErrors.empty()) {
-        fout << "There were critical errors (" << criticalErrors << ")." << std::endl;
-        fout << "These cause the analysis of the file to end prematurely." << std::endl;
+        fout << "There were critical errors (" << criticalErrors << ")." << '\n';
+        fout << "These cause the analysis of the file to end prematurely." << '\n';
     } else {
-        fout << "No critical errors encountered." << std::endl;
+        fout << "No critical errors encountered." << '\n';
         // TODO: mention "information" and "debug" as source for indications of bailouts
         // TODO: still rephrase this - this message does not provides confidence in the results
         // TODO: document what a bailout is and why it is done - mention it in the upcoming security/tuning guide
         // TODO: make bailouts a separate group - need to differentiate between user bailouts (missing data like configuration/includes) and internal bailouts (e.g. limitations of ValueFlow)
-        fout << "Note: There might still have been non-critical bailouts which might lead to false negatives." << std::endl;
+        fout << "Note: There might still have been non-critical bailouts which might lead to false negatives." << '\n';
     }
 
-    fout << std::endl << std::endl;
-    fout << "Open source checkers" << std::endl;
-    fout << "--------------------" << std::endl;
+    fout << '\n' << '\n';
+    fout << "Open source checkers" << '\n';
+    fout << "--------------------" << '\n';
 
     std::size_t maxCheckerSize = 0;
     for (const auto& checkReq: checkers::allCheckers) {
@@ -190,13 +190,13 @@ std::string CheckersReport::getReport(const std::string& criticalErrors) const
         fout << (active ? "Yes  " : "No   ") << checker;
         if (!active && !req.empty())
             fout << std::string(maxCheckerSize + 4 - checker.size(), ' ') << "require:" + req;
-        fout << std::endl;
+        fout << '\n';
     }
 
     for (const auto& addonInfo: mSettings.addonInfos) {
         if (addonInfo.checkers.empty())
             continue;
-        fout << std::endl << std::endl;
+        fout << '\n'<< '\n';
         std::string title;
         if (mSettings.premium && addonInfo.name == "premiumaddon.json")
             title = "Cppcheck Premium";
@@ -206,8 +206,8 @@ std::string CheckersReport::getReport(const std::string& criticalErrors) const
                 title.erase(title.rfind('.'));
         }
         title += " checkers";
-        fout << title << std::endl;
-        fout << std::string(title.size(), '-') << std::endl;
+        fout << title << '\n';
+        fout << std::string(title.size(), '-') << '\n';
 
         maxCheckerSize = 0;
         for (const auto& checkReq: addonInfo.checkers) {
@@ -222,7 +222,7 @@ std::string CheckersReport::getReport(const std::string& criticalErrors) const
             fout << (active ? "Yes  " : "No   ") << checker;
             if (!active && !req.empty())
                 fout << std::string(maxCheckerSize + 4 - checker.size(), ' ') << "require:" << req;
-            fout << std::endl;
+            fout << '\n';
         }
     }
 

--- a/lib/clangimport.cpp
+++ b/lib/clangimport.cpp
@@ -508,12 +508,12 @@ void clangimport::AstNode::dumpAst(int num, int indent) const
     std::cout << std::string(indent, ' ') << nodeType;
     for (const auto& tok: mExtTokens)
         std::cout << " " << tok;
-    std::cout << std::endl;
+    std::cout << '\n';
     for (int c = 0; c < children.size(); ++c) {
         if (children[c])
             children[c]->dumpAst(c, indent + 2);
         else
-            std::cout << std::string(indent + 2, ' ') << "<<<<NULL>>>>>" << std::endl;
+            std::cout << std::string(indent + 2, ' ') << "<<<<NULL>>>>>" << '\n';
     }
 }
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -696,7 +696,7 @@ unsigned int CppCheck::checkClang(const FileWithDetails &file)
     }
 
     if (!mExecuteCommand) {
-        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (no command callback provided)" << std::endl;
+        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (no command callback provided)" << '\n';
         return 0; // TODO: report as failure?
     }
 
@@ -708,13 +708,13 @@ unsigned int CppCheck::checkClang(const FileWithDetails &file)
     // TODO: this might also fail if compiler errors are encountered - we should report them properly
     if (exitcode != EXIT_SUCCESS) {
         // TODO: report as proper error
-        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (exitcode: " << exitcode << " / output: " << output2 << ")" << std::endl;
+        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (exitcode: " << exitcode << " / output: " << output2 << ")" << '\n';
         return 0; // TODO: report as failure?
     }
 
     if (output2.find("TranslationUnitDecl") == std::string::npos) {
         // TODO: report as proper error
-        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (no TranslationUnitDecl in output)" << std::endl;
+        std::cerr << "Failed to execute '" << exe << " " << args2 << " " << redirect2 << "' - (no TranslationUnitDecl in output)" << '\n';
         return 0; // TODO: report as failure?
     }
 
@@ -1210,15 +1210,15 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
 
                 // dump xml if --dump
                 if ((mSettings.dump || !mSettings.addons.empty()) && fdump.is_open()) {
-                    fdump << "<dump cfg=\"" << ErrorLogger::toxml(currentConfig) << "\">" << std::endl;
-                    fdump << "  <standards>" << std::endl;
-                    fdump << "    <c version=\"" << mSettings.standards.getC() << "\"/>" << std::endl;
-                    fdump << "    <cpp version=\"" << mSettings.standards.getCPP() << "\"/>" << std::endl;
+                    fdump << "<dump cfg=\"" << ErrorLogger::toxml(currentConfig) << "\">" << '\n';
+                    fdump << "  <standards>" << '\n';
+                    fdump << "    <c version=\"" << mSettings.standards.getC() << "\"/>" << '\n';
+                    fdump << "    <cpp version=\"" << mSettings.standards.getCPP() << "\"/>" << '\n';
                     fdump << "  </standards>" << std::endl;
                     fdump << getLibraryDumpData();
                     preprocessor.dump(fdump);
                     tokenizer.dump(fdump);
-                    fdump << "</dump>" << std::endl;
+                    fdump << "</dump>" << '\n';
                 }
 
                 if (mSettings.inlineSuppressions) {
@@ -1266,7 +1266,7 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         // TODO: will not be closed if we encountered an exception
         // dumped all configs, close root </dumps> element now
         if (fdump.is_open()) {
-            fdump << "</dumps>" << std::endl;
+            fdump << "</dumps>" << '\n';
             fdump.close();
         }
 
@@ -1514,7 +1514,7 @@ void CppCheck::executeAddons(const std::vector<std::string>& files, const std::s
         filesDeleter.addFile(fileList);
         // TODO: check if file could be created
         for (const std::string& f: files)
-            fout << f << std::endl;
+            fout << f << '\n';
     }
 
     // ensure all addons have already been resolved - TODO: remove when settings are const after creation
@@ -1752,7 +1752,7 @@ void CppCheck::analyseClangTidy(const FileSettings &fileSettings)
     std::string output;
     if (const int exitcode = mExecuteCommand(exe, split(args), "2>&1", output)) {
         // TODO: needs to be a proper error
-        std::cerr << "Failed to execute '" << exe << "' (exitcode: " << std::to_string(exitcode) << ")" << std::endl;
+        std::cerr << "Failed to execute '" << exe << "' (exitcode: " << std::to_string(exitcode) << ")" << '\n';
         return;
     }
 

--- a/lib/platform.cpp
+++ b/lib/platform.cpp
@@ -224,11 +224,11 @@ bool Platform::loadFromFile(const std::vector<std::string>& paths, const std::st
         err = doc.LoadFile(f.c_str());
         if (err == tinyxml2::XML_SUCCESS) {
             if (debug)
-                std::cout << "Success" << std::endl;
+                std::cout << "Success" << '\n';
             break;
         }
         if (debug)
-            std::cout << doc.ErrorStr() << std::endl;
+            std::cout << doc.ErrorStr() << '\n';
         if (err != tinyxml2::XML_ERROR_FILE_NOT_FOUND)
             break;
     }

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -1084,7 +1084,7 @@ void Preprocessor::dump(std::ostream &out) const
     // Create a xml dump.
 
     if (!mMacroUsage.empty()) {
-        out << "  <macro-usage>" << std::endl;
+        out << "  <macro-usage>" << '\n';
         for (const simplecpp::MacroUsage &macroUsage: mMacroUsage) {
             out << "    <macro"
                 << " name=\"" << macroUsage.macroName << "\""
@@ -1095,13 +1095,13 @@ void Preprocessor::dump(std::ostream &out) const
                 << " useline=\"" << macroUsage.useLocation.line << "\""
                 << " usecolumn=\"" << macroUsage.useLocation.col << "\""
                 << " is-known-value=\"" << bool_to_string(macroUsage.macroValueKnown) << "\""
-                << "/>" << std::endl;
+                << "/>" << '\n';
         }
-        out << "  </macro-usage>" << std::endl;
+        out << "  </macro-usage>" << '\n';
     }
 
     if (!mIfCond.empty()) {
-        out << "  <simplecpp-if-cond>" << std::endl;
+        out << "  <simplecpp-if-cond>" << '\n';
         for (const simplecpp::IfCond &ifCond: mIfCond) {
             out << "    <if-cond"
                 << " file=\"" << ErrorLogger::toxml(mTokens.file(ifCond.location)) << "\""
@@ -1109,9 +1109,9 @@ void Preprocessor::dump(std::ostream &out) const
                 << " column=\"" << ifCond.location.col << "\""
                 << " E=\"" << ErrorLogger::toxml(ifCond.E) << "\""
                 << " result=\"" << ifCond.result << "\""
-                << "/>" << std::endl;
+                << "/>" << '\n';
         }
-        out << "  </simplecpp-if-cond>" << std::endl;
+        out << "  </simplecpp-if-cond>" << '\n';
     }
 }
 

--- a/lib/summaries.cpp
+++ b/lib/summaries.cpp
@@ -79,7 +79,7 @@ std::string Summaries::create(const Tokenizer &tokenizer, const std::string &cfg
             ostr << " call:[" << join(calledFunctions) << "]";
         if (!noreturn.empty())
             ostr << " noreturn:[" << join(noreturn) << "]";
-        ostr << std::endl;
+        ostr << '\n';
     }
 
     if (!settings.buildDir.empty()) {

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -516,7 +516,7 @@ void SuppressionList::dump(std::ostream & out, const std::string& filePath) cons
 {
     std::lock_guard<std::mutex> lg(mSuppressionsSync);
 
-    out << "  <suppressions>" << std::endl;
+    out << "  <suppressions>" << '\n';
     for (const Suppression &suppression : mSuppressions) {
         if (suppression.isInline && !suppression.fileName.empty() && !filePath.empty() && filePath != suppression.fileName)
             continue;
@@ -550,9 +550,9 @@ void SuppressionList::dump(std::ostream & out, const std::string& filePath) cons
             out << " inline=\"false\"";
         if (!suppression.extraComment.empty())
             out << " comment=\"" << ErrorLogger::toxml(suppression.extraComment) << "\"";
-        out << " />" << std::endl;
+        out << " />" << '\n';
     }
-    out << "  </suppressions>" << std::endl;
+    out << "  </suppressions>" << '\n';
 }
 
 std::list<SuppressionList::Suppression> SuppressionList::getUnmatchedLocalSuppressions(const FileWithDetails &file) const

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -4128,12 +4128,12 @@ static std::string tokenType(const Token * tok)
 
 void SymbolDatabase::printVariable(const Variable *var, const char *indent) const
 {
-    std::cout << indent << "mNameToken: " << tokenToString(var->nameToken(), mTokenizer) << std::endl;
+    std::cout << indent << "mNameToken: " << tokenToString(var->nameToken(), mTokenizer) << '\n';
     if (var->nameToken()) {
-        std::cout << indent << "    declarationId: " << var->declarationId() << std::endl;
+        std::cout << indent << "    declarationId: " << var->declarationId() << '\n';
     }
-    std::cout << indent << "mTypeStartToken: " << tokenToString(var->typeStartToken(), mTokenizer) << std::endl;
-    std::cout << indent << "mTypeEndToken: " << tokenToString(var->typeEndToken(), mTokenizer) << std::endl;
+    std::cout << indent << "mTypeStartToken: " << tokenToString(var->typeStartToken(), mTokenizer) << '\n';
+    std::cout << indent << "mTypeEndToken: " << tokenToString(var->typeEndToken(), mTokenizer) << '\n';
 
     if (var->typeStartToken()) {
         const Token * autoTok = nullptr;
@@ -4143,49 +4143,49 @@ void SymbolDatabase::printVariable(const Variable *var, const char *indent) cons
             if (tok->str() == "auto")
                 autoTok = tok;
         }
-        std::cout << std::endl;
+        std::cout << '\n';
         if (autoTok) {
             const ValueType * valueType = autoTok->valueType();
-            std::cout << indent << "    auto valueType: " << valueType << std::endl;
+            std::cout << indent << "    auto valueType: " << valueType << '\n';
             if (var->typeStartToken()->valueType()) {
-                std::cout << indent << "        " << valueType->str() << std::endl;
+                std::cout << indent << "        " << valueType->str() << '\n';
             }
         }
     } else if (var->valueType()) {
-        std::cout << indent << "   " << var->valueType()->str() << std::endl;
+        std::cout << indent << "   " << var->valueType()->str() << '\n';
     }
-    std::cout << indent << "mIndex: " << var->index() << std::endl;
-    std::cout << indent << "mAccess: " << accessControlToString(var->accessControl()) << std::endl;
-    std::cout << indent << "mFlags: " << std::endl;
-    std::cout << indent << "    isMutable: " << var->isMutable() << std::endl;
-    std::cout << indent << "    isStatic: " << var->isStatic() << std::endl;
-    std::cout << indent << "    isExtern: " << var->isExtern() << std::endl;
-    std::cout << indent << "    isLocal: " << var->isLocal() << std::endl;
-    std::cout << indent << "    isConst: " << var->isConst() << std::endl;
-    std::cout << indent << "    isClass: " << var->isClass() << std::endl;
-    std::cout << indent << "    isArray: " << var->isArray() << std::endl;
-    std::cout << indent << "    isPointer: " << var->isPointer() << std::endl;
-    std::cout << indent << "    isReference: " << var->isReference() << std::endl;
-    std::cout << indent << "    isRValueRef: " << var->isRValueReference() << std::endl;
-    std::cout << indent << "    hasDefault: " << var->hasDefault() << std::endl;
-    std::cout << indent << "    isStlType: " << var->isStlType() << std::endl;
+    std::cout << indent << "mIndex: " << var->index() << '\n';
+    std::cout << indent << "mAccess: " << accessControlToString(var->accessControl()) << '\n';
+    std::cout << indent << "mFlags: " << '\n';
+    std::cout << indent << "    isMutable: " << var->isMutable() << '\n';
+    std::cout << indent << "    isStatic: " << var->isStatic() << '\n';
+    std::cout << indent << "    isExtern: " << var->isExtern() << '\n';
+    std::cout << indent << "    isLocal: " << var->isLocal() << '\n';
+    std::cout << indent << "    isConst: " << var->isConst() << '\n';
+    std::cout << indent << "    isClass: " << var->isClass() << '\n';
+    std::cout << indent << "    isArray: " << var->isArray() << '\n';
+    std::cout << indent << "    isPointer: " << var->isPointer() << '\n';
+    std::cout << indent << "    isReference: " << var->isReference() << '\n';
+    std::cout << indent << "    isRValueRef: " << var->isRValueReference() << '\n';
+    std::cout << indent << "    hasDefault: " << var->hasDefault() << '\n';
+    std::cout << indent << "    isStlType: " << var->isStlType() << '\n';
     std::cout << indent << "mType: ";
     if (var->type()) {
         std::cout << var->type()->type() << " " << var->type()->name();
         std::cout << " " << mTokenizer.list.fileLine(var->type()->classDef);
-        std::cout << " " << var->type() << std::endl;
+        std::cout << " " << var->type() << '\n';
     } else
-        std::cout << "none" << std::endl;
+        std::cout << "none" << '\n';
 
     if (var->nameToken()) {
         const ValueType * valueType = var->nameToken()->valueType();
-        std::cout << indent << "valueType: " << valueType << std::endl;
+        std::cout << indent << "valueType: " << valueType << '\n';
         if (valueType) {
-            std::cout << indent << "    " << valueType->str() << std::endl;
+            std::cout << indent << "    " << valueType->str() << '\n';
         }
     }
 
-    std::cout << indent << "mScope: " << scopeToString(var->scope(), mTokenizer) << std::endl;
+    std::cout << indent << "mScope: " << scopeToString(var->scope(), mTokenizer) << '\n';
 
     std::cout << indent << "mDimensions:";
     for (std::size_t i = 0; i < var->dimensions().size(); i++) {
@@ -4193,7 +4193,7 @@ void SymbolDatabase::printVariable(const Variable *var, const char *indent) cons
         if (!var->dimensions()[i].known)
             std::cout << "?";
     }
-    std::cout << std::endl;
+    std::cout << '\n';
 }
 
 void SymbolDatabase::printOut(const char *title) const
@@ -4203,40 +4203,40 @@ void SymbolDatabase::printOut(const char *title) const
         std::cout << "\n### " << title << " ###\n";
 
     for (auto scope = scopeList.cbegin(); scope != scopeList.cend(); ++scope) {
-        std::cout << "Scope: " << &*scope << " " << scope->type << std::endl;
-        std::cout << "    className: " << scope->className << std::endl;
-        std::cout << "    classDef: " << tokenToString(scope->classDef, mTokenizer) << std::endl;
-        std::cout << "    bodyStart: " << tokenToString(scope->bodyStart, mTokenizer) << std::endl;
-        std::cout << "    bodyEnd: " << tokenToString(scope->bodyEnd, mTokenizer) << std::endl;
+        std::cout << "Scope: " << &*scope << " " << scope->type << '\n';
+        std::cout << "    className: " << scope->className << '\n';
+        std::cout << "    classDef: " << tokenToString(scope->classDef, mTokenizer) << '\n';
+        std::cout << "    bodyStart: " << tokenToString(scope->bodyStart, mTokenizer) << '\n';
+        std::cout << "    bodyEnd: " << tokenToString(scope->bodyEnd, mTokenizer) << '\n';
 
         // find the function body if not implemented inline
         for (auto func = scope->functionList.cbegin(); func != scope->functionList.cend(); ++func) {
-            std::cout << "    Function: " << &*func << std::endl;
-            std::cout << "        name: " << tokenToString(func->tokenDef, mTokenizer) << std::endl;
-            std::cout << "        type: " << functionTypeToString(func->type) << std::endl;
-            std::cout << "        access: " << accessControlToString(func->access) << std::endl;
-            std::cout << "        hasBody: " << func->hasBody() << std::endl;
-            std::cout << "        isInline: " << func->isInline() << std::endl;
-            std::cout << "        isConst: " << func->isConst() << std::endl;
-            std::cout << "        hasVirtualSpecifier: " << func->hasVirtualSpecifier() << std::endl;
-            std::cout << "        isPure: " << func->isPure() << std::endl;
-            std::cout << "        isStatic: " << func->isStatic() << std::endl;
-            std::cout << "        isStaticLocal: " << func->isStaticLocal() << std::endl;
-            std::cout << "        isExtern: " << func->isExtern() << std::endl;
-            std::cout << "        isFriend: " << func->isFriend() << std::endl;
-            std::cout << "        isExplicit: " << func->isExplicit() << std::endl;
-            std::cout << "        isDefault: " << func->isDefault() << std::endl;
-            std::cout << "        isDelete: " << func->isDelete() << std::endl;
-            std::cout << "        hasOverrideSpecifier: " << func->hasOverrideSpecifier() << std::endl;
-            std::cout << "        hasFinalSpecifier: " << func->hasFinalSpecifier() << std::endl;
-            std::cout << "        isNoExcept: " << func->isNoExcept() << std::endl;
-            std::cout << "        isThrow: " << func->isThrow() << std::endl;
-            std::cout << "        isOperator: " << func->isOperator() << std::endl;
-            std::cout << "        hasLvalRefQual: " << func->hasLvalRefQualifier() << std::endl;
-            std::cout << "        hasRvalRefQual: " << func->hasRvalRefQualifier() << std::endl;
-            std::cout << "        isVariadic: " << func->isVariadic() << std::endl;
-            std::cout << "        isVolatile: " << func->isVolatile() << std::endl;
-            std::cout << "        hasTrailingReturnType: " << func->hasTrailingReturnType() << std::endl;
+            std::cout << "    Function: " << &*func << '\n';
+            std::cout << "        name: " << tokenToString(func->tokenDef, mTokenizer) << '\n';
+            std::cout << "        type: " << functionTypeToString(func->type) << '\n';
+            std::cout << "        access: " << accessControlToString(func->access) << '\n';
+            std::cout << "        hasBody: " << func->hasBody() << '\n';
+            std::cout << "        isInline: " << func->isInline() << '\n';
+            std::cout << "        isConst: " << func->isConst() << '\n';
+            std::cout << "        hasVirtualSpecifier: " << func->hasVirtualSpecifier() << '\n';
+            std::cout << "        isPure: " << func->isPure() << '\n';
+            std::cout << "        isStatic: " << func->isStatic() << '\n';
+            std::cout << "        isStaticLocal: " << func->isStaticLocal() << '\n';
+            std::cout << "        isExtern: " << func->isExtern() << '\n';
+            std::cout << "        isFriend: " << func->isFriend() << '\n';
+            std::cout << "        isExplicit: " << func->isExplicit() << '\n';
+            std::cout << "        isDefault: " << func->isDefault() << '\n';
+            std::cout << "        isDelete: " << func->isDelete() << '\n';
+            std::cout << "        hasOverrideSpecifier: " << func->hasOverrideSpecifier() << '\n';
+            std::cout << "        hasFinalSpecifier: " << func->hasFinalSpecifier() << '\n';
+            std::cout << "        isNoExcept: " << func->isNoExcept() << '\n';
+            std::cout << "        isThrow: " << func->isThrow() << '\n';
+            std::cout << "        isOperator: " << func->isOperator() << '\n';
+            std::cout << "        hasLvalRefQual: " << func->hasLvalRefQualifier() << '\n';
+            std::cout << "        hasRvalRefQual: " << func->hasRvalRefQualifier() << '\n';
+            std::cout << "        isVariadic: " << func->isVariadic() << '\n';
+            std::cout << "        isVolatile: " << func->isVolatile() << '\n';
+            std::cout << "        hasTrailingReturnType: " << func->hasTrailingReturnType() << '\n';
             std::cout << "        attributes:";
             if (func->isAttributeConst())
                 std::cout << " const ";
@@ -4252,41 +4252,41 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << " destructor ";
             if (func->isAttributeNodiscard())
                 std::cout << " nodiscard ";
-            std::cout << std::endl;
-            std::cout << "        noexceptArg: " << (func->noexceptArg ? func->noexceptArg->str() : "none") << std::endl;
-            std::cout << "        throwArg: " << (func->throwArg ? func->throwArg->str() : "none") << std::endl;
-            std::cout << "        tokenDef: " << tokenToString(func->tokenDef, mTokenizer) << std::endl;
-            std::cout << "        argDef: " << tokenToString(func->argDef, mTokenizer) << std::endl;
+            std::cout << '\n';
+            std::cout << "        noexceptArg: " << (func->noexceptArg ? func->noexceptArg->str() : "none") << '\n';
+            std::cout << "        throwArg: " << (func->throwArg ? func->throwArg->str() : "none") << '\n';
+            std::cout << "        tokenDef: " << tokenToString(func->tokenDef, mTokenizer) << '\n';
+            std::cout << "        argDef: " << tokenToString(func->argDef, mTokenizer) << '\n';
             if (!func->isConstructor() && !func->isDestructor())
-                std::cout << "        retDef: " << tokenToString(func->retDef, mTokenizer) << std::endl;
+                std::cout << "        retDef: " << tokenToString(func->retDef, mTokenizer) << '\n';
             if (func->retDef) {
                 std::cout << "           ";
                 for (const Token * tok = func->retDef; tok && tok != func->tokenDef && !Token::Match(tok, "{|;|override|final"); tok = tok->next())
                     std::cout << " " << tokenType(tok);
-                std::cout << std::endl;
+                std::cout << '\n';
             }
-            std::cout << "        retType: " << func->retType << std::endl;
+            std::cout << "        retType: " << func->retType << '\n';
 
             if (const ValueType* valueType = func->tokenDef->next()->valueType()) {
-                std::cout << "        valueType: " << valueType << std::endl;
-                std::cout << "            " << valueType->str() << std::endl;
+                std::cout << "        valueType: " << valueType << '\n';
+                std::cout << "            " << valueType->str() << '\n';
             }
 
             if (func->hasBody()) {
-                std::cout << "        token: " << tokenToString(func->token, mTokenizer) << std::endl;
-                std::cout << "        arg: " << tokenToString(func->arg, mTokenizer) << std::endl;
+                std::cout << "        token: " << tokenToString(func->token, mTokenizer) << '\n';
+                std::cout << "        arg: " << tokenToString(func->arg, mTokenizer) << '\n';
             }
-            std::cout << "        nestedIn: " << scopeToString(func->nestedIn, mTokenizer) << std::endl;
-            std::cout << "        functionScope: " << scopeToString(func->functionScope, mTokenizer) << std::endl;
+            std::cout << "        nestedIn: " << scopeToString(func->nestedIn, mTokenizer) << '\n';
+            std::cout << "        functionScope: " << scopeToString(func->functionScope, mTokenizer) << '\n';
 
             for (auto var = func->argumentList.cbegin(); var != func->argumentList.cend(); ++var) {
-                std::cout << "        Variable: " << &*var << std::endl;
+                std::cout << "        Variable: " << &*var << '\n';
                 printVariable(&*var, "            ");
             }
         }
 
         for (auto var = scope->varlist.cbegin(); var != scope->varlist.cend(); ++var) {
-            std::cout << "    Variable: " << &*var << std::endl;
+            std::cout << "    Variable: " << &*var << '\n';
             printVariable(&*var, "        ");
         }
 
@@ -4296,8 +4296,8 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << scope->enumType->stringify(false, true, false);
             } else
                 std::cout << "int";
-            std::cout << std::endl;
-            std::cout << "    enumClass: " << scope->enumClass << std::endl;
+            std::cout << '\n';
+            std::cout << "    enumClass: " << scope->enumClass << '\n';
             for (const Enumerator &enumerator : scope->enumeratorList) {
                 std::cout << "        Enumerator: " << enumerator.name->str() << " = ";
                 if (enumerator.value_known)
@@ -4315,7 +4315,7 @@ void SymbolDatabase::printOut(const char *title) const
                     std::cout << "]";
                 }
 
-                std::cout << std::endl;
+                std::cout << '\n';
             }
         }
 
@@ -4324,9 +4324,9 @@ void SymbolDatabase::printOut(const char *title) const
             std::cout << " " << scope->nestedIn->type << " "
                       << scope->nestedIn->className;
         }
-        std::cout << std::endl;
+        std::cout << '\n';
 
-        std::cout << "    definedType: " << scope->definedType << std::endl;
+        std::cout << "    definedType: " << scope->definedType << '\n';
 
         std::cout << "    nestedList[" << scope->nestedList.size() << "] = (";
 
@@ -4337,7 +4337,7 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << ",";
         }
 
-        std::cout << " )" << std::endl;
+        std::cout << " )" << '\n';
 
         for (auto use = scope->usingList.cbegin(); use != scope->usingList.cend(); ++use) {
             std::cout << "    using: " << use->scope << " " << use->start->strAt(2);
@@ -4346,32 +4346,32 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << "::" << tok1->strAt(1);
                 tok1 = tok1->tokAt(2);
             }
-            std::cout << " " << mTokenizer.list.fileLine(use->start) << std::endl;
+            std::cout << " " << mTokenizer.list.fileLine(use->start) << '\n';
         }
 
-        std::cout << "    functionOf: " << scopeToString(scope->functionOf, mTokenizer) << std::endl;
+        std::cout << "    functionOf: " << scopeToString(scope->functionOf, mTokenizer) << '\n';
 
         std::cout << "    function: " << scope->function;
         if (scope->function)
             std::cout << " " << scope->function->name();
-        std::cout << std::endl;
+        std::cout << '\n';
     }
 
     for (auto type = typeList.cbegin(); type != typeList.cend(); ++type) {
-        std::cout << "Type: " << &(*type) << std::endl;
-        std::cout << "    name: " << type->name() << std::endl;
-        std::cout << "    classDef: " << tokenToString(type->classDef, mTokenizer) << std::endl;
-        std::cout << "    classScope: " << type->classScope << std::endl;
+        std::cout << "Type: " << &(*type) << '\n';
+        std::cout << "    name: " << type->name() << '\n';
+        std::cout << "    classDef: " << tokenToString(type->classDef, mTokenizer) << '\n';
+        std::cout << "    classScope: " << type->classScope << '\n';
         std::cout << "    enclosingScope: " << type->enclosingScope;
         if (type->enclosingScope) {
             std::cout << " " << type->enclosingScope->type << " "
                       << type->enclosingScope->className;
         }
-        std::cout << std::endl;
+        std::cout << '\n';
         std::cout << "    needInitialization: " << (type->needInitialization == Type::NeedInitialization::Unknown ? "Unknown" :
                                                     type->needInitialization == Type::NeedInitialization::True ? "True" :
                                                     type->needInitialization == Type::NeedInitialization::False ? "False" :
-                                                    "Invalid") << std::endl;
+                                                    "Invalid") << '\n';
 
         std::cout << "    derivedFrom[" << type->derivedFrom.size() << "] = (";
         std::size_t count = type->derivedFrom.size();
@@ -4394,7 +4394,7 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << ",";
         }
 
-        std::cout << " )" << std::endl;
+        std::cout << " )" << '\n';
 
         std::cout << "    friendList[" << type->friendList.size() << "] = (";
         for (size_t i = 0; i < type->friendList.size(); i++) {
@@ -4410,7 +4410,7 @@ void SymbolDatabase::printOut(const char *title) const
                 std::cout << ',';
         }
 
-        std::cout << " )" << std::endl;
+        std::cout << " )" << '\n';
     }
 
     for (std::size_t i = 1; i < mVariableList.size(); i++) {
@@ -4419,7 +4419,7 @@ void SymbolDatabase::printOut(const char *title) const
             std::cout << " " << mVariableList[i]->name() << " "
                       << mTokenizer.list.fileLine(mVariableList[i]->nameToken());
         }
-        std::cout << std::endl;
+        std::cout << '\n';
     }
     std::cout << std::resetiosflags(std::ios::boolalpha);
 }

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3619,22 +3619,22 @@ void TemplateSimplifier::printOut(const TokenAndName &tokenAndName, const std::s
         std::cout << "\"" << tokenAndName.token()->str() << "\" " << mTokenList.fileLine(tokenAndName.token());
     else
         std::cout << "nullptr";
-    std::cout << std::endl;
-    std::cout << indent << "scope: \"" << tokenAndName.scope() << "\"" << std::endl;
-    std::cout << indent << "name: \"" << tokenAndName.name() << "\"" << std::endl;
-    std::cout << indent << "fullName: \"" << tokenAndName.fullName() << "\"" << std::endl;
+    std::cout << '\n';
+    std::cout << indent << "scope: \"" << tokenAndName.scope() << "\"" << '\n';
+    std::cout << indent << "name: \"" << tokenAndName.name() << "\"" << '\n';
+    std::cout << indent << "fullName: \"" << tokenAndName.fullName() << "\"" << '\n';
     std::cout << indent << "nameToken: ";
     if (tokenAndName.nameToken())
         std::cout << "\"" << tokenAndName.nameToken()->str() << "\" " << mTokenList.fileLine(tokenAndName.nameToken());
     else
         std::cout << "nullptr";
-    std::cout << std::endl;
+    std::cout << '\n';
     std::cout << indent << "paramEnd: ";
     if (tokenAndName.paramEnd())
         std::cout << "\"" << tokenAndName.paramEnd()->str() << "\" " << mTokenList.fileLine(tokenAndName.paramEnd());
     else
         std::cout << "nullptr";
-    std::cout << std::endl;
+    std::cout << '\n';
     std::cout << indent << "flags: ";
     if (tokenAndName.isClass())
         std::cout << " isClass";
@@ -3654,7 +3654,7 @@ void TemplateSimplifier::printOut(const TokenAndName &tokenAndName, const std::s
         std::cout << " isVariadic";
     if (tokenAndName.isFriend())
         std::cout << " isFriend";
-    std::cout << std::endl;
+    std::cout << '\n';
     if (tokenAndName.token() && !tokenAndName.paramEnd() && tokenAndName.token()->strAt(1) == "<") {
         const Token *end = tokenAndName.token()->next()->findClosingBracket();
         if (end) {
@@ -3670,38 +3670,38 @@ void TemplateSimplifier::printOut(const TokenAndName &tokenAndName, const std::s
                 std::cout << start->str();
                 start = start->next();
             }
-            std::cout << end->str() << std::endl;
+            std::cout << end->str() << '\n';
         }
     } else if (tokenAndName.isAlias() && tokenAndName.paramEnd()) {
         if (tokenAndName.aliasStartToken()) {
             std::cout << indent << "aliasStartToken: \"" << tokenAndName.aliasStartToken()->str() << "\" "
-                      << mTokenList.fileLine(tokenAndName.aliasStartToken()) << std::endl;
+                      << mTokenList.fileLine(tokenAndName.aliasStartToken()) << '\n';
         }
         if (tokenAndName.aliasEndToken()) {
             std::cout << indent << "aliasEndToken: \"" << tokenAndName.aliasEndToken()->str() << "\" "
-                      << mTokenList.fileLine(tokenAndName.aliasEndToken()) << std::endl;
+                      << mTokenList.fileLine(tokenAndName.aliasEndToken()) << '\n';
         }
     }
 }
 
 void TemplateSimplifier::printOut(const std::string & text) const
 {
-    std::cout << std::endl;
-    std::cout << text << std::endl;
-    std::cout << std::endl;
-    std::cout << "mTemplateDeclarations: " << mTemplateDeclarations.size() << std::endl;
+    std::cout << '\n';
+    std::cout << text << '\n';
+    std::cout << '\n';
+    std::cout << "mTemplateDeclarations: " << mTemplateDeclarations.size() << '\n';
     int count = 0;
     for (const auto & decl : mTemplateDeclarations) {
-        std::cout << "mTemplateDeclarations[" << count++ << "]:" << std::endl;
+        std::cout << "mTemplateDeclarations[" << count++ << "]:" << '\n';
         printOut(decl);
     }
-    std::cout << "mTemplateForwardDeclarations: " << mTemplateForwardDeclarations.size() << std::endl;
+    std::cout << "mTemplateForwardDeclarations: " << mTemplateForwardDeclarations.size() << '\n';
     count = 0;
     for (const auto & decl : mTemplateForwardDeclarations) {
-        std::cout << "mTemplateForwardDeclarations[" << count++ << "]:" << std::endl;
+        std::cout << "mTemplateForwardDeclarations[" << count++ << "]:" << '\n';
         printOut(decl);
     }
-    std::cout << "mTemplateForwardDeclarationsMap: " << mTemplateForwardDeclarationsMap.size() << std::endl;
+    std::cout << "mTemplateForwardDeclarationsMap: " << mTemplateForwardDeclarationsMap.size() << '\n';
     unsigned int mapIndex = 0;
     for (const auto & mapItem : mTemplateForwardDeclarationsMap) {
         unsigned int declIndex = 0;
@@ -3710,9 +3710,9 @@ void TemplateSimplifier::printOut(const std::string & text) const
                 unsigned int forwardIndex = 0;
                 for (const auto & forwardDecl : mTemplateForwardDeclarations) {
                     if (mapItem.second == forwardDecl.token()) {
-                        std::cout << "mTemplateForwardDeclarationsMap[" << mapIndex << "]:" << std::endl;
+                        std::cout << "mTemplateForwardDeclarationsMap[" << mapIndex << "]:" << '\n';
                         std::cout << "    mTemplateDeclarations[" << declIndex
-                                  << "] => mTemplateForwardDeclarations[" << forwardIndex << "]" << std::endl;
+                                  << "] => mTemplateForwardDeclarations[" << forwardIndex << "]" << '\n';
                         break;
                     }
                     forwardIndex++;
@@ -3723,7 +3723,7 @@ void TemplateSimplifier::printOut(const std::string & text) const
         }
         mapIndex++;
     }
-    std::cout << "mTemplateSpecializationMap: " << mTemplateSpecializationMap.size() << std::endl;
+    std::cout << "mTemplateSpecializationMap: " << mTemplateSpecializationMap.size() << '\n';
     for (const auto & mapItem : mTemplateSpecializationMap) {
         unsigned int decl1Index = 0;
         for (const auto & decl1 : mTemplateDeclarations) {
@@ -3732,9 +3732,9 @@ void TemplateSimplifier::printOut(const std::string & text) const
                 unsigned int decl2Index = 0;
                 for (const auto & decl2 : mTemplateDeclarations) {
                     if (mapItem.second == decl2.token()) {
-                        std::cout << "mTemplateSpecializationMap[" << mapIndex << "]:" << std::endl;
+                        std::cout << "mTemplateSpecializationMap[" << mapIndex << "]:" << '\n';
                         std::cout << "    mTemplateDeclarations[" << decl1Index
-                                  << "] => mTemplateDeclarations[" << decl2Index << "]" << std::endl;
+                                  << "] => mTemplateDeclarations[" << decl2Index << "]" << '\n';
                         found = true;
                         break;
                     }
@@ -3744,9 +3744,9 @@ void TemplateSimplifier::printOut(const std::string & text) const
                     decl2Index = 0;
                     for (const auto & decl2 : mTemplateForwardDeclarations) {
                         if (mapItem.second == decl2.token()) {
-                            std::cout << "mTemplateSpecializationMap[" << mapIndex << "]:" << std::endl;
+                            std::cout << "mTemplateSpecializationMap[" << mapIndex << "]:" << '\n';
                             std::cout << "    mTemplateDeclarations[" << decl1Index
-                                      << "] => mTemplateForwardDeclarations[" << decl2Index << "]" << std::endl;
+                                      << "] => mTemplateForwardDeclarations[" << decl2Index << "]" << '\n';
                             break;
                         }
                         decl2Index++;
@@ -3758,7 +3758,7 @@ void TemplateSimplifier::printOut(const std::string & text) const
         }
         mapIndex++;
     }
-    std::cout << "mTemplatePartialSpecializationMap: " << mTemplatePartialSpecializationMap.size() << std::endl;
+    std::cout << "mTemplatePartialSpecializationMap: " << mTemplatePartialSpecializationMap.size() << '\n';
     for (const auto & mapItem : mTemplatePartialSpecializationMap) {
         unsigned int decl1Index = 0;
         for (const auto & decl1 : mTemplateDeclarations) {
@@ -3767,9 +3767,9 @@ void TemplateSimplifier::printOut(const std::string & text) const
                 unsigned int decl2Index = 0;
                 for (const auto & decl2 : mTemplateDeclarations) {
                     if (mapItem.second == decl2.token()) {
-                        std::cout << "mTemplatePartialSpecializationMap[" << mapIndex << "]:" << std::endl;
+                        std::cout << "mTemplatePartialSpecializationMap[" << mapIndex << "]:" << '\n';
                         std::cout << "    mTemplateDeclarations[" << decl1Index
-                                  << "] => mTemplateDeclarations[" << decl2Index << "]" << std::endl;
+                                  << "] => mTemplateDeclarations[" << decl2Index << "]" << '\n';
                         found = true;
                         break;
                     }
@@ -3779,9 +3779,9 @@ void TemplateSimplifier::printOut(const std::string & text) const
                     decl2Index = 0;
                     for (const auto & decl2 : mTemplateForwardDeclarations) {
                         if (mapItem.second == decl2.token()) {
-                            std::cout << "mTemplatePartialSpecializationMap[" << mapIndex << "]:" << std::endl;
+                            std::cout << "mTemplatePartialSpecializationMap[" << mapIndex << "]:" << '\n';
                             std::cout << "    mTemplateDeclarations[" << decl1Index
-                                      << "] => mTemplateForwardDeclarations[" << decl2Index << "]" << std::endl;
+                                      << "] => mTemplateForwardDeclarations[" << decl2Index << "]" << '\n';
                             break;
                         }
                         decl2Index++;
@@ -3793,10 +3793,10 @@ void TemplateSimplifier::printOut(const std::string & text) const
         }
         mapIndex++;
     }
-    std::cout << "mTemplateInstantiations: " << mTemplateInstantiations.size() << std::endl;
+    std::cout << "mTemplateInstantiations: " << mTemplateInstantiations.size() << '\n';
     count = 0;
     for (const auto & decl : mTemplateInstantiations) {
-        std::cout << "mTemplateInstantiations[" << count++ << "]:" << std::endl;
+        std::cout << "mTemplateInstantiations[" << count++ << "]:" << '\n';
         printOut(decl);
     }
 }

--- a/lib/timer.cpp
+++ b/lib/timer.cpp
@@ -71,7 +71,7 @@ void TimerResults::showResults(size_t max_results, bool metrics) const
                 const double secMax = asSeconds(*std::max_element(iter->second.cbegin(), iter->second.cend())).count();
                 std::cout << " (avg. " << secAverage << "s / min " << secMin << "s / max " << secMax << "s - " << iter->second.size() << " result(s))";
             }
-            std::cout << std::endl;
+            std::cout << '\n';
         }
         ++ordinal;
     }
@@ -150,7 +150,7 @@ OneShotTimer::OneShotTimer(std::string name)
             std::lock_guard<std::mutex> l(stdCoutLock);
 
             // TODO: do not use std::cout directly
-            std::cout << name << ": " << durationToString(duration) << std::endl;
+            std::cout << name << ": " << durationToString(duration) << '\n';
         }
     };
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1240,23 +1240,23 @@ void Token::printOut(std::ostream& out, const char *title) const
 {
     if (title && title[0])
         out << "\n### " << title << " ###\n";
-    out << stringifyList(stringifyOptions::forPrintOut(), nullptr, nullptr) << std::endl;
+    out << stringifyList(stringifyOptions::forPrintOut(), nullptr, nullptr) << '\n';
 }
 
 void Token::printOut(std::ostream& out, bool xml, const char *title, const std::vector<std::string> &fileNames) const
 {
     if (xml)
     {
-        out << "<file>" << std::endl;
+        out << "<file>" << '\n';
         out << "<![CDATA[";
     }
     if (title && title[0])
         out << "\n### " << title << " ###\n";
-    out << stringifyList(stringifyOptions::forPrintOut(), &fileNames, nullptr) << std::endl;
+    out << stringifyList(stringifyOptions::forPrintOut(), &fileNames, nullptr) << '\n';
     if (xml)
     {
-        out << "]]>" << std::endl;
-        out << "</file>" << std::endl;
+        out << "]]>" << '\n';
+        out << "</file>" << '\n';
     }
 }
 
@@ -1266,7 +1266,7 @@ void Token::printLines(std::ostream& out, int lines) const
     const Token *end = this;
     while (end && end->linenr() < lines + linenr())
         end = end->next();
-    out << stringifyList(stringifyOptions::forDebugExprId(), nullptr, end) << std::endl;
+    out << stringifyList(stringifyOptions::forDebugExprId(), nullptr, end) << '\n';
 }
 
 std::string Token::stringify(const stringifyOptions& options) const
@@ -1652,23 +1652,23 @@ static void astStringXml(const Token *tok, nonneg int indent, std::ostream &out)
         out << " values=\"" << &tok->values() << '\"';
 
     if (!tok->astOperand1() && !tok->astOperand2()) {
-        out << "/>" << std::endl;
+        out << "/>" << '\n';
     }
 
     else {
-        out << '>' << std::endl;
+        out << '>' << '\n';
         if (tok->astOperand1())
             astStringXml(tok->astOperand1(), indent+2U, out);
         if (tok->astOperand2())
             astStringXml(tok->astOperand2(), indent+2U, out);
-        out << strindent << "</token>" << std::endl;
+        out << strindent << "</token>" << '\n';
     }
 }
 
 void Token::printAst(bool xml, const std::vector<std::string> &fileNames, std::ostream &out) const
 {
     if (!xml)
-        out << "\n\n##AST" << std::endl;
+        out << "\n\n##AST" << '\n';
 
     std::set<const Token *> printed;
     for (const Token *tok = this; tok; tok = tok->next()) {
@@ -1679,11 +1679,11 @@ void Token::printAst(bool xml, const std::vector<std::string> &fileNames, std::o
 
             if (xml) {
                 out << "<ast scope=\"" << tok->scope() << "\" fileIndex=\"" << tok->fileIndex() << "\" linenr=\"" << tok->linenr()
-                    << "\" column=\"" << tok->column() << "\">" << std::endl;
+                    << "\" column=\"" << tok->column() << "\">" << '\n';
                 astStringXml(tok, 2U, out);
-                out << "</ast>" << std::endl;
+                out << "</ast>" << '\n';
             } else
-                out << "[" << fileNames[tok->fileIndex()] << ":" << tok->linenr() << "]" << std::endl << tok->astStringVerbose() << std::endl;
+                out << "[" << fileNames[tok->fileIndex()] << ":" << tok->linenr() << "]" << '\n' << tok->astStringVerbose() << '\n';
             if (tok->str() == "(")
                 tok = tok->link();
         }

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6074,7 +6074,7 @@ void Tokenizer::printDebugOutput(std::ostream &out) const
     const bool xml = (mSettings.outputFormat == Settings::OutputFormat::xml);
 
     if (xml)
-        out << "<debug>" << std::endl;
+        out << "<debug>" << '\n';
 
     if (mSettings.debugSimplified || mSettings.debugnormal)
         list.front()->printOut(out, xml, nullptr, list.getFiles());

--- a/test/fixture.cpp
+++ b/test/fixture.cpp
@@ -113,7 +113,7 @@ bool TestFixture::prepareTest(const char testname[])
         std::putchar('.'); // Use putchar to write through redirection of std::cout/cerr
         std::fflush(stdout);
     } else {
-        std::cout << fullTestName << std::endl;
+        std::cout << fullTestName << '\n';
     }
     if (timer_results)
         mTimer.reset(new Timer(fullTestName, timer_results));
@@ -153,7 +153,7 @@ static std::string writestr(const std::string &str, bool gccStyle = false)
         if (*i == '\n') {
             ostr << "\\n";
             if ((i+1) != str.end() && !gccStyle)
-                ostr << std::endl;
+                ostr << '\n';
         } else if (*i == '\t')
             ostr << "\\t";
         else if (*i == '\"')
@@ -164,7 +164,7 @@ static std::string writestr(const std::string &str, bool gccStyle = false)
             ostr << "\\x" << std::hex << short{*i};
     }
     if (!str.empty() && !gccStyle)
-        ostr << std::endl;
+        ostr << '\n';
     else if (gccStyle)
         ostr << '\"';
     return ostr.str();
@@ -174,9 +174,9 @@ void TestFixture::assert_(const char * const filename, const unsigned int linenr
 {
     if (!condition) {
         ++fails_counter;
-        errmsg << getLocationStr(filename, linenr) << ": Assertion failed." << std::endl << "_____" << std::endl;
+        errmsg << getLocationStr(filename, linenr) << ": Assertion failed." << '\n' << "_____" << '\n';
         if (!msg.empty())
-            errmsg << "Hint:" << std::endl << msg << std::endl;
+            errmsg << "Hint:" << '\n' << msg << '\n';
         throw AssertFailedError();
     }
 }
@@ -184,14 +184,14 @@ void TestFixture::assert_(const char * const filename, const unsigned int linenr
 void TestFixture::assertFailure(const char* const filename, const unsigned int linenr, const std::string& expected, const std::string& actual, const std::string& msg) const
 {
     ++fails_counter;
-    errmsg << getLocationStr(filename, linenr) << ": Assertion failed. " << std::endl
-           << "Expected: " << std::endl
-           << writestr(expected) << std::endl
-           << "Actual: " << std::endl
-           << writestr(actual) << std::endl;
+    errmsg << getLocationStr(filename, linenr) << ": Assertion failed. " << '\n'
+           << "Expected: " << '\n'
+           << writestr(expected) << '\n'
+           << "Actual: " << '\n'
+           << writestr(actual) << '\n';
     if (!msg.empty())
-        errmsg << "Hint:" << std::endl << msg << std::endl;
-    errmsg << "_____" << std::endl;
+        errmsg << "Hint:" << '\n' << msg << '\n';
+    errmsg << "_____" << '\n';
     throw AssertFailedError();
 }
 
@@ -271,7 +271,7 @@ void TestFixture::todoAssertEquals(const char * const filename, const unsigned i
 {
     if (wanted == actual) {
         errmsg << getLocationStr(filename, linenr) << ": Assertion succeeded unexpectedly. "
-               << "Result: " << writestr(wanted, true)  << std::endl << "_____" << std::endl;
+               << "Result: " << writestr(wanted, true)  << '\n' << "_____" << '\n';
 
         ++succeeded_todos_counter;
     } else {
@@ -298,7 +298,7 @@ void TestFixture::assertThrow(const char * const filename, const unsigned int li
 {
     ++fails_counter;
     errmsg << getLocationStr(filename, linenr) << ": Assertion succeeded. "
-           << "The expected exception was thrown" << std::endl << "_____" << std::endl;
+           << "The expected exception was thrown" << '\n' << "_____" << '\n';
     throw AssertFailedError();
 }
 
@@ -306,7 +306,7 @@ void TestFixture::assertThrowFail(const char * const filename, const unsigned in
 {
     ++fails_counter;
     errmsg << getLocationStr(filename, linenr) << ": Assertion failed. "
-           << "The expected exception was not thrown"  << std::endl << "_____" << std::endl;
+           << "The expected exception was not thrown"  << '\n' << "_____" << '\n';
     throw AssertFailedError();
 }
 
@@ -333,7 +333,7 @@ void TestFixture::assertNoThrowFail(const char * const filename, const unsigned 
 
     ++fails_counter;
     errmsg << getLocationStr(filename, linenr) << ": Assertion failed. "
-           << "Unexpected exception was thrown: " << ex_msg << std::endl << "_____" << std::endl;
+           << "Unexpected exception was thrown: " << ex_msg << '\n' << "_____" << '\n';
     if (bailout)
         throw AssertFailedError();
 }
@@ -375,15 +375,15 @@ void TestFixture::run(const std::set<std::string> &tests)
     }
     catch (const InternalError& e) {
         ++fails_counter;
-        errmsg << classname << "::" << mTestname << " - InternalError: " << e.errorMessage << std::endl;
+        errmsg << classname << "::" << mTestname << " - InternalError: " << e.errorMessage << '\n';
     }
     catch (const std::exception& error) {
         ++fails_counter;
-        errmsg << classname << "::" << mTestname << " - Exception: " << error.what() << std::endl;
+        errmsg << classname << "::" << mTestname << " - Exception: " << error.what() << '\n';
     }
     catch (...) {
         ++fails_counter;
-        errmsg << classname << "::" << mTestname << " - Unknown exception" << std::endl;
+        errmsg << classname << "::" << mTestname << " - Unknown exception" << '\n';
     }
 }
 
@@ -429,17 +429,17 @@ std::size_t TestFixture::runTests(const options& args)
     }
 
     if (args.summary() && !args.dry_run()) {
-        std::cout << "\n\nTesting Complete\nNumber of tests: " << countTests << std::endl;
+        std::cout << "\n\nTesting Complete\nNumber of tests: " << countTests << '\n';
         std::cout << "Number of todos: " << todos_counter;
         if (succeeded_todos_counter > 0)
             std::cout << " (" << succeeded_todos_counter << " succeeded)";
-        std::cout << std::endl;
+        std::cout << '\n';
     }
     // calling flush here, to do all output before the error messages (in case the output is buffered)
     std::cout.flush();
 
     if (args.summary() && !args.dry_run()) {
-        std::cerr << "Tests failed: " << fails_counter << std::endl << std::endl;
+        std::cerr << "Tests failed: " << fails_counter << '\n' << '\n';
     }
     std::cerr << errmsg.str();
 
@@ -449,7 +449,7 @@ std::size_t TestFixture::runTests(const options& args)
 
 void TestFixture::reportOut(const std::string & outmsg, Color /*c*/)
 {
-    mOutput << outmsg << std::endl;
+    mOutput << outmsg << '\n';
 }
 
 void TestFixture::reportErr(const ErrorMessage &msg)
@@ -481,7 +481,7 @@ void TestFixture::reportErr(const ErrorMessage &msg)
             errormessage += "]";
         }
     }
-    mErrout << errormessage << std::endl;
+    mErrout << errormessage << '\n';
 }
 
 void TestFixture::setTemplateFormat(const std::string &templateFormat)

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -77,7 +77,7 @@ ScopedFile::ScopedFile(std::string name, const std::string &content, std::string
 ScopedFile::~ScopedFile() {
     const int remove_res = std::remove(mFullPath.c_str());
     if (remove_res != 0) {
-        std::cout << "ScopedFile(" << mFullPath + ") - could not delete file (" << remove_res << ")" << std::endl;
+        std::cout << "ScopedFile(" << mFullPath + ") - could not delete file (" << remove_res << ")" << '\n';
     }
     if (!mPath.empty() && mPath != Path::getCurrentPath()) {
         // TODO: remove all files
@@ -86,26 +86,26 @@ ScopedFile::~ScopedFile() {
         std::list<FileWithDetails> files;
         const std::string res = FileLister::addFiles(files, mPath, {".plist"}, false, PathMatch());
         if (!res.empty()) {
-            std::cout << "ScopedFile(" << mPath + ") - generating file list failed (" << res << ")" << std::endl;
+            std::cout << "ScopedFile(" << mPath + ") - generating file list failed (" << res << ")" << '\n';
         }
         for (const auto &f : files)
         {
             const std::string &file = f.path();
             const int rm_f_res = std::remove(file.c_str());
             if (rm_f_res != 0) {
-                std::cout << "ScopedFile(" << mPath + ") - could not delete '" << file << "' (" << rm_f_res << ")" << std::endl;
+                std::cout << "ScopedFile(" << mPath + ") - could not delete '" << file << "' (" << rm_f_res << ")" << '\n';
             }
         }
 
 #ifdef _WIN32
         if (!RemoveDirectoryA(mPath.c_str())) {
-            std::cout << "ScopedFile(" << mFullPath + ") - could not delete folder (" << GetLastError() << ")" << std::endl;
+            std::cout << "ScopedFile(" << mFullPath + ") - could not delete folder (" << GetLastError() << ")" << '\n';
         }
 #else
         const int rmdir_res = rmdir(mPath.c_str());
         if (rmdir_res == -1) {
             const int err = errno;
-            std::cout << "ScopedFile(" << mFullPath + ") - could not delete folder (" << err << ")" << std::endl;
+            std::cout << "ScopedFile(" << mFullPath + ") - could not delete folder (" << err << ")" << '\n';
         }
 #endif
     }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -7151,9 +7151,9 @@ private:
                 ASSERT(function != nullptr);
                 if (function) {
                     std::stringstream expected;
-                    expected << "Function call on line " << tok->linenr() << " calls function on line " << linenrs[index] << std::endl;
+                    expected << "Function call on line " << tok->linenr() << " calls function on line " << linenrs[index] << '\n';
                     std::stringstream actual;
-                    actual << "Function call on line " << tok->linenr() << " calls function on line " << function->tokenDef->linenr() << std::endl;
+                    actual << "Function call on line " << tok->linenr() << " calls function on line " << function->tokenDef->linenr() << '\n';
                     ASSERT_EQUALS(expected.str(), actual.str());
                 }
                 index++;

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -201,7 +201,7 @@ static int write_vcxproj(const std::string &proj_name, const std::function<void(
         // treat as binary to prevent implicit line ending conversions
         std::ifstream in(proj_name, std::ios::binary);
         if (!in.is_open()) {
-            std::cerr << "Could not open " << proj_name << std::endl;
+            std::cerr << "Could not open " << proj_name << '\n';
             return EXIT_FAILURE;
         }
 
@@ -441,7 +441,7 @@ int main(int argc, char **argv)
     std::vector<std::string> libfiles;
     std::string err = getCppFiles(libfiles, "lib/", false);
     if (!err.empty()) {
-        std::cerr << err << std::endl;
+        std::cerr << err << '\n';
         return EXIT_FAILURE;
     }
     const std::vector<std::string> libfiles_prio = prioritizelib(libfiles);
@@ -449,7 +449,7 @@ int main(int argc, char **argv)
     std::vector<std::string> extfiles;
     err = getCppFiles(extfiles, "externals/", true);
     if (!err.empty()) {
-        std::cerr << err << std::endl;
+        std::cerr << err << '\n';
         return EXIT_FAILURE;
     }
 
@@ -463,26 +463,26 @@ int main(int argc, char **argv)
     std::vector<std::string> clifiles;
     err = getCppFiles(clifiles, "cli/", false);
     if (!err.empty()) {
-        std::cerr << err << std::endl;
+        std::cerr << err << '\n';
         return EXIT_FAILURE;
     }
 
     std::vector<std::string> testfiles;
     err = getCppFiles(testfiles, "test/", false);
     if (!err.empty()) {
-        std::cerr << err << std::endl;
+        std::cerr << err << '\n';
         return EXIT_FAILURE;
     }
 
     std::vector<std::string> toolsfiles;
     err = getCppFiles(toolsfiles, "tools/dmake/", false);
     if (!err.empty()) {
-        std::cerr << err << std::endl;
+        std::cerr << err << '\n';
         return EXIT_FAILURE;
     }
 
     if (libfiles.empty() && frontendfiles.empty() && clifiles.empty() && testfiles.empty()) {
-        std::cerr << "No files found. Are you in the correct directory?" << std::endl;
+        std::cerr << "No files found. Are you in the correct directory?" << '\n';
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
This will also help with reducing `valueFlowBailoutIncompleteVar` warnings in our code base.