### PR TITLE
Fix wrong config defines in boost/windows.cfg

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -35,7 +35,7 @@
   <define name="BOOST_TEST(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
   <define name="BOOST_TEST_REQUIRE(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
   <define name="BOOST_WARN(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
-  <define name="BOOST_WARN_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_WARN_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); static_cast&lt;void&gt;(msg)" />
   <define name="BOOST_WARN_EQUAL(a, b)" value="static_cast&lt;void&gt;((a) == (b))" />
   <define name="BOOST_WARN_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
   <define name="BOOST_WARN_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
@@ -43,7 +43,7 @@
   <define name="BOOST_WARN_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
   <define name="BOOST_WARN_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
   <define name="BOOST_CHECK(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
-  <define name="BOOST_CHECK_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_CHECK_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); static_cast&lt;void&gt;(msg)" />
   <define name="BOOST_CHECK_EQUAL(a, b)" value="static_cast&lt;void&gt;((a) == (b))" />
   <define name="BOOST_CHECK_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
   <define name="BOOST_CHECK_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
@@ -51,7 +51,7 @@
   <define name="BOOST_CHECK_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
   <define name="BOOST_CHECK_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
   <define name="BOOST_REQUIRE(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
-  <define name="BOOST_REQUIRE_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); std::string(msg)" />
+  <define name="BOOST_REQUIRE_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); static_cast&lt;void&gt;(msg)" />
   <define name="BOOST_REQUIRE_EQUAL(a, b)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;((a) == (b)))" />
   <define name="BOOST_REQUIRE_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
   <define name="BOOST_REQUIRE_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />
@@ -84,6 +84,7 @@
   <define name="BOOST_MATH_INT_VALUE_SUFFIX" value=""/>
   <!-- Tell cppcheck to interpret BOOST_AUTO_TEST_CASE as a function definition -->
   <define name="BOOST_AUTO_TEST_CASE(...)" value="void BOOST_AUTO_TEST_CASE_run(__VA_ARGS__)"/>
+  <define name="BOOST_AUTO_TEST_CASE_TEMPLATE(test_name, type_name, TL)" value="template&lt;typename type_name&gt;void test_name()"/>
   <define name="BOOST_FIXTURE_TEST_CASE(name, fixture, ...)" value="struct name : fixture { void test_method(); }; void name::test_method()" />
   <define name="BOOST_FIXTURE_TEST_CASE_TEMPLATE(test_name, type_name, TL, F)" value="template&lt;typename type_name&gt; struct test_name : public F { void test_method(); }; template&lt;typename type_name&gt; void test_name&lt;type_name&gt;::test_method()" />
   <define name="BOOST_DATA_TEST_CASE(...)" value="void BOOST_DATA_TEST_CASE_run(__VA_ARGS__)"/>

--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -7119,8 +7119,8 @@ HFONT CreateFont(
   <define name="afx_msg" value=""/>
   <define name="AFX_EXT_CLASS" value=""/>
   <define name="DEBUG_NEW" value="new"/>
-  <define name="INVALID_HANDLE_VALUE" value="0"/>
-  <define name="INVALID_SOCKET" value="0"/>
+  <define name="INVALID_HANDLE_VALUE" value="-1"/>
+  <define name="INVALID_SOCKET" value="~0"/>
   <define name="WINAPI" value="__stdcall"/>
   <define name="STDMETHODCALLTYPE" value="__stdcall"/>
   <define name="STDMETHODIMP" value="HRESULT STDMETHODCALLTYPE"/>
@@ -14178,6 +14178,10 @@ HFONT CreateFont(
   <define name="SIID_CLUSTEREDDRIVE" value="140"/>
   <define name="SIID_MAX_ICONS" value="181"/>
   <!-- constants from winnt.h -->
+  <define name="GENERIC_READ" value="0x80000000L" />
+  <define name="GENERIC_WRITE" value="0x40000000L" />
+  <define name="GENERIC_EXECUTE" value="0x20000000L" />
+  <define name="GENERIC_ALL" value="0x10000000L" />
   <define name="LANG_AFRIKAANS" value="0x36"/>
   <define name="LANG_ALBANIAN" value="0x1c"/>
   <define name="LANG_ALSATIAN" value="0x84"/>

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -17,6 +17,7 @@
 #include <boost/smart_ptr/scoped_array.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
+#include <boost/test/unit_test.hpp>
 
 BOOST_FORCEINLINE void boost_forceinline_test()
 {}
@@ -105,3 +106,24 @@ void lock_guard_finiteLifetime(boost::mutex& m)
     // cppcheck-suppress unusedScopedObject
     boost::lock_guard<boost::mutex>{ m };
 }
+
+BOOST_AUTO_TEST_SUITE(my_auto_test_suite)
+
+BOOST_AUTO_TEST_CASE(test_message_macros)
+{
+    bool my_bool = false;
+    BOOST_WARN_MESSAGE(my_bool, "warn");
+    BOOST_CHECK_MESSAGE(my_bool, "check");
+    BOOST_REQUIRE_MESSAGE(my_bool, "require");
+
+    BOOST_WARN_MESSAGE(my_bool, "my_bool was: " << my_bool);
+}
+
+using test_types_w_tuples = std::tuple<int, long, unsigned char>;
+BOOST_AUTO_TEST_CASE_TEMPLATE(my_tuple_test, T, test_types_w_tuples)
+{
+    // cppcheck-suppress valueFlowBailoutIncompleteVar
+    BOOST_TEST(sizeof(T) == 4U);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -22,6 +22,26 @@
 #include <atlstr.h>
 #include <string>
 
+void invalidHandle_CreateFile(LPCWSTR lpFileName)
+{
+    HANDLE file = CreateFile(lpFileName, GENERIC_READ, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    // INVALID_HANDLE_VALUE is not the same as 0
+    if (file != INVALID_HANDLE_VALUE && file) {}
+
+    // cppcheck-suppress resourceLeak
+}
+
+void invalid_socket()
+{
+    SOCKET sock = socket(AF_INET, SOCK_RAW, IPPROTO_TCP);
+
+    // INVALID_SOCKET is not the same as 0
+    if (sock != INVALID_SOCKET && sock) {}
+
+    // cppcheck-suppress resourceLeak
+}
+
 void resourceLeak_OpenThread(const DWORD dwDesiredAccess, const BOOL bInheritHandle, const DWORD dwThreadId)
 {
     HANDLE proc = OpenThread(dwDesiredAccess, bInheritHandle, dwThreadId);


### PR DESCRIPTION
**Fix defines for boost test macros**

The _MESSAGE macros were causing an unusedScopedObject warning because
the created string was not used. Casting the message to void fixed the
warnings.
Add missing `BOOST_AUTO_TEST_CASE_TEMPLATE` macro accidentally removed
with d1b3670017e101a89c7eb11198d741c5199d42d4

**Fix wrong defined in windows.cfg**

INVALID_HANDLE_VALUE is defined as `-1` in the windows sdk
INVALID_SOCKET is defined as `~0` in the windwos sdk

Add missing generic rights