### PR TITLE
library.cpp: avoid useless cast

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -202,7 +202,7 @@ Library::Error Library::load(const char exename[], const char path[], bool debug
         if (Path::getFilenameExtension(fullfilename).empty()) {
             fullfilename += ".cfg";
             if (debug)
-                std::cout << "looking for library '" + std::string(fullfilename) + "'" << std::endl;
+                std::cout << "looking for library '" + fullfilename + "'" << std::endl;
             error = xml_LoadFile(doc, fullfilename.c_str());
             if (error != tinyxml2::XML_ERROR_FILE_NOT_FOUND)
                 absolute_path = Path::getAbsoluteFilePath(fullfilename);


### PR DESCRIPTION
As suggested by the compiler:

```
/home/runner/work/eni.os.dev/eni.os.dev/cppcheck/lib/library.cpp: In member function ‘Library::Error Library::load(const char*, const char*, bool)’:
/home/runner/work/eni.os.dev/eni.os.dev/cppcheck/lib/library.cpp:205:61: warning: useless cast to type ‘std::string’ {aka ‘class std::__cxx11::basic_string<char>’} [-Wuseless-cast]
  205 |                 std::cout << "looking for library '" + std::string(fullfilename) + "'" << std::endl;
      |                                                             ^~~~~~~~~~~~~~~~~~~~
```

It's already a _std::string_:

https://github.com/danmar/cppcheck/blob/main/lib/library.cpp#L201