### PR TITLE
small improvements to `Path::getAbsolutePath()`

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -363,7 +363,10 @@ std::string Path::getAbsoluteFilePath(const std::string& filePath)
     if (_fullpath(absolute, filePath.c_str(), _MAX_PATH))
         absolute_path = absolute;
 #elif defined(__linux__) || defined(__sun) || defined(__hpux) || defined(__GNUC__) || defined(__CPPCHECK__)
-    char * absolute = realpath(filePath.c_str(), nullptr);
+    // simplify the path since any non-existent part has to existed even if discarded by ".."
+    std::string spath = Path::simplifyPath(filePath);
+    // TODO: assert if path exists?
+    char * absolute = realpath(spath.c_str(), nullptr);
     if (absolute)
         absolute_path = absolute;
     free(absolute);

--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -357,11 +357,16 @@ bool Path::isHeader(const std::string &path)
 
 std::string Path::getAbsoluteFilePath(const std::string& filePath)
 {
+    if (filePath.empty())
+        return "";
+
     std::string absolute_path;
 #ifdef _WIN32
     char absolute[_MAX_PATH];
     if (_fullpath(absolute, filePath.c_str(), _MAX_PATH))
         absolute_path = absolute;
+    if (absolute_path.back() == '\\')
+        absolute_path.pop_back();
 #elif defined(__linux__) || defined(__sun) || defined(__hpux) || defined(__GNUC__) || defined(__CPPCHECK__)
     // simplify the path since any non-existent part has to existed even if discarded by ".."
     std::string spath = Path::simplifyPath(filePath);

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -48,6 +48,7 @@ private:
         TEST_CASE(identifyWithCppProbe);
         TEST_CASE(is_header);
         TEST_CASE(simplifyPath);
+        TEST_CASE(getAbsolutePath);
     }
 
     void removeQuotationMarks() const {
@@ -435,6 +436,44 @@ private:
 
         ASSERT_EQUALS("//home/file.cpp", Path::simplifyPath("\\\\home\\test\\..\\file.cpp"));
         ASSERT_EQUALS("//file.cpp", Path::simplifyPath("\\\\home\\..\\test\\..\\file.cpp"));
+    }
+
+    void getAbsolutePath() const {
+        const std::string cwd = Path::getCurrentPath();
+
+        ScopedFile file("testabspath.txt", "");
+        std::string expected = Path::toNativeSeparators(Path::join(cwd, "testabspath.txt"));
+
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath("testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath("./testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath(".\\testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath("test/../testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath("test\\..\\testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath("./test/../testabspath.txt"));
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath(".\\test\\../testabspath.txt"));
+
+        ASSERT_EQUALS(expected, Path::getAbsoluteFilePath(Path::join(cwd, "testabspath.txt")));
+
+        std::string cwd_up = Path::getPathFromFilename(cwd);
+        cwd_up.pop_back(); // remove trailing slash
+        ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, "..")));
+        ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, "../")));
+        ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, "..\\")));
+        ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, "./../")));
+        ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, ".\\..\\")));
+
+        ASSERT_EQUALS(cwd, Path::getAbsoluteFilePath("."));
+        TODO_ASSERT_EQUALS(cwd, "", Path::getAbsoluteFilePath("./"));
+        TODO_ASSERT_EQUALS(cwd, "", Path::getAbsoluteFilePath(".\\"));
+
+        ASSERT_EQUALS("", Path::getAbsoluteFilePath(""));
+
+#ifndef _WIN32
+        // the underlying realpath() call only returns something if the path actually exists
+        ASSERT_EQUALS("", Path::getAbsoluteFilePath("testabspath2.txt"));
+#else
+        ASSERT_EQUALS(Path::toNativeSeparators(Path::join(cwd, "testabspath2.txt")), Path::getAbsoluteFilePath("testabspath2.txt"));
+#endif
     }
 };
 

--- a/test/testpath.cpp
+++ b/test/testpath.cpp
@@ -463,8 +463,13 @@ private:
         ASSERT_EQUALS(cwd_up, Path::getAbsoluteFilePath(Path::join(cwd, ".\\..\\")));
 
         ASSERT_EQUALS(cwd, Path::getAbsoluteFilePath("."));
+#ifndef _WIN32
         TODO_ASSERT_EQUALS(cwd, "", Path::getAbsoluteFilePath("./"));
         TODO_ASSERT_EQUALS(cwd, "", Path::getAbsoluteFilePath(".\\"));
+#else
+        ASSERT_EQUALS(cwd, Path::getAbsoluteFilePath("./"));
+        ASSERT_EQUALS(cwd, Path::getAbsoluteFilePath(".\\"));
+#endif
 
         ASSERT_EQUALS("", Path::getAbsoluteFilePath(""));
 
@@ -474,6 +479,8 @@ private:
 #else
         ASSERT_EQUALS(Path::toNativeSeparators(Path::join(cwd, "testabspath2.txt")), Path::getAbsoluteFilePath("testabspath2.txt"));
 #endif
+
+        // TODO: test with symlinks
     }
 };
 


### PR DESCRIPTION
- fixed result on Linux if parts discarded by `..` do not exist
- small adjustments to Windows implementation to match Linux one