### PR TITLE
Fix #12989: Honor attribute cleanup in unusedFunction

### DIFF
--- a/lib/checkunusedfunctions.cpp
+++ b/lib/checkunusedfunctions.cpp
@@ -221,6 +221,13 @@ void CheckUnusedFunctions::parseTokens(const Tokenizer &tokenizer, const Setting
             }
         }
 
+        if (tok->hasAttributeCleanup()) {
+            const std::string& funcname = tok->getAttributeCleanup();
+            mFunctions[funcname].usedOtherFile = true;
+            mFunctionCalls.insert(funcname);
+            continue;
+        }
+
         const Token *funcname = nullptr;
 
         if (doMarkup)

--- a/lib/token.h
+++ b/lib/token.h
@@ -133,6 +133,8 @@ struct TokenImpl {
             mAttributeAlignas->push_back(a);
     }
 
+    std::string mAttributeCleanup;
+
     // For memoization, to speed up parsing of huge arrays #8897
     enum class Cpp11init : std::uint8_t { UNKNOWN, CPP11INIT, NOINIT } mCpp11init = Cpp11init::UNKNOWN;
 
@@ -564,6 +566,15 @@ public:
     }
     void addAttributeAlignas(const std::string& a) {
         mImpl->addAttributeAlignas(a);
+    }
+    void addAttributeCleanup(const std::string& funcname) {
+        mImpl->mAttributeCleanup = funcname;
+    }
+    const std::string& getAttributeCleanup() const {
+        return mImpl->mAttributeCleanup;
+    }
+    bool hasAttributeCleanup() const {
+        return !mImpl->mAttributeCleanup.empty();
     }
     void setCppcheckAttribute(TokenImpl::CppcheckAttributes::Type type, MathLib::bigint value) {
         mImpl->setCppcheckAttribute(type, value);

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9146,6 +9146,26 @@ static Token* getTokenAfterAttributes(Token* tok, bool gccattr) {
     return after;
 }
 
+static Token* getVariableTokenAfterAttributes(Token* tok) {
+    Token *vartok = nullptr;
+    Token *after = getTokenAfterAttributes(tok, true);
+
+    // check if after variable name
+    if (Token::Match(after, ";|=")) {
+        Token *prev = tok->previous();
+        while (Token::simpleMatch(prev, "]"))
+            prev = prev->link()->previous();
+        if (Token::Match(prev, "%type%"))
+            vartok = prev;
+    }
+
+    // check if before variable name
+    else if (Token::Match(after, "%type%"))
+        vartok = after;
+
+    return vartok;
+}
+
 Token* Tokenizer::getAttributeFuncTok(Token* tok, bool gccattr) const {
     if (!Token::Match(tok, "%name% ("))
         return nullptr;
@@ -9284,6 +9304,14 @@ void Tokenizer::simplifyAttribute()
 
                 else if (functok && Token::simpleMatch(attr, "( __visibility__ ( \"default\" ) )"))
                     functok->isAttributeExport(true);
+
+                else if (Token::Match(attr, "[(,] cleanup ( %name% )")) {
+                    Token *vartok = getVariableTokenAfterAttributes(tok);
+                    if (vartok) {
+                        const std::string& funcname = attr->strAt(3);
+                        vartok->addAttributeCleanup(funcname);
+                    }
+                }
             }
 
             Token::eraseTokens(tok, tok->linkAt(1)->next());

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9257,22 +9257,7 @@ void Tokenizer::simplifyAttribute()
                 }
 
                 else if (Token::Match(attr, "[(,] unused|__unused__|used|__used__ [,)]")) {
-                    Token *vartok = nullptr;
-                    Token *after = getTokenAfterAttributes(tok, true);
-
-                    // check if after variable name
-                    if (Token::Match(after, ";|=")) {
-                        Token *prev = tok->previous();
-                        while (Token::simpleMatch(prev, "]"))
-                            prev = prev->link()->previous();
-                        if (Token::Match(prev, "%type%"))
-                            vartok = prev;
-                    }
-
-                    // check if before variable name
-                    else if (Token::Match(after, "%type%"))
-                        vartok = after;
-
+                    Token *vartok = getVariableTokenAfterAttributes(tok);
                     if (vartok) {
                         const std::string &attribute(attr->strAt(1));
                         if (attribute.find("unused") != std::string::npos)

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -85,6 +85,7 @@ private:
         TEST_CASE(virtualFunc);
         TEST_CASE(parensInit);
         TEST_CASE(typeInCast);
+        TEST_CASE(attributeCleanup);
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -768,6 +769,15 @@ private:
               "    Type t2{ (Type)t };\n"
               "}\n");
         ASSERT_EQUALS("[test.cpp:2]: (style) The function 'Type' is never used.\n", errout_str());
+    }
+
+    void attributeCleanup()
+    {
+        check("void clean(void *ptr) {}\n"
+              "int main() {\n"
+              "    void * __attribute__((cleanup(clean))) p;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 };
 


### PR DESCRIPTION
Gets rid of FPs when a static function is only used with attribute cleanup.