### PR TITLE
fixed #13461 - test/cli/proj2_test.py: use temporary folders to run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,9 +91,9 @@ stage
 /.run
 
 # clang tooling temporary files
-.clangd/
-.cache/
-compile_commands.json
+/.clangd/
+/.cache/
+/compile_commands.json
 
 #vs code
 /.vscode

--- a/test/cli/proj2_test.py
+++ b/test/cli/proj2_test.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import shutil
 from testutils import create_gui_project_file, cppcheck
 
 __script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -17,10 +18,11 @@ __ERR_B = ('%s:1:7: error: Division by zero. [zerodiv]\n' +
            'x = 3 / 0;\n' +
            '      ^\n') % os.path.join('b', 'b.c')
 
-def __create_compile_commands():
-    j = [{'directory': os.path.join(__proj_dir, 'a'), 'command': 'gcc -c a.c', 'file': 'a.c'},
-         {'directory': __proj_dir, 'command': 'gcc -c b/b.c', 'file': 'b/b.c'}]
-    with open(os.path.join(__proj_dir, __COMPILE_COMMANDS_JSON), 'wt') as f:
+def __create_compile_commands(proj_dir):
+    proj_dir = str(proj_dir)
+    j = [{'directory': os.path.join(proj_dir, 'a'), 'command': 'gcc -c a.c', 'file': 'a.c'},
+         {'directory': proj_dir, 'command': 'gcc -c b/b.c', 'file': 'b/b.c'}]
+    with open(os.path.join(proj_dir, __COMPILE_COMMANDS_JSON), 'wt') as f:
         f.write(json.dumps(j))
 
 
@@ -34,63 +36,75 @@ def test_file_filter():
     assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file2) >= 0
 
