### PR TITLE
Add missing Qt compiler warning macros

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5375,7 +5375,10 @@
   <define name="QT_TRANSLATE_NOOP3_UTF8(scope, x, comment)" value="{x, comment}"/>
   <define name="QT_WARNING_PUSH" value=""/>
   <define name="QT_WARNING_POP" value=""/>
-  <define name="QT_WARNING_DISABLE_GCC(x)" value=""/>
+  <define name="QT_WARNING_DISABLE_MSVC(number)" value=""/>
+  <define name="QT_WARNING_DISABLE_INTEL(number)" value=""/>
+  <define name="QT_WARNING_DISABLE_CLANG(text)" value=""/>
+  <define name="QT_WARNING_DISABLE_GCC(text)" value=""/>
   <define name="QT_WARNING_DISABLE_DEPRECATED" value=""/>
   <define name="QT_STRINGIFY(x)" value="#x"/>
   <define name="QCOMPARE(actual, expected)" value="(void)((actual)==(expected))"/>


### PR DESCRIPTION
The compilation warnings macros disable the warning during compilation
for a certain platform and can thus be disregarded from cppcheck.