### PR TITLE
importproject: fix reading of msvc std option

### DIFF
--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -311,7 +311,11 @@ void ImportProject::fsParseCommand(FileSettings& fs, const std::string& command)
                 fs.includePaths.push_back(std::move(i));
         } else if (F=='s' && startsWith(fval,"td")) {
             ++pos;
-            fs.standard = readUntil(command, &pos, " ");
+            if (startsWith(fval, "td:")) {
+                fs.standard = fval.substr(3);
+            } else {
+                fs.standard = readUntil(command, &pos, " ");
+            }
         } else if (F == 'i' && fval == "system") {
             ++pos;
             std::string isystem = readUntil(command, &pos, " ");

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -200,6 +200,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(2, importer.fileSettings.size());
+        ASSERT_EQUALS("c++17", importer.fileSettings.cbegin()->standard);
         ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.cbegin()->includePaths.front());
     }
 
@@ -220,6 +221,7 @@ private:
         TestImporter importer;
         ASSERT_EQUALS(true, importer.importCompileCommands(istr));
         ASSERT_EQUALS(2, importer.fileSettings.size());
+        ASSERT_EQUALS("c++17", importer.fileSettings.cbegin()->standard);
         ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/src/", importer.fileSettings.cbegin()->includePaths.front());
         ASSERT_EQUALS("C:/Users/dan/git/test-cppcheck/mylib/second src/", importer.fileSettings.cbegin()->includePaths.back());
     }


### PR DESCRIPTION
Might need more tests. The fix is a bit hacky but I thought I'd make as small off a change as possible.