### PR TITLE
windows.cfg: Added support for obsolete UpdateTraceW()/UpdateTraceA().

### DIFF
--- a/cfg/windows.cfg
+++ b/cfg/windows.cfg
@@ -6775,6 +6775,21 @@ HFONT CreateFont(
       <not-bool/>
     </arg>
   </function>
+  <!-- ULONG UpdateTraceA(CONTROLTRACE_ID TraceId, LPCSTR  InstanceName, PEVENT_TRACE_PROPERTIES Properties); -->
+  <!-- ULONG UpdateTraceW(CONTROLTRACE_ID TraceId, LPCWSTR InstanceName, PEVENT_TRACE_PROPERTIES Properties); -->
+  <function name="UpdateTraceA,UpdateTraceW">
+    <noreturn>false</noreturn>
+    <returnValue type="ULONG"/>
+    <use-retval/>
+    <warn severity="style" alternatives="ControlTrace" reason="Obsolete">This function is obsolete. The ControlTrace function supersedes this function.</warn>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out"/>
+  </function>
   <!-- BOOL DeviceIoControl(
   _In_ HANDLE hDevice,
   _In_ DWORD dwIoControlCode,

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -13,6 +13,7 @@
 #include <WinCon.h>
 #include <cstdio>
 #include <direct.h>
+#include <evntrace.h>
 #include <cstdlib>
 #include <ctime>
 #include <memory.h>
@@ -21,6 +22,17 @@
 #include <wchar.h>
 #include <atlstr.h>
 #include <string>
+
+bool UpdateTraceACalled(TRACEHANDLE traceHandle, LPCSTR loggerName, EVENT_TRACE_PROPERTIES* pProperties)
+{
+    // cppcheck-suppress UpdateTraceACalled
+    return UpdateTraceA(traceHandle, loggerName, pProperties) != ERROR_SUCCESS;
+}
+bool UpdateTraceWCalled(TRACEHANDLE traceHandle, LPCWSTR loggerName, EVENT_TRACE_PROPERTIES* pProperties)
+{
+    // cppcheck-suppress UpdateTraceWCalled
+    return UpdateTraceW(traceHandle, loggerName, pProperties) != ERROR_SUCCESS;
+}
 
 void invalidHandle_CreateFile(LPCWSTR lpFileName)
 {


### PR DESCRIPTION
References:
- https://learn.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-updatetracea
- https://learn.microsoft.com/en-us/windows/win32/api/evntrace/nf-evntrace-updatetracew