### PR TITLE
Fix #12833 FP knownConditionTrueFalse regression

### DIFF
--- a/lib/vf_settokenvalue.cpp
+++ b/lib/vf_settokenvalue.cpp
@@ -442,8 +442,9 @@ namespace ValueFlow
         }
 
         // Offset of non null pointer is not null also
-        else if (astIsPointer(tok) && Token::Match(parent, "+|-") && value.isIntValue() && value.isImpossible() &&
-                 value.intvalue == 0) {
+        else if (astIsPointer(tok) && Token::Match(parent, "+|-") &&
+                 (parent->astOperand2() == nullptr || !astIsPointer(parent->astOperand2())) &&
+                 value.isIntValue() && value.isImpossible() && value.intvalue == 0) {
             setTokenValue(parent, value, settings);
         }
 

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -4620,6 +4620,17 @@ private:
               "    if (j != 0) {}\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());
+
+        check("void f() {\n"
+              "    const char *s1 = foo();\n"
+              "    const char *s2 = bar();\n"
+              "    if (s2 == NULL)\n"
+              "        return;\n"
+              "    size_t len = s2 - s1;\n"
+              "    if (len == 0)\n"
+              "        return;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void alwaysTrueSymbolic()


### PR DESCRIPTION
Performing arithmetic on two pointers is not guaranteed to always yield a non-zero value.

Introduced in commit ac0bd6d2fa30 ("Fix 12760: FN knownConditionTrueFalse for pointer + offset (#6491)").