### PR TITLE
Pick job count dynamically when -j0 is used

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -52,6 +52,7 @@
 #include <list>
 #include <set>
 #include <sstream>
+#include <thread>
 #include <unordered_set>
 #include <utility>
 
@@ -798,11 +799,14 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     return Result::Fail;
                 }
                 if (tmp == 0) {
-                    // TODO: implement get CPU logical core count and use that.
-                    // Usually, -j 0 would mean "use all available cores," but
-                    // if we get a 0, we just stall and don't do any work.
-                    mLogger.printError("argument for '-j' must be greater than 0.");
-                    return Result::Fail;
+                    tmp = std::thread::hardware_concurrency();
+
+                    if (tmp == 0)
+                    {
+                        mLogger.printError("Failed to get the system's CPU count. "
+                                           "Call again with a nonzero value for -j.");
+                        return Result::Fail;
+                    }
                 }
                 if (tmp > 1024) {
                     // Almost nobody has 1024 logical cores, but somebody out

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -200,9 +200,9 @@ private:
         TEST_CASE(inlineSuppr);
         TEST_CASE(jobs);
         TEST_CASE(jobs2);
+        TEST_CASE(jobs0);
         TEST_CASE(jobsMissingCount);
         TEST_CASE(jobsInvalid);
-        TEST_CASE(jobsNoJobs);
         TEST_CASE(jobsTooBig);
         TEST_CASE(maxConfigs);
         TEST_CASE(maxConfigsMissingCount);
@@ -1169,6 +1169,14 @@ private:
         ASSERT_EQUALS(3, settings->jobs);
     }
 
+    void jobs0() {
+        REDIRECT;
+        const char * const argv[] = {"cppcheck", "-j0", "file.cpp"};
+        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv));
+        // Resolves to a varying number equal to the system core count
+        ASSERT(0 != settings->jobs);
+    }
+
     void jobsMissingCount() {
         REDIRECT;
         const char * const argv[] = {"cppcheck", "-j", "file.cpp"};
@@ -1183,13 +1191,6 @@ private:
         // Fails since invalid count given for -j
         ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(4, argv));
         ASSERT_EQUALS("cppcheck: error: argument to '-j' is not valid - not an integer.\n", logger->str());
-    }
-
-    void jobsNoJobs() {
-        REDIRECT;
-        const char * const argv[] = {"cppcheck", "-j0", "file.cpp"};
-        ASSERT_EQUALS_ENUM(CmdLineParser::Result::Fail, parser->parseFromArgs(3, argv));
-        ASSERT_EQUALS("cppcheck: error: argument for '-j' must be greater than 0.\n", logger->str());
     }
 
     void jobsTooBig() {


### PR DESCRIPTION
Resolves a TODO for the -j argument, making it more similar to the behavior of tools like make and ninja. Instead of aborting when the user requests "zero jobs", pick a job count which is appropriate for the current system.

