### PR TITLE
Library: made all members private and moved implementations to source file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -787,7 +787,7 @@ test/testmathlib.o: test/testmathlib.cpp lib/addoninfo.h lib/check.h lib/color.h
 test/testmemleak.o: test/testmemleak.cpp lib/addoninfo.h lib/check.h lib/checkmemoryleak.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/sourcelocation.h lib/standards.h lib/suppressions.h lib/symboldatabase.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testmemleak.cpp
 
-test/testnullpointer.o: test/testnullpointer.cpp lib/addoninfo.h lib/check.h lib/checknullpointer.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h test/fixture.h test/helpers.h
+test/testnullpointer.o: test/testnullpointer.cpp externals/tinyxml2/tinyxml2.h lib/addoninfo.h lib/check.h lib/checknullpointer.h lib/color.h lib/config.h lib/ctu.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/templatesimplifier.h lib/token.h lib/tokenize.h lib/tokenlist.h lib/utils.h lib/vfvalue.h lib/xml.h test/fixture.h test/helpers.h
 	$(CXX) ${INCLUDE_FOR_TEST} $(CPPFLAGS) $(CXXFLAGS) -c -o $@ test/testnullpointer.cpp
 
 test/testoptions.o: test/testoptions.cpp lib/addoninfo.h lib/check.h lib/color.h lib/config.h lib/errorlogger.h lib/errortypes.h lib/library.h lib/mathlib.h lib/platform.h lib/settings.h lib/standards.h lib/suppressions.h lib/utils.h test/fixture.h test/options.h

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -2188,7 +2188,7 @@ static bool hasNoreturnFunction(const Token* tok, const Library& library, const 
         } else if (Token::Match(ftok, "exit|abort")) {
             return true;
         }
-        if (unknownFunc && !function && library.functions.count(library.getFunctionName(ftok)) == 0)
+        if (unknownFunc && !function && library.functions().count(library.getFunctionName(ftok)) == 0)
             *unknownFunc = ftok;
         return false;
     }

--- a/lib/checkfunctions.cpp
+++ b/lib/checkfunctions.cpp
@@ -654,7 +654,7 @@ void CheckFunctions::checkLibraryMatchFunctions()
         if (functionName.empty())
             continue;
 
-        if (mSettings->library.functions.find(functionName) != mSettings->library.functions.end())
+        if (mSettings->library.functions().find(functionName) != mSettings->library.functions().end())
             continue;
 
         if (mSettings->library.podtype(tok->expressionString()))

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1179,6 +1179,7 @@ bool Library::isScopeNoReturn(const Token *end, std::string *unknownFunc) const
     return false;
 }
 
+// cppcheck-suppress unusedFunction - used in tests only
 const std::unordered_map<std::string, Library::Container>& Library::containers() const
 {
     return mContainers;

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -285,7 +285,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
                         mDealloc[n] = temp;
                 } else if (memorynodename == "use")
                     for (const auto& n : names)
-                        functions[n].use = true;
+                        mFunctions[n].use = true;
                 else
                     unknown_elements.insert(memorynodename);
             }
@@ -420,12 +420,12 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
             if (!id)
                 return Error(ErrorCode::MISSING_ATTRIBUTE, "id");
 
