### PR TITLE
Fix emscripten config

### DIFF
--- a/cfg/emscripten.cfg
+++ b/cfg/emscripten.cfg
@@ -1,14 +1,108 @@
 <?xml version="1.0"?>
 <def format="2">
-  <define name="EM_ASM(...)" value=""/>
-  <define name="EM_ASM_DOUBLE(...)" value=""/>
-  <define name="EM_ASM_INT(...)" value=""/>
-  <define name="EM_ASM_PTR(...)" value=""/>
-  <define name="EM_JS(...)" value=""/>
-  <define name="MAIN_THREAD_ASYNC_EM_ASM(...)" value=""/>
-  <define name="MAIN_THREAD_EM_ASM(...)" value=""/>
-  <define name="MAIN_THREAD_EM_ASM_DOUBLE(...)" value=""/>
-  <define name="MAIN_THREAD_EM_ASM_INT(...)" value=""/>
-  <define name="MAIN_THREAD_EM_ASM_PTR(...)" value=""/>
-  <define name="EMSCRIPTEN_BINDINGS(...)" value=""/>
+  <function name="emscripten_asm_const_int">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="int" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_double">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="double" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_ptr">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="void*" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_async_on_main_thread">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <returnValue type="void" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_int_sync_on_main_thread">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="int" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_double_sync_on_main_thread">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="int" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <function name="emscripten_asm_const_ptr_sync_on_main_thread">
+    <arg nr="1" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-null/>
+    </arg>
+    <arg nr="variadic" direction="in" />
+    <use-retval/>
+    <returnValue type="void*" unknownValues="all"/>
+    <noreturn>false</noreturn>
+  </function>
+  <resource>
+    <alloc init="true">emscripten_asm_const_ptr</alloc>
+    <alloc init="true">emscripten_asm_const_ptr_sync_on_main_thread</alloc>
+    <dealloc>free</dealloc>
+  </resource>
+
+  <!-- macros from em_asm.h -->
+  <define name="EM_ASM(code, ...)" value="((void)emscripten_asm_const_int(#code, __VA_ARGS__))"/>
+  <define name="EM_ASM_DOUBLE(code, ...)" value="emscripten_asm_const_double(#code, __VA_ARGS__)"/>
+  <define name="EM_ASM_INT(code, ...)" value="emscripten_asm_const_int(#code, __VA_ARGS__)"/>
+  <define name="EM_ASM_PTR(code, ...)" value="emscripten_asm_const_ptr(#code, __VA_ARGS__)"/>
+  <define name="MAIN_THREAD_ASYNC_EM_ASM(code, ...)" value="emscripten_asm_const_async_on_main_thread(#code, __VA_ARGS__)"/>
+  <define name="MAIN_THREAD_EM_ASM(code, ...)" value="((void)emscripten_asm_const_int_sync_on_main_thread(#code, __VA_ARGS__))"/>
+  <define name="MAIN_THREAD_EM_ASM_DOUBLE(code, ...)" value="emscripten_asm_const_double_sync_on_main_thread(#code, __VA_ARGS__)"/>
+  <define name="MAIN_THREAD_EM_ASM_INT(code, ...)" value="emscripten_asm_const_int_sync_on_main_thread(#code, __VA_ARGS__)"/>
+  <define name="MAIN_THREAD_EM_ASM_PTR(code, ...)" value="emscripten_asm_const_ptr_sync_on_main_thread(#code, __VA_ARGS__)"/>
+
+  <!-- macros from bind.h -->
+  <define name="EMSCRIPTEN_BINDINGS(name)" value=""/>
+
+  <!-- macros from em_js.h -->
+  <define name="EM_JS(return_type, function_name, arguments, code)" value="return_type function_name(arguments)"/>
 </def>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,6 +138,7 @@ if (BUILD_TESTS)
         add_cfg(bsd.c)
         add_cfg(cairo.c)
         add_cfg(cppunit.cpp)
+        add_cfg(emscripten.cpp)
         # TODO: posix needs to specified first or it has a different mmap() config
         # TODO: get rid of posix dependency
         add_cfg(gnu.c ADD_LIBRARY posix)

