### PR TITLE
Fix detection of _Static_assert() in C

### DIFF
--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -6920,7 +6920,7 @@ private:
         check("void f() {\n"
               "    enum { Four = 4 };\n"
               "    _Static_assert(Four == 4, \"\");\n"
-              "}");
+              "}", false);
         ASSERT_EQUALS("", errout_str());
 
         check("void f() {\n"


### PR DESCRIPTION
Correct previous by honoring _Static_assert (introduced in C11) in C.