### PR TITLE
gnu.cfg: Added support for __builtin_bit_cast

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -64,7 +64,7 @@
       <not-bool/>
     </arg>
   </function>
-  <define name="__builtin_bit_cast(type,value)" value="std::bit_cast<type>(value)"/>
+  <define name="__builtin_bit_cast(type,value)" value="std::bit_cast&lt;type&gt;(value)"/>
   <define name="__bswap_constant_64(x)" value="bswap_64(x)"/>
   <define name="__builtin_bswap64(x)" value="bswap_64(x)"/>
   <define name="__bswap_64(x)" value="bswap_64(x)"/>

--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -64,6 +64,7 @@
       <not-bool/>
     </arg>
   </function>
+  <define name="__builtin_bit_cast(type,value)" value="std::bit_cast<type>(value)"/>
   <define name="__bswap_constant_64(x)" value="bswap_64(x)"/>
   <define name="__builtin_bswap64(x)" value="bswap_64(x)"/>
   <define name="__bswap_64(x)" value="bswap_64(x)"/>


### PR DESCRIPTION
Reference: https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html