### PR TITLE
ProgramMemory: no longer offer mutable iterators

### DIFF
--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -132,18 +132,6 @@ struct CPPCHECKLIB ProgramMemory {
 
     void replace(ProgramMemory pm);
 
-    Map::iterator begin() {
-        copyOnWrite();
-
-        return mValues->begin();
-    }
-
-    Map::iterator end() {
-        copyOnWrite();
-
-        return mValues->end();
-    }
-
     Map::const_iterator begin() const {
         return mValues->cbegin();
     }


### PR DESCRIPTION
This avoids copy-on-write with range loops.