### PR TITLE
removed redundant `Path::fromNativeSeparators()` calls

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -897,7 +897,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
 
             // Write results in file
             else if (std::strncmp(argv[i], "--output-file=", 14) == 0)
-                mSettings.outputFile = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 14));
+                mSettings.outputFile = Path::simplifyPath(argv[i] + 14);
 
             // Experimental: limit execution time for extended valueflow analysis. basic valueflow analysis
             // is always executed.
@@ -933,7 +933,7 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
 
             // Write results in results.plist
             else if (std::strncmp(argv[i], "--plist-output=", 15) == 0) {
-                mSettings.plistOutput = Path::simplifyPath(Path::fromNativeSeparators(argv[i] + 15));
+                mSettings.plistOutput = Path::simplifyPath(argv[i] + 15);
                 if (mSettings.plistOutput.empty())
                     mSettings.plistOutput = ".";
 

--- a/lib/analyzerinfo.cpp
+++ b/lib/analyzerinfo.cpp
@@ -53,14 +53,14 @@ void AnalyzerInformation::writeFilesTxt(const std::string &buildDir, const std::
     std::ofstream fout(filesTxt);
     for (const std::string &f : sourcefiles) {
         const std::string afile = getFilename(f);
-        fout << afile << ".a" << (++fileCount[afile]) << "::" << Path::simplifyPath(Path::fromNativeSeparators(f)) << '\n';
+        fout << afile << ".a" << (++fileCount[afile]) << "::" << Path::simplifyPath(f) << '\n';
         if (!userDefines.empty())
-            fout << afile << ".a" << (++fileCount[afile]) << ":" << userDefines << ":" << Path::simplifyPath(Path::fromNativeSeparators(f)) << '\n';
+            fout << afile << ".a" << (++fileCount[afile]) << ":" << userDefines << ":" << Path::simplifyPath(f) << '\n';
     }
 
     for (const FileSettings &fs : fileSettings) {
         const std::string afile = getFilename(fs.filename());
-        fout << afile << ".a" << (++fileCount[afile]) << ":" << fs.cfg << ":" << Path::simplifyPath(Path::fromNativeSeparators(fs.filename())) << std::endl;
+        fout << afile << ".a" << (++fileCount[afile]) << ":" << fs.cfg << ":" << Path::simplifyPath(fs.filename()) << std::endl;
     }
 }
 

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -731,8 +731,7 @@ std::string ErrorMessage::FileLocation::getOrigFile(bool convert) const
 
 void ErrorMessage::FileLocation::setfile(std::string file)
 {
-    mFileName = Path::fromNativeSeparators(std::move(file));
-    mFileName = Path::simplifyPath(std::move(mFileName));
+    mFileName = Path::simplifyPath(std::move(file));
 }
 
 std::string ErrorMessage::FileLocation::stringify() const

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -138,7 +138,7 @@ static bool simplifyPathWithVariables(std::string &s, std::map<std::string, std:
     }
     if (s.find("$(") != std::string::npos)
         return false;
-    s = Path::simplifyPath(Path::fromNativeSeparators(std::move(s)));
+    s = Path::simplifyPath(std::move(s));
     return true;
 }
 


### PR DESCRIPTION
`Path::simplifyPath()` includes the operation