### PR TITLE
[cmake] Do not set CMP0048 explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5)
 if(MSVC)
     cmake_minimum_required(VERSION 3.13)
 endif()
-cmake_policy(SET CMP0048 NEW) # allow VERSION in project()
 project(Cppcheck VERSION 2.14.99 LANGUAGES CXX)
 
 include(cmake/cxx11.cmake)


### PR DESCRIPTION
Since CMake 3.0 it is set implicitly to NEW, cppcheck requires CMake 3.5

https://cmake.org/cmake/help/latest/policy/CMP0048.html