### PR TITLE
Add QT_USE_NAMESPACE macro

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5368,6 +5368,7 @@
   <define name="Q_RETURN_ARG(type, data)" value="QReturnArgument&lt;type &gt;(#type, data)"/>
   <define name="Q_UNLIKELY(expr)" value="expr"/>
   <define name="Q_UNUSED(X)" value="(void)(X);"/>
+  <define name="QT_USE_NAMESPACE" value=""/>
   <define name="QT_BEGIN_NAMESPACE" value=""/>
   <define name="QT_END_NAMESPACE" value=""/>
   <define name="QT_BEGIN_MOC_NAMESPACE" value=""/>


### PR DESCRIPTION
The macro `QT_USE_NAMESPACE` should expand to nothing for most Qt builds, i.e. built with an empty `QT_NAMESPACE` variable.

However if Qt is built using a custom namespace then all forward declarations must be wrapped with `QT_BEGIN_NAMESPACE` and `QT_END_NAMESPACE`. Today CppCheck defines these macros as empty, thus `QT_USE_NAMESPACE` should be empty as well.

Reference:
https://wiki.qt.io/Qt_In_Namespace