-            Container& container = containers[id];
+            Container& container = mContainers[id];
 
             const char* const inherits = node->Attribute("inherits");
             if (inherits) {
-                const std::unordered_map<std::string, Container>::const_iterator i = containers.find(inherits);
-                if (i != containers.end())
+                const std::unordered_map<std::string, Container>::const_iterator i = mContainers.find(inherits);
+                if (i != mContainers.end())
                     container = i->second; // Take values from parent and overwrite them if necessary
                 else
                     return Error(ErrorCode::BAD_ATTRIBUTE_VALUE, inherits);
@@ -539,7 +539,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
             const char *className = node->Attribute("class-name");
             if (!className)
                 return Error(ErrorCode::MISSING_ATTRIBUTE, "class-name");
-            SmartPointer& smartPointer = smartPointers[className];
+            SmartPointer& smartPointer = mSmartPointers[className];
             smartPointer.name = className;
             for (const tinyxml2::XMLElement* smartPointerNode = node->FirstChildElement(); smartPointerNode;
                  smartPointerNode = smartPointerNode->NextSiblingElement()) {
@@ -679,7 +679,7 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
         return Error(ErrorCode::OK);
 
     // TODO: write debug warning if we modify an existing entry
-    Function& func = functions[name];
+    Function& func = mFunctions[name];
 
     for (const tinyxml2::XMLElement *functionnode = node->FirstChildElement(); functionnode; functionnode = functionnode->NextSiblingElement()) {
         const std::string functionnodename = functionnode->Name();
@@ -989,7 +989,7 @@ std::string Library::getFunctionName(const Token *ftok, bool &error) const
                     tok = tok->next();
                 }
                 name += "::" + ftok->str();
-                if (functions.find(name) != functions.end() && matchArguments(ftok, name))
+                if (mFunctions.find(name) != mFunctions.end() && matchArguments(ftok, name))
                     return name;
             }
         }
@@ -1050,8 +1050,8 @@ bool Library::isnullargbad(const Token *ftok, int argnr) const
     if (!arg) {
         // scan format string argument should not be null
         const std::string funcname = getFunctionName(ftok);
-        const std::unordered_map<std::string, Function>::const_iterator it = functions.find(funcname);
-        if (it != functions.cend() && it->second.formatstr && it->second.formatstr_scan)
+        const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(funcname);
+        if (it != mFunctions.cend() && it->second.formatstr && it->second.formatstr_scan)
             return true;
     }
     return arg && arg->notnull;
@@ -1063,8 +1063,8 @@ bool Library::isuninitargbad(const Token *ftok, int argnr, int indirect, bool *h
     if (!arg) {
         // non-scan format string argument should not be uninitialized
         const std::string funcname = getFunctionName(ftok);
-        const std::unordered_map<std::string, Function>::const_iterator it = functions.find(funcname);
-        if (it != functions.cend() && it->second.formatstr && !it->second.formatstr_scan)
+        const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(funcname);
+        if (it != mFunctions.cend() && it->second.formatstr && !it->second.formatstr_scan)
             return true;
     }
     if (hasIndirect && arg && arg->notuninit >= 1)
@@ -1079,7 +1079,7 @@ const Library::AllocFunc* Library::getAllocFuncInfo(const Token *tok) const
     while (Token::simpleMatch(tok, "::"))
         tok = tok->astOperand2() ? tok->astOperand2() : tok->astOperand1();
     const std::string funcname = getFunctionName(tok);
-    return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mAlloc, funcname);
+    return isNotLibraryFunction(tok) && mFunctions.find(funcname) != mFunctions.end() ? nullptr : getAllocDealloc(mAlloc, funcname);
 }
 
 /** get deallocation info for function */
@@ -1088,7 +1088,7 @@ const Library::AllocFunc* Library::getDeallocFuncInfo(const Token *tok) const
     while (Token::simpleMatch(tok, "::"))
         tok = tok->astOperand2() ? tok->astOperand2() : tok->astOperand1();
     const std::string funcname = getFunctionName(tok);
-    return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mDealloc, funcname);
+    return isNotLibraryFunction(tok) && mFunctions.find(funcname) != mFunctions.end() ? nullptr : getAllocDealloc(mDealloc, funcname);
 }
 
 /** get reallocation info for function */
@@ -1097,7 +1097,7 @@ const Library::AllocFunc* Library::getReallocFuncInfo(const Token *tok) const
     while (Token::simpleMatch(tok, "::"))
         tok = tok->astOperand2() ? tok->astOperand2() : tok->astOperand1();
     const std::string funcname = getFunctionName(tok);
