### PR TITLE
Fix #12992 (Refactoring: Use l-value reference specifier for assignment operators to prevent misuse)

### DIFF
--- a/cppcheckpremium-suppressions
+++ b/cppcheckpremium-suppressions
@@ -10,6 +10,8 @@ normalCheckLevelMaxBranches
 # Cert C++
 ###########################################################################################################################
 
+# False positives for (a?b:c)&=true;
+premium-cert-exp35-c
 # False positives for initializations
 premium-cert-exp45-c
 # False positives when casting to uintptr

--- a/cppcheckpremium-suppressions
+++ b/cppcheckpremium-suppressions
@@ -68,7 +68,6 @@ premium-misra-cpp-2023-13.1.2
 premium-misra-cpp-2023-13.3.1
 premium-misra-cpp-2023-13.3.2
 premium-misra-cpp-2023-13.3.3
-premium-misra-cpp-2023-15.0.2
 premium-misra-cpp-2023-15.1.2
 premium-misra-cpp-2023-15.1.3
 premium-misra-cpp-2023-18.1.1

--- a/lib/analyzer.h
+++ b/lib/analyzer.h
@@ -36,7 +36,7 @@ struct Analyzer {
 
         Action() = default;
         Action(const Action&) = default;
-        Action& operator=(const Action& rhs) = default;
+        Action& operator=(const Action& rhs) & = default;
 
         template<class T,
                  REQUIRES("T must be convertible to unsigned int", std::is_convertible<T, unsigned int> ),

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -74,7 +74,7 @@ public:
     ImportProject() = default;
     virtual ~ImportProject() = default;
     ImportProject(const ImportProject&) = default;
-    ImportProject& operator=(const ImportProject&) = default;
+    ImportProject& operator=(const ImportProject&) & = default;
 
     void selectOneVsConfig(Platform::Type platform);
     void selectVsConfigurations(Platform::Type platform, const std::vector<std::string> &configurations);

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -153,7 +153,7 @@ Library::Library(const Library& other)
     : mData(new LibraryData(*other.mData))
 {}
 
-Library& Library::operator=(const Library& other)
+Library& Library::operator=(const Library& other) &
 {
     mData.reset(new LibraryData(*other.mData));
     return *this;

--- a/lib/library.h
+++ b/lib/library.h
@@ -57,7 +57,7 @@ public:
     ~Library();
 
     Library(const Library& other);
-    Library& operator=(const Library& other);
+    Library& operator=(const Library& other) &;
 
     enum class ErrorCode : std::uint8_t {
         OK,

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -2252,7 +2252,7 @@ Variable::~Variable()
     delete mValueType;
 }
 
-Variable& Variable::operator=(const Variable &var)
+Variable& Variable::operator=(const Variable &var) &
 {
     if (this == &var)
         return *this;

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -236,7 +236,7 @@ public:
 
     ~Variable();
 
-    Variable &operator=(const Variable &var);
+    Variable &operator=(const Variable &var) &;
 
     /**
      * Get name token.

--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -81,7 +81,7 @@ public:
         swap(mClone, rhs.mClone);
     }
 
-    ValuePtr<T>& operator=(ValuePtr rhs) {
+    ValuePtr<T>& operator=(ValuePtr rhs) & {
         swap(rhs);
         return *this;
     }


### PR DESCRIPTION
Misra C++ 2023 15.0.2