### PR TITLE
fixed #13066 - Makefile: need to use `override` when appending to variable specified on the command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifndef CPPFLAGS
 endif
 
 ifdef FILESDIR
-    CPPFLAGS+=-DFILESDIR=\"$(FILESDIR)\"
+    override CPPFLAGS+=-DFILESDIR=\"$(FILESDIR)\"
 endif
 
 RDYNAMIC=-rdynamic

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -599,7 +599,7 @@ int main(int argc, char **argv)
 
     // explicit files dir..
     fout << "ifdef FILESDIR\n"
-         << "    CPPFLAGS+=-DFILESDIR=\\\"$(FILESDIR)\\\"\n"
+         << "    override CPPFLAGS+=-DFILESDIR=\\\"$(FILESDIR)\\\"\n"
          << "endif\n\n";
 
     // enable backtrac


### PR DESCRIPTION
see https://www.gnu.org/software/make/manual/make.html#Override-Directive