### PR TITLE
Fix #11786 deferencing fail to warn after the loop

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -643,6 +643,11 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
             }
         }
 
+        // Handle loops (possible?)
+        else if (Token::Match(tok, "for|while|do")) {
+            continue;
+        }
+
         // unknown control.. (TODO: handle loops)
         else if ((Token::Match(tok, "%type% (") && Token::simpleMatch(tok->linkAt(1), ") {")) || Token::simpleMatch(tok, "do {")) {
             varInfo.clear();


### PR DESCRIPTION
Try to handle loops, it works for https://trac.cppcheck.net/ticket/11786. However, I am uncertain if this change may introduce additional errors or unintended consequences.
```
else if (Token::Match(tok, "for|while|do")) {
    continue;
}

// unknown control.. (TODO: handle loops)
else if ((Token::Match(tok, "%type% (") && Token::simpleMatch(tok->linkAt(1), ") {")) || Token::simpleMatch(tok, "do {")) {
    varInfo.clear();
    return false;
}
```