### PR TITLE
Fix #13094 internalError for function pointer typedef

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -752,9 +752,10 @@ namespace {
                 return;
 
             mUsed = true;
+            const bool isFunctionPointer = Token::Match(mNameToken, "%name% )");
 
             // Special handling for T(...) when T is a pointer
-            if (Token::Match(tok, "%name% [({]") && !Token::simpleMatch(tok->linkAt(1), ") (")) {
+            if (Token::Match(tok, "%name% [({]") && !isFunctionPointer) {
                 bool pointerType = false;
                 for (const Token* type = mRangeType.first; type != mRangeType.second; type = type->next()) {
                     if (type->str() == "*" || type->str() == "&") {
@@ -791,7 +792,6 @@ namespace {
             }
 
             // Special handling of function pointer cast
-            const bool isFunctionPointer = Token::Match(mNameToken, "%name% )");
             if (isFunctionPointer && isCast(tok->previous())) {
                 tok->insertToken("*");
                 Token* const tok_1 = insertTokens(tok, std::pair<Token*, Token*>(mRangeType.first, mNameToken->linkAt(1)));

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -4334,11 +4334,7 @@ private:
                            "if ( g != ( void * ) p ) { } "
                            "}",
                            tok(code,false));
-        ASSERT_EQUALS("[test.cpp:4]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
-                      "[test.cpp:5]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
-                      "[test.cpp:4]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
-                      "[test.cpp:5]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n",
-                      errout_str());
+        ignore_errout(); // we are not interested in the output
     }
 
     void simplifyTypedefStruct() {

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -233,6 +233,7 @@ private:
         TEST_CASE(simplifyTypedefFunction8);
         TEST_CASE(simplifyTypedefFunction9);
         TEST_CASE(simplifyTypedefFunction10); // #5191
+        TEST_CASE(simplifyTypedefFunction11);
 
         TEST_CASE(simplifyTypedefStruct); // #12081 - volatile struct
 
@@ -4313,6 +4314,31 @@ private:
                       "Format_E1 ( * * t1 ) ( ) ; "
                       "MySpace :: Format_E2 ( * * t2 ) ( ) ;",
                       tok(code,false));
+    }
+
+    void simplifyTypedefFunction11() {
+        const char code[] = "typedef void (*func_t) (int);\n"
+                            "void g(int);\n"
+                            "void f(void* p) {\n"
+                            "    if (g != func_t(p)) {}\n"
+                            "    if (g != (func_t)p) {}\n"
+                            "}\n";
+        TODO_ASSERT_EQUALS("void g ( int ) ; "
+                           "void f ( void * p ) { "
+                           "if ( g != ( void ( * ) ( int ) ) ( p ) ) { } "
+                           "if ( g != ( void ( * ) ( int ) ) p ) { } "
+                           "}",
+                           "void g ( int ) ; "
+                           "void f ( void * p ) { "
+                           "if ( g != void * ( p ) ) { } "
+                           "if ( g != ( void * ) p ) { } "
+                           "}",
+                           tok(code,false));
+        ASSERT_EQUALS("[test.cpp:4]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
+                      "[test.cpp:5]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
+                      "[test.cpp:4]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n"
+                      "[test.cpp:5]: (debug) valueflow.cpp:3929:(valueFlow) bailout: valueFlowAfterCondition: bailing in conditional block\n",
+                      errout_str());
     }
 
     void simplifyTypedefStruct() {


### PR DESCRIPTION
We have a block `// Special handling of function pointer cast` but the simplifications are incorrect.