### PR TITLE
Safety: Use proper ref specifiers on methods that returns reference to members

### DIFF
--- a/lib/analyzer.h
+++ b/lib/analyzer.h
@@ -110,7 +110,7 @@ struct Analyzer {
             return get(Match);
         }
 
-        Action& operator|=(Action a) {
+        Action& operator|=(Action a) & {
             set(a.mFlag);
             return *this;
         }

--- a/lib/check.h
+++ b/lib/check.h
@@ -88,7 +88,7 @@ public:
     const std::string& name() const & {
         return mName;
     }
-    const std::string& name() && {
+    std::string name() && {
         return mName;
     }
 

--- a/lib/check.h
+++ b/lib/check.h
@@ -85,7 +85,10 @@ public:
     virtual void getErrorMessages(ErrorLogger *errorLogger, const Settings *settings) const = 0;
 
     /** class name, used to generate documentation */
-    const std::string& name() const {
+    const std::string& name() const & {
+        return mName;
+    }
+    const std::string& name() && {
         return mName;
     }
 

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -150,7 +150,7 @@ public:
     const std::map<nonneg int, VariableUsage> &varUsage() const & {
         return mVarUsage;
     }
-    const std::map<nonneg int, VariableUsage> &varUsage() && {
+    std::map<nonneg int, VariableUsage> varUsage() && {
         return mVarUsage;
     }
     void addVar(const Variable *var, VariableType type, bool write_);

--- a/lib/checkunusedvar.cpp
+++ b/lib/checkunusedvar.cpp
@@ -147,7 +147,10 @@ public:
     void clear() {
         mVarUsage.clear();
     }
-    const std::map<nonneg int, VariableUsage> &varUsage() const {
+    const std::map<nonneg int, VariableUsage> &varUsage() const & {
+        return mVarUsage;
+    }
+    const std::map<nonneg int, VariableUsage> &varUsage() && {
         return mVarUsage;
     }
     void addVar(const Variable *var, VariableType type, bool write_);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1511,7 +1511,7 @@ void CppCheck::executeAddonsWholeProgram(const std::list<FileWithDetails> &files
     }
 }
 
-Settings &CppCheck::settings()
+Settings &CppCheck::settings()&
 {
     return mSettings;
 }

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -110,7 +110,7 @@ public:
      * @brief Get reference to current settings.
      * @return a reference to current settings
      */
-    Settings &settings();
+    Settings &settings()&;
 
     /**
      * @brief Returns current version number as a string.

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -96,7 +96,7 @@ public:
             return mInfo;
         }
 
-        const std::string& getinfo() && {
+        std::string getinfo() && {
             return mInfo;
         }
 
@@ -189,7 +189,7 @@ public:
         return mShortMessage;
     }
 
-    const std::string &shortMessage() && {
+    std::string shortMessage() && {
         return mShortMessage;
     }
 
@@ -199,7 +199,7 @@ public:
         return mVerboseMessage;
     }
 
-    const std::string &verboseMessage() && {
+    std::string verboseMessage() && {
         return mVerboseMessage;
     }
 
@@ -208,7 +208,7 @@ public:
         return mSymbolNames;
     }
 
-    const std::string &symbolNames() && {
+    std::string symbolNames() && {
         return mSymbolNames;
     }
 

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -92,7 +92,11 @@ public:
         int line; // negative value means "no line"
         unsigned int column;
 
-        const std::string& getinfo() const {
+        const std::string& getinfo() const & {
+            return mInfo;
+        }
+
+        const std::string& getinfo() && {
             return mInfo;
         }
 
@@ -181,18 +185,30 @@ public:
     void setmsg(const std::string &msg);
 
     /** Short message (single line short message) */
-    const std::string &shortMessage() const {
+    const std::string &shortMessage() const & {
+        return mShortMessage;
+    }
+
+    const std::string &shortMessage() && {
         return mShortMessage;
     }
 
     /** Verbose message (may be the same as the short message) */
     // cppcheck-suppress unusedFunction - used by GUI only
-    const std::string &verboseMessage() const {
+    const std::string &verboseMessage() const & {
+        return mVerboseMessage;
+    }
+
+    const std::string &verboseMessage() && {
         return mVerboseMessage;
     }
 
     /** Symbol names */
-    const std::string &symbolNames() const {
+    const std::string &symbolNames() const & {
+        return mSymbolNames;
+    }
+
+    const std::string &symbolNames() && {
         return mSymbolNames;
     }
 

--- a/lib/filesettings.h
+++ b/lib/filesettings.h
@@ -50,7 +50,7 @@ public:
         return mPath;
     }
 
-    const std::string& path() &&
+    std::string path() &&
     {
         return mPath;
     }
@@ -59,7 +59,7 @@ public:
     {
         return mPathSimplified;
     }
-    const std::string& spath() &&
+    std::string spath() &&
     {
         return mPathSimplified;
     }

--- a/lib/filesettings.h
+++ b/lib/filesettings.h
@@ -45,12 +45,21 @@ public:
             throw std::runtime_error("empty path specified");
     }
 
-    const std::string& path() const
+    const std::string& path() const &
     {
         return mPath;
     }
 
-    const std::string& spath() const
+    const std::string& path() &&
+    {
+        return mPath;
+    }
+
+    const std::string& spath() const &
+    {
+        return mPathSimplified;
+    }
+    const std::string& spath() &&
     {
         return mPathSimplified;
     }

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -88,10 +88,16 @@ struct Library::LibraryData
         void addBlock(const char* blockName) {
             mBlocks.insert(blockName);
         }
-        const std::string& start() const {
+        const std::string& start() const & {
             return mStart;
         }
-        const std::string& end() const {
+        const std::string& start() && {
+            return mStart;
+        }
+        const std::string& end() const & {
+            return mEnd;
+        }
+        const std::string& end() && {
             return mEnd;
         }
         int offset() const {

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -91,13 +91,13 @@ struct Library::LibraryData
         const std::string& start() const & {
             return mStart;
         }
-        const std::string& start() && {
+        std::string start() && {
             return mStart;
         }
         const std::string& end() const & {
             return mEnd;
         }
-        const std::string& end() && {
+        std::string end() && {
             return mEnd;
         }
         int offset() const {

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -517,7 +517,12 @@ std::list<SuppressionList::Suppression> SuppressionList::getUnmatchedGlobalSuppr
     return result;
 }
 
-const std::list<SuppressionList::Suppression> &SuppressionList::getSuppressions() const
+const std::list<SuppressionList::Suppression> &SuppressionList::getSuppressions() const &
+{
+    return mSuppressions;
+}
+
+const std::list<SuppressionList::Suppression> &SuppressionList::getSuppressions() &&
 {
     return mSuppressions;
 }

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -522,7 +522,7 @@ const std::list<SuppressionList::Suppression> &SuppressionList::getSuppressions(
     return mSuppressions;
 }
 
-const std::list<SuppressionList::Suppression> &SuppressionList::getSuppressions() &&
+std::list<SuppressionList::Suppression> SuppressionList::getSuppressions() &&
 {
     return mSuppressions;
 }

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -55,7 +55,7 @@ public:
         const std::string &getFileName() const& {
             return mFileName;
         }
-        const std::string &getFileName() && {
+        std::string getFileName() && {
             return mFileName;
         }
         int lineNumber;
@@ -245,7 +245,7 @@ public:
      * @return list of suppressions
      */
     const std::list<Suppression> &getSuppressions() const&;
-    const std::list<Suppression> &getSuppressions() &&;
+    std::list<Suppression> getSuppressions() &&;
 
     /**
      * @brief Marks Inline Suppressions as checked if source line is in the token stream

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -52,7 +52,10 @@ public:
         std::size_t hash;
         std::string errorId;
         void setFileName(std::string s);
-        const std::string &getFileName() const {
+        const std::string &getFileName() const& {
+            return mFileName;
+        }
+        const std::string &getFileName() && {
             return mFileName;
         }
         int lineNumber;
@@ -241,7 +244,8 @@ public:
      * @brief Returns list of all suppressions.
      * @return list of suppressions
      */
-    const std::list<Suppression> &getSuppressions() const;
+    const std::list<Suppression> &getSuppressions() const&;
+    const std::list<Suppression> &getSuppressions() &&;
 
     /**
      * @brief Marks Inline Suppressions as checked if source line is in the token stream

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -537,7 +537,7 @@ public:
     const std::vector<Dimension> &dimensions() const& {
         return mDimensions;
     }
-    const std::vector<Dimension> &dimensions() && {
+    std::vector<Dimension> dimensions() && {
         return mDimensions;
     }
 
@@ -1379,9 +1379,7 @@ public:
     const std::vector<const Variable *> & variableList() const& {
         return mVariableList;
     }
-    const std::vector<const Variable *> & variableList() && {
-        return mVariableList;
-    }
+    std::vector<const Variable *> variableList() &&; // Unimplemented by intention; Not safe to use this on temporary object
 
     /**
      * @brief output a debug message

--- a/lib/symboldatabase.h
+++ b/lib/symboldatabase.h
@@ -534,7 +534,10 @@ public:
      * Get array dimensions.
      * @return array dimensions vector
      */
-    const std::vector<Dimension> &dimensions() const {
+    const std::vector<Dimension> &dimensions() const& {
+        return mDimensions;
+    }
+    const std::vector<Dimension> &dimensions() && {
         return mDimensions;
     }
 
@@ -1373,7 +1376,10 @@ public:
         return mVariableList.at(varId);
     }
 
-    const std::vector<const Variable *> & variableList() const {
+    const std::vector<const Variable *> & variableList() const& {
+        return mVariableList;
+    }
+    const std::vector<const Variable *> & variableList() && {
         return mVariableList;
     }
 

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -50,7 +50,10 @@ class CPPCHECKLIB TemplateSimplifier {
 public:
     explicit TemplateSimplifier(Tokenizer &tokenizer);
 
-    const std::string& dump() const {
+    const std::string& dump() const & {
+        return mDump;
+    }
+    const std::string& dump() && {
         return mDump;
     }
 
@@ -169,13 +172,22 @@ public:
         void token(Token * token) {
             mToken = token;
         }
-        const std::string & scope() const {
+        const std::string & scope() const & {
             return mScope;
         }
-        const std::string & name() const {
+        const std::string & scope() && {
+            return mScope;
+        }
+        const std::string & name() const & {
             return mName;
         }
-        const std::string & fullName() const {
+        const std::string & name() && {
+            return mName;
+        }
+        const std::string & fullName() const & {
+            return mFullName;
+        }
+        const std::string & fullName() && {
             return mFullName;
         }
         const Token * nameToken() const {

--- a/lib/templatesimplifier.h
+++ b/lib/templatesimplifier.h
@@ -53,7 +53,7 @@ public:
     const std::string& dump() const & {
         return mDump;
     }
-    const std::string& dump() && {
+    std::string dump() && {
         return mDump;
     }
 
@@ -175,19 +175,19 @@ public:
         const std::string & scope() const & {
             return mScope;
         }
-        const std::string & scope() && {
+        std::string scope() && {
             return mScope;
         }
         const std::string & name() const & {
             return mName;
         }
-        const std::string & name() && {
+        std::string name() && {
             return mName;
         }
         const std::string & fullName() const & {
             return mFullName;
         }
-        const std::string & fullName() && {
+        std::string fullName() && {
             return mFullName;
         }
         const Token * nameToken() const {

--- a/lib/token.h
+++ b/lib/token.h
@@ -206,7 +206,7 @@ public:
     const std::string &str() const & {
         return mStr;
     }
-    const std::string &str() && {
+    std::string str() && {
         return mStr;
     }
 

--- a/lib/token.h
+++ b/lib/token.h
@@ -203,7 +203,10 @@ public:
      */
     void concatStr(std::string const& b);
 
-    const std::string &str() const {
+    const std::string &str() const & {
+        return mStr;
+    }
+    const std::string &str() && {
         return mStr;
     }
 

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -142,7 +142,7 @@ public:
     const std::vector<std::string>& getFiles() const & {
         return mFiles;
     }
-    const std::vector<std::string>& getFiles() && {
+    std::vector<std::string> getFiles() && {
         return mFiles;
     }
 

--- a/lib/tokenlist.h
+++ b/lib/tokenlist.h
@@ -139,7 +139,10 @@ public:
      * The first filename is the filename for the sourcefile
      * @return vector with filenames
      */
-    const std::vector<std::string>& getFiles() const {
+    const std::vector<std::string>& getFiles() const & {
+        return mFiles;
+    }
+    const std::vector<std::string>& getFiles() && {
         return mFiles;
     }
 

--- a/lib/tokenrange.h
+++ b/lib/tokenrange.h
@@ -47,7 +47,7 @@ public:
         T* mt;
         TokenIterator() : mt(nullptr) {}
         explicit TokenIterator(T* t) : mt(t) {}
-        TokenIterator& operator++() {
+        TokenIterator& operator++() & {
             mt = mt->next();
             return *this;
         }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -1532,14 +1532,14 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
     const std::unordered_map<nonneg int, const Variable*>& getVars() const & {
         return varids;
     }
-    const std::unordered_map<nonneg int, const Variable*>& getVars() && {
+    std::unordered_map<nonneg int, const Variable*> getVars() && {
         return varids;
     }
 
     const std::unordered_map<nonneg int, const Variable*>& getAliasedVars() const & {
         return aliases;
     }
-    const std::unordered_map<nonneg int, const Variable*>& getAliasedVars() && {
+    std::unordered_map<nonneg int, const Variable*> getAliasedVars() && {
         return aliases;
     }
 

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -759,7 +759,7 @@ class SelectValueFromVarIdMapRange {
             return &mIt->second;
         }
 
-        Iterator &operator++() {
+        Iterator &operator++() & {
             // cppcheck-suppress postfixOperator - forward iterator needs to perform post-increment
             mIt++;
             return *this;
@@ -1529,11 +1529,17 @@ struct SingleValueFlowAnalyzer : ValueFlowAnalyzer {
 
     SingleValueFlowAnalyzer(ValueFlow::Value v, const Settings& s) : ValueFlowAnalyzer(s), value(std::move(v)) {}
 
-    const std::unordered_map<nonneg int, const Variable*>& getVars() const {
+    const std::unordered_map<nonneg int, const Variable*>& getVars() const & {
+        return varids;
+    }
+    const std::unordered_map<nonneg int, const Variable*>& getVars() && {
         return varids;
     }
 
-    const std::unordered_map<nonneg int, const Variable*>& getAliasedVars() const {
+    const std::unordered_map<nonneg int, const Variable*>& getAliasedVars() const & {
+        return aliases;
+    }
+    const std::unordered_map<nonneg int, const Variable*>& getAliasedVars() && {
         return aliases;
     }
 


### PR DESCRIPTION
A method that returns a reference to member data will be dangerous to use on temporary objects. Use ref specifiers we can prevent that these methods are used on temporary objects.

This example code does not compile:
```
#include <string>
#include <vector>

struct C {
    const std::string& getx(int i) & { return x.at(i); }
    std::vector<std::string> x{"abc", "def"};
};

int main() {
    const std::string& x = C().getx(0);  // This is dangerous
    if (x=="abc") {}
    return 0;
}
```
