### PR TITLE
Refactoring: Use NOEXCEPT for swap methods

### DIFF
--- a/cppcheckpremium-suppressions
+++ b/cppcheckpremium-suppressions
@@ -223,9 +223,6 @@ premium-misra-cpp-2023-18.1.1
 # TODO do not throw token pointer?
 premium-misra-cpp-2023-18.3.2:lib/tokenize.cpp
 
-# TODO use noexcept
-premium-misra-cpp-2023-18.4.1
-
 # in smallvector we intentionally put a constant above some preprocessor includes
 premium-misra-cpp-2023-19.0.3:lib/smallvector.h
 

--- a/lib/checkleakautovar.h
+++ b/lib/checkleakautovar.h
@@ -76,7 +76,7 @@ public:
         referenced.erase(varid);
     }
 
-    void swap(VarInfo &other) {
+    void swap(VarInfo &other) NOEXCEPT {
         alloctype.swap(other.alloctype);
         possibleUsage.swap(other.possibleUsage);
         conditionalAlloc.swap(other.conditionalAlloc);

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -184,7 +184,7 @@ void ProgramMemory::erase_if(const std::function<bool(const ExprIdToken&)>& pred
     }
 }
 
-void ProgramMemory::swap(ProgramMemory &pm)
+void ProgramMemory::swap(ProgramMemory &pm) NOEXCEPT
 {
     mValues.swap(pm.mValues);
 }

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -124,7 +124,7 @@ struct CPPCHECKLIB ProgramMemory {
 
     void erase_if(const std::function<bool(const ExprIdToken&)>& pred);
 
-    void swap(ProgramMemory &pm);
+    void swap(ProgramMemory &pm) NOEXCEPT;
 
     void clear();
 

--- a/lib/valueptr.h
+++ b/lib/valueptr.h
@@ -75,7 +75,7 @@ public:
         return get();
     }
 
-    void swap(ValuePtr& rhs) {
+    void swap(ValuePtr& rhs) NOEXCEPT {
         using std::swap;
         swap(mPtr, rhs.mPtr);
         swap(mClone, rhs.mClone);


### PR DESCRIPTION
Misra C++ 2023 rule 18.4.1: Exception-unfriendly functions shall be noexcept