### PR TITLE
Added Support for Shared Items Projects

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -865,11 +865,11 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
 
 ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
 {
-    for (const auto &entry : cache) {
-        if (filename == entry.pathToProjectFile) {
-            return entry;
-        }
-    }
+    auto isInCacheCheck = [filename](const auto& e) -> bool { return filename == e.pathToProjectFile; };
+    auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
+	if (iterator != std::end(cache)) {
+        return *iterator;
+	}
 
     SharedItemsProject result{};
     result.pathToProjectFile = filename;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -187,6 +187,8 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
     mPath = Path::getPathFromFilename(Path::fromNativeSeparators(filename));
     if (!mPath.empty() && !endsWith(mPath,'/'))
         mPath += '/';
+    if (mPath.empty())
+        mPath = std::string("./");
 
     const std::vector<std::string> fileFilters =
         settings ? settings->fileFilters : std::vector<std::string>();

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -777,7 +777,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                                 printError("Could not simplify path to referenced shared items project");
                                 exit(-1);
                             }
-							
+
                             SharedItemsProject toAdd = importVcxitems(pathToSharedItemsFile, fileFilters, cache);
                             if (!toAdd.successFull) {
                                 printError("Could not load shared items project \"" + pathToSharedItemsFile + "\" from original path \"" + std::string(projectAttribute) + "\".");

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -452,7 +452,7 @@ bool ImportProject::importSln(std::istream &istr, const std::string &path, const
     std::vector<SharedItemsProject> sharedItemsProjects{};
     while (std::getline(istr,line)) {
         if (!startsWith(line,"Project("))
-            continue;        
+            continue;
         const std::string::size_type pos = line.find(".vcxproj");
         if (pos == std::string::npos)
             continue;
@@ -791,7 +791,9 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                 }
             }
         }
-    }
+    }    
+	// # TODO: support signedness of char via /J (and potential XML option for it)?
+    // we can only set it globally but in this context it needs to be treated per file
 
     // Include shared items project files
     std::vector<std::string> sharedItemsIncludePaths{};
@@ -824,7 +826,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
             FileSettings fs;
             fs.filename = cfilename;
             fs.cfg = p.name;
-			// TODO: detect actual MSC version
+            // TODO: detect actual MSC version
             fs.msc = true;
             fs.useMfc = useOfMfc;
             fs.defines = "_WIN32=1";

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -187,8 +187,6 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
     mPath = Path::getPathFromFilename(Path::fromNativeSeparators(filename));
     if (!mPath.empty() && !endsWith(mPath,'/'))
         mPath += '/';
-    if (mPath.empty())
-        mPath = "./";
 
     const std::vector<std::string> fileFilters =
         settings ? settings->fileFilters : std::vector<std::string>();

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -190,7 +190,6 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
 
     const std::vector<std::string> fileFilters =
         settings ? settings->fileFilters : std::vector<std::string>();
