### PR TITLE
Ignore knownConditionTrueFalse in static assertions

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2574,6 +2574,12 @@ namespace {
     }
 }
 
+static bool
+isStaticAssert(const Token *tok)
+{
+    return Token::Match(tok, "_Static_assert|static_assert (");
+}
+
 void CheckOther::checkDuplicateExpression()
 {
     {
@@ -2700,7 +2706,7 @@ void CheckOther::checkDuplicateExpression()
                                     while (parent && parent->astParent()) {
                                         parent = parent->astParent();
                                     }
-                                    if (parent && parent->previous() && parent->strAt(-1) == "static_assert") {
+                                    if (parent && isStaticAssert(parent->previous())) {
                                         continue;
                                     }
                                 }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6919,6 +6919,12 @@ private:
 
         check("void f() {\n"
               "    enum { Four = 4 };\n"
+              "    _Static_assert(Four == 4, \"\");\n"
+              "}");
+        ASSERT_EQUALS("", errout_str());
+
+        check("void f() {\n"
+              "    enum { Four = 4 };\n"
               "    static_assert(4 == Four, \"\");\n"
               "}");
         ASSERT_EQUALS("", errout_str());


### PR DESCRIPTION
_Static_assert (deprecated in C23) should be treated like static_assert.