### PR TITLE
Support msvc build for x86

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -7,7 +7,6 @@ if(MSVC)
     add_definitions(-DWIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     add_definitions(-DWIN32_LEAN_MEAN)
-    add_definitions(-D_WIN64)
 endif()
 
 # TODO: this should probably apply to the compiler and not the platform - I think it is only "broken" with MinGW


### PR DESCRIPTION
This option enforces msvc to switch to _WIN64 of the header file `vcruntime.h` when building for x86, but __int64 does not exist actually.
```cpp
#ifdef _WIN64
    typedef unsigned __int64 size_t;
    typedef __int64          ptrdiff_t;
    typedef __int64          intptr_t;
#else
    typedef unsigned int     size_t;
    typedef int              ptrdiff_t;
    typedef int              intptr_t;
#endif
```
And remove it to support x86 msvc build.

