### PR TITLE
std.cfg: Added support for std::format_error

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8991,6 +8991,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <check>std::underflow_error</check>
       <check>std::regex_error</check>
       <check>std::system_error</check>
+      <check>std::format_error</check>
       <check>std::bad_typeid</check>
       <check>std::bad_cast</check>
       <check>std::bad_optional_access</check>

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -57,6 +57,9 @@
 #ifdef __cpp_lib_span
 #include <span>
 #endif
+#ifdef __cpp_lib_format
+#include <format>
+#endif
 
 #if __cplusplus <= 201402L
 void unreachableCode_std_unexpected(int &x)
@@ -5178,6 +5181,14 @@ struct S_std_as_const { // #12974
     }
     std::list<int> l;
 };
+
+#if __cpp_lib_format
+void unreadVariable_std_format_error(char * c)
+{
+    // cppcheck-suppress unreadVariable
+    std::format_error x(c);
+}
+#endif
 
 void containerOutOfBounds_std_string(std::string &var) { // #11403
     std::string s0{"x"};


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/cpp/utility/format/format_error