### PR TITLE
run all Qt-based tests (in CI)

### DIFF
--- a/gui/test/resultstree/CMakeLists.txt
+++ b/gui/test/resultstree/CMakeLists.txt
@@ -31,7 +31,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if (REGISTER_GUI_TESTS)
-    add_test(NAME test-resultstree COMMAND $<TARGET_FILE:test-resultstree> -platform offscreen)
+    # TODO: might crash - see #13223
+    #add_test(NAME test-resultstree COMMAND $<TARGET_FILE:test-resultstree> -platform offscreen)
 endif()
 
 add_dependencies(gui-tests test-resultstree)

--- a/gui/test/resultstree/CMakeLists.txt
+++ b/gui/test/resultstree/CMakeLists.txt
@@ -31,8 +31,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if (REGISTER_GUI_TESTS)
-    # TODO: does not work in the CI
-    # add_test(NAME test-resultstree COMMAND $<TARGET_FILE:test-resultstree>)
+    add_test(NAME test-resultstree COMMAND $<TARGET_FILE:test-resultstree> -platform offscreen)
 endif()
 
 add_dependencies(gui-tests test-resultstree)

--- a/gui/test/translationhandler/CMakeLists.txt
+++ b/gui/test/translationhandler/CMakeLists.txt
@@ -16,8 +16,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if (REGISTER_GUI_TESTS)
-    # TODO: requires X session - run with QT_QPA_PLATFORM=offscreen?
-    #add_test(NAME test-translationhandler COMMAND $<TARGET_FILE:test-translationhandler>)
+    add_test(NAME test-translationhandler COMMAND $<TARGET_FILE:test-translationhandler> -platform offscreen)
 endif()
 
 add_dependencies(gui-tests test-translationhandler)

--- a/gui/test/translationhandler/testtranslationhandler.cpp
+++ b/gui/test/translationhandler/testtranslationhandler.cpp
@@ -36,7 +36,7 @@ static QStringList getTranslationNames(const TranslationHandler& handler)
 void TestTranslationHandler::construct() const
 {
     TranslationHandler handler;
-    QCOMPARE(getTranslationNames(handler).size(), 13);  // 12 translations + english
+    QCOMPARE(getTranslationNames(handler).size(), 15);  // 14 translations + english
     QCOMPARE(handler.getCurrentLanguage(), QString("en"));
 }
 


### PR DESCRIPTION
tests which require a display are now run with the `offscreen`  platform plugin.