### PR TITLE
fixed #12763 - do not assert in markup processing for `unusedFunction` when a language is enforced

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -643,7 +643,8 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
             if (mUnusedFunctionsCheck && mSettings.useSingleJob() && mSettings.buildDir.empty()) {
                 // this is not a real source file - we just want to tokenize it. treat it as C anyways as the language needs to be determined.
                 Tokenizer tokenizer(mSettings, *this);
-                tokenizer.list.setLang(Standards::Language::C);
+                // enforce the language since markup files are special and do not adhere to the enforced language
+                tokenizer.list.setLang(Standards::Language::C, true);
                 if (fileStream) {
                     tokenizer.list.createTokens(*fileStream, filename);
                 }

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -2181,10 +2181,13 @@ bool TokenList::isCPP() const
     return mLang == Standards::Language::CPP;
 }
 
-void TokenList::setLang(Standards::Language lang)
+void TokenList::setLang(Standards::Language lang, bool force)
 {
     ASSERT_LANG(lang != Standards::Language::None);
-    ASSERT_LANG(mLang == Standards::Language::None);
+    if (!force)
+    {
+        ASSERT_LANG(mLang == Standards::Language::None);
+    }
 
     mLang = lang;
 }

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -68,7 +68,8 @@ public:
     /** @return true if the code is C++ */
     bool isCPP() const;
 
-    void setLang(Standards::Language lang);
+    // TODO: get rid of this
+    void setLang(Standards::Language lang, bool force = false);
 
     /**
      * Delete all tokens in given token list

--- a/test/cli/other_test.py
+++ b/test/cli/other_test.py
@@ -1358,3 +1358,25 @@ void f() { }
     assert lines == [
         "{}:4:0: style: found 'f' [rule]".format(test_file)
     ]
+
+
+def test_markup_lang(tmpdir):
+    test_file_1 = os.path.join(tmpdir, 'test_1.qml')
+    with open(test_file_1, 'wt') as f:
+        pass
+    test_file_2 = os.path.join(tmpdir, 'test_2.cpp')
+    with open(test_file_2, 'wt') as f:
+        pass
+
+    # do not assert processing markup file with enforced language
+    args = [
+        '--library=qt',
+        '--enable=unusedFunction',
+        '--language=c++',
+        '-j1',
+        test_file_1,
+        test_file_2
+    ]
+
+    exitcode, stdout, _ = cppcheck(args)
+    assert exitcode == 0, stdout


### PR DESCRIPTION
cherry pick from 9c21862159cffc02adc8c0c1c6f5272973068966