### PR TITLE
valueflow.cpp: fixed `-Wmaybe-uninitialized` GCC warning in optimized build

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -8425,7 +8425,7 @@ const Token* ValueFlow::solveExprValue(const Token* expr,
         return expr;
     if (value.isSymbolicValue() && !Token::Match(expr, "+|-"))
         return expr;
-    MathLib::bigint intval;
+    MathLib::bigint intval = 0;
     const Token* binaryTok = parseBinaryIntOp(expr, eval, intval);
     const bool rhs = astIsRHS(binaryTok);
     // If its on the rhs, then -1 multiplication is needed, which is not possible with simple delta analysis used currently for symbolic values


### PR DESCRIPTION
```
lib/valueflow.cpp: In function ‘const Token* ValueFlow::solveExprValue(const Token*, const std::function<std::vector<long long int>(const Token*)>&, Value&)’:
lib/valueflow.cpp:8405:28: warning: ‘intval’ may be used uninitialized [-Wmaybe-uninitialized]
 8405 |             value.intvalue /= intval;
      |             ~~~~~~~~~~~~~~~^~~~~~~~~
lib/valueflow.cpp:8383:21: note: ‘intval’ was declared here
 8383 |     MathLib::bigint intval;
      |                     ^~~~~~
```