### PR TITLE
changed `ccache-action` GitHub action to `v1.2` for most workflows

### DIFF
--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -41,7 +41,7 @@ jobs:
             mingw-w64-x86_64-ccache
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -43,6 +43,10 @@ jobs:
       # we need to stay at v3 for now because Node 20 does not support the older distros
       # /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
       - uses: actions/checkout@v3
+        if: matrix.image == 'ubuntu:16.04' || matrix.image == 'ubuntu:18.04'
+
+      - uses: actions/checkout@v4
+        if: matrix.image != 'ubuntu:16.04' && matrix.image != 'ubuntu:18.04'
 
       - name: Install missing software on ubuntu
         if: contains(matrix.image, 'ubuntu')
@@ -57,11 +61,20 @@ jobs:
 
       # needs to be called after the package installation since
       # - it doesn't call "apt-get update"
-      # - it doesn't support centos
       #
-      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178
+      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178.
+      # using the older version will cause a two minute hang in its post-run step.
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.11
+        if: matrix.image == 'ubuntu:16.04' || matrix.image == 'ubuntu:18.04'
+        with:
+          key: ${{ github.workflow }}-${{ matrix.image }}
+
+      # needs to be called after the package installation since
+      # - it doesn't call "apt-get update"
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: matrix.image != 'ubuntu:16.04' && matrix.image != 'ubuntu:18.04'
         with:
           key: ${{ github.workflow }}-${{ matrix.image }}
 
@@ -109,6 +122,10 @@ jobs:
       # we need to stay at v3 for now because Node 20 does not support the older distros
       # /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
       - uses: actions/checkout@v3
+        if: matrix.image == 'ubuntu:16.04' || matrix.image == 'ubuntu:18.04'
+
+      - uses: actions/checkout@v4
+        if: matrix.image != 'ubuntu:16.04' && matrix.image != 'ubuntu:18.04'
 
       - name: Install missing software on ubuntu
         if: contains(matrix.image, 'ubuntu')
@@ -118,24 +135,31 @@ jobs:
 
       # needs to be called after the package installation since
       # - it doesn't call "apt-get update"
-      # - it doesn't support centos
       #
-      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178
+      # needs to be to fixated on 1.2.11 so it works with older images - see https://github.com/hendrikmuhs/ccache-action/issues/178.
+      # using the older version will cause a two minute hang in its post-run step.
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.11
+        if: matrix.image == 'ubuntu:16.04' || matrix.image == 'ubuntu:18.04'
+        with:
+          key: ${{ github.workflow }}-${{ matrix.image }}
+
+      # needs to be called after the package installation since
+      # - it doesn't call "apt-get update"
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        if: matrix.image != 'ubuntu:16.04' && matrix.image != 'ubuntu:18.04'
         with:
           key: ${{ github.workflow }}-${{ matrix.image }}
 
       - name: Build cppcheck
         run: |
-          # "/usr/lib64" for centos / "/usr/lib" for ubuntu
-          export PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) HAVE_RULES=yes CXXFLAGS="-w"
 
       - name: Build test
         run: |
-          # "/usr/lib64" for centos / "/usr/lib" for ubuntu
-          export PATH="/usr/lib64/ccache:/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           make -j$(nproc) testrunner HAVE_RULES=yes CXXFLAGS="-w"
 
       - name: Run test

--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -272,7 +272,7 @@ jobs:
           brew link qt@5 --force
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -345,7 +345,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 
@@ -505,7 +505,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get install libboost-container-dev
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: ccache
-        uses: hendrikmuhs/ccache-action@v1.2.11
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.workflow }}-${{ runner.os }}
 


### PR DESCRIPTION
This fixes the two minute hang in the `Post ccache` step.