### PR TITLE
Add --macro-file option to parse it and add multiple #define

### DIFF
--- a/cli/cmdlineparser.h
+++ b/cli/cmdlineparser.h
@@ -154,6 +154,13 @@ private:
      */
     bool loadAddons(Settings& settings);
 
+    /**
+     * @brief Load macro file and set userDefines based on it
+     * @param path File path
+     * @return Returns true if successful
+     */
+    bool loadMacroFile(const std::string & path);
+
     bool loadCppcheckCfg();
 
     CmdLineLogger &mLogger;


### PR DESCRIPTION
I have several macro files in my project that are included via the -imacro option. To enhance flexibility, I added support for adding custom defines from a file to the build flow.

Example usage:
```sh
  --macro-file=defines.h
```

will produce this user defines
```
Defines: CONFIG_GPIO=1;CONFIG_ADC_INIT_PRIORITY=50;CONFIG_GPIO_INIT_PRIORITY=40;CONFIG_SRAM_SIZE=446;
```

defines.h contents:
```
#define CONFIG_GPIO 1
#define CONFIG_ADC_INIT_PRIORITY 50
#define CONFIG_GPIO_INIT_PRIORITY 40
#define CONFIG_SRAM_SIZE 446
```

