### PR TITLE
fixed #13134 - no longer implicitly enable `missingInclude` with `information`

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -370,7 +370,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
     ImportProject project;
 
     bool executorAuto = true;
-    int8_t logMissingInclude{0};
 
     for (int i = 1; i < argc; i++) {
         if (argv[i][0] == '-') {
@@ -593,9 +592,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     mLogger.printError(errmsg);
                     return Result::Fail;
                 }
-                if (std::string(argv[i] + 10).find("missingInclude") != std::string::npos) {
-                    --logMissingInclude;
-                }
             }
 
             // dump cppcheck data
@@ -614,13 +610,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
                     mSettings.addEnabled("warning");
                     mSettings.addEnabled("performance");
                     mSettings.addEnabled("portability");
-                }
-                if (enable_arg.find("information") != std::string::npos && logMissingInclude == 0) {
-                    ++logMissingInclude;
-                    mSettings.addEnabled("missingInclude");
-                }
-                if (enable_arg.find("missingInclude") != std::string::npos) {
-                    --logMissingInclude;
                 }
             }
 
@@ -1405,9 +1394,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
             mPathNames.emplace_back(Path::fromNativeSeparators(Path::removeQuotationMarks(argv[i])));
         }
     }
-
-    if (logMissingInclude == 1)
-        mLogger.printMessage("'--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.");
 
     if (!loadCppcheckCfg())
         return Result::Fail;

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -17,4 +17,5 @@ Deprecations:
 -
 
 Other:
+- "missingInclude" is no longer implicitly enabled with "information" - you need to enable it explicitly now.
 -

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -114,7 +114,6 @@ if (BUILD_TESTS)
             endif()
             if ("cfg-${TEST_NAME}" IN_LIST SKIP_TESTS)
             else()
