### PR TITLE
fixed #13238 - GUI: Fix start application with Qt6

### DIFF
--- a/gui/resultstree.cpp
+++ b/gui/resultstree.cpp
@@ -1028,14 +1028,22 @@ void ResultsTree::startApplication(const QStandardItem *target, int application)
         }
 #endif // Q_OS_WIN
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         const QString cmdLine = QString("%1 %2").arg(program).arg(params);
+#endif
 
         // this is reported as deprecated in Qt 5.15.2 but no longer in Qt 6
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         SUPPRESS_WARNING_CLANG_PUSH("-Wdeprecated")
         SUPPRESS_WARNING_GCC_PUSH("-Wdeprecated-declarations")
 #endif
+
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         const bool success = QProcess::startDetached(cmdLine);
+#else
+        const bool success = QProcess::startDetached(program, QProcess::splitCommand(params));
+#endif
+
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         SUPPRESS_WARNING_GCC_POP
             SUPPRESS_WARNING_CLANG_POP


### PR DESCRIPTION
It doesn't work with Qt6.
Qt5 `QProcess::startDetached(const QString &command)` was removed and replaced with:
`QProcess::startDetached(const QString &program, const QStringList &arguments = {},
			const QString &workingDirectory = QString(),
			qint64 *pid = nullptr)`

Due to Qt6 default arguments, build doesn't break but we end up feeding it the wrong arguments.