### PR TITLE
fixed #13083 - correct addons and cfgs install locations

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -75,15 +75,15 @@ if (BUILD_CLI)
         COMPONENT applications)
 
     install(FILES ${addons}
-       DESTINATION ${FILESDIR}/addons
+       DESTINATION ${FILESDIR_DEF}/addons
        COMPONENT headers)
 
     install(FILES ${cfgs}
-       DESTINATION ${FILESDIR}/cfg
+       DESTINATION ${FILESDIR_DEF}/cfg
        COMPONENT headers)
 
     install(FILES ${platforms}
-       DESTINATION ${FILESDIR}/platforms
+       DESTINATION ${FILESDIR_DEF}/platforms
        COMPONENT headers)
 
 endif()


### PR DESCRIPTION
`FILESDIR_DEF` is an actual path which should be used for installation, while `FILESDIR` is an option with default value of `OFF` which leads to files installed to `${CMAKE_INSTALL_PREFIX}/OFF/{addons,cfgs,platforms}`