### PR TITLE
refs #12348 - fixed missing parsing of markup files when a build dir is specified

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -648,7 +648,7 @@ unsigned int CppCheck::checkFile(const FileWithDetails& file, const std::string 
 
     try {
         if (mSettings.library.markupFile(file.spath())) {
-            if (mUnusedFunctionsCheck && mSettings.useSingleJob() && mSettings.buildDir.empty()) {
+            if (mUnusedFunctionsCheck && (mSettings.useSingleJob() || !mSettings.buildDir.empty())) {
                 // this is not a real source file - we just want to tokenize it. treat it as C anyways as the language needs to be determined.
                 Tokenizer tokenizer(mSettings, *this);
                 // enforce the language since markup files are special and do not adhere to the enforced language
@@ -661,6 +661,7 @@ unsigned int CppCheck::checkFile(const FileWithDetails& file, const std::string 
                     tokenizer.list.createTokens(in, file.spath());
                 }
                 mUnusedFunctionsCheck->parseTokens(tokenizer, mSettings);
+                // TODO: set analyzer information
             }
             return EXIT_SUCCESS;
         }


### PR DESCRIPTION
this only fixes the check which was broken back in ea905c9a360f224d8e1d676fc3a0d70e443fa85a.