### PR TITLE
Multiline Pragma Directive False Positive

### DIFF
--- a/externals/simplecpp/simplecpp.cpp
+++ b/externals/simplecpp/simplecpp.cpp
@@ -894,7 +894,7 @@ void simplecpp::TokenList::readfile(Stream &stream, const std::string &filename,
 
             if (newlines > 0 ) {
                 const Token * const llTok = lastLineTok();
-                if (llTok && llTok->op == '#' && llTok->next && llTok->next->str() == "define" && llTok->next->next) {
+                if (llTok && llTok->op == '#' && llTok->next && ((llTok->next->str() == "define") || (llTok->next->str() == "pragma")) && llTok->next->next) {
                     multiline += newlines;
                     location.adjust(s);
                     continue;


### PR DESCRIPTION
When #pragma is a multiline directive, cppcheck doesn't mark the directive as a multiline resulting in a false positive of the end parenthesis ')'.

TestCpp.C

```
#pragma comment (longstring, \
 "HEADER\
 This is a very long string that is\
 a multi-line string.\
 How much more do I have to say?\
 Well, be prepared, because the \
 story is just beginning. This is a test \
 of CPPChecker and why it's failing. ")

int main()
{
  return 0;
}
```