### PR TITLE
fix #13021: cmdline: validate option --std

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1257,7 +1257,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             // --std
             else if (std::strncmp(argv[i], "--std=", 6) == 0) {
                 const std::string std = argv[i] + 6;
-                // TODO: print error when standard is unknown
                 if (std::strncmp(std.c_str(), "c++", 3) == 0) {
                     const Standards::cppstd_t cppstd = Standards::getCPP(std);
                     if (cppstd == Standards::CPPInvalid) {

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1259,10 +1259,20 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                 const std::string std = argv[i] + 6;
                 // TODO: print error when standard is unknown
                 if (std::strncmp(std.c_str(), "c++", 3) == 0) {
-                    mSettings.standards.cpp = Standards::getCPP(std);
+                    const Standards::cppstd_t cppstd = Standards::getCPP(std);
+                    if (cppstd == Standards::CPPInvalid) {
+                        mLogger.printError("unknown --std value '" + std + "'");
+                        return Result::Fail;
+                    }
+                    mSettings.standards.cpp = cppstd;
                 }
                 else if (std::strncmp(std.c_str(), "c", 1) == 0) {
-                    mSettings.standards.c = Standards::getC(std);
+                    const Standards::cstd_t cstd = Standards::getC(std);
+                    if (cstd == Standards::CInvalid) {
+                        mLogger.printError("unknown --std value '" + std + "'");
+                        return Result::Fail;
+                    }
+                    mSettings.standards.c = cstd;
                 }
                 else {
                     mLogger.printError("unknown --std value '" + std + "'");

--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -1257,23 +1257,17 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             // --std
             else if (std::strncmp(argv[i], "--std=", 6) == 0) {
                 const std::string std = argv[i] + 6;
+                bool unknown = false;
                 if (std::strncmp(std.c_str(), "c++", 3) == 0) {
-                    const Standards::cppstd_t cppstd = Standards::getCPP(std);
-                    if (cppstd == Standards::CPPInvalid) {
-                        mLogger.printError("unknown --std value '" + std + "'");
-                        return Result::Fail;
-                    }
-                    mSettings.standards.cpp = cppstd;
+                    mSettings.standards.cpp = Standards::getCPP(std, unknown);
                 }
                 else if (std::strncmp(std.c_str(), "c", 1) == 0) {
-                    const Standards::cstd_t cstd = Standards::getC(std);
-                    if (cstd == Standards::CInvalid) {
-                        mLogger.printError("unknown --std value '" + std + "'");
-                        return Result::Fail;
-                    }
-                    mSettings.standards.c = cstd;
+                    mSettings.standards.c = Standards::getC(std, unknown);
                 }
                 else {
+                    unknown = true;
+                }
+                if (unknown) {
                     mLogger.printError("unknown --std value '" + std + "'");
                     return Result::Fail;
                 }

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -289,7 +289,7 @@ bool ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
             while (pos < command.size() && command[pos] == ' ')
                 ++pos;
         }
-        const std::string fval = readUntil(command, &pos, " =:");
+        const std::string fval = readUntil(command, &pos, " =");
         if (F=='D') {
             std::string defval = readUntil(command, &pos, " ");
             defs += fval;
@@ -309,8 +309,12 @@ bool ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
             if (std::find(fs.includePaths.cbegin(), fs.includePaths.cend(), i) == fs.includePaths.cend())
                 fs.includePaths.push_back(std::move(i));
         } else if (F=='s' && startsWith(fval,"td")) {
-            ++pos;
-            fs.standard = readUntil(command, &pos, " ");
+            if (command[pos] == '=') {
+                ++pos;
+                fs.standard = readUntil(command, &pos, " ");
+            } else {
+                fs.standard = fval.substr(3);
+            }
             bool unknown_std = false;
             (void)Standards::getCPP(fs.standard, unknown_std);
             if (unknown_std) (void)Standards::getC(fs.standard, unknown_std);

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -289,7 +289,7 @@ bool ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
             while (pos < command.size() && command[pos] == ' ')
                 ++pos;
         }
-        const std::string fval = readUntil(command, &pos, " =");
+        const std::string fval = readUntil(command, &pos, " =:");
         if (F=='D') {
             std::string defval = readUntil(command, &pos, " ");
             defs += fval;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -315,7 +315,7 @@ bool ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
             (void)Standards::getCPP(fs.standard, unknown_std);
             if (unknown_std) (void)Standards::getC(fs.standard, unknown_std);
             if (unknown_std) {
-                printError("unkown --std value '" + fs.standard + "'");
+                printError("unknown --std value '" + fs.standard + "'");
                 return false;
             }
         } else if (F == 'i' && fval == "system") {

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -319,8 +319,12 @@ bool ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
             (void)Standards::getCPP(fs.standard, unknown_std);
             if (unknown_std) (void)Standards::getC(fs.standard, unknown_std);
             if (unknown_std) {
-                printError("unknown --std value '" + fs.standard + "'");
-                return false;
+                const Standards::cppstd_t gnustd = Standards::getGnuCPP(fs.standard, unknown_std);
+                if (unknown_std) {
+                    printError("unknown --std value '" + fs.standard + "'");
+                    return false;
+                }
+                fs.standard = Standards::getCPP(gnustd);
             }
         } else if (F == 'i' && fval == "system") {
             ++pos;

--- a/lib/importproject.h
+++ b/lib/importproject.h
@@ -64,7 +64,7 @@ public:
         CPPCHECK_GUI
     };
 
-    static void fsParseCommand(FileSettings& fs, const std::string& command);
+    static bool fsParseCommand(FileSettings& fs, const std::string& command);
     static void fsSetDefines(FileSettings& fs, std::string defs);
     static void fsSetIncludePaths(FileSettings& fs, const std::string &basepath, const std::list<std::string> &in, std::map<std::string, std::string, cppcheck::stricmp> &variables);
 

--- a/lib/keywords.cpp
+++ b/lib/keywords.cpp
@@ -181,8 +181,6 @@ const std::unordered_set<std::string>& Keywords::getAll(Standards::cstd_t cStd)
         return c17_keywords_all;
     case Standards::cstd_t::C23:
         return c23_keywords_all;
-    case Standards::cstd_t::CInvalid:
-        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -205,8 +203,6 @@ const std::unordered_set<std::string>& Keywords::getAll(Standards::cppstd_t cppS
         return cpp23_keywords_all;
     case Standards::cppstd_t::CPP26:
         return cpp26_keywords_all;
-    case Standards::cppstd_t::CPPInvalid:
-        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -226,8 +222,6 @@ const std::unordered_set<std::string>& Keywords::getOnly(Standards::cstd_t cStd)
         return c17_keywords;
     case Standards::cstd_t::C23:
         return c23_keywords;
-    case Standards::cstd_t::CInvalid:
-        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -251,8 +245,6 @@ const std::unordered_set<std::string>& Keywords::getOnly(Standards::cppstd_t cpp
         return cpp23_keywords;
     case Standards::cppstd_t::CPP26:
         return cpp26_keywords;
-    case Standards::cppstd_t::CPPInvalid:
-        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }

--- a/lib/keywords.cpp
+++ b/lib/keywords.cpp
@@ -181,6 +181,8 @@ const std::unordered_set<std::string>& Keywords::getAll(Standards::cstd_t cStd)
         return c17_keywords_all;
     case Standards::cstd_t::C23:
         return c23_keywords_all;
+    case Standards::cstd_t::CInvalid:
+        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -203,6 +205,8 @@ const std::unordered_set<std::string>& Keywords::getAll(Standards::cppstd_t cppS
         return cpp23_keywords_all;
     case Standards::cppstd_t::CPP26:
         return cpp26_keywords_all;
+    case Standards::cppstd_t::CPPInvalid:
+        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -222,6 +226,8 @@ const std::unordered_set<std::string>& Keywords::getOnly(Standards::cstd_t cStd)
         return c17_keywords;
     case Standards::cstd_t::C23:
         return c23_keywords;
+    case Standards::cstd_t::CInvalid:
+        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }
@@ -245,6 +251,8 @@ const std::unordered_set<std::string>& Keywords::getOnly(Standards::cppstd_t cpp
         return cpp23_keywords;
     case Standards::cppstd_t::CPP26:
         return cpp26_keywords;
+    case Standards::cppstd_t::CPPInvalid:
+        cppcheck::unreachable();
     }
     cppcheck::unreachable();
 }

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -149,6 +149,33 @@ struct Standards {
         unknown = true;
         return Standards::CPPLatest;
     }
+    static cppstd_t getGnuCPP(const std::string &std, bool &unknown) {
+        // treat gnu++XX as c++XX
+        unknown = false;
+        if (std == "gnu++03") {
+            return Standards::CPP03;
+        }
+        if (std == "gnu++11") {
+            return Standards::CPP11;
+        }
+        if (std == "gnu++14") {
+            return Standards::CPP14;
+        }
+        if (std == "gnu++17") {
+            return Standards::CPP17;
+        }
+        if (std == "gnu++20") {
+            return Standards::CPP20;
+        }
+        if (std == "gnu++23") {
+            return Standards::CPP23;
+        }
+        if (std == "gnu++26") {
+            return Standards::CPP26;
+        }
+        unknown = true;
+        return Standards::CPPLatest;
+    }
 };
 
 /// @}

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -38,10 +38,10 @@ struct Standards {
     enum Language : std::uint8_t { None, C, CPP };
 
     /** C code standard */
-    enum cstd_t : std::uint8_t { C89, C99, C11, C17, C23, CLatest = C23, CInvalid } c = CLatest;
+    enum cstd_t : std::uint8_t { C89, C99, C11, C17, C23, CLatest = C23 } c = CLatest;
 
     /** C++ code standard */
-    enum cppstd_t : std::uint8_t { CPP03, CPP11, CPP14, CPP17, CPP20, CPP23, CPP26, CPPLatest = CPP26, CPPInvalid } cpp = CPPLatest;
+    enum cppstd_t : std::uint8_t { CPP03, CPP11, CPP14, CPP17, CPP20, CPP23, CPP26, CPPLatest = CPP26 } cpp = CPPLatest;
 
     /** --std value given on command line */
     std::string stdValue;
@@ -64,12 +64,15 @@ struct Standards {
             return "c17";
         case C23:
             return "c23";
-        case CInvalid:
-            return "";
         }
         return "";
     }
     static cstd_t getC(const std::string &std) {
+        bool _unused;
+        return getC(std, _unused);
+    }
+    static cstd_t getC(const std::string &std, bool &unknown) {
+        unknown = false;
         if (std == "c89") {
             return Standards::C89;
         }
@@ -85,7 +88,8 @@ struct Standards {
         if (std == "c23") {
             return Standards::C23;
         }
-        return Standards::CInvalid;
+        unknown = true;
+        return Standards::CLatest;
     }
     bool setCPP(std::string str) {
         stdValue = str;
@@ -112,12 +116,15 @@ struct Standards {
             return "c++23";
         case CPP26:
             return "c++26";
-        case CPPInvalid:
-            return "";
         }
         return "";
     }
     static cppstd_t getCPP(const std::string &std) {
+        bool _unused;
+        return getCPP(std, _unused);
+    }
+    static cppstd_t getCPP(const std::string &std, bool &unknown) {
+        unknown = false;
         if (std == "c++03") {
             return Standards::CPP03;
         }
@@ -139,7 +146,8 @@ struct Standards {
         if (std == "c++26") {
             return Standards::CPP26;
         }
-        return Standards::CPPInvalid;
+        unknown = true;
+        return Standards::CPPLatest;
     }
 };
 

--- a/lib/standards.h
+++ b/lib/standards.h
@@ -38,10 +38,10 @@ struct Standards {
     enum Language : std::uint8_t { None, C, CPP };
 
     /** C code standard */
-    enum cstd_t : std::uint8_t { C89, C99, C11, C17, C23, CLatest = C23 } c = CLatest;
+    enum cstd_t : std::uint8_t { C89, C99, C11, C17, C23, CLatest = C23, CInvalid } c = CLatest;
 
     /** C++ code standard */
-    enum cppstd_t : std::uint8_t { CPP03, CPP11, CPP14, CPP17, CPP20, CPP23, CPP26, CPPLatest = CPP26 } cpp = CPPLatest;
+    enum cppstd_t : std::uint8_t { CPP03, CPP11, CPP14, CPP17, CPP20, CPP23, CPP26, CPPLatest = CPP26, CPPInvalid } cpp = CPPLatest;
 
     /** --std value given on command line */
     std::string stdValue;
@@ -64,6 +64,8 @@ struct Standards {
             return "c17";
         case C23:
             return "c23";
+        case CInvalid:
+            return "";
         }
         return "";
     }
@@ -83,7 +85,7 @@ struct Standards {
         if (std == "c23") {
             return Standards::C23;
         }
-        return Standards::CLatest;
+        return Standards::CInvalid;
     }
     bool setCPP(std::string str) {
         stdValue = str;
@@ -110,6 +112,8 @@ struct Standards {
             return "c++23";
         case CPP26:
             return "c++26";
+        case CPPInvalid:
+            return "";
         }
         return "";
     }
@@ -135,7 +139,7 @@ struct Standards {
         if (std == "c++26") {
             return Standards::CPP26;
         }
-        return Standards::CPPLatest;
+        return Standards::CPPInvalid;
     }
 };
 

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -1369,8 +1369,8 @@ private:
     void stdunknown2() {
         REDIRECT;
         const char *const argv[] = {"cppcheck", "--std=cplusplus11", "file.cpp"};
-        TODO_ASSERT_EQUALS(static_cast<int>(CmdLineParser::Result::Fail), static_cast<int>(CmdLineParser::Result::Success), static_cast<int>(parser->parseFromArgs(3, argv)));
-        TODO_ASSERT_EQUALS("cppcheck: error: unknown --std value 'cplusplus11'\n", "", logger->str());
+        ASSERT_EQUALS(static_cast<int>(CmdLineParser::Result::Fail), static_cast<int>(parser->parseFromArgs(3, argv)));
+        ASSERT_EQUALS("cppcheck: error: unknown --std value 'cplusplus11'\n", logger->str());
     }
 
     void platformWin64() {


### PR DESCRIPTION
Command line parsing fails with an error on commands such as
```
$ cppcheck --std=c++19 somefile.cpp
```