### PR TITLE
Fix cmake install path issue

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -75,15 +75,15 @@ if (BUILD_CLI)
         COMPONENT applications)
 
     install(FILES ${addons}
-       DESTINATION ${FILESDIR}/addons
+       DESTINATION ${FILESDIR_DEF}/addons
        COMPONENT headers)
 
     install(FILES ${cfgs}
-       DESTINATION ${FILESDIR}/cfg
+       DESTINATION ${FILESDIR_DEF}/cfg
        COMPONENT headers)
 
     install(FILES ${platforms}
-       DESTINATION ${FILESDIR}/platforms
+       DESTINATION ${FILESDIR_DEF}/platforms
        COMPONENT headers)
 
 endif()


### PR DESCRIPTION
Hi,

I compile using `cmake`:

`cmake -DHAVE_RULES=ON -DUSE_MATCHCOMPILER=On ..`

I see on the log:

```
-- FILESDIR =              OFF
-- FILESDIR_DEF =          /usr/local/share/Cppcheck
```

and when it install I got:

```
-- Install configuration: "Debug"
-- Installing: /usr/local/bin/cppcheck
-- Installing: /usr/local/OFF/addons/__init__.py
-- Installing: /usr/local/OFF/addons/cppcheck.py
...
-- Installing: /usr/local/OFF/cfg/avr.cfg
-- Installing: /usr/local/OFF/cfg/bento4.cfg
...
-- Installing: /usr/local/OFF/platforms/aix_ppc64.xml
-- Installing: /usr/local/OFF/platforms/arm32-wchar_t2.xml
-- Installing: /usr/local/OFF/platforms/arm32-wchar_t4.xml
```

and of course when running cppcheck I got:

```
Your Cppcheck installation is broken, please re-install. The Cppcheck binary was compiled with FILESDIR set to "/usr/local/share/Cppcheck" and will therefore search for std.cfg in /usr/local/share/Cppcheck/cfg.
```