### PR TITLE
Fix 12681: FP: knownConditionTrueFalse

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2838,15 +2838,8 @@ struct ValueFlowAnalyzer : Analyzer {
 
                     /* Handle overflow/underflow for value bounds */
                     if (value->bound != ValueFlow::Value::Bound::Point) {
-                        if (newvalue > value->intvalue) {
-                            if ((inc && value->bound == ValueFlow::Value::Bound::Lower)
-                            || (!inc && value->bound == ValueFlow::Value::Bound::Upper))
-                                value->invertBound();
-                        } else if (newvalue < value->intvalue) {
-                            if ((!inc && value->bound == ValueFlow::Value::Bound::Lower)
-                            || (inc && value->bound == ValueFlow::Value::Bound::Upper))
-                                value->invertBound();
-                        }
+                        if ((newvalue > value->intvalue && !inc) || (newvalue < value->intvalue && inc))
+                            value->invertBound();
                     }
 
                     value->intvalue = newvalue;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -2833,7 +2833,7 @@ struct ValueFlowAnalyzer : Analyzer {
             const ValueType *dst = tok->valueType();
             if (dst) {
                 const size_t sz = ValueFlow::getSizeOf(*dst, settings);
-                if (sz > 0 && sz < 8) {
+                if (sz > 0 && sz < sizeof(MathLib::biguint)) {
                     long long newvalue = truncateIntValue(value->intvalue, sz, dst->sign);
 
                     /* Handle overflow/underflow for value bounds */
@@ -6058,7 +6058,7 @@ static std::list<ValueFlow::Value> truncateValues(std::list<ValueFlow::Value> va
             value.valueType = ValueFlow::Value::ValueType::INT;
         }
 
-        if (value.isIntValue() && sz > 0 && sz < 8)
+        if (value.isIntValue() && sz > 0 && sz < sizeof(MathLib::biguint))
             value.intvalue = truncateIntValue(value.intvalue, sz, dst->sign);
     }
     return values;

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -4784,11 +4784,19 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout_str());
 
-      // #12681
+        // #12681
         check("void f(unsigned u) {\n"
               "      if (u > 0) {\n"
               "             u--;\n"
               "             if (u == 0) {}\n"
+              "      }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
+
+        check("void f(unsigned u) {\n"
+              "      if (u < 0xFFFFFFFF) {\n"
+              "             u++;\n"
+              "             if (u == 0xFFFFFFFF) {}\n"
               "      }\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -4783,6 +4783,15 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());
+
+      // #12681
+        check("void f(unsigned u) {\n"
+              "      if (u > 0) {\n"
+              "             u--;\n"
+              "             if (u == 0) {}\n"
+              "      }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void alwaysTrueInfer() {


### PR DESCRIPTION
While truncating integer values for upper/lower bounds, underflows/overflows must be handled correctly by
inverting the bound.