### PR TITLE
Fix doc around USE_MATCH_COMPILER

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ For rules support (requires pcre) use the flag.
 -DHAVE_RULES=ON
 
 For release builds it is recommended that you use:
--DUSE_MATCHCOMPILER=ON
+-DUSE_MATCHCOMPILER=On
 
 For building the tests use the flag.
 -DBUILD_TESTS=ON


### PR DESCRIPTION
I'm not sure if this is a doc issue or a CMake issue in [`cmake/options.cmake`](https://github.com/danmar/cppcheck/blob/main/cmake/options.cmake#L25). But on ubuntu 22.04 I got:

```
+ cmake -DHAVE_RULES=ON -DUSE_MATCHCOMPILER=ON ..
-- The CXX compiler identification is GNU 11.4.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at cmake/options.cmake:28 (message):
  Invalid USE_MATCHCOMPILER value 'ON'
Call Stack (most recent call first):
  CMakeLists.txt:18 (include)
```