### PR TITLE
fixed `-Wmissing-include-dirs` warning by running autogen before PCH generation in CI

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -61,13 +61,13 @@ jobs:
 
       - name: Prepare CMake dependencies
         run: |
+          # make sure the auto-generated GUI sources exist
+          make -C cmake.output autogen
           # make sure the precompiled headers exist
           make -C cmake.output/cli cmake_pch.hxx.pch
           make -C cmake.output/gui cmake_pch.hxx.pch
           make -C cmake.output/lib cmake_pch.hxx.pch
           make -C cmake.output/test cmake_pch.hxx.pch
-          # make sure the auto-generated GUI sources exist
-          make -C cmake.output autogen
 
       - name: Clang-Tidy
         run: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Prepare CMake
         run: |
-          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DUSE_QT6=On -DWITH_QCHART=On -DENABLE_CHECK_INTERNAL=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On -DCPPCHK_GLIBCXX_DEBUG=Off
+          cmake -S . -B cmake.output -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=On -DBUILD_GUI=On -DUSE_QT6=On -DWITH_QCHART=On -DENABLE_CHECK_INTERNAL=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On -DCPPCHK_GLIBCXX_DEBUG=Off WARNINGS_ARE_ERRORS=On
         env:
           CC: clang-19
           CXX: clang++-19

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -96,13 +96,13 @@ jobs:
       # /__w/cppcheck/Qt/6.7.0/gcc_64/libexec/rcc: error while loading shared libraries: libglib-2.0.so.0: cannot open shared object file: No such file or directory
       - name: Prepare CMake dependencies
         run: |
+          # make sure the auto-generated GUI sources exist
+          make -C cmake.output autogen
           # make sure the precompiled headers exist
           #make -C cmake.output/cli cmake_pch.hxx.pch
           #make -C cmake.output/gui cmake_pch.hxx.pch
           #make -C cmake.output/lib cmake_pch.hxx.pch
           #make -C cmake.output/test cmake_pch.hxx.pch
-          # make sure the auto-generated GUI sources exist
-          make -C cmake.output autogen
           # make sure the auto-generated GUI dependencies exist
           make -C cmake.output gui-build-deps
           make -C cmake.output triage-build-ui-deps
@@ -167,13 +167,13 @@ jobs:
 
       - name: Prepare CMake dependencies
         run: |
+          # make sure the auto-generated GUI sources exist
+          make -C cmake.output autogen
           # make sure the precompiled headers exist
           #make -C cmake.output/cli cmake_pch.hxx.pch
           #make -C cmake.output/gui cmake_pch.hxx.pch
           #make -C cmake.output/lib cmake_pch.hxx.pch
           #make -C cmake.output/test cmake_pch.hxx.pch
-          # make sure the auto-generated GUI sources exist
-          make -C cmake.output autogen
           # make sure the auto-generated GUI dependencies exist
           make -C cmake.output gui-build-deps
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -66,11 +66,12 @@ jobs:
 
       - name: Generate dependencies
         run: |
+          # make sure auto-generated GUI files exist
+          make -C cmake.output autogen
           # make sure the precompiled headers exist
           make -C cmake.output lib/CMakeFiles/cppcheck-core.dir/cmake_pch.hxx.cxx
           make -C cmake.output test/CMakeFiles/testrunner.dir/cmake_pch.hxx.cxx
-          # make sure auto-generated GUI files exist
-          make -C cmake.output autogen
+          # make sure the auto-generated GUI dependencies exist
           make -C cmake.output gui-build-deps
 
       # TODO: find a way to report unmatched suppressions without need to add information checks
@@ -92,10 +93,11 @@ jobs:
 
       - name: Generate dependencies (no test)
         run: |
-          # make sure the precompiled headers exist
-          make -C cmake.output.notest lib/CMakeFiles/cppcheck-core.dir/cmake_pch.hxx.cxx
           # make sure auto-generated GUI files exist
           make -C cmake.output.notest autogen
+          # make sure the precompiled headers exist
+          make -C cmake.output.notest lib/CMakeFiles/cppcheck-core.dir/cmake_pch.hxx.cxx
+          # make sure the auto-generated GUI dependencies exist
           make -C cmake.output.notest gui-build-deps
 
       # TODO: find a way to report unmatched suppressions without need to add information checks
@@ -133,10 +135,11 @@ jobs:
 
       - name: Generate dependencies (no test / no cli)
         run: |
-          # make sure the precompiled headers exist
-          make -C cmake.output.notest_nocli lib/CMakeFiles/cppcheck-core.dir/cmake_pch.hxx.cxx
           # make sure auto-generated GUI files exist
           make -C cmake.output.notest_nocli autogen
+          # make sure the precompiled headers exist
+          make -C cmake.output.notest_nocli lib/CMakeFiles/cppcheck-core.dir/cmake_pch.hxx.cxx
+          # make sure the auto-generated GUI dependencies exist
           make -C cmake.output.notest_nocli gui-build-deps
 
       # TODO: find a way to report unmatched suppressions without need to add information checks
@@ -160,10 +163,11 @@ jobs:
 
       - name: Generate dependencies (corpus)
         run: |
-          # make sure the precompiled headers exist
-          make -C cmake.output.corpus lib/CMakeFiles/lib_objs.dir/cmake_pch.hxx.cxx
           # make sure auto-generated GUI files exist
           make -C cmake.output.corpus autogen
+          # make sure the precompiled headers exist
+          make -C cmake.output.corpus lib/CMakeFiles/lib_objs.dir/cmake_pch.hxx.cxx
+          # make sure the auto-generated GUI dependencies exist
           make -C cmake.output.corpus gui-build-deps
 
       # TODO: find a way to report unmatched suppressions without need to add information checks


### PR DESCRIPTION
```
Building CXX object gui/CMakeFiles/cppcheck-gui.dir/cmake_pch.hxx.pch
clang++-19: warning: no such include directory: '/home/runner/work/cppcheck/cppcheck/cmake.output/gui/cppcheck-gui_autogen/include' [-Wmissing-include-dirs]
```