### PR TITLE
fixed  #13343 - Bump `cmake_minimum_required()` to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-if(MSVC)
-    cmake_minimum_required(VERSION 3.13)
-endif()
+cmake_minimum_required(VERSION 3.13)
 project(Cppcheck VERSION 2.16.99 LANGUAGES CXX)
 
 include(cmake/options.cmake)

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -53,16 +53,7 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(CMAKE_VERSION VERSION_EQUAL "3.12" OR CMAKE_VERSION VERSION_GREATER "3.12")
-    find_package(Python COMPONENTS Interpreter)
-else()
-    find_package(PythonInterp 3 QUIET)
-    if(PYTHONINTERP_FOUND)
-        set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
-        set(Python_VERSION ${PYTHON_VERSION_STRING})
-        set(Python_Interpreter_FOUND ${PYTHONINTERP_FOUND})
-    endif()
-endif()
+find_package(Python COMPONENTS Interpreter)
 
 if(NOT Python_Interpreter_FOUND)
     if(NOT USE_MATCHCOMPILER_OPT STREQUAL "Off")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -91,10 +91,6 @@ else()
     set(CMAKE_DISABLE_PRECOMPILE_HEADERS On CACHE BOOL "Disable precompiled headers")
 endif()
 
-if(BUILD_TESTS AND REGISTER_TESTS AND CMAKE_VERSION VERSION_LESS "3.9")
-    message(FATAL_ERROR "Registering tests with CTest requires at least CMake 3.9. Use REGISTER_TESTS=OFF to disable this.")
-endif()
-
 set(CMAKE_INCLUDE_DIRS_CONFIGCMAKE ${CMAKE_INSTALL_PREFIX}/include      CACHE PATH "Output directory for headers")
 set(CMAKE_LIB_DIRS_CONFIGCMAKE     ${CMAKE_INSTALL_PREFIX}/lib          CACHE PATH "Output directory for libraries")
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The minimum required Python version is 3.6.
 
 ### CMake
 
-The minimum required version is CMake 3.5.
+The minimum required version is CMake 3.13.
 
 Example, compiling Cppcheck with cmake:
 

--- a/test/signal/CMakeLists.txt
+++ b/test/signal/CMakeLists.txt
@@ -1,28 +1,24 @@
-if (CMAKE_VERSION VERSION_EQUAL "3.13" OR CMAKE_VERSION VERSION_GREATER "3.13")
-    # target_link_options requires CMake 3.13
+add_executable(test-signalhandler
+        test-signalhandler.cpp
+        ${PROJECT_SOURCE_DIR}/cli/signalhandler.cpp
+        ${PROJECT_SOURCE_DIR}/cli/stacktrace.cpp)
+target_include_directories(test-signalhandler PRIVATE ${PROJECT_SOURCE_DIR}/cli ${PROJECT_SOURCE_DIR}/lib)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # names for static functions are omitted from trace
+    target_compile_options_safe(test-signalhandler -Wno-missing-declarations)
+    target_compile_options_safe(test-signalhandler -Wno-missing-prototypes)
+    # required for backtrace() to produce function names
+    target_link_options(test-signalhandler PRIVATE -rdynamic)
+endif()
 
-    add_executable(test-signalhandler
-            test-signalhandler.cpp
-            ${PROJECT_SOURCE_DIR}/cli/signalhandler.cpp
-            ${PROJECT_SOURCE_DIR}/cli/stacktrace.cpp)
-    target_include_directories(test-signalhandler PRIVATE ${PROJECT_SOURCE_DIR}/cli ${PROJECT_SOURCE_DIR}/lib)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # names for static functions are omitted from trace
-        target_compile_options_safe(test-signalhandler -Wno-missing-declarations)
-        target_compile_options_safe(test-signalhandler -Wno-missing-prototypes)
-        # required for backtrace() to produce function names
-        target_link_options(test-signalhandler PRIVATE -rdynamic)
-    endif()
-
-    add_executable(test-stacktrace
-            test-stacktrace.cpp
-            ${PROJECT_SOURCE_DIR}/cli/stacktrace.cpp)
-    target_include_directories(test-stacktrace PRIVATE ${PROJECT_SOURCE_DIR}/cli ${PROJECT_SOURCE_DIR}/lib)
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # names for static functions are omitted from trace
-        target_compile_options_safe(test-stacktrace -Wno-missing-declarations)
-        target_compile_options_safe(test-stacktrace -Wno-missing-prototypes)
-        # required for backtrace() to produce function names
-        target_link_options(test-stacktrace PRIVATE -rdynamic)
-    endif()
+add_executable(test-stacktrace
+        test-stacktrace.cpp
+        ${PROJECT_SOURCE_DIR}/cli/stacktrace.cpp)
+target_include_directories(test-stacktrace PRIVATE ${PROJECT_SOURCE_DIR}/cli ${PROJECT_SOURCE_DIR}/lib)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # names for static functions are omitted from trace
+    target_compile_options_safe(test-stacktrace -Wno-missing-declarations)
+    target_compile_options_safe(test-stacktrace -Wno-missing-prototypes)
+    # required for backtrace() to produce function names
+    target_link_options(test-stacktrace PRIVATE -rdynamic)
 endif()


### PR DESCRIPTION
and do associated cleanups.
    
Fixes #13343
    
Recent CMake versions emit:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```