### PR TITLE
fixed #13298: fixed missing executable icon on Windows (#6999)

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -32,6 +32,9 @@ CheckOptions:
             list(APPEND cppcheck-gui_SOURCES $<TARGET_OBJECTS:tinyxml2_objs>)
         endif()
     endif()
+    if (WIN32)
+        list(APPEND cppcheck-gui_SOURCES cppcheck-gui.rc)
+    endif()
 
     add_executable(cppcheck-gui ${cppcheck-gui-deps} ${cppcheck-gui_SOURCES})
     set_target_properties(cppcheck-gui PROPERTIES AUTOMOC ON)


### PR DESCRIPTION
(cherry picked from commit a8b5307918fd76ab1b85022e38b16185d43b353b)