### PR TITLE
oss-fuzz: aligned timeout in targets with what we are actually testing with

### DIFF
--- a/oss-fuzz/Makefile
+++ b/oss-fuzz/Makefile
@@ -120,18 +120,18 @@ preprare-samples:
 
 do-fuzz: oss-fuzz-client preprare-samples
 	mkdir -p corpus
-	./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout
+	./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout
 
 dedup-corpus: oss-fuzz-client preprare-samples
 	mv corpus corpus_
 	mkdir -p corpus
-	./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus corpus_ samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -merge=1
+	./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus corpus_ samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -merge=1
 
 # jobs:
-# ./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -workers=12 -jobs=9
+# ./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -workers=12 -jobs=9
 
 # minimize:
-# ./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 -minimize_crash=1 crash-0123456789abcdef
+# ./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 -minimize_crash=1 crash-0123456789abcdef
 
 simplecpp.o: ../externals/simplecpp/simplecpp.cpp ../externals/simplecpp/simplecpp.h
 	$(CXX) ${LIB_FUZZING_ENGINE} $(CPPFLAGS) $(CXXFLAGS) -w -c -o $@ ../externals/simplecpp/simplecpp.cpp

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -376,18 +376,18 @@ static void write_ossfuzz_makefile(std::vector<std::string> libfiles_prio, std::
     fout << '\n';
     fout << "do-fuzz: oss-fuzz-client preprare-samples\n";
     fout << "\tmkdir -p corpus\n";
-    fout << "\t./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout\n";
+    fout << "\t./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout\n";
     fout << '\n';
     fout << "dedup-corpus: oss-fuzz-client preprare-samples\n";
     fout << "\tmv corpus corpus_\n";
     fout << "\tmkdir -p corpus\n";
-    fout << "\t./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus corpus_ samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -merge=1\n";
+    fout << "\t./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus corpus_ samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -merge=1\n";
     fout << '\n';
     fout << "# jobs:\n";
-    fout << "# ./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -workers=12 -jobs=9\n";
+    fout << "# ./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 corpus samples ../test/cli/fuzz-crash ../test/cli/fuzz-timeout -workers=12 -jobs=9\n";
     fout << '\n';
     fout << "# minimize:\n";
-    fout << "# ./oss-fuzz-client -only_ascii=1 -timeout=3 -detect_leaks=0 -minimize_crash=1 crash-0123456789abcdef\n";
+    fout << "# ./oss-fuzz-client -only_ascii=1 -timeout=5 -detect_leaks=0 -minimize_crash=1 crash-0123456789abcdef\n";
     fout << '\n';
 
     compilefiles(fout, extfiles, "${LIB_FUZZING_ENGINE}");


### PR DESCRIPTION
The Python test is using a 5 seconds timeout. I probably lowered it locally for some tests and accidentally put those in the Makefile.