-def test_local_path():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=compile_commands.json'], cwd=__proj_dir)
+def test_local_path(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=compile_commands.json'], cwd=proj_dir)
     file1 = os.path.join('a', 'a.c')
     file2 = os.path.join('b', 'b.c')
     assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
-def test_local_path_force():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=compile_commands.json', '--force'], cwd=__proj_dir)
+def test_local_path_force(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=compile_commands.json', '--force'], cwd=proj_dir)
     assert ret == 0, stdout
     assert stdout.find('AAA') >= 0
 
-def test_local_path_maxconfigs():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=compile_commands.json', '--max-configs=2'], cwd=__proj_dir)
+def test_local_path_maxconfigs(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=compile_commands.json', '--max-configs=2'], cwd=proj_dir)
     assert ret == 0, stdout
     assert stdout.find('AAA') >= 0
 
-def test_relative_path():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=proj2/' + __COMPILE_COMMANDS_JSON], cwd=__script_dir)
+def test_relative_path(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=proj2/' + __COMPILE_COMMANDS_JSON], cwd=tmp_path)
     file1 = os.path.join('proj2', 'a', 'a.c')
     file2 = os.path.join('proj2', 'b', 'b.c')
     assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
-def test_absolute_path():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=' + os.path.join(__proj_dir, __COMPILE_COMMANDS_JSON)], cwd=__script_dir)
-    file1 = os.path.join(__proj_dir, 'a', 'a.c')
-    file2 = os.path.join(__proj_dir, 'b', 'b.c')
+def test_absolute_path(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=' + os.path.join(proj_dir, __COMPILE_COMMANDS_JSON)], cwd=tmp_path)
+    file1 = os.path.join(proj_dir, 'a', 'a.c')
+    file2 = os.path.join(proj_dir, 'b', 'b.c')
     assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
-def test_gui_project_loads_compile_commands_1():
-    __create_compile_commands()
-    ret, stdout, _ = cppcheck(['--project=proj2/proj2.cppcheck'], cwd=__script_dir)
+def test_gui_project_loads_compile_commands_1(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
+    ret, stdout, _ = cppcheck(['--project=proj2/proj2.cppcheck'], cwd=tmp_path)
     file1 = os.path.join('proj2', 'a', 'a.c')
     file2 = os.path.join('proj2', 'b', 'b.c')
     assert ret == 0, stdout
     assert stdout.find('Checking %s ...' % file1) >= 0
     assert stdout.find('Checking %s ...' % file2) >= 0
 
-def test_gui_project_loads_compile_commands_2():
-    __create_compile_commands()
+def test_gui_project_loads_compile_commands_2(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    __create_compile_commands(proj_dir)
     exclude_path_1 = 'proj2/b'
-    # TODO: generate in temporary folder
-    create_gui_project_file(os.path.join(__proj_dir, 'test.cppcheck'),
+    create_gui_project_file(os.path.join(proj_dir, 'test.cppcheck'),
                             import_project='compile_commands.json',
                             exclude_paths=[exclude_path_1])
-    ret, stdout, _ = cppcheck(['--project=' + os.path.join('proj2','test.cppcheck')], cwd=__script_dir)
-    os.remove(os.path.join(__proj_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
+    ret, stdout, _ = cppcheck(['--project=' + os.path.join('proj2','test.cppcheck')], cwd=tmp_path)
     file1 = os.path.join('proj2', 'a', 'a.c')
     file2 = os.path.join('proj2', 'b', 'b.c') # Excluded by test.cppcheck
     assert ret == 0, stdout
@@ -98,10 +112,11 @@ def test_gui_project_loads_compile_commands_2():
     assert stdout.find('Checking %s ...' % file2) < 0
 
 
-def test_gui_project_loads_relative_vs_solution():
-    create_gui_project_file(os.path.join(__script_dir, 'test.cppcheck'), import_project='proj2/proj2.sln')  # TODO: generate in temporary folder
-    ret, stdout, _ = cppcheck(['--project=test.cppcheck'], cwd=__script_dir)
-    os.remove(os.path.join(__script_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
+def test_gui_project_loads_relative_vs_solution(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    create_gui_project_file(os.path.join(tmp_path, 'test.cppcheck'), import_project='proj2/proj2.sln')
+    ret, stdout, _ = cppcheck(['--project=test.cppcheck'], cwd=tmp_path)
     file1 = os.path.join('proj2', 'a', 'a.c')
     file2 = os.path.join('proj2', 'b', 'b.c')
     assert ret == 0, stdout
@@ -114,12 +129,13 @@ def test_gui_project_loads_relative_vs_solution():
     assert stdout.find('Checking %s Release|Win32...' % file2) >= 0
     assert stdout.find('Checking %s Release|x64...' % file2) >= 0
 
-def test_gui_project_loads_absolute_vs_solution():
-    create_gui_project_file(os.path.join(__script_dir, 'test.cppcheck'), import_project=os.path.join(__proj_dir, 'proj2.sln'))  # TODO: generate in temporary folder
-    ret, stdout, _ = cppcheck(['--project=test.cppcheck'], cwd=__script_dir)
-    os.remove(os.path.join(__script_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
-    file1 = os.path.join(__proj_dir, 'a', 'a.c')
-    file2 = os.path.join(__proj_dir, 'b', 'b.c')
+def test_gui_project_loads_absolute_vs_solution(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    create_gui_project_file(os.path.join(tmp_path, 'test.cppcheck'), import_project=os.path.join(proj_dir, 'proj2.sln'))
+    ret, stdout, _ = cppcheck(['--project=test.cppcheck'], cwd=tmp_path)
+    file1 = os.path.join(proj_dir, 'a', 'a.c')
+    file2 = os.path.join(proj_dir, 'b', 'b.c')
     assert ret == 0, stdout
     assert stdout.find('Checking %s Debug|Win32...' % file1) >= 0
     assert stdout.find('Checking %s Debug|x64...' % file1) >= 0
@@ -130,26 +146,28 @@ def test_gui_project_loads_absolute_vs_solution():
     assert stdout.find('Checking %s Release|Win32...' % file2) >= 0
     assert stdout.find('Checking %s Release|x64...' % file2) >= 0
 
-def test_gui_project_loads_relative_vs_solution_2():
-    create_gui_project_file(os.path.join(__script_dir, 'test.cppcheck'), root_path='proj2', import_project='proj2/proj2.sln')  # TODO: generate in temporary folder
-    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=__script_dir)
-    os.remove(os.path.join(__script_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
+def test_gui_project_loads_relative_vs_solution_2(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    create_gui_project_file(os.path.join(tmp_path, 'test.cppcheck'), root_path='proj2', import_project='proj2/proj2.sln')
+    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=tmp_path)
     assert ret == 0, stdout
     assert stderr == __ERR_A + __ERR_B
 
-def test_gui_project_loads_relative_vs_solution_with_exclude():
-    create_gui_project_file(os.path.join(__script_dir, 'test.cppcheck'), root_path='proj2', import_project='proj2/proj2.sln', exclude_paths=['b'])  # TODO: generate in temporary folder
-    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=__script_dir)
-    os.remove(os.path.join(__script_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
+def test_gui_project_loads_relative_vs_solution_with_exclude(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    create_gui_project_file(os.path.join(tmp_path, 'test.cppcheck'), root_path='proj2', import_project='proj2/proj2.sln', exclude_paths=['b'])
+    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=tmp_path)
     assert ret == 0, stdout
     assert stderr == __ERR_A
 
-def test_gui_project_loads_absolute_vs_solution_2():
-    # TODO: generate in temporary folder
-    create_gui_project_file(os.path.join(__script_dir, 'test.cppcheck'),
-                            root_path=__proj_dir,
-                            import_project=os.path.join(__proj_dir, 'proj2.sln'))
-    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=__script_dir)
-    os.remove(os.path.join(__script_dir, 'test.cppcheck'))  # TODO: do not remove explicitly
+def test_gui_project_loads_absolute_vs_solution_2(tmp_path):
+    proj_dir = tmp_path / 'proj2'
+    shutil.copytree(__proj_dir, proj_dir)
+    create_gui_project_file(os.path.join(tmp_path, 'test.cppcheck'),
+                            root_path=str(proj_dir),
+                            import_project=os.path.join(proj_dir, 'proj2.sln'))
+    ret, stdout, stderr = cppcheck(['--project=test.cppcheck'], cwd=tmp_path)
     assert ret == 0, stdout
     assert stderr == __ERR_A + __ERR_B


### PR DESCRIPTION
fixes potential issues when tests are run in parallel