### PR TITLE
Added rule to simplify token matching

### DIFF
--- a/rules/token-matching.xml
+++ b/rules/token-matching.xml
@@ -48,4 +48,12 @@
       <summary>Simplify 'tok-&gt;next()-&gt;next()' to 'tok-&gt;tokAt(2).'</summary>
     </message>
   </rule>
+  <rule version="1">
+    <pattern><![CDATA[(?:\b\w+\b) \. next \( \) \. link \( \)]]></pattern>
+    <message>
+      <id>TokenNext</id>
+      <severity>error</severity>
+      <summary>Simplify 'tok-&gt;next()-&gt;link()' to 'tok-&gt;linkAt(1).'</summary>
+    </message>
+  </rule>
 </rules>

--- a/rules/token-matching.xml
+++ b/rules/token-matching.xml
@@ -51,7 +51,7 @@
   <rule version="1">
     <pattern><![CDATA[(?:\b\w+\b) \. next \( \) \. link \( \)]]></pattern>
     <message>
-      <id>TokenNext</id>
+      <id>TokenLink</id>
       <severity>error</severity>
       <summary>Simplify 'tok-&gt;next()-&gt;link()' to 'tok-&gt;linkAt(1).'</summary>
     </message>

--- a/rules/token-matching.xml
+++ b/rules/token-matching.xml
@@ -40,4 +40,12 @@
       <summary>Simplify 'Token :: Match ( expr , %var% ) &amp;&amp; expr-&gt;variable()' to 'expr-&gt;variable()'</summary>
     </message>
   </rule>
+  <rule version="1">
+    <pattern><![CDATA[(?:\b\w+\b) \. next \( \) \. next \( \)]]></pattern>
+    <message>
+      <id>TokenNext</id>
+      <severity>error</severity>
+      <summary>Simplify 'tok-&gt;next()-&gt;next()' to 'tok-&gt;tokAt(2).'</summary>
+    </message>
+  </rule>
 </rules>


### PR DESCRIPTION
This rule catches cases where multiple `tok->next()-next()` calls can be simplified to `tok-tokAt(2)`

Reference: https://github.com/danmar/cppcheck/pull/6442/files/13b2cabb6384ff5279b17a75062a63c5f240f74a#r1623220527