### PR TITLE
std.cfg: Added support for 'std::monostate' for unusedScopedObject-check

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8996,6 +8996,7 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
       <check>std::format_error</check>
       <check>std::bad_typeid</check>
       <check>std::bad_cast</check>
+      <check>std::monostate</check>
       <check>std::bad_optional_access</check>
       <check>std::bad_expected_access</check>
       <check>std::bad_weak_ptr</check>

--- a/test/cfg/std.cpp
+++ b/test/cfg/std.cpp
@@ -53,6 +53,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <version>
 #ifdef __cpp_lib_span
@@ -2634,6 +2635,12 @@ void uninitvar_llround(void)
     long double ld;
     // cppcheck-suppress uninitvar
     (void)std::llroundl(ld);
+}
+
+void unusedScopedObject_std_monostate(void)
+{
+    // cppcheck-suppress unusedScopedObject
+    std::monostate{};
 }
 
 void uninitvar_srand(void)


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/cpp/utility/variant/monostate