### PR TITLE
Fix #13326: FP shiftNegative for template argument

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -3815,7 +3815,7 @@ static const Token *skipUnreachableElseBranch(const Token *tok)
     condTok = condTok->astOperand2();
 
     if ((condTok->hasKnownIntValue() && condTok->getKnownIntValue() != 0)
-        || (unknownLeafValuesAreTemplateArgs(condTok) && !condTok->getValue(0))) {
+        || (unknownLeafValuesAreTemplateArgs(condTok) && condTok->getValueNE(0))) {
         tok = tok->link();
     }
 

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -3798,7 +3798,7 @@ static const Token *skipUnreachableIfBranch(const Token *tok)
 
 static const Token *skipUnreachableElseBranch(const Token *tok)
 {
-    if (Token::simpleMatch(tok->previous(), ")"))
+    if (!Token::simpleMatch(tok->tokAt(-2), "} else {"))
         return tok;
 
     const Token *condTok = tok->linkAt(-2);
@@ -3809,7 +3809,7 @@ static const Token *skipUnreachableElseBranch(const Token *tok)
     if (!condTok)
         return tok;
 
-    if (!Token::simpleMatch(condTok->tokAt(-1), "if") && !Token::simpleMatch(condTok->tokAt(-2), "if constexpr"))
+    if (!Token::simpleMatch(condTok->tokAt(-1), "if (") && !Token::simpleMatch(condTok->tokAt(-2), "if constexpr ("))
         return tok;
 
     condTok = condTok->astOperand2();

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -450,6 +450,6 @@ bool isExhaustiveSwitch(const Token *startbrace);
 
 bool isUnreachableOperand(const Token *tok);
 
-void skipUnreachableBranch(const Token *&tok);
+const Token *skipUnreachableBranch(const Token *tok);
 
 #endif // astutilsH

--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -450,4 +450,6 @@ bool isExhaustiveSwitch(const Token *startbrace);
 
 bool isUnreachableOperand(const Token *tok);
 
+void skipUnreachableBranch(const Token *&tok);
+
 #endif // astutilsH

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3114,7 +3114,7 @@ void CheckOther::checkNegativeBitwiseShift()
     logChecker("CheckOther::checkNegativeBitwiseShift");
 
     for (const Token* tok = mTokenizer->tokens(); tok; tok = tok->next()) {
-        skipUnreachableBranch(tok);
+        tok = skipUnreachableBranch(tok);
 
         if (!tok->astOperand1() || !tok->astOperand2())
             continue;

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3114,6 +3114,8 @@ void CheckOther::checkNegativeBitwiseShift()
     logChecker("CheckOther::checkNegativeBitwiseShift");
 
     for (const Token* tok = mTokenizer->tokens(); tok; tok = tok->next()) {
+        skipUnreachableBranch(tok);
+
         if (!tok->astOperand1() || !tok->astOperand2())
             continue;
 

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1894,6 +1894,16 @@ const ValueFlow::Value * Token::getValueGE(const MathLib::bigint val, const Sett
     });
 }
 
+const ValueFlow::Value * Token::getValueNE(MathLib::bigint val) const
+{
+    if (!mImpl->mValues)
+        return nullptr;
+    const auto it = std::find_if(mImpl->mValues->cbegin(), mImpl->mValues->cend(), [=](const ValueFlow::Value& value) {
+        return value.isIntValue() && !value.isImpossible() && value.intvalue != val;
+    });
+    return it == mImpl->mValues->end() ? nullptr : &*it;
+}
+
 const ValueFlow::Value * Token::getInvalidValue(const Token *ftok, nonneg int argnr, const Settings &settings) const
 {
     if (!mImpl->mValues)

--- a/lib/token.h
+++ b/lib/token.h
@@ -1300,6 +1300,7 @@ public:
 
     const ValueFlow::Value * getValueLE(MathLib::bigint val, const Settings &settings) const;
     const ValueFlow::Value * getValueGE(MathLib::bigint val, const Settings &settings) const;
+    const ValueFlow::Value * getValueNE(MathLib::bigint val) const;
 
     const ValueFlow::Value * getInvalidValue(const Token *ftok, nonneg int argnr, const Settings &settings) const;
 

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -9369,6 +9369,21 @@ private:
               "    }\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());
+
+        // #13326
+        check("template<int b>\n"
+              "int f(int a)\n"
+              "{\n"
+              "    if constexpr (b >= 0) {\n"
+              "        return a << b;\n"
+              "    } else {\n"
+              "        return a << -b;\n"
+              "    }\n"
+              "}\n"
+              "int g() {\n"
+              "    return f<1>(2)\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void incompleteArrayFill() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -9384,6 +9384,20 @@ private:
               "    return f<1>(2)\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());
+
+        check("template<int b>\n"
+              "int f(int a)\n"
+              "{\n"
+              "    if constexpr (b >= 0) {\n"
+              "        return a << b;\n"
+              "    } else {\n"
+              "        return a << -b;\n"
+              "    }\n"
+              "}\n"
+              "int g() {\n"
+              "    return f<-1>(2)\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void incompleteArrayFill() {


### PR DESCRIPTION
Would love to get som feedback on this since it's making quite bold assumptions about expression that depend on template arguments.