### PR TITLE
fix #11542: FP memleak when using memcpy() with pointer

### DIFF
--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -363,6 +363,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
         while (Token::Match(ftok, "%name% :: %name%"))
             ftok = ftok->tokAt(2);
 
+        // bailout for variable passed to library function with out parameter
         if (const Library::Function *libFunc = mSettings->library.getFunction(ftok)) {
             using ArgumentChecks = Library::ArgumentChecks;
             using Direction = ArgumentChecks::Direction;
@@ -381,7 +382,7 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                     if (!argChecks.count(i + 1))
                         continue;
                     const ArgumentChecks argCheck = argChecks.at(i + 1);
-                    bool isInParam = std::any_of(argCheck.direction.cbegin(), argCheck.direction.cend(), [&](const Direction dir) {
+                    const bool isInParam = std::any_of(argCheck.direction.cbegin(), argCheck.direction.cend(), [&](const Direction dir) {
                         return dir == Direction::DIR_IN;
                     });
                     if (!isInParam)

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -386,14 +386,14 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
                     });
                     if (!isInParam)
                         continue;
-                    const Token *varTok = args[i];
+                    const Token *inTok = args[i];
                     int indirect = 0;
-                    while (varTok->isUnaryOp("&")) {
-                        varTok = varTok->astOperand1();
+                    while (inTok->isUnaryOp("&")) {
+                        inTok = inTok->astOperand1();
                         indirect++;
                     }
-                    if (varTok->isVariable() && indirect) {
-                        varInfo.erase(varTok->varId());
+                    if (inTok->isVariable() && indirect) {
+                        varInfo.erase(inTok->varId());
                     }
                 }
             }

--- a/lib/checkleakautovar.cpp
+++ b/lib/checkleakautovar.cpp
@@ -369,14 +369,11 @@ bool CheckLeakAutoVar::checkScope(const Token * const startToken,
             using Direction = ArgumentChecks::Direction;
             const std::vector<const Token *> args = getArguments(ftok);
             const std::map<int, ArgumentChecks> &argChecks = libFunc->argumentChecks;
-            bool hasOutParam = false;
-            for (const auto &pair : argChecks) {
-                hasOutParam |= std::any_of(pair.second.direction.cbegin(), pair.second.direction.cend(), [&](const Direction dir) {
+            bool hasOutParam = std::any_of(argChecks.cbegin(), argChecks.cend(), [](const std::pair<int, ArgumentChecks> &pair) {
+                return std::any_of(pair.second.direction.cbegin(), pair.second.direction.cend(), [](const Direction dir) {
                     return dir == Direction::DIR_OUT;
                 });
-                if (hasOutParam)
-                    break;
-            }
+            });
             if (hasOutParam) {
                 for (int i = 0; i < args.size(); i++) {
                     if (!argChecks.count(i + 1))

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -64,6 +64,9 @@ private:
         TEST_CASE(assign25);
         TEST_CASE(assign26);
 
+        TEST_CASE(memcpyWithPtr1); // #11542
+        TEST_CASE(memcpyWithPtr2);
+
         TEST_CASE(isAutoDealloc);
 
         TEST_CASE(realloc1);
@@ -630,6 +633,26 @@ private:
               "    int* p = (int*)malloc(10);\n"
               "    x = p != nullptr ? p : nullptr;\n"
               "}", true);
+        ASSERT_EQUALS("", errout_str());
+    }
+
+    void memcpyWithPtr1() { // #11542
+        check("#include <string.h>\n"
+              "void f(char** old, char* value) {\n"
+              "    char *str = strdup(value);\n"
+              "    memcpy(old, &str, sizeof(char*));\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
+    }
+
+    void memcpyWithPtr2() {
+        check("#include <string.h>\n"
+              "void f(char* value) {\n"
+              "    char *old = NULL;\n"
+              "    char *str = strdup(value);\n"
+              "    memcpy(&old, &str, sizeof(char*));\n"
+              "}\n");
+        // TODO: make this fail
         ASSERT_EQUALS("", errout_str());
     }
 

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -638,8 +638,7 @@ private:
 
     void memcpyWithPtr1() { // #11542
         const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
-        check("#include <string.h>\n"
-              "void f(char** old, char* value) {\n"
+        check("void f(char** old, char* value) {\n"
               "    char *str = strdup(value);\n"
               "    memcpy(old, &str, sizeof(char*));\n"
               "}\n", &s);
@@ -648,14 +647,12 @@ private:
 
     void memcpyWithPtr2() {
         const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
-        check("#include <string.h>\n"
-              "void f(char* value) {\n"
+        check("void f(char* value) {\n"
               "    char *old = NULL;\n"
               "    char *str = strdup(value);\n"
               "    memcpy(&old, &str, sizeof(char*));\n"
               "}\n", &s);
-        // TODO: make this fail
-        ASSERT_EQUALS("", errout_str());
+        ASSERT_EQUALS("[test.cpp:5]: (error) Memory leak: old\n", errout_str());
     }
 
     void isAutoDealloc() {

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -637,21 +637,23 @@ private:
     }
 
     void memcpyWithPtr1() { // #11542
+        const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
         check("#include <string.h>\n"
               "void f(char** old, char* value) {\n"
               "    char *str = strdup(value);\n"
               "    memcpy(old, &str, sizeof(char*));\n"
-              "}\n");
+              "}\n", &s);
         ASSERT_EQUALS("", errout_str());
     }
 
     void memcpyWithPtr2() {
+        const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
         check("#include <string.h>\n"
               "void f(char* value) {\n"
               "    char *old = NULL;\n"
               "    char *str = strdup(value);\n"
               "    memcpy(&old, &str, sizeof(char*));\n"
-              "}\n");
+              "}\n", &s);
         // TODO: make this fail
         ASSERT_EQUALS("", errout_str());
     }

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -637,7 +637,7 @@ private:
     }
 
     void memcpy1() { // #11542
-        const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
+        const Settings s = settingsBuilder().library("std.cfg").build();
         check("void f(char** old, char* value) {\n"
               "    char *str = strdup(value);\n"
               "    memcpy(old, &str, sizeof(char*));\n"
@@ -646,7 +646,7 @@ private:
     }
 
     void memcpy2() {
-        const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
+        const Settings s = settingsBuilder().library("std.cfg").build();
         check("void f(char* old, char* value, size_t len) {\n"
               "    char *str = strdup(value);\n"
               "    memcpy(old, str, len);\n"

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -64,8 +64,8 @@ private:
         TEST_CASE(assign25);
         TEST_CASE(assign26);
 
-        TEST_CASE(memcpyWithPtr1); // #11542
-        TEST_CASE(memcpyWithPtr2);
+        TEST_CASE(memcpy1); // #11542
+        TEST_CASE(memcpy2);
 
         TEST_CASE(isAutoDealloc);
 
@@ -636,7 +636,7 @@ private:
         ASSERT_EQUALS("", errout_str());
     }
 
-    void memcpyWithPtr1() { // #11542
+    void memcpy1() { // #11542
         const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
         check("void f(char** old, char* value) {\n"
               "    char *str = strdup(value);\n"
@@ -645,14 +645,13 @@ private:
         ASSERT_EQUALS("", errout_str());
     }
 
-    void memcpyWithPtr2() {
+    void memcpy2() {
         const Settings s = settingsBuilder().library("std.cfg").library("posix.cfg").build();
-        check("void f(char* value) {\n"
-              "    char *old = NULL;\n"
+        check("void f(char* old, char* value, size_t len) {\n"
               "    char *str = strdup(value);\n"
-              "    memcpy(&old, &str, sizeof(char*));\n"
+              "    memcpy(old, str, len);\n"
               "}\n", &s);
-        ASSERT_EQUALS("[test.cpp:5]: (error) Memory leak: old\n", errout_str());
+        ASSERT_EQUALS("[test.cpp:4]: (error) Memory leak: str\n", errout_str());
     }
 
     void isAutoDealloc() {


### PR DESCRIPTION
Work in progress.

Just wanted to check if I'm heading in the right direction and using the
internal API correctly.

Is there a way to check if a variable is a pointer to a pointer?