### PR TITLE
fix #12658 Remove constructor initialize also with checkHeaders = false

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6233,12 +6233,11 @@ void Tokenizer::simplifyHeadersAndUnusedTemplates()
             }
             if (start && start->str() == ":") {
                 const Token *next = start;
-                while (Token::Match(next, "[,:]")) {
-                    // Skip to ( or {
-                    while (next && !next->link())
-                        next = next->next();
-                    if (next) {
-                        next = next->link();
+                while (Token::Match(next, "[,:] %name%")) {
+                    next = next->next(); // Go to %name%
+                    next = next->next(); // Go to opening '(' or '{'
+                    if (next && next->link()) {
+                        next = next->link(); // Go to closing ')' or '}'
                         next = next->next(); // Go to next, either ',' or '{'
                     }
                 }

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6225,6 +6225,17 @@ void Tokenizer::simplifyHeadersAndUnusedTemplates()
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         const bool isIncluded = (tok->fileIndex() != 0);
 
+        // Remove constructor initializer
+        if (isIncluded && !mSettings.checkHeaders && tok->str() == ":") {
+            if (tok->previous() && tok->previous()->str() == ")") {
+                const Token *next = tok->next();
+                while (next && next->str() != "{")
+                    next = next->next();
+                Token::eraseTokens(tok, next);
+                tok->deleteThis();
+            }
+        }
+
         // Remove executable code
         if (isIncluded && !mSettings.checkHeaders && tok->str() == "{") {
             // TODO: We probably need to keep the executable code if this function is called from the source file.

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6229,10 +6229,26 @@ void Tokenizer::simplifyHeadersAndUnusedTemplates()
         if (isIncluded && !mSettings.checkHeaders && tok->str() == ":") {
             if (tok->previous() && tok->previous()->str() == ")") {
                 const Token *next = tok->next();
-                while (next && next->str() != "{")
+                //Skip over firts name
+                while (next && !next->link())
                     next = next->next();
-                Token::eraseTokens(tok, next);
-                tok->deleteThis();
+                if (next) {
+                    next = next->link();
+                    next = next->next();
+                    //Skip over all following elements that start with , (still part of the initializer)
+                    while (next && next->str() == ",") {
+                        while (next && !next->link())
+                            next = next->next();
+                        if (next) {
+                            next = next->link();
+                            next = next->next();
+                        }
+                    }
+                    if (next) {
+                        Token::eraseTokens(tok, next);
+                        tok->deleteThis();
+                    }
+                }
             }
         }
 

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6226,28 +6226,24 @@ void Tokenizer::simplifyHeadersAndUnusedTemplates()
         const bool isIncluded = (tok->fileIndex() != 0);
 
         // Remove constructor initializer
-        if (isIncluded && !mSettings.checkHeaders && tok->str() == ":") {
-            if (tok->previous() && tok->previous()->str() == ")") {
-                const Token *next = tok->next();
-                //Skip over firts name
-                while (next && !next->link())
-                    next = next->next();
-                if (next) {
-                    next = next->link();
-                    next = next->next();
-                    //Skip over all following elements that start with , (still part of the initializer)
-                    while (next && next->str() == ",") {
-                        while (next && !next->link())
-                            next = next->next();
-                        if (next) {
-                            next = next->link();
-                            next = next->next();
-                        }
-                    }
+        if (isIncluded && !mSettings.checkHeaders && Token::Match(tok, "%name% (")) {
+            Token *start = tok->next()->link();
+            if (start) {
+                start = start->next();
+            }
+            if (start && start->str() == ":") {
+                const Token *next = start;
+                while (Token::Match(next, "[,:]")) {
+                    // Skip to ( or {
+                    while (next && !next->link())
+                        next = next->next();
                     if (next) {
-                        Token::eraseTokens(tok, next);
-                        tok->deleteThis();
+                        next = next->link();
+                        next = next->next(); // Go to next, either ',' or '{'
                     }
+                }
+                if (next && next->str() == "{") {
+                    Token::eraseTokens(start->previous(), next);
                 }
             }
         }

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -433,6 +433,7 @@ private:
         TEST_CASE(cppcast);
 
         TEST_CASE(checkHeader1);
+        TEST_CASE(checkHeader2);
 
         TEST_CASE(removeExtraTemplateKeywords);
 
@@ -7747,6 +7748,26 @@ private:
                       "|\n"
                       "4:\n"
                       "5: ;\n",
+                      checkHdrs(code, false));
+    }
+
+    void checkHeader2() {
+        // #9977
+        const char code[] = "# 1 \"test.h\"\n"
+                            "A::A(const int &value)\n"
+                            "    :data(value)\n"
+                            "    {}\n";
+
+        ASSERT_EQUALS("\n\n##file 1\n"
+                      "1: A :: A ( const int & value )\n"
+                      "2: : data ( value )\n"
+                      "3: { }\n",
+                      checkHdrs(code, true));
+
+        ASSERT_EQUALS("\n\n##file 1\n"
+                      "1: A :: A ( const int & value )\n"
+                      "2:\n"
+                      "3: ;\n",
                       checkHdrs(code, false));
     }
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -434,6 +434,7 @@ private:
 
         TEST_CASE(checkHeader1);
         TEST_CASE(checkHeader2);
+        TEST_CASE(checkHeader3);
 
         TEST_CASE(removeExtraTemplateKeywords);
 
@@ -7755,19 +7756,45 @@ private:
         // #9977
         const char code[] = "# 1 \"test.h\"\n"
                             "A::A(const int &value)\n"
-                            "    :data(value)\n"
+                            "    :data(value),\n"
+                            "     data2(value)\n"
                             "    {}\n";
 
         ASSERT_EQUALS("\n\n##file 1\n"
                       "1: A :: A ( const int & value )\n"
-                      "2: : data ( value )\n"
-                      "3: { }\n",
+                      "2: : data ( value ) ,\n"
+                      "3: data2 ( value )\n"
+                      "4: { }\n",
                       checkHdrs(code, true));
 
         ASSERT_EQUALS("\n\n##file 1\n"
                       "1: A :: A ( const int & value )\n"
                       "2:\n"
-                      "3: ;\n",
+                      "3:\n"
+                      "4: ;\n",
+                      checkHdrs(code, false));
+    }
+
+    void checkHeader3() {
+        // #9977
+        const char code[] = "# 1 \"test.h\"\n"
+                            "A::A(const int &value)\n"
+                            "    :data{value},\n"
+                            "     data2{value}\n"
+                            "    {}\n";
+
+        ASSERT_EQUALS("\n\n##file 1\n"
+                      "1: A :: A ( const int & value )\n"
+                      "2: : data { value } ,\n"
+                      "3: data2 { value }\n"
+                      "4: { }\n",
+                      checkHdrs(code, true));
+
+        ASSERT_EQUALS("\n\n##file 1\n"
+                      "1: A :: A ( const int & value )\n"
+                      "2:\n"
+                      "3:\n"
+                      "4: ;\n",
                       checkHdrs(code, false));
     }
 


### PR DESCRIPTION
Fixes https://trac.cppcheck.net/ticket/12658 by also removing the construcot initializer to leave valid code after removing executable code