### PR TITLE
Fix #13537 FP passedByValue for template type

### DIFF
--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3731,7 +3731,8 @@ bool Variable::arrayDimensions(const Settings& settings, bool& isContainer)
             // TODO: only perform when ValueFlow is enabled
             // TODO: collect timing information for this call?
             ValueFlow::valueFlowConstantFoldAST(const_cast<Token *>(dimension_.tok), settings);
-            if (dimension_.tok && dimension_.tok->hasKnownIntValue()) {
+            if (dimension_.tok && (dimension_.tok->hasKnownIntValue() || 
+                                   (dimension_.tok->isTemplateArg() && !dimension_.tok->values().empty()))) {
                 dimension_.num = dimension_.tok->getKnownIntValue();
                 dimension_.known = true;
             }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -3731,7 +3731,7 @@ bool Variable::arrayDimensions(const Settings& settings, bool& isContainer)
             // TODO: only perform when ValueFlow is enabled
             // TODO: collect timing information for this call?
             ValueFlow::valueFlowConstantFoldAST(const_cast<Token *>(dimension_.tok), settings);
-            if (dimension_.tok && (dimension_.tok->hasKnownIntValue() || 
+            if (dimension_.tok && (dimension_.tok->hasKnownIntValue() ||
                                    (dimension_.tok->isTemplateArg() && !dimension_.tok->values().empty()))) {
                 dimension_.num = dimension_.tok->getKnownIntValue();
                 dimension_.known = true;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -10994,6 +10994,13 @@ private:
               "    C(A<T> x_, B<T> y_) : x(x_), y(y_) {}\n"
               "};\n");
         ASSERT_EQUALS("", errout_str()); // don't crash
+
+        check("template <typename T, int N>\n" // #13537
+              "    struct S {\n"
+              "    T a[N];\n"
+              "};\n"
+              "void f(S<int, 3> s) {}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void checkComparisonFunctionIsAlwaysTrueOrFalse() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -10999,7 +10999,7 @@ private:
               "    struct S {\n"
               "    T a[N];\n"
               "};\n"
-              "void f(S<int, 3> s) {}\n");
+              "void f(S<char, 3> s) {}\n");
         ASSERT_EQUALS("", errout_str());
     }
 


### PR DESCRIPTION
The same logic also exists in `setArrayDimensionsUsingValueFlow()` (not changed yet).