### PR TITLE
Fixed exception dispatch idiom not being recognized in the middle of a function

### DIFF
--- a/lib/checkexceptionsafety.cpp
+++ b/lib/checkexceptionsafety.cpp
@@ -374,6 +374,7 @@ void CheckExceptionSafety::rethrowNoCurrentException()
 {
     logChecker("CheckExceptionSafety::rethrowNoCurrentException");
     const SymbolDatabase* const symbolDatabase = mTokenizer->getSymbolDatabase();
+    
     for (const Scope * scope : symbolDatabase->functionScopes) {
         const Function* function = scope->function;
         if (!function)

--- a/test/testexceptionsafety.cpp
+++ b/test/testexceptionsafety.cpp
@@ -455,22 +455,22 @@ private:
 
     void exceptionDispatchIdiomInMiddleOfFunction() {
       check("void on_error() { int foo = 5; try { throw; } catch (...) { ; } }");
-      ASSERT_EQUALS("", errout.str());
+      ASSERT_EQUALS("", errout_str());
 
       check("void on_error() { int foo = 5; try { throw; } catch (const std::exception& e) { ; } }");
-      ASSERT_EQUALS("", errout.str());
+      ASSERT_EQUALS("", errout_str());
     }
 
     void exceptionDispatchIdiomExtraStatements() {
       // extra statements aside from the rethrow should be done before/after the idiom rather than inside it.
       check("void on_error() { try { int foo = 5; throw; } catch (...) { ; } }");
-      ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow. If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object\n", errout.str());
+      ASSERT_EQUALS("[test.cpp:1]: (error) Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow. If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object\n", errout_str());
     }
 
     void exceptionDispatchIdiomSubsequentRethrows() {
       // if you use the exception dispatch idiom, you have already asserted that you are in a catch block, so subsequent rethrows are valid.
       check("void on_error() { int foo = 5; try { throw; } catch (...) { ; } throw; }");
-      ASSERT_EQUALS("", errout.str());
+      ASSERT_EQUALS("", errout_str());
     }
 };
 


### PR DESCRIPTION
The existing check for the exception dispatch idiom only checks the beginning of a function. This PR checks the entire function for the idiom, and adds 3 new unit tests.