--- a/test/cfg/emscripten.cpp
+++ b/test/cfg/emscripten.cpp
@@ -1,0 +1,91 @@
+
+// Test library configuration for emscripten.cfg
+//
+// Usage:
+// $ cppcheck --check-library --library=emscripten --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/emscripten.cpp
+// =>
+// No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
+//
+
+#include <stdio.h>
+#include <emscripten.h>
+
+void em_asm_test()
+{
+    // inline some JavaScript
+    EM_ASM(alert('hello'););
+    MAIN_THREAD_EM_ASM(alert('hello main thread'););
+
+    // pass parameters to JavaScript
+    EM_ASM(
+        {
+            console.log('I received: ' + [$0, $1]);
+        },
+        100, 35.5);
+
+    // pass a string to JavaScript
+    EM_ASM({console.log('hello ' + UTF8ToString($0))}, "world!");
+}
+
+void em_asm_int_test()
+{
+    // cppcheck-suppress unreadVariable
+    const int x = EM_ASM_INT({
+        return $0 + 42;
+    }, 100);
+
+    // cppcheck-suppress unreadVariable
+    const int y = MAIN_THREAD_EM_ASM_INT({return 2;});
+}
+
+void em_asm_double_test()
+{
+    // cppcheck-suppress unreadVariable
+    const double x = EM_ASM_DOUBLE({
+        return $0 + 1.0;
+    }, 2.0);
+
+    // cppcheck-suppress unreadVariable
+    const double y = MAIN_THREAD_EM_ASM_DOUBLE({return 1.0;});
+}
+
+void em_asm_ptr_test()
+{
+    void* ptr = EM_ASM_PTR({
+        return stringToNewUTF8("Hello");
+    });
+    printf("%s", static_cast<const char*>(ptr));
+    free(ptr);
+}
+
+void em_asm_ptr_memleak_test()
+{
+    const char *str = static_cast<char*>(EM_ASM_PTR({
+        return stringToNewUTF8("Hello");
+    }));
+    printf("%s", str);
+
+    // cppcheck-suppress memleak
+}
+
+void main_thread_em_asm_ptr_test()
+{
+    // cppcheck-suppress leakReturnValNotUsed
+    MAIN_THREAD_EM_ASM_PTR(
+        return stringToNewUTF8("Hello");
+    );
+}
+
+EM_JS(void, two_alerts, (), {
+        alert('hai');
+        alert('bai');
+    });
+EM_JS(void, take_args, (int x, float y), {
+    console.log('I received: ' + [x, y]);
+ });
+
+void em_js_test()
+{
+    two_alerts();
+    take_args(100, 35.5);
+}

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -447,6 +447,13 @@ function cppunit_fn {
     fi
 }
 
+# emscripten.cpp
+function emscripten_fn {
+    # TODO: Syntax check via g++ does not work because it can not find a valid emscripten.h
+    # ${CXX} "${CXX_OPT[@]}" ${DIR}emscripten.cpp
+    true
+}
+
 function check_file {
     f=$(basename "$1")
     lib="${f%%.*}"
@@ -465,6 +472,10 @@ function check_file {
             ;;
         cppunit.cpp)
             cppunit_fn
+            "${CPPCHECK}" "${CPPCHECK_OPT[@]}" --library="$lib" "${DIR}""$f"
+            ;;
+        emscripten.cpp)
+            emscripten_fn
             "${CPPCHECK}" "${CPPCHECK_OPT[@]}" --library="$lib" "${DIR}""$f"
             ;;
         gnu.c)

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -16,7 +16,7 @@ import copy
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.59"
+CLIENT_VERSION = "1.3.60"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60
@@ -681,6 +681,7 @@ class LibraryIncludes:
                             'bsd': ['<sys/queue.h>', '<sys/tree.h>', '<sys/uio.h>','<bsd/', '<fts.h>', '<db.h>', '<err.h>', '<vis.h>'],
                             'cairo': ['<cairo.h>'],
                             'cppunit': ['<cppunit/'],
+                            'emscripten': ['<emscripten.h>'],
                             'icu': ['<unicode/', '"unicode/'],
                             'ginac': ['<ginac/', '"ginac/'],
                             'googletest': ['<gtest/gtest.h>'],


### PR DESCRIPTION
Leaving the emscripten macros, returning a value, empty was leading to syntax errors

The pointer returned by `EM_ASM_PTR` must be freed by calling `free` see
https://emscripten.org/docs/api_reference/emscripten.h.html?highlight=em_asm_ptr#c.EM_ASM_PTR