### PR TITLE
std.cfg: Added support for std::filesystem::create_* functions

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -6621,6 +6621,22 @@ The obsolete function 'gets' is called. With 'gets' you'll get a buffer overrun 
     <arg nr="1" direction="in"/>
     <arg nr="2" direction="out" default=""/>
   </function>
+  <!-- https://en.cppreference.com/w/cpp/filesystem/create_symlink -->
+  <!-- (1) (since C++17) void create_symlink(const std::filesystem::path& target, const std::filesystem::path& link ); -->
+  <!-- (2) (since C++17) void create_symlink(const std::filesystem::path& target, const std::filesystem::path& link, std::error_code& ec ) noexcept; -->
+  <!-- (1) (since C++17) void create_directory_symlink(const std::filesystem::path& target, const std::filesystem::path& link ); -->
+  <!-- (2) (since C++17) void create_directory_symlink(const std::filesystem::path& target, const std::filesystem::path& link, std::error_code& ec ) noexcept; -->
+  <!-- https://en.cppreference.com/w/cpp/filesystem/create_hard_link -->
+  <!-- (1) (since C++17) void create_hard_link(const std::filesystem::path& target, const std::filesystem::path& link ); -->
+  <!-- (2) (since C++17) void create_hard_link(const std::filesystem::path& target, const std::filesystem::path& link, std::error_code& ec ) noexcept; -->
+  <function name="std::filesystem::create_symlink,std::filesystem::create_directory_symlink,std::filesystem::create_hard_link">
+    <returnValue type="void"/>
+    <noreturn>false</noreturn>
+    <leak-ignore/>
+    <arg nr="1" direction="in"/>
+    <arg nr="2" direction="in"/>
+    <arg nr="3" direction="out" default=""/>
+  </function>
   <!-- std::string std::ostringstream::str() const; -->
   <!-- std::string std::stringstream::str() const; -->
   <!-- std::string std::basic_stringstream::str() const; -->


### PR DESCRIPTION
References: 
- https://en.cppreference.com/w/cpp/filesystem/create_hard_link
- https://en.cppreference.com/w/cpp/filesystem/create_symlink
