### PR TITLE
Makefile: removed obsolete `CFGDIR` code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,16 +438,6 @@ ifdef FILESDIR
 	  rm -rf ${DESTDIR}${FILESDIR}; \
 	fi
 endif
-ifdef CFGDIR 
-	@if test -d ${DESTDIR}${CFGDIR}; then \
-	  files="`cd cfg 2>/dev/null && ls`"; \
-	  if test -n "$$files"; then \
-	    echo '(' cd ${DESTDIR}${CFGDIR} '&&' rm -f $$files ')'; \
-	    ( cd ${DESTDIR}${CFGDIR} && rm -f $$files ); \
-	  fi; \
-	fi
-endif
-
 # Validation of library files:
 ConfigFiles := $(wildcard cfg/*.cfg)
 ConfigFilesCHECKED := $(patsubst %.cfg,%.checked,$(ConfigFiles))

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -822,15 +822,6 @@ int main(int argc, char **argv)
     fout << "\t  rm -rf ${DESTDIR}${FILESDIR}; \\\n";
     fout << "\tfi\n";
     fout << "endif\n";
-    fout << "ifdef CFGDIR \n";
-    fout << "\t@if test -d ${DESTDIR}${CFGDIR}; then \\\n";
-    fout << "\t  files=\"`cd cfg 2>/dev/null && ls`\"; \\\n";
-    fout << "\t  if test -n \"$$files\"; then \\\n";
-    fout << "\t    echo '(' cd ${DESTDIR}${CFGDIR} '&&' rm -f $$files ')'; \\\n";
-    fout << "\t    ( cd ${DESTDIR}${CFGDIR} && rm -f $$files ); \\\n";
-    fout << "\t  fi; \\\n";
-    fout << "\tfi\n";
-    fout << "endif\n\n";
     fout << "# Validation of library files:\n";
     fout << "ConfigFiles := $(wildcard cfg/*.cfg)\n";
     fout << "ConfigFilesCHECKED := $(patsubst %.cfg,%.checked,$(ConfigFiles))\n";


### PR DESCRIPTION
this is a left-over from its removal in a17f2a6f05feb09d5e163b38e0e313396201b76b