### PR TITLE
feat: enforcing MISRA compliant Boolean values

### DIFF
--- a/lib/checkbool.h
+++ b/lib/checkbool.h
@@ -63,6 +63,7 @@ private:
         checkBool.checkIncrementBoolean();
         checkBool.checkAssignBoolToPointer();
         checkBool.checkBitwiseOnBoolean();
+        checkBool.checkAssignedLiteralToBoolean();
     }
 
     /** @brief %Check for comparison of function returning bool*/
@@ -86,6 +87,9 @@ private:
     /** @brief %Check for using bool in bitwise expression */
     void checkBitwiseOnBoolean();
 
+    /** @brief %Check for using literal in bool expression */
+    void checkAssignedLiteralToBoolean();
+
     /** @brief %Check for comparing a bool expression with an integer other than 0 or 1 */
     void checkComparisonOfBoolExpressionWithInt();
 
@@ -105,6 +109,7 @@ private:
     void assignBoolToPointerError(const Token *tok);
     void assignBoolToFloatError(const Token *tok);
     void bitwiseOnBooleanError(const Token* tok, const std::string& expression, const std::string& op, bool isCompound = false);
+    void assignedLiteralToBooleanError(const Token* tok, const std::string& value);
     void comparisonOfBoolExpressionWithIntError(const Token *tok, bool not0or1);
     void pointerArithBoolError(const Token *tok);
     void returnValueBoolError(const Token *tok);

--- a/lib/checkers.cpp
+++ b/lib/checkers.cpp
@@ -30,6 +30,7 @@ namespace checkers {
         {"CheckBool::checkComparisonOfBoolWithBool","style,c++"},
         {"CheckBool::checkAssignBoolToPointer",""},
         {"CheckBool::checkComparisonOfBoolExpressionWithInt","warning"},
+        {"CheckBool::checkAssignedLiteralToBoolean","style"},
         {"CheckBool::pointerArithBool",""},
         {"CheckBool::checkAssignBoolToFloat","style,c++"},
         {"CheckBool::returnValueOfFunctionReturningBool","style"},


### PR DESCRIPTION
This PR adds a literal to boolean style check.

```cpp
bool x = 1;  // Warning: Boolean variable assigned a numeric literal '1'. Consider using 'true' instead.
bool y = 0;  // Warning: Boolean variable assigned a numeric literal '0'. Consider using 'false' instead.
```

ref: https://github.com/commaai/panda/pull/1876, https://github.com/commaai/panda/issues/2105