### PR TITLE
coverage.yml: temporarily disabled because of permanent upload failures

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,8 @@ jobs:
   build:
 
     runs-on: ubuntu-22.04
-    if: ${{ github.repository_owner == 'danmar' }}
+    # FIXME: disabled because the tokenless upload suddenly started to permanently fail
+    if: false # ${{ github.repository_owner == 'danmar' }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The `v3` action appears to use the `v4` API:
```
[2024-04-07T11:12:15.874Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.6-uploader-0.7.2&token=*******&branch=windows_cfg_added_more_obsolte_functions&build=8586929612&build_url=https%3A%2F%2Fgithub.com%2Fdanmar%2Fcppcheck%2Factions%2Fruns%2F8586929612%2Fjob%2F23532898031&commit=5f9e79c47e8f116481df6fb981dc67eef975344e&job=Coverage&pr=6251&service=github-actions&slug=danmar%2Fcppcheck&name=danmar%2Fcppcheck&tag=&flags=unittests&parent=
[2024-04-07T11:12:16.167Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov: Failed to properly upload: The process '/home/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255
```

I filed https://github.com/codecov/codecov-action/issues/1359 upstream.