### PR TITLE
Add QT_BEGIN_HEADER & QT_END_HEADER macros

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5372,6 +5372,8 @@
   <define name="QT_END_NAMESPACE" value=""/>
   <define name="QT_BEGIN_MOC_NAMESPACE" value=""/>
   <define name="QT_END_MOC_NAMESPACE" value=""/>
+  <define name="QT_BEGIN_HEADER" value=""/>
+  <define name="QT_END_HEADER" value=""/>
   <define name="QT_TR_NOOP(x)" value="x"/>
   <define name="QT_TR_NOOP_UTF8(x)" value="x"/>
   <define name="QT_TRANSLATE_NOOP(scope, x)" value="x"/>


### PR DESCRIPTION
The macros `QT_BEGIN_HEADER` and `QT_END_HEADER` was removed from Qt in 2012.

Empty since 2012: 
https://github.com/qt/qtbase/commit/ba3dc5f3b56d1fab6fe37fe7ae08096d7dc68bcb#diff-25c4cd4ef98b78f1b822c473dbbb29beb03092d0629b2c82982260ade1aa8521L143-L148

Removed completely in Qt6.0: 
https://github.com/qt/qtbase/commit/2584998c66f866770e0d4237828f119213aae663#diff-25c4cd4ef98b78f1b822c473dbbb29beb03092d0629b2c82982260ade1aa8521L213-L216