### PR TITLE
fixed `common.cpp` compilation for `test-translationhandler`

### DIFF
--- a/gui/common.h
+++ b/gui/common.h
@@ -19,6 +19,8 @@
 #ifndef COMMON_H
 #define COMMON_H
 
+#include <cstdint>
+
 #include <QMap>
 #include <QString>
 


### PR DESCRIPTION
```
In file included from /mnt/s/GitHub/cppcheck-fw/gui/common.cpp:20:
/mnt/s/GitHub/cppcheck-fw/gui/common.h:55:25: error: no type named 'uint8_t' in namespace 'std'; did you mean simply 'uint8_t'?
   55 | enum class ReportType : std::uint8_t { normal=0, autosar=1, certC=2, certCpp=3, misraC=4, misraCpp2008=5, misraCpp2023=6 };
      |                         ^~~~~~~~~~~~
      |                         uint8_t
/usr/include/x86_64-linux-gnu/bits/stdint-uintn.h:24:19: note: 'uint8_t' declared here
   24 | typedef __uint8_t uint8_t;
      |                   ^
```

I have no idea why this does not happen in the CI.