### PR TITLE
googletest: add TYPED_TEST macros

### DIFF
--- a/cfg/googletest.cfg
+++ b/cfg/googletest.cfg
@@ -32,6 +32,8 @@
   <define name="TEST(A,B)" value="void __ ## A ## _ ## B ( )"/>
   <define name="TEST_F(A,B)" value="void __ ## A ## _ ## B ( )"/>
   <define name="TEST_P(A,B)" value="void __ ## A ## _ ## B ( )"/>
+  <define name="TYPED_TEST(A,B)" value="void __ ## A ## _ ## B ( )"/>
+  <define name="TYPED_TEST_P(A,B)" value="void __ ## A ## _ ## B ( )"/>
   <define name="GTEST_API_" value=""/>
   <define name="GTEST_FLAG(name)" value="FLAGS_gtest_##name"/>
   <define name="GTEST_DECLARE_bool_(name)" value="GTEST_API_ extern bool GTEST_FLAG(name)"/>

--- a/test/cfg/googletest.cpp
+++ b/test/cfg/googletest.cpp
@@ -30,6 +30,16 @@ namespace ExampleNamespace {
     {
         return (arg == TOLERANCE);
     }
+
+    // syntaxError when TYPED_TEST is not known
+    TYPED_TEST (ExampleTypedTest, cppcheck_test)
+    {
+    }
+
+    // syntaxError when TYPED_TEST_P is not known
+    TYPED_TEST_P (ExampleTypedTestP, cppcheck)
+    {
+    }
 }
 
 TEST(ASSERT, ASSERT)


### PR DESCRIPTION
Add `TYPED_TEST` and `TYPED_TEST_P` macro definitions (see http://google.github.io/googletest/reference/testing.html).