-    std::vector<SharedItemsProject> sharedItemsProjects{};
 
     if (endsWith(filename, ".json")) {
         if (importCompileCommands(fin)) {
@@ -204,6 +203,7 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
         }
     } else if (endsWith(filename, ".vcxproj")) {
         std::map<std::string, std::string, cppcheck::stricmp> variables;
+        std::vector<SharedItemsProject> sharedItemsProjects{};
         if (importVcxproj(filename, variables, emptyString, fileFilters, sharedItemsProjects)) {
             setRelativePaths(filename);
             return ImportProject::Type::VS_VCXPROJ;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -847,6 +847,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
             FileSettings fs;
             fs.filename = cfilename;
             fs.cfg = p.name;
+			// TODO: detect actual MSC version
             fs.msc = true;
             fs.useMfc = useOfMfc;
             fs.defines = "_WIN32=1";

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -203,7 +203,7 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
         }
     } else if (endsWith(filename, ".vcxproj")) {
         std::map<std::string, std::string, cppcheck::stricmp> variables;
-        std::vector<SharedItemsProject> sharedItemsProjects{};
+        std::vector<SharedItemsProject> sharedItemsProjects;
         if (importVcxproj(filename, variables, emptyString, fileFilters, sharedItemsProjects)) {
             setRelativePaths(filename);
             return ImportProject::Type::VS_VCXPROJ;
@@ -447,7 +447,7 @@ bool ImportProject::importSln(std::istream &istr, const std::string &path, const
     variables["SolutionDir"] = path;
 
     bool found = false;
-    std::vector<SharedItemsProject> sharedItemsProjects{};
+    std::vector<SharedItemsProject> sharedItemsProjects;
     while (std::getline(istr,line)) {
         if (!startsWith(line,"Project("))
             continue;
@@ -794,7 +794,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
     // we can only set it globally but in this context it needs to be treated per file
 
     // Include shared items project files
-    std::vector<std::string> sharedItemsIncludePaths{};
+    std::vector<std::string> sharedItemsIncludePaths;
     for (const auto& sharedProject : sharedItemsProjects) {
         for (const auto &file : sharedProject.sourceFiles) {
             std::string pathToFile = Path::simplifyPath(Path::getPathFromFilename(sharedProject.pathToProjectFile) + file);
@@ -873,7 +873,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         return *iterator;
     }
 
-    SharedItemsProject result{};
+    SharedItemsProject result;
     result.pathToProjectFile = filename;
 
     tinyxml2::XMLDocument doc;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -742,16 +742,16 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
         printError(std::string("Visual Studio project file is not a valid XML - ") + tinyxml2::XMLDocument::ErrorIDToName(error));
         return false;
     }
-    const tinyxml2::XMLElement* const rootnode = doc.FirstChildElement();
+    const tinyxml2::XMLElement * const rootnode = doc.FirstChildElement();
     if (rootnode == nullptr) {
         printError("Visual Studio project file has no XML root node");
         return false;
     }
-    for (const tinyxml2::XMLElement* node = rootnode->FirstChildElement(); node; node = node->NextSiblingElement()) {
+    for (const tinyxml2::XMLElement *node = rootnode->FirstChildElement(); node; node = node->NextSiblingElement()) {
         if (std::strcmp(node->Name(), "ItemGroup") == 0) {
-            const char* labelAttribute = node->Attribute("Label");
+            const char *labelAttribute = node->Attribute("Label");
             if (labelAttribute && std::strcmp(labelAttribute, "ProjectConfigurations") == 0) {
-                for (const tinyxml2::XMLElement* cfg = node->FirstChildElement(); cfg; cfg = cfg->NextSiblingElement()) {
+                for (const tinyxml2::XMLElement *cfg = node->FirstChildElement(); cfg; cfg = cfg->NextSiblingElement()) {
                     if (std::strcmp(cfg->Name(), "ProjectConfiguration") == 0) {
                         const ProjectConfiguration p(cfg);
                         if (p.platform != ProjectConfiguration::Unknown) {
@@ -760,11 +760,10 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                         }
                     }
                 }
-            }
-            else {
-                for (const tinyxml2::XMLElement* e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
+            } else {
+                for (const tinyxml2::XMLElement *e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
                     if (std::strcmp(e->Name(), "ClCompile") == 0) {
-                        const char* include = e->Attribute("Include");
+                        const char *include = e->Attribute("Include");
                         if (include && Path::acceptFile(include)) {
                             std::string toInclude = Path::simplifyPath(Path::isAbsolute(include) ? include : Path::getPathFromFilename(filename) + include);
                             compileList.emplace_back(toInclude);
@@ -786,13 +785,11 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                             loadVisualStudioProperties(projectAttribute, variables, includePath, additionalIncludeDirectories, itemDefinitionGroupList);
                     }
                 }
-            }
-            else if (labelAttribute && std::strcmp(labelAttribute, "Shared") == 0) {
-                for (const tinyxml2::XMLElement* e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
+            } else if (labelAttribute && std::strcmp(labelAttribute, "Shared") == 0) {
+                for (const tinyxml2::XMLElement *e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
                     if (std::strcmp(e->Name(), "Import") == 0) {
-                        const char* projectAttribute = e->Attribute("Project");
-                        if (projectAttribute)
-                        {
+                        const char *projectAttribute = e->Attribute("Project");
+                        if (projectAttribute) {
                             // Path to shared items project is relative to current project directory,
                             // unless the string starts with $(SolutionDir)
                             std::string pathToSharedItemsFile;
@@ -805,9 +802,9 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                                 printError("Could not simplify path to referenced shared items project");
                                 exit(-1);
                             }
+							
                             SharedItemsProject toAdd = importVcxitems(pathToSharedItemsFile, fileFilters, cache);
-                            if (!toAdd.successFull)
-                            {
+                            if (!toAdd.successFull) {
                                 printError("Could not load shared items project \"" + pathToSharedItemsFile + "\" from original path \"" + std::string(projectAttribute) + "\".");
                                 return false;
                             }
@@ -822,27 +819,27 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
     // Include shared items project files
     std::vector<std::string> sharedItemsIncludePaths{};
     for (const auto& sharedProject : sharedItemsProjects) {
-        for (const auto& file : sharedProject.sourceFiles) {
+        for (const auto &file : sharedProject.sourceFiles) {
             std::string pathToFile = Path::simplifyPath(Path::getPathFromFilename(sharedProject.pathToProjectFile) + file);
             compileList.emplace_back(std::move(pathToFile));
         }
-        for (const auto& p : sharedProject.includePaths) {
+        for (const auto &p : sharedProject.includePaths) {
             std::string path = Path::simplifyPath(Path::getPathFromFilename(sharedProject.pathToProjectFile) + p);
             sharedItemsIncludePaths.emplace_back(std::move(path));
         }
     }
 
     // Project files
-    for (const std::string& cfilename : compileList) {
+    for (const std::string &cfilename : compileList) {
         if (!fileFilters.empty() && !matchglobs(fileFilters, cfilename))
             continue;
 
-        for (const ProjectConfiguration& p : projectConfigurationList) {
+        for (const ProjectConfiguration &p : projectConfigurationList) {
 
             if (!guiProject.checkVsConfigs.empty()) {
                 const bool doChecking = std::any_of(guiProject.checkVsConfigs.cbegin(), guiProject.checkVsConfigs.cend(), [&](const std::string& c) {
                     return c == p.configuration;
-                    });
+                });
                 if (!doChecking)
                     continue;
             }
@@ -902,10 +899,8 @@ static std::string stringReplace(const std::string& original, const std::string&
 
 ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
 {
-    for (const auto& entry : cache)
-    {
-        if (filename == entry.pathToProjectFile)
-        {
+    for (const auto &entry : cache) {
+        if (filename == entry.pathToProjectFile) {
             return entry;
         }
     }
@@ -919,14 +914,14 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         printError(std::string("Visual Studio project file is not a valid XML - ") + tinyxml2::XMLDocument::ErrorIDToName(error));
         return result;
     }
-    const tinyxml2::XMLElement* const rootnode = doc.FirstChildElement();
+    const tinyxml2::XMLElement * const rootnode = doc.FirstChildElement();
     if (rootnode == nullptr) {
         printError("Visual Studio project file has no XML root node");
         return result;
     }
-    for (const tinyxml2::XMLElement* node = rootnode->FirstChildElement(); node; node = node->NextSiblingElement()) {
+    for (const tinyxml2::XMLElement *node = rootnode->FirstChildElement(); node; node = node->NextSiblingElement()) {
         if (std::strcmp(node->Name(), "ItemGroup") == 0) {
-            for (const tinyxml2::XMLElement* e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
+            for (const tinyxml2::XMLElement *e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
                 if (std::strcmp(e->Name(), "ClCompile") == 0) {
                     const char* include = e->Attribute("Include");
                     if (include && Path::acceptFile(include)) {
@@ -943,8 +938,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
                     }
                 }
             }
-        }
-        else if (std::strcmp(node->Name(), "ItemDefinitionGroup") == 0) {
+        } else if (std::strcmp(node->Name(), "ItemDefinitionGroup") == 0) {
             ItemDefinitionGroup temp(node, "");
             for (const auto& includePath : toStringList(temp.additionalIncludePaths)) {
                 if (includePath == std::string("%(AdditionalIncludeDirectories)"))

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -857,7 +857,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                 fs.defines += ";_WIN64=1";
             }
             std::string additionalIncludePaths;
-            for (const ItemDefinitionGroup& i : itemDefinitionGroupList) {
+            for (const ItemDefinitionGroup &i : itemDefinitionGroupList) {
                 if (!i.conditionIsTrue(p))
                     continue;
                 fs.standard = Standards::getCPP(i.cppstd);
@@ -876,7 +876,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
             }
             fs.setDefines(fs.defines);
             fs.setIncludePaths(Path::getPathFromFilename(filename), toStringList(includePath + ';' + additionalIncludePaths), variables);
-            for (const auto& path : sharedItemsIncludePaths) {
+            for (const auto &path : sharedItemsIncludePaths) {
                 fs.includePaths.emplace_back(path);
             }
             fileSettings.push_back(std::move(fs));
@@ -886,7 +886,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
     return true;
 }
 
-static std::string stringReplace(const std::string& original, const std::string& toReplace, const std::string& replaceWith) 
+static std::string stringReplace(const std::string &original, const std::string &toReplace, const std::string &replaceWith) 
 {
     std::string result(original);
     size_t pos = result.find(toReplace);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -865,7 +865,9 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
 
 ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
 {
-    auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool { return filename == e.pathToProjectFile; };
+    auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool { 
+        return filename == e.pathToProjectFile; 
+    };
     auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
     if (iterator != std::end(cache)) {
         return *iterator;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -769,9 +769,9 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                             // unless the string starts with $(SolutionDir)
                             std::string pathToSharedItemsFile;
                             if (std::string(projectAttribute).rfind("$(SolutionDir)", 0) == 0) {
-                                pathToSharedItemsFile = std::string(projectAttribute);
+                                pathToSharedItemsFile = projectAttribute;
                             } else {
-                                pathToSharedItemsFile = variables["ProjectDir"] + std::string(projectAttribute);
+                                pathToSharedItemsFile = variables["ProjectDir"] + projectAttribute;
                             }
                             if (!simplifyPathWithVariables(pathToSharedItemsFile, variables)) {
                                 printError("Could not simplify path to referenced shared items project");
@@ -779,7 +779,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                             }
 
                             SharedItemsProject toAdd = importVcxitems(pathToSharedItemsFile, fileFilters, cache);
-                            if (!toAdd.successFull) {
+                            if (!toAdd.successful) {
                                 printError("Could not load shared items project \"" + pathToSharedItemsFile + "\" from original path \"" + std::string(projectAttribute) + "\".");
                                 return false;
                             }
@@ -868,7 +868,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
     auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool {
         return filename == e.pathToProjectFile;
     };
-    auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
+    const auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
     if (iterator != std::end(cache)) {
         return *iterator;
     }
@@ -920,7 +920,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         }
     }
 
-    result.successFull = true;
+    result.successful = true;
     cache.emplace_back(result);
     return result;
 }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -188,7 +188,7 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
     if (!mPath.empty() && !endsWith(mPath,'/'))
         mPath += '/';
     if (mPath.empty())
-        mPath = std::string("./");
+        mPath = "./";
 
     const std::vector<std::string> fileFilters =
         settings ? settings->fileFilters : std::vector<std::string>();

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -873,7 +873,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         return *iterator;
     }
 
-    SharedItemsProject result;
+    SharedItemsProject result{};
     result.pathToProjectFile = filename;
 
     tinyxml2::XMLDocument doc;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -873,7 +873,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         return *iterator;
     }
 
-    SharedItemsProject result{};
+    SharedItemsProject result;
     result.pathToProjectFile = filename;
 
     tinyxml2::XMLDocument doc;
@@ -910,7 +910,7 @@ ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::strin
         } else if (std::strcmp(node->Name(), "ItemDefinitionGroup") == 0) {
             ItemDefinitionGroup temp(node, "");
             for (const auto& includePath : toStringList(temp.additionalIncludePaths)) {
-                if (includePath == std::string("%(AdditionalIncludeDirectories)"))
+                if (includePath == "%(AdditionalIncludeDirectories)")
                     continue;
 
                 std::string toAdd(includePath);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -775,7 +775,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                             }
                             if (!simplifyPathWithVariables(pathToSharedItemsFile, variables)) {
                                 printError("Could not simplify path to referenced shared items project");
-                                exit(-1);
+                                false;
                             }
 
                             SharedItemsProject toAdd = importVcxitems(pathToSharedItemsFile, fileFilters, cache);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -192,6 +192,7 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
 
     const std::vector<std::string> fileFilters =
         settings ? settings->fileFilters : std::vector<std::string>();
+    std::vector<SharedItemsProject> sharedItemsProjects{};
 
     if (endsWith(filename, ".json")) {
         if (importCompileCommands(fin)) {
@@ -205,7 +206,7 @@ ImportProject::Type ImportProject::import(const std::string &filename, Settings 
         }
     } else if (endsWith(filename, ".vcxproj")) {
         std::map<std::string, std::string, cppcheck::stricmp> variables;
-        if (importVcxproj(filename, variables, emptyString, fileFilters)) {
+        if (importVcxproj(filename, variables, emptyString, fileFilters, sharedItemsProjects)) {
             setRelativePaths(filename);
             return ImportProject::Type::VS_VCXPROJ;
         }
@@ -448,7 +449,7 @@ bool ImportProject::importSln(std::istream &istr, const std::string &path, const
     variables["SolutionDir"] = path;
 
     bool found = false;
-
+    std::vector<SharedItemsProject> sharedItemsProjects{};
     while (std::getline(istr,line)) {
         if (!startsWith(line,"Project("))
             continue;
@@ -841,8 +842,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
     return true;
 }
 
-
-bool ImportProject::importVcxitems(const std::string& filename, std::map<std::string, std::string, cppcheck::stricmp>& variables, const std::string& additionalIncludeDirectories, const std::vector<std::string>& fileFilters)
+bool ImportProject::importVcxproj(const std::string& filename, std::map<std::string, std::string, cppcheck::stricmp>& variables, const std::string& additionalIncludeDirectories, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject>& cache)
 {
     variables["ProjectDir"] = Path::simplifyPath(Path::getPathFromFilename(filename));
 
@@ -850,6 +850,7 @@ bool ImportProject::importVcxitems(const std::string& filename, std::map<std::st
     std::list<std::string> compileList;
     std::list<ItemDefinitionGroup> itemDefinitionGroupList;
     std::string includePath;
+    std::vector<SharedItemsProject> sharedItemsProjects;
 
     bool useOfMfc = false;
 
@@ -905,45 +906,57 @@ bool ImportProject::importVcxitems(const std::string& filename, std::map<std::st
                     }
                 }
             }
-        }
-    }
-    // # TODO: support signedness of char via /J (and potential XML option for it)?
-    // we can only set it globally but in this context it needs to be treated per file
-    for (const std::string& c : compileList) {
-        std::string cfilename = Path::simplifyPath(Path::isAbsolute(c) ? c : Path::getPathFromFilename(filename) + c);
-
-        // Remove "msbuild this file directory"
-        {
-            std::string toRemove("$(MSBuildThisFileDirectory)");
-            size_t pos = cfilename.find(toRemove);
-            while (pos != std::string::npos)
-            {
-                auto test = cfilename.erase(pos, toRemove.length());
-                pos = cfilename.find(toRemove);
+            else if (labelAttribute && std::strcmp(labelAttribute, "Shared") == 0) {
+                for (const tinyxml2::XMLElement* e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
+                    if (std::strcmp(e->Name(), "Import") == 0) {
+                        const char* projectAttribute = e->Attribute("Project");
+                        if (projectAttribute)
+                        {
+                            std::string pathToSharedItemsFile(projectAttribute);
+                            if (!simplifyPathWithVariables(pathToSharedItemsFile, variables)) {
+                                printError("Could not simplify path to referenced shared items project");
+                                exit(-1);
+                            }
+                            sharedItemsProjects.emplace_back(importVcxitems(pathToSharedItemsFile, fileFilters, cache));
+                        }
+                    }
+                }
             }
         }
+    }
 
+    // Project files
+    for (const std::string& c : compileList) {
+        const std::string cfilename = Path::simplifyPath(Path::isAbsolute(c) ? c : Path::getPathFromFilename(filename) + c);
         if (!fileFilters.empty() && !matchglobs(fileFilters, cfilename))
             continue;
 
-        // TODO(Felix): make this robust by iterating over the projects,
-        // checking retrieving their configurations and add them 
-        // if this the shared item project is referenced
-        
-        // Assuming x64 configuration
-        std::string configs[] = { "Debug|x64", "Release|x64", };
-        for (auto& c : configs)
-        {
+        for (const ProjectConfiguration& p : projectConfigurationList) {
+
+            if (!guiProject.checkVsConfigs.empty()) {
+                const bool doChecking = std::any_of(guiProject.checkVsConfigs.cbegin(), guiProject.checkVsConfigs.cend(), [&](const std::string& c) {
+                    return c == p.configuration;
+                    });
+                if (!doChecking)
+                    continue;
+            }
+
             FileSettings fs;
             fs.filename = cfilename;
-            fs.cfg = c;
-            // TODO: detect actual MSC version
+            fs.cfg = p.name;
             fs.msc = true;
             fs.useMfc = useOfMfc;
-            fs.defines = "_WIN32=1;_WIN64=1";
-            fs.platformType = cppcheck::Platform::Type::Win64;
+            fs.defines = "_WIN32=1";
+            if (p.platform == ProjectConfiguration::Win32)
+                fs.platformType = cppcheck::Platform::Type::Win32W;
+            else if (p.platform == ProjectConfiguration::x64) {
+                fs.platformType = cppcheck::Platform::Type::Win64;
+                fs.defines += ";_WIN64=1";
+            }
             std::string additionalIncludePaths;
             for (const ItemDefinitionGroup& i : itemDefinitionGroupList) {
+                if (!i.conditionIsTrue(p))
+                    continue;
                 fs.standard = Standards::getCPP(i.cppstd);
                 fs.defines += ';' + i.preprocessorDefinitions;
                 if (i.enhancedInstructionSet == "StreamingSIMDExtensions")
@@ -964,7 +977,140 @@ bool ImportProject::importVcxitems(const std::string& filename, std::map<std::st
         }
     }
 
+    // Shared items files
+    for (const auto& sharedProject : sharedItemsProjects) {
+        for (const auto& c : sharedProject.sourceFiles) {
+            const std::string cfilename = Path::simplifyPath(c);
+            if (!fileFilters.empty() && !matchglobs(fileFilters, cfilename))
+                continue;
+
+            for (const ProjectConfiguration& p : projectConfigurationList) {
+                if (!guiProject.checkVsConfigs.empty()) {
+                    const bool doChecking = std::any_of(guiProject.checkVsConfigs.cbegin(), guiProject.checkVsConfigs.cend(), [&](const std::string& c) {
+                        return c == p.configuration;
+                        });
+                    if (!doChecking)
+                        continue;
+                }
+
+                FileSettings fs;
+                fs.filename = cfilename;
+                fs.cfg = p.name;
+                fs.msc = true;
+                fs.useMfc = useOfMfc;
+                fs.defines = "_WIN32=1";
+                if (p.platform == ProjectConfiguration::Win32)
+                    fs.platformType = cppcheck::Platform::Type::Win32W;
+                else if (p.platform == ProjectConfiguration::x64) {
+                    fs.platformType = cppcheck::Platform::Type::Win64;
+                    fs.defines += ";_WIN64=1";
+                }
+                std::string additionalIncludePaths;
+                for (const ItemDefinitionGroup& i : itemDefinitionGroupList) {
+                    if (!i.conditionIsTrue(p))
+                        continue;
+                    fs.standard = Standards::getCPP(i.cppstd);
+                    fs.defines += ';' + i.preprocessorDefinitions;
+                    if (i.enhancedInstructionSet == "StreamingSIMDExtensions")
+                        fs.defines += ";__SSE__";
+                    else if (i.enhancedInstructionSet == "StreamingSIMDExtensions2")
+                        fs.defines += ";__SSE2__";
+                    else if (i.enhancedInstructionSet == "AdvancedVectorExtensions")
+                        fs.defines += ";__AVX__";
+                    else if (i.enhancedInstructionSet == "AdvancedVectorExtensions2")
+                        fs.defines += ";__AVX2__";
+                    else if (i.enhancedInstructionSet == "AdvancedVectorExtensions512")
+                        fs.defines += ";__AVX512__";
+                    additionalIncludePaths += ';' + i.additionalIncludePaths;
+                }
+                fs.setDefines(fs.defines);
+                fs.setIncludePaths(Path::getPathFromFilename(filename), toStringList(includePath + ';' + additionalIncludePaths), variables);
+                for (const auto& toAddIncludePath : sharedProject.includePaths) {
+                    fs.includePaths.emplace_back(Path::simplifyPath(toAddIncludePath));
+                }
+                fileSettings.push_back(std::move(fs));
+            }
+        }
+    }
+
     return true;
+}
+
+static std::string stringReplace(const std::string& original, const std::string& toReplace, const std::string& replaceWith) 
+{
+    std::string result(original);
+    size_t pos = result.find(toReplace);
+    while (pos != std::string::npos) {
+        result.replace(pos, toReplace.length(), replaceWith);
+        pos = result.find(toReplace);
+    }
+    return result;
+}
+
+ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
+{
+    for (const auto& entry : cache)
+    {
+        if (filename == entry.pathToProjectFile)
+        {
+            return entry;
+        }
+    }
+
+    std::string projectDir = Path::simplifyPath(Path::getPathFromFilename(filename));
+    if (projectDir.empty())
+    {
+        projectDir = std::string("./");
+    }
+
+    SharedItemsProject result{};
+    result.pathToProjectFile = filename;
+
+    tinyxml2::XMLDocument doc;
+    const tinyxml2::XMLError error = doc.LoadFile(filename.c_str());
+    if (error != tinyxml2::XML_SUCCESS) {
+        printError(std::string("Visual Studio project file is not a valid XML - ") + tinyxml2::XMLDocument::ErrorIDToName(error));
+        exit(-1);
+    }
+    const tinyxml2::XMLElement* const rootnode = doc.FirstChildElement();
+    if (rootnode == nullptr) {
+        printError("Visual Studio project file has no XML root node");
+        exit(-1);
+    }
+    for (const tinyxml2::XMLElement* node = rootnode->FirstChildElement(); node; node = node->NextSiblingElement()) {
+        if (std::strcmp(node->Name(), "ItemGroup") == 0) {
+            const char* labelAttribute = node->Attribute("Label");
+            for (const tinyxml2::XMLElement* e = node->FirstChildElement(); e; e = e->NextSiblingElement()) {
+                if (std::strcmp(e->Name(), "ClCompile") == 0) {
+                    const char* include = e->Attribute("Include");
+                    if (include && Path::acceptFile(include)) {
+                        std::string filename = stringReplace(include, "$(MSBuildThisFileDirectory)", projectDir);
+
+                        // Don't include file if it matches the filter
+                        if (!fileFilters.empty() && !matchglobs(fileFilters, filename))
+                            continue;
+
+                        result.sourceFiles.emplace_back(filename);
+                    } else {
+                        printError("Could not find shared items source file");
+                        exit(-1);
+                    }
+                }
+            }
+        }
+        else if (std::strcmp(node->Name(), "ItemDefinitionGroup") == 0) {
+            ItemDefinitionGroup temp(node, "");
+            for (const auto& includePath : toStringList(temp.additionalIncludePaths)) {
+                if (includePath == std::string("%(AdditionalIncludeDirectories)"))
+                    continue;
+
+                result.includePaths.emplace_back(stringReplace(includePath, "$(MSBuildThisFileDirectory)", projectDir));
+            }
+        }
+    }
+
+    cache.emplace_back(result);
+    return result;
 }
 
 bool ImportProject::importBcb6Prj(const std::string &projectFilename)

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -791,8 +791,8 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                 }
             }
         }
-    }    
-	// # TODO: support signedness of char via /J (and potential XML option for it)?
+    }
+    // # TODO: support signedness of char via /J (and potential XML option for it)?
     // we can only set it globally but in this context it needs to be treated per file
 
     // Include shared items project files

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -775,7 +775,7 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
                             }
                             if (!simplifyPathWithVariables(pathToSharedItemsFile, variables)) {
                                 printError("Could not simplify path to referenced shared items project");
-                                false;
+                                return false;
                             }
 
                             SharedItemsProject toAdd = importVcxitems(pathToSharedItemsFile, fileFilters, cache);
@@ -865,8 +865,8 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
 
 ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
 {
-    auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool { 
-        return filename == e.pathToProjectFile; 
+    auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool {
+        return filename == e.pathToProjectFile;
     };
     auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
     if (iterator != std::end(cache)) {

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -865,11 +865,11 @@ bool ImportProject::importVcxproj(const std::string &filename, std::map<std::str
 
 ImportProject::SharedItemsProject ImportProject::importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache)
 {
-    auto isInCacheCheck = [filename](const auto& e) -> bool { return filename == e.pathToProjectFile; };
+    auto isInCacheCheck = [filename](const ImportProject::SharedItemsProject& e) -> bool { return filename == e.pathToProjectFile; };
     auto iterator = std::find_if(cache.begin(), cache.end(), isInCacheCheck);
-	if (iterator != std::end(cache)) {
+    if (iterator != std::end(cache)) {
         return *iterator;
-	}
+    }
 
     SharedItemsProject result{};
     result.pathToProjectFile = filename;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -103,7 +103,7 @@ protected:
 
 private:
     struct SharedItemsProject {
-        bool successful;
+        bool successful = false;
         std::string pathToProjectFile;
         std::vector<std::string> includePaths;
         std::vector<std::string> sourceFiles;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -100,10 +100,17 @@ protected:
     bool importCompileCommands(std::istream &istr);
     bool importCppcheckGuiProject(std::istream &istr, Settings *settings);
     virtual bool sourceFileExists(const std::string &file);
+
 private:
+    struct SharedItemsProject {
+        std::string pathToProjectFile;
+        std::vector<std::string> includePaths;
+        std::vector<std::string> sourceFiles;
+    };
+
     bool importSln(std::istream &istr, const std::string &path, const std::vector<std::string> &fileFilters);
-    bool importVcxproj(const std::string &filename, std::map<std::string, std::string, cppcheck::stricmp> &variables, const std::string &additionalIncludeDirectories, const std::vector<std::string> &fileFilters);
-    bool importVcxitems(const std::string& filename, std::map<std::string, std::string, cppcheck::stricmp>& variables, const std::string& additionalIncludeDirectories, const std::vector<std::string>& fileFilters);
+    static SharedItemsProject importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache);
+    bool importVcxproj(const std::string &filename, std::map<std::string, std::string, cppcheck::stricmp> &variables, const std::string &additionalIncludeDirectories, const std::vector<std::string> &fileFilters, std::vector<SharedItemsProject> &cache);
     bool importBcb6Prj(const std::string &projectFilename);
 
     static void printError(const std::string &message);

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -110,7 +110,7 @@ private:
     };
 
     bool importSln(std::istream &istr, const std::string &path, const std::vector<std::string> &fileFilters);
-    static SharedItemsProject importVcxitems(const std::string& filename, const std::vector<std::string>& fileFilters, std::vector<SharedItemsProject> &cache);
+    static SharedItemsProject importVcxitems(const std::string &filename, const std::vector<std::string> &fileFilters, std::vector<SharedItemsProject> &cache);
     bool importVcxproj(const std::string &filename, std::map<std::string, std::string, cppcheck::stricmp> &variables, const std::string &additionalIncludeDirectories, const std::vector<std::string> &fileFilters, std::vector<SharedItemsProject> &cache);
     bool importBcb6Prj(const std::string &projectFilename);
 

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -103,6 +103,7 @@ protected:
 
 private:
     struct SharedItemsProject {
+        bool successFull;
         std::string pathToProjectFile;
         std::vector<std::string> includePaths;
         std::vector<std::string> sourceFiles;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -103,6 +103,7 @@ protected:
 private:
     bool importSln(std::istream &istr, const std::string &path, const std::vector<std::string> &fileFilters);
     bool importVcxproj(const std::string &filename, std::map<std::string, std::string, cppcheck::stricmp> &variables, const std::string &additionalIncludeDirectories, const std::vector<std::string> &fileFilters);
+    bool importVcxitems(const std::string& filename, std::map<std::string, std::string, cppcheck::stricmp>& variables, const std::string& additionalIncludeDirectories, const std::vector<std::string>& fileFilters);
     bool importBcb6Prj(const std::string &projectFilename);
 
     static void printError(const std::string &message);

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -103,7 +103,7 @@ protected:
 
 private:
     struct SharedItemsProject {
-        bool successFull;
+        bool successful;
         std::string pathToProjectFile;
         std::vector<std::string> includePaths;
         std::vector<std::string> sourceFiles;

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -755,7 +755,6 @@ def test_json_file_ignore_2(tmpdir):
     assert_cppcheck(args, ec_exp=1, err_exp=[], out_exp=out_lines)
 
 
-<<<<<<< HEAD
 @pytest.mark.xfail(strict=True)
 def test_project_D(tmpdir):
     test_file = os.path.join(tmpdir, 'test.cpp')

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -859,7 +859,7 @@ def test_shared_items_project(tmpdir = ""):
         '--project-configuration=Release|x64',
         '-j1'
     ]
-    
+
     exitcode, stdout, stderr = cppcheck(args)
     assert exitcode == 0
     lines = stdout.splitlines()

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -849,8 +849,6 @@ def test_shared_items_project(tmpdir = ""):
     # tmpdir is unused
     solutionDir = os.path.join(os.getcwd(), 'shared-items-project')
     solutionFile = os.path.join(solutionDir, 'Solution.sln')
-    codeMainFile = os.path.join(solutionDir, 'Main', 'MainFile.cpp')
-    codeSharedFile = os.path.join(solutionDir, 'Shared', 'TestClass.cpp')
 
     args = [
         '--platform=win64',

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -843,3 +843,15 @@ def test_compdb_D(tmpdir):
     assert stdout.splitlines() == out_expected
     assert stderr.splitlines() == []
     assert ret == 0, stdout
+
+
+def test_shared_items_project(tmpdir):
+    solutionDir = os.path.join(os.getcwd(), 'shared-items-project')
+    solutionFile = f"{solutionDir}/Solution.sln"
+    
+    args = ['--project={}'.format(solutionFile), "-j1"]
+
+    # TODO: 
+    # - Assert "shared-items-project\Main\MainFile.Cpp"
+    # - Assert "shared-items-project\Shared\TestClass.Cpp"
+

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -755,6 +755,7 @@ def test_json_file_ignore_2(tmpdir):
     assert_cppcheck(args, ec_exp=1, err_exp=[], out_exp=out_lines)
 
 
+<<<<<<< HEAD
 @pytest.mark.xfail(strict=True)
 def test_project_D(tmpdir):
     test_file = os.path.join(tmpdir, 'test.cpp')
@@ -845,13 +846,29 @@ def test_compdb_D(tmpdir):
     assert ret == 0, stdout
 
 
-def test_shared_items_project(tmpdir):
+def test_shared_items_project(tmpdir = ""):
+    # tmpdir is unused
     solutionDir = os.path.join(os.getcwd(), 'shared-items-project')
-    solutionFile = f"{solutionDir}/Solution.sln"
+    solutionFile = os.path.join(solutionDir, 'Solution.sln')
+    codeMainFile = os.path.join(solutionDir, 'Main', 'MainFile.cpp')
+    codeSharedFile = os.path.join(solutionDir, 'Shared', 'TestClass.cpp')
+
+    args = [
+        '--platform=win64',
+        '--project={}'.format(solutionFile), 
+        '--project-configuration=Release|x64',
+        '-j1'
+    ]
     
-    args = ['--project={}'.format(solutionFile), "-j1"]
-
-    # TODO: 
-    # - Assert "shared-items-project\Main\MainFile.Cpp"
-    # - Assert "shared-items-project\Shared\TestClass.Cpp"
-
+    exitcode, stdout, stderr = cppcheck(args)
+    assert exitcode == 0
+    lines = stdout.splitlines()
+    assert lines == [
+        'Checking {} Release|x64...'.format(codeMainFile),
+        'Checking {}: _WIN32=1;_WIN64=1;_MSC_VER=1900...'.format(codeMainFile),
+        '1/2 files checked 50% done',
+        'Checking {} Release|x64...'.format(codeSharedFile),
+        'Checking {}: _WIN32=1;_WIN64=1;_MSC_VER=1900...'.format(codeSharedFile),
+        '2/2 files checked 100% done',
+    ]
+    assert stderr == ''

--- a/test/cli/more-projects_test.py
+++ b/test/cli/more-projects_test.py
@@ -863,12 +863,7 @@ def test_shared_items_project(tmpdir = ""):
     exitcode, stdout, stderr = cppcheck(args)
     assert exitcode == 0
     lines = stdout.splitlines()
-    assert lines == [
-        'Checking {} Release|x64...'.format(codeMainFile),
-        'Checking {}: _WIN32=1;_WIN64=1;_MSC_VER=1900...'.format(codeMainFile),
-        '1/2 files checked 50% done',
-        'Checking {} Release|x64...'.format(codeSharedFile),
-        'Checking {}: _WIN32=1;_WIN64=1;_MSC_VER=1900...'.format(codeSharedFile),
-        '2/2 files checked 100% done',
-    ]
+
+    # Assume no errors, and that shared items code files have been checked as well
+    assert any('2/2 files checked 100% done' in x for x in lines)
     assert stderr == ''

--- a/test/cli/shared-items-project/Main/Main.vcxproj
+++ b/test/cli/shared-items-project/Main/Main.vcxproj
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -26,25 +14,6 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
@@ -58,59 +27,10 @@
   <ImportGroup Label="Shared">
     <Import Project="$(SolutionDir)\Shared\Shared.vcxitems" Label="Shared" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>

--- a/test/cli/shared-items-project/Main/Main.vcxproj
+++ b/test/cli/shared-items-project/Main/Main.vcxproj
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{074143a3-6080-409a-a181-24e4e468bfd8}</ProjectGuid>
+    <RootNamespace>Blub</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+    <Import Project="$(SolutionDir)\Shared\Shared.vcxitems" Label="Shared" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="MainFile.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/test/cli/shared-items-project/Main/MainFile.cpp
+++ b/test/cli/shared-items-project/Main/MainFile.cpp
@@ -1,0 +1,7 @@
+#include <TestClass.h>
+
+int main(void)
+{
+	Shared::TestClass test{};
+	return 0;
+}

--- a/test/cli/shared-items-project/Shared/Shared.vcxitems
+++ b/test/cli/shared-items-project/Shared/Shared.vcxitems
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <ItemsProjectGuid>{3633ee6f-e5e8-46fc-87c9-f13a18db966a}</ItemsProjectGuid>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ProjectCapability Include="SourceItemsFromImports" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(MSBuildThisFileDirectory)TestClass.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)TestClass.cpp" />
+  </ItemGroup>
+</Project>

--- a/test/cli/shared-items-project/Shared/TestClass.cpp
+++ b/test/cli/shared-items-project/Shared/TestClass.cpp
@@ -1,0 +1,11 @@
+#include "TestClass.h"
+
+using namespace Shared;
+
+TestClass::TestClass() 
+{
+}
+
+TestClass::~TestClass() 
+{
+}

--- a/test/cli/shared-items-project/Shared/TestClass.h
+++ b/test/cli/shared-items-project/Shared/TestClass.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Shared
+{
+    class TestClass
+    {
+      public:
+        explicit TestClass();
+        virtual ~TestClass();
+    };
+} // namespace Shared

--- a/test/cli/shared-items-project/Solution.sln
+++ b/test/cli/shared-items-project/Solution.sln
@@ -9,20 +9,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Main", "Main\Main.vcxproj",
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x64.ActiveCfg = Debug|x64
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x64.Build.0 = Debug|x64
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x86.ActiveCfg = Debug|Win32
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x86.Build.0 = Debug|Win32
 		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x64.ActiveCfg = Release|x64
 		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x64.Build.0 = Release|x64
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x86.ActiveCfg = Release|Win32
-		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/cli/shared-items-project/Solution.sln
+++ b/test/cli/shared-items-project/Solution.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Shared", "Shared\Shared.vcxitems", "{3633EE6F-E5E8-46FC-87C9-F13A18DB966A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Main", "Main\Main.vcxproj", "{074143A3-6080-409A-A181-24E4E468BFD8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x64.ActiveCfg = Debug|x64
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x64.Build.0 = Debug|x64
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x86.ActiveCfg = Debug|Win32
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Debug|x86.Build.0 = Debug|Win32
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x64.ActiveCfg = Release|x64
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x64.Build.0 = Release|x64
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x86.ActiveCfg = Release|Win32
+		{074143A3-6080-409A-A181-24E4E468BFD8}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {510D1526-E6EE-452F-A697-173A3D4C4E93}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Shared\Shared.vcxitems*{074143a3-6080-409a-a181-24e4e468bfd8}*SharedItemsImports = 4
+		Shared\Shared.vcxitems*{3633ee6f-e5e8-46fc-87c9-f13a18db966a}*SharedItemsImports = 9
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
At work (Areus Gmbh), we use Shared Items Projects in order to deduplicate code. In contrast to conventional project files (`.vcxproj`), the compilation configuration is set by the "includee", which makes the code-reuse of the project more flexible.

This pull-request adds support for Shared Items Projects (`.vcxitems`) in Visual studio projects / solutions. 

The idea is that for each `.vcxproj`, we check for referenced shared items projects. When all the source files and include paths are build, we add the ones defined in the referenced `.vcxitems`. 
The implementation probably isn't 100% robust, but this works for our projects and could serve as a starting point :)

I apologize for the commit history - it's a bit wonky as we currently still use 2.11. I tried to merge the changes to the main branch so other could benefit from these changes as well, but seems like the git history looks a bit weird as a result.