-                # TODO: remove missingInclude disabling when it no longer is implied by --enable=information
                 # TODO: add syntax check
                 add_test(NAME cfg-${TEST_NAME}
                         COMMAND $<TARGET_FILE:cppcheck>
@@ -126,7 +125,6 @@ if (BUILD_TESTS)
                         --inconclusive
                         --force
                         --error-exitcode=1
-                        --disable=missingInclude
                         --inline-suppr
                         --debug-warnings
                         --suppress=checkersReport

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for boost.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=boost --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/boost.cpp
+// $ cppcheck --check-library --library=boost --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/boost.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/bsd.c
+++ b/test/cfg/bsd.c
@@ -1,7 +1,7 @@
 // Test library configuration for bsd.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=bsd --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/bsd.c
+// $ cppcheck --check-library --library=bsd --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/bsd.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cairo.c
+++ b/test/cfg/cairo.c
@@ -2,7 +2,7 @@
 // Test library configuration for cairo.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cairo --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/cairo.c
+// $ cppcheck --check-library --library=cairo --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/cairo.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/cppunit.cpp
+++ b/test/cfg/cppunit.cpp
@@ -1,7 +1,7 @@
 // Test library configuration for cppunit.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=cppunit --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/cppunit.cpp
+// $ cppcheck --check-library --library=cppunit --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/cppunit.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/emscripten.cpp
+++ b/test/cfg/emscripten.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for emscripten.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=emscripten --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/emscripten.cpp
+// $ cppcheck --check-library --library=emscripten --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/emscripten.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -2,7 +2,7 @@
 // Test library configuration for gnu.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=gnu --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/gnu.c
+// $ cppcheck --check-library --library=gnu --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/gnu.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for googletest.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=googletest --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/googletest.cpp
+// $ cppcheck --check-library --library=googletest --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/googletest.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -2,7 +2,7 @@
 // Test library configuration for gtk.cfg
 //
 // Usage:
-// $ cppcheck --check-library --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr --library=gtk test/cfg/gtk.c
+// $ cppcheck --check-library --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr --library=gtk test/cfg/gtk.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/kde.cpp
+++ b/test/cfg/kde.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for kde.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=kde --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/kde.cpp
+// $ cppcheck --check-library --library=kde --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/kde.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libcurl.c
+++ b/test/cfg/libcurl.c
@@ -2,7 +2,7 @@
 // Test library configuration for libcurl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=libcurl --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/libcurl.c
+// $ cppcheck --check-library --library=libcurl --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/libcurl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/libsigc++.cpp
+++ b/test/cfg/libsigc++.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for libsigc++.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=libsigc++ --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/libsigc++.cpp
+// $ cppcheck --check-library --library=libsigc++ --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/libsigc++.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/lua.c
+++ b/test/cfg/lua.c
@@ -2,7 +2,7 @@
 // Test library configuration for lua.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=lua --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/lua.c
+// $ cppcheck --check-library --library=lua --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/lua.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/opencv2.cpp
+++ b/test/cfg/opencv2.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for opencv2.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=opencv2 --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/opencv2.cpp
+// $ cppcheck --check-library --library=opencv2 --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/opencv2.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openmp.c
+++ b/test/cfg/openmp.c
@@ -2,7 +2,7 @@
 // Test library configuration for openmp.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openmp --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/openmp.c
+// $ cppcheck --check-library --library=openmp --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/openmp.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/openssl.c
+++ b/test/cfg/openssl.c
@@ -2,7 +2,7 @@
 // Test library configuration for openssl.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=openssl --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/openssl.c
+// $ cppcheck --check-library --library=openssl --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/openssl.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/posix.c
+++ b/test/cfg/posix.c
@@ -2,7 +2,7 @@
 // Test library configuration for posix.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=posix --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/posix.c
+// $ cppcheck --check-library --library=posix --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/posix.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/python.c
+++ b/test/cfg/python.c
@@ -2,7 +2,7 @@
 // Test library configuration for python.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=python --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/python.c
+// $ cppcheck --check-library --library=python --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/python.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for qt.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=qt --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/qt.cpp
+// $ cppcheck --check-library --library=qt --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/qt.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/runtests.sh
+++ b/test/cfg/runtests.sh
@@ -35,7 +35,6 @@ CPPCHECK_OPT=(
     "--force"
     "--check-level=exhaustive"
     "--error-exitcode=-1"
-    "--disable=missingInclude"
     "--inline-suppr"
     "--template=\"{file}:{line}:{severity}:{id}:{message}\""
     "--debug-warnings"

--- a/test/cfg/selinux.c
+++ b/test/cfg/selinux.c
@@ -2,7 +2,7 @@
 // Test library configuration for selinux.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=selinux --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/selinux.c
+// $ cppcheck --check-library --library=selinux --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/selinux.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/sqlite3.c
+++ b/test/cfg/sqlite3.c
@@ -2,7 +2,7 @@
 // Test library configuration for sqlite3.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=sqlite3 --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/sqlite3.c
+// $ cppcheck --check-library --library=sqlite3 --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/sqlite3.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.c
+++ b/test/cfg/std.c
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=std --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/std.c
+// $ cppcheck --check-library --library=std --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/std.c
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for std.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=std --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/std.cpp
+// $ cppcheck --check-library --library=std --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/std.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/windows.cpp
+++ b/test/cfg/windows.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for windows.cfg
 //
 // Usage:
-// $ cppcheck --check-library --library=windows --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/windows.cpp
+// $ cppcheck --check-library --library=windows --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/windows.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cfg/wxwidgets.cpp
+++ b/test/cfg/wxwidgets.cpp
@@ -2,7 +2,7 @@
 // Test library configuration for wxwidgets.cfg
 //
 // Usage:
-// $ ./cppcheck --check-library --library=wxwidgets --enable=style,information --inconclusive --error-exitcode=1 --disable=missingInclude --inline-suppr test/cfg/wxwidgets.cpp
+// $ ./cppcheck --check-library --library=wxwidgets --enable=style,information --inconclusive --error-exitcode=1 --inline-suppr test/cfg/wxwidgets.cpp
 // =>
 // No warnings about bad library configuration, unmatched suppressions, etc. exitcode=0
 //

--- a/test/cli/clang-import_test.py
+++ b/test/cli/clang-import_test.py
@@ -147,7 +147,6 @@ def __test_cmd(tmp_path, file_name, extra_args, stdout_exp_1):
 
     args = [
         '--enable=information',
-        '--disable=missingInclude',  # TODO: remove
         '--verbose',
         '--clang',
         file_name

--- a/test/cli/inline-suppress_test.py
+++ b/test/cli/inline-suppress_test.py
@@ -60,7 +60,6 @@ def test_unmatched_suppression():
         '--template=simple',
         '--inline-suppr',
         '--enable=information',
-        '--disable=missingInclude',
         '--error-exitcode=1',
         '{}2.c'.format(__proj_inline_suppres_path)
     ]
@@ -79,7 +78,6 @@ def test_unmatched_suppression_path_with_extra_stuff():
         '--template=simple',
         '--inline-suppr',
         '--enable=information',
-        '--disable=missingInclude',
         '--error-exitcode=1',
         '{}2.c'.format(__proj_inline_suppres_path)
     ]
@@ -186,7 +184,6 @@ def test_unmatched_suppression_ifdef():
         '-q',
         '--template=simple',
         '--enable=information',
-        '--disable=missingInclude',
         '--inline-suppr',
         '-DNO_ZERO_DIV',
         'trac5704/trac5704a.c'
@@ -203,7 +200,6 @@ def test_unmatched_suppression_ifdef_0():
         '-q',
         '--template=simple',
         '--enable=information',
-        '--disable=missingInclude',
         '--inline-suppr',
         'trac5704/trac5704b.c'
     ]
