### PR TITLE
Fix #12788: IDE integration: passing --project as extra argument

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1407,8 +1407,20 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
     }
 
     if (!mPathNames.empty() && project.projectType != ImportProject::Type::NONE) {
-        mLogger.printError("--project cannot be used in conjunction with source files.");
-        return Result::Fail;
+        if (project.fileSettings.empty()) {
+            // FIXME should we enforce that mPathNames belong in the project?
+            project.guiProject.pathNames = mPathNames;
+        } else {
+            // convert mPathNames to file filters..
+            // FIXME warn about paths that does not have any matches?
+            for (const auto &path : mPathNames) {
+                if (Path::isDirectory(path))
+                    mSettings.fileFilters.emplace_back(path + "/*");
+                else
+                    mSettings.fileFilters.emplace_back(path);
+            }
+        }
+        mPathNames.clear();
     }
 
     // Print error only if we have "real" command and expect files


### PR DESCRIPTION
Imagine that a IDE plugin is used. When the IDE plugin checks file foo.c maybe it normally uses some command line for instance:

    cppcheck foo.c

The IDE plugin allows the user to add some extra arguments. Let's say `--project=helloworld.cppcheck` is configured as an extra argument.. then the command is:

    cppcheck foo.c --project=helloworld.cppcheck

This will generate a error from cppcheck. And the error can't be avoided if the user wants to use --project.

I have seen this problem with more than 1 plugin when I wanted to use --project as extra argument. Cppcheclipse used to have this problem, but that is fixed now. A popular vscode plugin has this problem and I don't know when it might be fixed.
