### PR TITLE
windows.cfg: Added support for some obsolete functions

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -2326,7 +2326,7 @@
     implemented in Cppcheck. It can not (yet) be configured in the configuration
     file. See #8381 -->
   </function>
-  <!-- int _sprintf_s_l(char *buffer, size_t sizeOfBuffer, const char *format, locale_t locale, ... ); 
+  <!-- int _sprintf_s_l(char *buffer, size_t sizeOfBuffer, const char *format, locale_t locale, ... );
        int _swprintf_s_l(wchar_t *buffer, size_t sizeOfBuffer, const wchar_t *format, locale_t locale, ...);-->
   <function name="_sprintf_s_l,_swprintf_s_l">
     <noreturn>false</noreturn>
@@ -2376,7 +2376,7 @@
     <arg nr="7" direction="inout"/>
     <arg nr="8" direction="out"/>
   </function>
-  <!-- 
+  <!--
 HFONT CreateFont(
   _In_  int nHeight,
   _In_  int nWidth,
@@ -2453,8 +2453,8 @@ HFONT CreateFont(
     </arg>
     <arg nr="4"/>
   </function>
-  <!-- int _vsnprintf_l (char *buffer   , size_t count, const char *format, locale_t locale,  va_list argptr); 
-       int _vsnwprintf_l(wchar_t *buffer, size_t count, const wchar_t *format, locale_t locale, va_list argptr); 
+  <!-- int _vsnprintf_l (char *buffer   , size_t count, const char *format, locale_t locale,  va_list argptr);
+       int _vsnwprintf_l(wchar_t *buffer, size_t count, const wchar_t *format, locale_t locale, va_list argptr);
        int _vswprintf_l(wchar_t *buffer,  size_t count, const wchar_t *format, locale_t locale, va_list argptr);-->
   <function name="_vsnprintf_l,_vsnwprintf_l,_vswprintf_l">
     <noreturn>false</noreturn>
@@ -2478,7 +2478,7 @@ HFONT CreateFont(
     </arg>
     <arg nr="5"/>
   </function>
-  <!-- int vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr); 
+  <!-- int vsnprintf_s(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr);
        int _vsnprintf_s( char *buffer, size_t sizeOfBuffer, size_t count, const char *format, va_list argptr);
        int _vsnwprintf_s( wchar_t *buffer, size_t sizeOfBuffer, size_t count, const wchar_t *format, va_list argptr); -->
   <function name="vsnprintf_s,_vsnprintf_s,_vsnwprintf_s">
@@ -2504,7 +2504,7 @@ HFONT CreateFont(
     </arg>
     <arg nr="5"/>
   </function>
-  <!-- int _vsnprintf_s_l(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, locale_t locale,  va_list argptr); 
+  <!-- int _vsnprintf_s_l(char *buffer, size_t sizeOfBuffer, size_t count, const char *format, locale_t locale,  va_list argptr);
        int _vsnwprintf_s_l(wchar_t *buffer, size_t sizeOfBuffer, size_t count, const wchar_t *format, locale_t locale, va_list argptr); -->
   <function name="_vsnprintf_s_l,_vsnwprintf_s_l">
     <noreturn>false</noreturn>
@@ -2531,7 +2531,7 @@ HFONT CreateFont(
     </arg>
     <arg nr="6"/>
   </function>
-  <!-- int _vsprintf_l(char *buffer, const char *format, locale_t locale, va_list argptr); 
+  <!-- int _vsprintf_l(char *buffer, const char *format, locale_t locale, va_list argptr);
       int __vswprintf_l(wchar_t *buffer, const wchar_t *format, locale_t locale, va_list argptr);-->
   <function name="_vsprintf_l,__vswprintf_l">
     <noreturn>false</noreturn>
@@ -2571,7 +2571,7 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <!-- char *_strdup_dbg(const char *strSource, int blockType, const char *filename, int linenumber );  
+  <!-- char *_strdup_dbg(const char *strSource, int blockType, const char *filename, int linenumber );
        wchar_t *_wcsdup_dbg(const wchar_t *strSource, int blockType, const char *filename, int linenumber);-->
   <function name="_strdup_dbg,_wcsdup_dbg,_tcsdup_dbg">
     <noreturn>false</noreturn>
@@ -2628,7 +2628,7 @@ HFONT CreateFont(
     </arg>
     <arg nr="3" direction="in"/>
   </function>
-  <!-- int _snprintf(char *s, size_t n, const char *format, ...); 
+  <!-- int _snprintf(char *s, size_t n, const char *format, ...);
        int _snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...);-->
   <function name="_snprintf,_snwprintf,_sntprintf">
     <noreturn>false</noreturn>
@@ -2748,8 +2748,8 @@ HFONT CreateFont(
       <valid>0:2</valid>
     </arg>
   </function>
-  <!-- __int64 _ftelli64(FILE *stream); 
-         long _ftell_nolock(FILE *stream);  
+  <!-- __int64 _ftelli64(FILE *stream);
+         long _ftell_nolock(FILE *stream);
        __int64 _ftelli64_nolock(FILE *stream); -->
   <function name="_ftelli64,_ftell_nolock,_ftelli64_nolock">
     <noreturn>false</noreturn>
@@ -3575,7 +3575,7 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <!-- int _rmdir(const char *dirname); 
+  <!-- int _rmdir(const char *dirname);
        int _wrmdir(const wchar_t *dirname);-->
   <function name="_rmdir,_wrmdir">
     <noreturn>false</noreturn>
@@ -3681,7 +3681,7 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <!-- FILE *_popen( const char *command, const char *mode ); 
+  <!-- FILE *_popen( const char *command, const char *mode );
        FILE *_wpopen(const wchar_t *command, const wchar_t *mode);-->
   <function name="_popen,_wpopen,_tpopen">
     <noreturn>false</noreturn>
@@ -4297,8 +4297,8 @@ HFONT CreateFont(
       <strz/>
     </arg>
   </function>
-  <!-- unsigned char *_mbsrchr_l(const unsigned char *str, unsigned int c, _locale_t locale ); // C only  
-       unsigned char *_mbsrchr_l(unsigned char *str, unsigned int c, _locale_t locale ); // C++ only  
+  <!-- unsigned char *_mbsrchr_l(const unsigned char *str, unsigned int c, _locale_t locale ); // C only
+       unsigned char *_mbsrchr_l(unsigned char *str, unsigned int c, _locale_t locale ); // C++ only
        const unsigned char *_mbsrchr_l(const unsigned char *str, unsigned int c, _locale_t locale ); // C++ only-->
   <function name="_mbsrchr_l">
     <use-retval/>
@@ -4331,8 +4331,8 @@ HFONT CreateFont(
       <not-uninit/>
     </arg>
   </function>
-  <!-- unsigned char *_mbsrchr(const unsigned char *str, unsigned int c); // C only  
-       unsigned char *_mbsrchr(unsigned char *str, unsigned int c); // C++ only  
+  <!-- unsigned char *_mbsrchr(const unsigned char *str, unsigned int c); // C only
+       unsigned char *_mbsrchr(unsigned char *str, unsigned int c); // C++ only
        const unsigned char *_mbsrchr(const unsigned char *str, unsigned int c); // C++ only-->
   <function name="_mbsrchr,_tcsrchr">
     <use-retval/>
@@ -4578,6 +4578,108 @@ HFONT CreateFont(
     <arg nr="1" direction="out">
       <not-bool/>
     </arg>
+  </function>
+  <!-- unsigned int _setsystime(struct tm * tp, unsigned int ms); -->
+  <function name="_setsystime">
+    <returnValue type="unsigned int"/>
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="SetLocalTime"/>
+  </function>
+  <!-- unsigned int _getsystime(struct tm * tp)-->
+  <function name="_getsystime">
+    <returnValue type="unsigned int"/>
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-null/>
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="GetLocalTime"/>
+  </function>
+  <!-- void _sleep(unsigned long ulTime); -->
+  <function name="_sleep">
+    <returnValue type="void"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="Sleep"/>
+  </function>
+  <!-- void _beep(unsigned nFreq, unsigned nDur); -->
+  <function name="_beep">
+    <returnValue type="void"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="Beep"/>
+  </function>
+  <!-- void _seterrormode (int mode); -->
+  <function name="_seterrormode">
+    <returnValue type="void"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="SetErrorMode"/>
+  </function>
+  <!-- intptr_t _loaddll (char *name); -->
+  <function name="_loaddll">
+    <returnValue type="intptr_t"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-bool/>
+      <not-null/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="LoadLibrary,LoadLibraryEx,LoadPackagedLibrary"/>
+  </function>
+  <!-- int _unloaddll(intptr_t handle); -->
+  <function name="_unloaddll">
+    <returnValue type="int"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="FreeLibrary"/>
+  </function>
+  <!-- FARPROC _getdllprocaddr (intptr_t hModule, char *lpProcName, intptr_t iOrdinal)-->
+  <function name="_getdllprocaddr">
+    <returnValue type="FARPROC"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-bool/>
+      <not-null/>
+    </arg>
+    <arg nr="3" direction="in">
+      <not-bool/>
+      <not-uninit/>
+    </arg>
+    <warn severity="style" reason="Obsolete" alternatives="GetProcAddress"/>
   </function>
   <!-- BOOL WINAPI CreateDirectory(_In_ LPCTSTR lpPathName,
                                    _In_opt_ LPSECURITY_ATTRIBUTES lpSecurityAttributes); -->


### PR DESCRIPTION
Reference: https://learn.microsoft.com/en-us/cpp/c-runtime-library/obsolete-functions?view=msvc-170