### PR TITLE
temporally fixated Python 3.12 in CI to 3.12.3

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -86,11 +86,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12.3
         if: matrix.config == 'release'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.12.3'
           check-latest: true
 
       - name: Set up Visual Studio environment

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12.3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.12.3'
           check-latest: true
 
       - name: Install missing software on ubuntu

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12.3']
         include:
-          - python-version: '3.12'
+          - python-version: '3.12.3'
             python-latest: true
 
       fail-fast: false

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12.3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.12.3'
           check-latest: true
 
       - name: Install missing software on ubuntu

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.12.3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.12.3'
           check-latest: true
 
       - name: Install missing software on ubuntu


### PR DESCRIPTION
To work around https://github.com/actions/setup-python/issues/886.