### PR TITLE
Fix #13139 Assert failure in valueflow.cpp::setSymbolic()

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -1587,7 +1587,8 @@ namespace {
                 !((tok->astParent()->astParent() && tok->astParent()->isAssignmentOp() && tok->astParent()->astParent()->isAssignmentOp()) ||
                   isLambdaCaptureList(op2) ||
                   (op2->str() == "(" && isLambdaCaptureList(op2->astOperand1())) ||
-                  Token::simpleMatch(op2, "{ }")))
+                  Token::simpleMatch(op2, "{ }") ||
+                  (Token::simpleMatch(tok->astParent(), "[") && op2->str() == "{")))
                 break;
 
             if (tok->astParent()->isExpandedMacro() || Token::Match(tok->astParent(), "++|--")) {

--- a/test/testvarid.cpp
+++ b/test/testvarid.cpp
@@ -4223,6 +4223,14 @@ private:
                                  "4: h (@UNIQUE g (@UNIQUE { } ) .@UNIQUE get (@UNIQUE ) ) ;\n"
                                  "5: }\n";
         ASSERT_EQUALS(expected4, tokenizeExpr(code4));
+
+        const char code5[] = "int* g(std::map<int, std::unique_ptr<int>>& m) {\n"
+                             "    return m[{0}].get();\n"
+                             "}\n";
+        const char expected5[] = "1: int * g ( std :: map < int , std :: unique_ptr < int > > & m ) {\n"
+                                 "2: return m@1 [@UNIQUE { 0 } ] .@UNIQUE get (@UNIQUE ) ;\n"
+                                 "3: }\n";
+        ASSERT_EQUALS(expected5, tokenizeExpr(code5));
     }
 
     void exprid9()


### PR DESCRIPTION
I wonder why all those special cases are necessary.