-    return isNotLibraryFunction(tok) && functions.find(funcname) != functions.end() ? nullptr : getAllocDealloc(mRealloc, funcname);
+    return isNotLibraryFunction(tok) && mFunctions.find(funcname) != mFunctions.end() ? nullptr : getAllocDealloc(mRealloc, funcname);
 }
 
 /** get allocation id for function */
@@ -1126,8 +1126,8 @@ const Library::ArgumentChecks * Library::getarg(const Token *ftok, int argnr) co
 {
     if (isNotLibraryFunction(ftok))
         return nullptr;
-    const std::unordered_map<std::string, Function>::const_iterator it1 = functions.find(getFunctionName(ftok));
-    if (it1 == functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it1 = mFunctions.find(getFunctionName(ftok));
+    if (it1 == mFunctions.cend())
         return nullptr;
     const std::map<int,ArgumentChecks>::const_iterator it2 = it1->second.argumentChecks.find(argnr);
     if (it2 != it1->second.argumentChecks.cend())
@@ -1179,6 +1179,11 @@ bool Library::isScopeNoReturn(const Token *end, std::string *unknownFunc) const
     return false;
 }
 
+const std::unordered_map<std::string, Library::Container>& Library::containers() const
+{
+    return mContainers;
+}
+
 const Library::Container* Library::detectContainerInternal(const Token* const typeStart, DetectContainer detect, bool* isIterator, bool withoutStd) const
 {
     const Token* firstLinkedTok = nullptr;
@@ -1190,7 +1195,7 @@ const Library::Container* Library::detectContainerInternal(const Token* const ty
         break;
     }
 
-    for (const std::pair<const std::string, Library::Container> & c : containers) {
+    for (const std::pair<const std::string, Library::Container> & c : mContainers) {
         const Container& container = c.second;
         if (container.startPattern.empty())
             continue;
@@ -1303,8 +1308,8 @@ bool Library::matchArguments(const Token *ftok, const std::string &functionName)
     if (functionName.empty())
         return false;
     const int callargs = numberOfArgumentsWithoutAst(ftok);
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(functionName);
-    if (it == functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(functionName);
+    if (it == mFunctions.cend())
         return false;
     int args = 0;
     int firstOptionalArg = -1;
@@ -1380,15 +1385,15 @@ bool Library::formatstr_function(const Token* ftok) const
     if (isNotLibraryFunction(ftok))
         return false;
 
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(getFunctionName(ftok));
+    if (it != mFunctions.cend())
         return it->second.formatstr;
     return false;
 }
 
 int Library::formatstr_argno(const Token* ftok) const
 {
-    const std::map<int, Library::ArgumentChecks>& argumentChecksFunc = functions.at(getFunctionName(ftok)).argumentChecks;
+    const std::map<int, Library::ArgumentChecks>& argumentChecksFunc = mFunctions.at(getFunctionName(ftok)).argumentChecks;
     auto it = std::find_if(argumentChecksFunc.cbegin(), argumentChecksFunc.cend(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
         return a.second.formatstr;
     });
@@ -1397,12 +1402,12 @@ int Library::formatstr_argno(const Token* ftok) const
 
 bool Library::formatstr_scan(const Token* ftok) const
 {
-    return functions.at(getFunctionName(ftok)).formatstr_scan;
+    return mFunctions.at(getFunctionName(ftok)).formatstr_scan;
 }
 
 bool Library::formatstr_secure(const Token* ftok) const
 {
-    return functions.at(getFunctionName(ftok)).formatstr_secure;
+    return mFunctions.at(getFunctionName(ftok)).formatstr_secure;
 }
 
 const Library::NonOverlappingData* Library::getNonOverlappingData(const Token *ftok) const
@@ -1427,8 +1432,8 @@ Library::UseRetValType Library::getUseRetValType(const Token *ftok) const
         }
         return Library::UseRetValType::NONE;
     }
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(getFunctionName(ftok));
+    if (it != mFunctions.cend())
         return it->second.useretval;
     return Library::UseRetValType::NONE;
 }
@@ -1475,8 +1480,8 @@ const Library::Function *Library::getFunction(const Token *ftok) const
 {
     if (isNotLibraryFunction(ftok))
         return nullptr;
-    const std::unordered_map<std::string, Function>::const_iterator it1 = functions.find(getFunctionName(ftok));
-    if (it1 == functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it1 = mFunctions.find(getFunctionName(ftok));
+    if (it1 == mFunctions.cend())
         return nullptr;
     return &it1->second;
 }
@@ -1486,8 +1491,8 @@ bool Library::hasminsize(const Token *ftok) const
 {
     if (isNotLibraryFunction(ftok))
         return false;
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
-    if (it == functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(getFunctionName(ftok));
+    if (it == mFunctions.cend())
         return false;
     return std::any_of(it->second.argumentChecks.cbegin(), it->second.argumentChecks.cend(), [](const std::pair<const int, Library::ArgumentChecks>& a) {
         return !a.second.minsizes.empty();
@@ -1512,29 +1517,33 @@ Library::ArgumentChecks::Direction Library::getArgDirection(const Token* ftok, i
 
 bool Library::ignorefunction(const std::string& functionName) const
 {
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(functionName);
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(functionName);
+    if (it != mFunctions.cend())
         return it->second.ignore;
     return false;
 }
+const std::unordered_map<std::string, Library::Function>& Library::functions() const
+{
+    return mFunctions;
+}
 bool Library::isUse(const std::string& functionName) const
 {
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(functionName);
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(functionName);
+    if (it != mFunctions.cend())
         return it->second.use;
     return false;
 }
 bool Library::isLeakIgnore(const std::string& functionName) const
 {
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(functionName);
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(functionName);
+    if (it != mFunctions.cend())
         return it->second.leakignore;
     return false;
 }
 bool Library::isFunctionConst(const std::string& functionName, bool pure) const
 {
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(functionName);
-    if (it != functions.cend())
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(functionName);
+    if (it != mFunctions.cend())
         return pure ? it->second.ispure : it->second.isconst;
     return false;
 }
@@ -1551,8 +1560,8 @@ bool Library::isFunctionConst(const Token *ftok) const
         }
         return false;
     }
-    const std::unordered_map<std::string, Function>::const_iterator it = functions.find(getFunctionName(ftok));
-    return (it != functions.cend() && it->second.isconst);
+    const std::unordered_map<std::string, Function>::const_iterator it = mFunctions.find(getFunctionName(ftok));
+    return (it != mFunctions.cend() && it->second.isconst);
 }
 
 bool Library::isnoreturn(const Token *ftok) const
@@ -1710,6 +1719,11 @@ const Token* Library::getContainerFromAction(const Token* tok, Library::Containe
     return nullptr;
 }
 
+const std::unordered_map<std::string, Library::SmartPointer>& Library::smartPointers() const
+{
+    return mSmartPointers;
+}
+
 bool Library::isSmartPointer(const Token* tok) const
 {
     return detectSmartPointer(tok);
@@ -1722,8 +1736,8 @@ const Library::SmartPointer* Library::detectSmartPointer(const Token* tok, bool 
         typestr += tok->str();
         tok = tok->next();
     }
-    auto it = smartPointers.find(typestr);
-    if (it == smartPointers.end())
+    auto it = mSmartPointers.find(typestr);
+    if (it == mSmartPointers.end())
         return nullptr;
     return &it->second;
 }
@@ -1808,4 +1822,86 @@ std::shared_ptr<Token> createTokenFromExpression(const std::string& returnValue,
     Token* expr = tokenList->front()->astOperand1();
     ValueFlow::valueFlowConstantFoldAST(expr, settings);
     return {tokenList, expr};
+}
+
+const Library::AllocFunc* Library::getAllocFuncInfo(const char name[]) const
+{
+    return getAllocDealloc(mAlloc, name);
+}
+
+const Library::AllocFunc* Library::getDeallocFuncInfo(const char name[]) const
+{
+    return getAllocDealloc(mDealloc, name);
+}
+
+// cppcheck-suppress unusedFunction
+int Library::allocId(const char name[]) const
+{
+    const AllocFunc* af = getAllocDealloc(mAlloc, name);
+    return af ? af->groupId : 0;
+}
+
+int Library::deallocId(const char name[]) const
+{
+    const AllocFunc* af = getAllocDealloc(mDealloc, name);
+    return af ? af->groupId : 0;
+}
+
+const std::set<std::string> &Library::markupExtensions() const
+{
+    return mMarkupExtensions;
+}
+
+bool Library::isexporter(const std::string &prefix) const
+{
+    return mExporters.find(prefix) != mExporters.end();
+}
+
+bool Library::isexportedprefix(const std::string &prefix, const std::string &token) const
+{
+    const std::map<std::string, ExportedFunctions>::const_iterator it = mExporters.find(prefix);
+    return (it != mExporters.end() && it->second.isPrefix(token));
+}
+
+bool Library::isexportedsuffix(const std::string &prefix, const std::string &token) const
+{
+    const std::map<std::string, ExportedFunctions>::const_iterator it = mExporters.find(prefix);
+    return (it != mExporters.end() && it->second.isSuffix(token));
+}
+
+bool Library::isreflection(const std::string &token) const
+{
+    return mReflection.find(token) != mReflection.end();
+}
+
+int Library::reflectionArgument(const std::string &token) const
+{
+    const std::map<std::string, int>::const_iterator it = mReflection.find(token);
+    if (it != mReflection.end())
+        return it->second;
+    return -1;
+}
+
+bool Library::isentrypoint(const std::string &func) const
+{
+    return func == "main" || mEntrypoints.find(func) != mEntrypoints.end();
+}
+
+const Library::PodType *Library::podtype(const std::string &name) const
+{
+    const std::unordered_map<std::string, struct PodType>::const_iterator it = mPodTypes.find(name);
+    return (it != mPodTypes.end()) ? &(it->second) : nullptr;
+}
+
+const Library::PlatformType *Library::platform_type(const std::string &name, const std::string & platform) const
+{
+    const std::map<std::string, Platform>::const_iterator it = mPlatforms.find(platform);
+    if (it != mPlatforms.end()) {
+        const PlatformType * const type = it->second.platform_type(name);
+        if (type)
+            return type;
+    }
+
+    const std::map<std::string, PlatformType>::const_iterator it2 = mPlatformTypes.find(name);
+    return (it2 != mPlatformTypes.end()) ? &(it2->second) : nullptr;
 }

--- a/lib/library.h
+++ b/lib/library.h
@@ -109,30 +109,19 @@ public:
 
     // TODO: get rid of this
     /** get allocation info for function by name (deprecated, use other alloc) */
-    const AllocFunc* getAllocFuncInfo(const char name[]) const {
-        return getAllocDealloc(mAlloc, name);
-    }
+    const AllocFunc* getAllocFuncInfo(const char name[]) const;
 
     // TODO: get rid of this
     /** get deallocation info for function by name (deprecated, use other alloc) */
-    const AllocFunc* getDeallocFuncInfo(const char name[]) const {
-        return getAllocDealloc(mDealloc, name);
-    }
+    const AllocFunc* getDeallocFuncInfo(const char name[]) const;
 
     // TODO: get rid of this
     /** get allocation id for function by name (deprecated, use other alloc) */
-    // cppcheck-suppress unusedFunction
-    int allocId(const char name[]) const {
-        const AllocFunc* af = getAllocDealloc(mAlloc, name);
-        return af ? af->groupId : 0;
-    }
+    int allocId(const char name[]) const;
 
     // TODO: get rid of this
     /** get deallocation id for function by name (deprecated, use other alloc) */
-    int deallocId(const char name[]) const {
-        const AllocFunc* af = getAllocDealloc(mDealloc, name);
-        return af ? af->groupId : 0;
-    }
+    int deallocId(const char name[]) const;
 
     static bool isCompliantValidationExpression(const char* p);
 
@@ -267,7 +256,7 @@ public:
         static Yield yieldFrom(const std::string& yieldName);
         static Action actionFrom(const std::string& actionName);
     };
-    std::unordered_map<std::string, Container> containers;
+    const std::unordered_map<std::string, Container>& containers() const;
     const Container* detectContainer(const Token* typeStart) const;
     const Container* detectIterator(const Token* typeStart) const;
     const Container* detectContainerOrIterator(const Token* typeStart, bool* isIterator = nullptr, bool withoutStd = false) const;
@@ -327,7 +316,7 @@ public:
     };
 
     const Function *getFunction(const Token *ftok) const;
-    std::unordered_map<std::string, Function> functions;
+    const std::unordered_map<std::string, Function>& functions() const;
     bool isUse(const std::string& functionName) const;
     bool isLeakIgnore(const std::string& functionName) const;
     bool isFunctionConst(const std::string& functionName, bool pure) const;
@@ -377,9 +366,7 @@ public:
 
     bool processMarkupAfterCode(const std::string &path) const;
 
-    const std::set<std::string> &markupExtensions() const {
-        return mMarkupExtensions;
-    }
+    const std::set<std::string> &markupExtensions() const;
 
     bool reportErrors(const std::string &path) const;
 
@@ -394,19 +381,11 @@ public:
 
     bool iskeyword(const std::string &file, const std::string &keyword) const;
 
-    bool isexporter(const std::string &prefix) const {
-        return mExporters.find(prefix) != mExporters.end();
-    }
+    bool isexporter(const std::string &prefix) const;
 
-    bool isexportedprefix(const std::string &prefix, const std::string &token) const {
-        const std::map<std::string, ExportedFunctions>::const_iterator it = mExporters.find(prefix);
-        return (it != mExporters.end() && it->second.isPrefix(token));
-    }
+    bool isexportedprefix(const std::string &prefix, const std::string &token) const;
 
-    bool isexportedsuffix(const std::string &prefix, const std::string &token) const {
-        const std::map<std::string, ExportedFunctions>::const_iterator it = mExporters.find(prefix);
-        return (it != mExporters.end() && it->second.isSuffix(token));
-    }
+    bool isexportedsuffix(const std::string &prefix, const std::string &token) const;
 
     bool isimporter(const std::string& file, const std::string &importer) const;
 
@@ -416,20 +395,11 @@ public:
     static bool isContainerYield(const Token* const cond, Library::Container::Yield y, const std::string& fallback = emptyString);
     static Library::Container::Yield getContainerYield(const Token* const cond);
 
-    bool isreflection(const std::string &token) const {
-        return mReflection.find(token) != mReflection.end();
-    }
+    bool isreflection(const std::string &token) const;
 
-    int reflectionArgument(const std::string &token) const {
-        const std::map<std::string, int>::const_iterator it = mReflection.find(token);
-        if (it != mReflection.end())
-            return it->second;
-        return -1;
-    }
+    int reflectionArgument(const std::string &token) const;
 
-    bool isentrypoint(const std::string &func) const {
-        return func == "main" || mEntrypoints.find(func) != mEntrypoints.end();
-    }
+    bool isentrypoint(const std::string &func) const;
 
     std::set<std::string> defines; // to provide some library defines
 
@@ -438,7 +408,7 @@ public:
         bool unique = false;
     };
 
-    std::unordered_map<std::string, SmartPointer> smartPointers;
+    const std::unordered_map<std::string, SmartPointer>& smartPointers() const;
     bool isSmartPointer(const Token *tok) const;
     const SmartPointer* detectSmartPointer(const Token* tok, bool withoutStd = false) const;
 
@@ -447,10 +417,7 @@ public:
         char sign;
         enum class Type { NO, BOOL, CHAR, SHORT, INT, LONG, LONGLONG } stdtype;
     };
-    const PodType *podtype(const std::string &name) const {
-        const std::unordered_map<std::string, PodType>::const_iterator it = mPodTypes.find(name);
-        return (it != mPodTypes.end()) ? &(it->second) : nullptr;
-    }
+    const PodType *podtype(const std::string &name) const;
 
     struct PlatformType {
         bool operator == (const PlatformType & type) const {
@@ -482,17 +449,7 @@ public:
         std::map<std::string, PlatformType> mPlatformTypes;
     };
 
-    const PlatformType *platform_type(const std::string &name, const std::string & platform) const {
-        const std::map<std::string, Platform>::const_iterator it = mPlatforms.find(platform);
-        if (it != mPlatforms.end()) {
-            const PlatformType * const type = it->second.platform_type(name);
-            if (type)
-                return type;
-        }
-
-        const std::map<std::string, PlatformType>::const_iterator it2 = mPlatformTypes.find(name);
-        return (it2 != mPlatformTypes.end()) ? &(it2->second) : nullptr;
-    }
+    const PlatformType *platform_type(const std::string &name, const std::string & platform) const;
 
     /**
      * Get function name for function call
@@ -566,6 +523,9 @@ private:
         int mOffset{};
         std::set<std::string> mBlocks;
     };
+    std::unordered_map<std::string, Container> mContainers;
+    std::unordered_map<std::string, Function> mFunctions;
+    std::unordered_map<std::string, SmartPointer> mSmartPointers;
     enum class FalseTrueMaybe { False, True, Maybe };
     int mAllocId{};
     std::set<std::string> mFiles;

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1496,7 +1496,7 @@ void SymbolDatabase::createSymbolDatabaseIncompleteVars()
             fstr.insert(0, ftok->previous()->str() + "::");
             ftok = ftok->tokAt(-2);
         }
-        if (mSettings.library.functions.find(fstr) != mSettings.library.functions.end())
+        if (mSettings.library.functions().find(fstr) != mSettings.library.functions().end())
             continue;
         if (tok->isCpp()) {
             const Token* parent = tok->astParent();
@@ -7539,10 +7539,10 @@ void SymbolDatabase::setValueTypeInTokenList(bool reportDebugWarnings, Token *to
                             vt.smartPointerType = vt.typeScope->definedType;
                             vt.typeScope = nullptr;
                         }
-                        if (e == "std::make_shared" && mSettings.library.smartPointers.count("std::shared_ptr") > 0)
-                            vt.smartPointer = &mSettings.library.smartPointers.at("std::shared_ptr");
-                        if (e == "std::make_unique" && mSettings.library.smartPointers.count("std::unique_ptr") > 0)
-                            vt.smartPointer = &mSettings.library.smartPointers.at("std::unique_ptr");
+                        if (e == "std::make_shared" && mSettings.library.smartPointers().count("std::shared_ptr") > 0)
+                            vt.smartPointer = &mSettings.library.smartPointers().at("std::shared_ptr");
+                        if (e == "std::make_unique" && mSettings.library.smartPointers().count("std::unique_ptr") > 0)
+                            vt.smartPointer = &mSettings.library.smartPointers().at("std::unique_ptr");
                         vt.type = ValueType::Type::SMART_POINTER;
                         vt.smartPointerTypeToken = tok->astOperand1()->tokAt(3);
                         setValueType(tok, vt);

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -105,7 +105,7 @@ private:
         constexpr char xmldata[] = "<?xml version=\"1.0\"?>\n<def/>";
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT(library.functions.empty());
+        ASSERT(library.functions().empty());
     }
 
     void function() const {
@@ -122,8 +122,8 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(library.functions.size(), 1U);
-        ASSERT(library.functions.at("foo").argumentChecks.empty());
+        ASSERT_EQUALS(library.functions().size(), 1U);
+        ASSERT(library.functions().at("foo").argumentChecks.empty());
         ASSERT(library.isnotnoreturn(tokenList.front()));
     }
 
@@ -252,13 +252,13 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[1].notuninit);
-        ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[2].notnull);
-        ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[3].formatstr);
-        ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[4].strz);
-        ASSERT_EQUALS(false, library.functions["foo"].argumentChecks[4].optional);
-        ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[5].notbool);
-        ASSERT_EQUALS(true, library.functions["foo"].argumentChecks[5].optional);
+        ASSERT_EQUALS(0, library.functions().at("foo").argumentChecks.at(1).notuninit);
+        ASSERT_EQUALS(true, library.functions().at("foo").argumentChecks.at(2).notnull);
+        ASSERT_EQUALS(true, library.functions().at("foo").argumentChecks.at(3).formatstr);
+        ASSERT_EQUALS(true, library.functions().at("foo").argumentChecks.at(4).strz);
+        ASSERT_EQUALS(false, library.functions().at("foo").argumentChecks.at(4).optional);
+        ASSERT_EQUALS(true, library.functions().at("foo").argumentChecks.at(5).notbool);
+        ASSERT_EQUALS(true, library.functions().at("foo").argumentChecks.at(5).optional);
     }
 
     void function_arg_any() const {
@@ -271,7 +271,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
+        ASSERT_EQUALS(0, library.functions().at("foo").argumentChecks.at(-1).notuninit);
     }
 
     void function_arg_variadic() const {
@@ -285,7 +285,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(0, library.functions["foo"].argumentChecks[-1].notuninit);
+        ASSERT_EQUALS(0, library.functions().at("foo").argumentChecks.at(-1).notuninit);
 
         const char code[] = "foo(a,b,c,d,e);";
         SimpleTokenList tokenList(code);
@@ -540,9 +540,9 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(library.functions.size(), 2U);
-        ASSERT(library.functions.at("Foo::foo").argumentChecks.empty());
-        ASSERT(library.functions.at("bar").argumentChecks.empty());
+        ASSERT_EQUALS(library.functions().size(), 2U);
+        ASSERT(library.functions().at("Foo::foo").argumentChecks.empty());
+        ASSERT(library.functions().at("bar").argumentChecks.empty());
 
         {
             const char code[] = "Foo::foo();";
@@ -567,7 +567,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT_EQUALS(library.functions.size(), 1U);
+        ASSERT_EQUALS(library.functions().size(), 1U);
 
         {
             SimpleTokenizer tokenizer(settings, *this);
@@ -656,7 +656,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT(library.functions.empty());
+        ASSERT(library.functions().empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
         ASSERT(af && af->arg == -1);
@@ -699,7 +699,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT(library.functions.empty());
+        ASSERT(library.functions().empty());
 
         const Library::AllocFunc* af = library.getAllocFuncInfo("CreateX");
         ASSERT(af && af->arg == 5 && !af->initData);
@@ -718,7 +718,7 @@ private:
 
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
-        ASSERT(library.functions.empty());
+        ASSERT(library.functions().empty());
 
         ASSERT(Library::isresource(library.allocId("CreateX")));
         ASSERT_EQUALS(library.allocId("CreateX"), library.deallocId("DeleteX"));
@@ -815,9 +815,9 @@ private:
         Library library;
         ASSERT(loadxmldata(library, xmldata, sizeof(xmldata)));
 
-        const Library::Container& A = library.containers["A"];
-        const Library::Container& B = library.containers["B"];
-        const Library::Container& C = library.containers["C"];
+        const Library::Container& A = library.containers().at("A");
+        const Library::Container& B = library.containers().at("B");
+        const Library::Container& C = library.containers().at("C");
 
         ASSERT_EQUALS(A.type_templateArgNo, 1);
         ASSERT_EQUALS(A.size_templateArgNo, 4);


### PR DESCRIPTION
This ensures that we do not modify the library directly. And the implementations are moved in preparation of moving all the data into an implementation class.