### PR TITLE
gnu.cfg: Added support for __builtin_unreachable ()

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -217,7 +217,8 @@
     <arg nr="2"/>
   </function>
   <!-- void __builtin_trap (void) -->
-  <function name="__builtin_trap">
+  <!-- void __builtin_unreachable (void) -->
+  <function name="__builtin_trap,__builtin_unreachable">
     <noreturn>true</noreturn>
   </function>
   <!-- int __builtin_popcount (unsigned int x) -->


### PR DESCRIPTION
Reference: https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html