### PR TITLE
cmdlineparser.cpp: removed unnecessary `Path::fromNativeSeparators()` call

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -745,7 +745,6 @@ CmdLineParser::Result CmdLineParser::parseFromArgs(int argc, const char* const a
 
                 if (!path.empty()) {
                     path = Path::removeQuotationMarks(std::move(path));
-                    path = Path::fromNativeSeparators(std::move(path));
                     path = Path::simplifyPath(std::move(path));
 
                     // TODO: this only works when it exists


### PR DESCRIPTION
this is also done in `Path::simplifyPath()`