### PR TITLE
Detect C functions that can be declared with static linkage

### DIFF
--- a/lib/checkunusedfunctions.h
+++ b/lib/checkunusedfunctions.h
@@ -76,6 +76,8 @@ private:
         unsigned int fileIndex{};
         bool usedSameFile{};
         bool usedOtherFile{};
+        bool isC{};
+        bool isStatic{};
     };
 
     std::unordered_map<std::string, FunctionUsage> mFunctions;

--- a/samples/AssignmentAddressToInteger/bad.c
+++ b/samples/AssignmentAddressToInteger/bad.c
@@ -1,4 +1,4 @@
-int foo(int *p)
+static int foo(int *p)
 {
     int a = p;
     return a + 4;

--- a/samples/AssignmentAddressToInteger/good.c
+++ b/samples/AssignmentAddressToInteger/good.c
@@ -1,4 +1,4 @@
-int* foo(int *p)
+static int* foo(int *p)
 {
     return p + 4;
 }

--- a/samples/autoVariables/bad.c
+++ b/samples/autoVariables/bad.c
@@ -1,4 +1,4 @@
-void foo(int **a)
+static void foo(int **a)
 {
     int b = 1;
     *a = &b;

--- a/samples/autoVariables/good.c
+++ b/samples/autoVariables/good.c
@@ -1,4 +1,4 @@
-void foo(int **a)
+static void foo(int **a)
 {
     int b = 1;
     **a = b;

--- a/samples/incorrectLogicOperator/bad.c
+++ b/samples/incorrectLogicOperator/bad.c
@@ -1,5 +1,5 @@
 
-void foo(int x) {
+static void foo(int x) {
     if (x >= 0 || x <= 10) {}
 }
 

--- a/samples/incorrectLogicOperator/good.c
+++ b/samples/incorrectLogicOperator/good.c
@@ -1,5 +1,5 @@
 
-void foo(int x) {
+static void foo(int x) {
     if (x >= 0 && x <= 10) {}
 }
 

--- a/test/testunusedfunctions.cpp
+++ b/test/testunusedfunctions.cpp
@@ -88,6 +88,7 @@ private:
         TEST_CASE(attributeCleanup);
         TEST_CASE(attributeUnused);
         TEST_CASE(attributeMaybeUnused);
+        TEST_CASE(staticFunction);
     }
 
 #define check(...) check_(__FILE__, __LINE__, __VA_ARGS__)
@@ -819,6 +820,21 @@ private:
 
         check("[[maybe_unused]] void f() {}\n");
         ASSERT_EQUALS("", errout_str());
+    }
+
+    void staticFunction()
+    {
+        check("void f(void) {}\n"
+              "int main() {\n"
+              "    f();\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
+
+        check("void f(void) {}\n"
+              "int main() {\n"
+              "    f();\n"
+              "}\n", Platform::Type::Native, nullptr, false);
+        ASSERT_EQUALS("[test.c:1]: (style) The function 'f' should have static linkage since it is not used outside of its translation unit.\n", errout_str());
     }
 };
 


### PR DESCRIPTION
Currently limited to C as I assume the anonymous namespace should be favored for C++.