### PR TITLE
generate ctu-info from FileSettings for whole project analysis

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1461,7 +1461,7 @@ void CppCheck::executeAddons(const std::vector<std::string>& files, const std::s
     }
 }
 
-void CppCheck::executeAddonsWholeProgram(const std::list<std::pair<std::string, std::size_t>> &files)
+void CppCheck::executeAddonsWholeProgram(const std::list<std::pair<std::string, std::size_t>> &files, const std::list<FileSettings>& fileSettings)
 {
     if (mSettings.addons.empty())
         return;
@@ -1470,6 +1470,15 @@ void CppCheck::executeAddonsWholeProgram(const std::list<std::pair<std::string, 
     for (const auto &f: files) {
         const std::string &dumpFileName = getDumpFileName(mSettings, f.first);
         ctuInfoFiles.push_back(getCtuInfoFileName(dumpFileName));
+    }
+
+    for (const auto &f: fileSettings) { // --project
+        const std::string &dumpFileName = getDumpFileName(mSettings, f.filename);
+        
+        // ignore duplciates
+        auto it = std::find(ctuInfoFiles.begin(), ctuInfoFiles.end(), getCtuInfoFileName(dumpFileName));
+        if (it == ctuInfoFiles.end())
+            ctuInfoFiles.push_back(getCtuInfoFileName(dumpFileName));
     }
 
     try {
@@ -1758,7 +1767,7 @@ bool CppCheck::analyseWholeProgram()
 
 unsigned int CppCheck::analyseWholeProgram(const std::string &buildDir, const std::list<std::pair<std::string, std::size_t>> &files, const std::list<FileSettings>& fileSettings)
 {
-    executeAddonsWholeProgram(files); // TODO: pass FileSettings
+    executeAddonsWholeProgram(files, fileSettings);
     if (buildDir.empty()) {
         removeCtuInfoFiles(files, fileSettings);
         return mExitCode;

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -868,7 +868,7 @@ unsigned int CppCheck::checkFile(const std::string& filename, const std::string 
                 if (!mSettings.quiet && (!mCurrentConfig.empty() || checkCount > 1)) {
                     std::string fixedpath = Path::simplifyPath(filename);
                     fixedpath = Path::toNativeSeparators(std::move(fixedpath));
-                    mErrorLogger.reportOut("Checking " + fixedpath + ": " + mCurrentConfig + "...", Color::FgGreen);
+                    mErrorLogger.reportOut("Checking... " + fixedpath + ": " + mCurrentConfig, Color::FgGreen);
                 }
 
                 if (!tokenizer.tokens())
@@ -1480,7 +1480,7 @@ void CppCheck::executeAddonsWholeProgram(const std::list<std::pair<std::string, 
         if (it == ctuInfoFiles.end())
             ctuInfoFiles.push_back(getCtuInfoFileName(dumpFileName));
     }
-
+    mErrorLogger.reportOut("Checking... whole program", Color::FgGreen);
     try {
         executeAddons(ctuInfoFiles, "");
     } catch (const InternalError& e) {

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -192,7 +192,7 @@ private:
     /**
      * Execute addons
      */
-    void executeAddonsWholeProgram(const std::list<std::pair<std::string, std::size_t>> &files);
+    void executeAddonsWholeProgram(const std::list<std::pair<std::string, std::size_t>> &files, const std::list<FileSettings>& fileSettings);
 
 #ifdef HAVE_RULES
     /**


### PR DESCRIPTION
Partially fixes https://sourceforge.net/p/cppcheck/discussion/general/thread/1911a624d8/ - for multiple configurations only the last one is analyzed.  There still needs to be some way of generating and handling multiple ctu for the same file. 