### PR TITLE
explicitly convert `MathLib::big{u}int` to/from other types / small cleanup

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -4047,7 +4047,7 @@ void CheckOther::knownPointerToBoolError(const Token* tok, const ValueFlow::Valu
         reportError(tok, Severity::style, "knownPointerToBool", "Pointer expression 'p' converted to bool is always true.");
         return;
     }
-    std::string cond = bool_to_string(value->intvalue);
+    std::string cond = bool_to_string(!!value->intvalue);
     const std::string& expr = tok->expressionString();
     std::string errmsg = "Pointer expression '" + expr + "' converted to bool is always " + cond + ".";
     const ErrorPath errorPath = getErrorPath(tok, value, errmsg);

--- a/lib/fwdanalysis.cpp
+++ b/lib/fwdanalysis.cpp
@@ -224,7 +224,7 @@ FwdAnalysis::Result FwdAnalysis::checkRecursive(const Token *expr, const Token *
             const Token *conditionStart = tok->next();
             const Token *condTok = conditionStart->astOperand2();
             if (condTok->hasKnownIntValue()) {
-                const bool cond = condTok->values().front().intvalue;
+                const bool cond = !!condTok->values().front().intvalue;
                 if (cond) {
                     FwdAnalysis::Result result = checkRecursive(expr, bodyStart, bodyStart->link(), exprVarIds, local, true, depth);
                     if (result.type != Result::Type::NONE)

--- a/lib/infer.cpp
+++ b/lib/infer.cpp
@@ -349,7 +349,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
         std::vector<const ValueFlow::Value*> refs;
         std::vector<bool> r = Interval::compare(op, lhs, rhs, &refs);
         if (!r.empty()) {
-            ValueFlow::Value value(r.front());
+            ValueFlow::Value value(static_cast<int>(r.front()));
             addToErrorPath(value, refs);
             setValueKind(value, refs);
             result.push_back(std::move(value));

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -1055,7 +1055,7 @@ bool Library::isIntArgValid(const Token *ftok, int argnr, const MathLib::bigint 
     if (!ac || ac->valid.empty())
         return true;
     if (ac->valid.find('.') != std::string::npos)
-        return isFloatArgValid(ftok, argnr, argvalue);
+        return isFloatArgValid(ftok, argnr, static_cast<double>(argvalue));
     TokenList tokenList(nullptr);
     gettokenlistfromvalid(ac->valid, ftok->isCpp(), tokenList);
     for (const Token *tok = tokenList.front(); tok; tok = tok->next()) {

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -116,7 +116,7 @@ void MathLib::value::promote(const MathLib::value &v)
         }
     } else if (!isFloat()) {
         mIsUnsigned = false;
-        mDoubleValue = mIntValue;
+        mDoubleValue = static_cast<double>(mIntValue);
         mType = MathLib::value::Type::FLOAT;
     }
 }

--- a/lib/pathanalysis.cpp
+++ b/lib/pathanalysis.cpp
@@ -50,7 +50,7 @@ std::pair<bool, bool> PathAnalysis::checkCond(const Token * tok, bool& known)
 {
     if (tok->hasKnownIntValue()) {
         known = true;
-        return std::make_pair(tok->values().front().intvalue, !tok->values().front().intvalue);
+        return std::make_pair(!!tok->values().front().intvalue, !tok->values().front().intvalue);
     }
     auto it = std::find_if(tok->values().cbegin(), tok->values().cend(), [](const ValueFlow::Value& v) {
         return v.isIntValue();
@@ -62,7 +62,7 @@ std::pair<bool, bool> PathAnalysis::checkCond(const Token * tok, bool& known)
         return true;
     })) {
         known = false;
-        return std::make_pair(it->intvalue, !it->intvalue);
+        return std::make_pair(!!it->intvalue, !it->intvalue);
     }
     return std::make_pair(true, true);
 }

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -715,8 +715,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::sin(value);
+        v.floatValue = std::sin(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -726,8 +725,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::lgamma(value);
+        v.floatValue = std::lgamma(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -737,8 +735,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::cos(value);
+        v.floatValue = std::cos(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -748,8 +745,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::tan(value);
+        v.floatValue = std::tan(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -759,8 +755,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::asin(value);
+        v.floatValue = std::asin(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -770,8 +765,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::acos(value);
+        v.floatValue = std::acos(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -781,8 +775,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::atan(value);
+        v.floatValue = std::atan(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -791,10 +784,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::atan2(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::atan2(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -803,10 +795,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::remainder(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::remainder(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -815,10 +806,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::nextafter(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::nextafter(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -827,10 +817,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::nexttoward(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::nexttoward(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -839,10 +828,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::hypot(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::hypot(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -851,10 +839,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::fdim(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::fdim(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -863,10 +850,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::fmax(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::fmax(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -875,10 +861,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::fmin(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::fmin(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -887,10 +872,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::fmod(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::fmod(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -899,10 +883,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::pow(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::pow(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -911,10 +894,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::scalbln(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::scalbln(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -923,10 +905,9 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
             return v.isFloatValue() || v.isIntValue();
         }))
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
         ValueFlow::Value v;
         combineValueProperties(args[0], args[1], v);
-        v.floatValue = std::ldexp(value, args[1].isFloatValue() ? args[1].floatValue : args[1].intvalue);
+        v.floatValue = std::ldexp(asFloat(args[0]), asFloat(args[1]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -936,8 +917,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.intvalue = std::ilogb(value);
+        v.intvalue = std::ilogb(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::INT;
         return v;
     };
@@ -947,8 +927,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::erf(value);
+        v.floatValue = std::erf(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -958,8 +937,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::erfc(value);
+        v.floatValue = std::erfc(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -969,8 +947,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::floor(value);
+        v.floatValue = std::floor(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -980,8 +957,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::sqrt(value);
+        v.floatValue = std::sqrt(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -991,8 +967,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::cbrt(value);
+        v.floatValue = std::cbrt(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1002,8 +977,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::ceil(value);
+        v.floatValue = std::ceil(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1013,8 +987,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::exp(value);
+        v.floatValue = std::exp(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1024,8 +997,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::exp2(value);
+        v.floatValue = std::exp2(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1035,8 +1007,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::expm1(value);
+        v.floatValue = std::expm1(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1046,8 +1017,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::fabs(value);
+        v.floatValue = std::fabs(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1057,8 +1027,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::log(value);
+        v.floatValue = std::log(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1068,8 +1037,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::log10(value);
+        v.floatValue = std::log10(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1079,8 +1047,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::log1p(value);
+        v.floatValue = std::log1p(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1090,8 +1057,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::log2(value);
+        v.floatValue = std::log2(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1101,8 +1067,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::logb(value);
+        v.floatValue = std::logb(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1112,8 +1077,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::nearbyint(value);
+        v.floatValue = std::nearbyint(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1123,8 +1087,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::sinh(value);
+        v.floatValue = std::sinh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1134,8 +1097,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::cosh(value);
+        v.floatValue = std::cosh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1145,8 +1107,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::tanh(value);
+        v.floatValue = std::tanh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1156,8 +1117,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::asinh(value);
+        v.floatValue = std::asinh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1167,8 +1127,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::acosh(value);
+        v.floatValue = std::acosh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1178,8 +1137,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::atanh(value);
+        v.floatValue = std::atanh(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1189,8 +1147,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::round(value);
+        v.floatValue = std::round(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1200,8 +1157,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::tgamma(value);
+        v.floatValue = std::tgamma(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };
@@ -1211,8 +1167,7 @@ static std::unordered_map<std::string, BuiltinLibraryFunction> createBuiltinLibr
         ValueFlow::Value v = args[0];
         if (!v.isFloatValue() && !v.isIntValue())
             return ValueFlow::Value::unknown();
-        const double value = args[0].isFloatValue() ? args[0].floatValue : args[0].intvalue;
-        v.floatValue = std::trunc(value);
+        v.floatValue = std::trunc(asFloat(args[0]));
         v.valueType = ValueFlow::Value::ValueType::FLOAT;
         return v;
     };

--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -575,7 +575,7 @@ static bool isNumericValue(const ValueFlow::Value& value) {
 
 static double asFloat(const ValueFlow::Value& value)
 {
-    return value.isFloatValue() ? value.floatValue : value.intvalue;
+    return value.isFloatValue() ? value.floatValue : static_cast<double>(value.intvalue);
 }
 
 static std::string removeAssign(const std::string& assign) {
@@ -1467,7 +1467,7 @@ namespace {
                     return unknown();
                 const MathLib::bigint index = rhs.intvalue;
                 if (index >= 0 && index < strValue.size())
-                    return ValueFlow::Value{strValue[index]};
+                    return ValueFlow::Value{strValue[static_cast<std::size_t>(index)]};
                 if (index == strValue.size())
                     return ValueFlow::Value{};
             } else if (Token::Match(expr, "%cop%") && expr->astOperand1() && expr->astOperand2()) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -9899,7 +9899,7 @@ void Tokenizer::simplifyBitfields()
             !Token::simpleMatch(tok->tokAt(2), "default :")) {
             Token *tok1 = (tok->strAt(1) == "const") ? tok->tokAt(3) : tok->tokAt(2);
             if (Token::Match(tok1, "%name% : %num% [;=]"))
-                tok1->setBits(MathLib::toBigNumber(tok1->strAt(2)));
+                tok1->setBits(static_cast<unsigned char>(MathLib::toBigNumber(tok1->strAt(2))));
             if (tok1 && tok1->tokAt(2) &&
                 (Token::Match(tok1->tokAt(2), "%bool%|%num%") ||
                  !Token::Match(tok1->tokAt(2), "public|protected|private| %type% ::|<|,|{|;"))) {

--- a/lib/vf_analyzers.cpp
+++ b/lib/vf_analyzers.cpp
@@ -470,7 +470,7 @@ private:
             return T{};
         }
         if (assign == "=")
-            return y;
+            return static_cast<T>(y);
         return calculate<T, T>(removeAssign(assign), x, y, error);
     }
 

--- a/lib/vf_common.cpp
+++ b/lib/vf_common.cpp
@@ -335,7 +335,7 @@ namespace ValueFlow
         if (value.isFloatValue()) {
             value.valueType = Value::ValueType::INT;
             if (value.floatValue >= std::numeric_limits<int>::min() && value.floatValue <= std::numeric_limits<int>::max()) {
-                value.intvalue = value.floatValue;
+                value.intvalue = static_cast<MathLib::bigint>(value.floatValue);
             } else { // don't perform UB
                 value.intvalue = 0;
             }

--- a/lib/vf_settokenvalue.cpp
+++ b/lib/vf_settokenvalue.cpp
@@ -143,7 +143,7 @@ namespace ValueFlow
             Value floatValue = value;
             floatValue.valueType = Value::ValueType::FLOAT;
             if (value.isIntValue())
-                floatValue.floatValue = value.intvalue;
+                floatValue.floatValue = static_cast<double>(value.intvalue);
             setTokenValue(parent, std::move(floatValue), settings);
         } else if (value.isIntValue()) {
             const long long charMax = settings.platform.signedCharMax();
@@ -494,8 +494,8 @@ namespace ValueFlow
                             continue;
                         result.valueType = Value::ValueType::FLOAT;
                     }
-                    const double floatValue1 = value1.isFloatValue() ? value1.floatValue : value1.intvalue;
-                    const double floatValue2 = value2.isFloatValue() ? value2.floatValue : value2.intvalue;
+                    const double floatValue1 = value1.isFloatValue() ? value1.floatValue : static_cast<double>(value1.intvalue);
+                    const double floatValue2 = value2.isFloatValue() ? value2.floatValue : static_cast<double>(value2.intvalue);
                     const auto intValue1 = [&]() -> MathLib::bigint {
                         return value1.isFloatValue() ? static_cast<MathLib::bigint>(value1.floatValue) : value1.intvalue;
                     };


### PR DESCRIPTION
fixes some compiler warnings with `USE_BOOST_INT128` as those implicit conversions are not allowed