@@ -272,7 +268,6 @@ def test_suppress_unmatched_inline_suppression():  # 11172
         '-q',
         '--template=simple',
         '--enable=information',
-        '--disable=missingInclude',
         '--suppress=unmatchedSuppression',
         '--inline-suppr',
         '{}2.c'.format(__proj_inline_suppres_path)

--- a/test/cli/whole-program_test.py
+++ b/test/cli/whole-program_test.py
@@ -33,7 +33,6 @@ def __test_addon_suppress_inline(extra_args):
         '--addon=misra',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--inline-suppr',
         '--error-exitcode=1',
         'whole-program/whole1.c',
@@ -83,7 +82,6 @@ def __test_addon_suppress_inline_project(tmpdir, extra_args):
         '--addon=misra',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--inline-suppr',
         '--error-exitcode=1',
         '--project={}'.format(compile_db)
@@ -126,7 +124,6 @@ def __test_suppress_inline(extra_args):
         '-q',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--inline-suppr',
         '--error-exitcode=1',
         'whole-program/odr1.cpp',
@@ -177,7 +174,6 @@ def __test_suppress_inline_project(tmpdir, extra_args):
         '-q',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--inline-suppr',
         '--error-exitcode=1',
         '--project={}'.format(compile_db)
@@ -220,7 +216,6 @@ def __test_checkclass(extra_args):
         '-q',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--error-exitcode=1',
         'whole-program/odr1.cpp',
         'whole-program/odr2.cpp'
@@ -265,7 +260,6 @@ def __test_checkclass_project(tmpdir, extra_args):
         '-q',
         '--template=simple',
         '--enable=information,style',
-        '--disable=missingInclude',  # TODO: remove
         '--error-exitcode=1',
         '--project={}'.format(compile_db)
     ]

--- a/test/testcmdlineparser.cpp
+++ b/test/testcmdlineparser.cpp
@@ -876,8 +876,7 @@ private:
         ASSERT_EQUALS_ENUM(CmdLineParser::Result::Success, parser->parseFromArgs(3, argv));
         ASSERT(settings->severity.isEnabled(Severity::error));
         ASSERT(settings->severity.isEnabled(Severity::information));
-        ASSERT(settings->checks.isEnabled(Checks::missingInclude));
-        ASSERT_EQUALS("cppcheck: '--enable=information' will no longer implicitly enable 'missingInclude' starting with 2.16. Please enable it explicitly if you require it.\n", logger->str());
+        ASSERT(!settings->checks.isEnabled(Checks::missingInclude));
     }
 
     void enabledUnusedFunction() {

--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -444,7 +444,7 @@ def scan_package(cppcheck_path, source_path, libraries, capture_callstack=True, 
     # Reference for GNU C: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
     options = '{} --inconclusive --enable={} --inline-suppr --template=daca2'.format(libs, enable)
     if 'information' in enable:
-        # TODO: remove missingInclude disabling when it no longer is implied by --enable=information
+        # TODO: remove missingInclude disabling after 2.16 has been released
         options += ' --disable=missingInclude --suppress=unmatchedSuppression'
     if check_level:
         options += ' --check-level=' + check_level


### PR DESCRIPTION
this was deprecated in 2.11