### PR TITLE
test/CMakeLists.txt: bumped CTest timeout to accommodate `macos-*` runner slowness

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -68,7 +68,8 @@ if (BUILD_TESTS)
         include(ProcessorCount)
         ProcessorCount(N)
         set(CTEST_PARALLEL_LEVEL ${N} CACHE STRING "CTest parallel level")
-        set(CTEST_TIMEOUT 90 CACHE STRING "CTest timeout")
+        # the macos-* runners are sporadically much slower than other runners so chose a high timeout
+        set(CTEST_TIMEOUT 130 CACHE STRING "CTest timeout")
         add_custom_target(check ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${CTEST_PARALLEL_LEVEL} -C ${CMAKE_CFG_INTDIR} --timeout ${CTEST_TIMEOUT}
                 DEPENDS testrunner cppcheck)
 


### PR DESCRIPTION
The `macos-*` runners are much slower than the other leading to sporadic timeouts when running CTest with a debug build in the CI.