### PR TITLE
test/cfg/boost.cpp: added missing include for `BOOST_SCOPED_ENUM_DECL…

### DIFF
--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -18,6 +18,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/test/unit_test.hpp>
+#include <boost/core/scoped_enum.hpp>
 
 BOOST_FORCEINLINE void boost_forceinline_test()
 {}


### PR DESCRIPTION
…ARE_*` (#6808)

Fixes potential syntax checking in cfg tests on `macos-12` as some runners might now have Boost installed:
```
Boost found and working, checking syntax with g++ now.
/Users/runner/work/cppcheck/cppcheck/test/cfg/boost.cpp:90:49: error: expected ';' after expression
    BOOST_SCOPED_ENUM_DECLARE_BEGIN(future_errc) {
                                                ^
                                                ;
/Users/runner/work/cppcheck/cppcheck/test/cfg/boost.cpp:90:37: error: use of undeclared identifier 'future_errc'
    BOOST_SCOPED_ENUM_DECLARE_BEGIN(future_errc) {
                                    ^
/Users/runner/work/cppcheck/cppcheck/test/cfg/boost.cpp:92:9: error: use of undeclared identifier 'no_state'
        no_state
        ^
/Users/runner/work/cppcheck/cppcheck/test/cfg/boost.cpp:94:47: error: expected ';' after expression
    BOOST_SCOPED_ENUM_DECLARE_END(future_errc)
                                              ^
                                              ;
/Users/runner/work/cppcheck/cppcheck/test/cfg/boost.cpp:94:35: error: use of undeclared identifier 'future_errc'
    BOOST_SCOPED_ENUM_DECLARE_END(future_errc)
                                  ^
5 errors generated.
make: *** [checkcfg] Error 1
```

(cherry picked from commit 31991023b75ff4e5cc1c6dac39756fc06b8f7ab8)