### PR TITLE
Add PROTOBUF_PRAGMA_INIT_SEG to protobuf.cfg

### DIFF
--- a/cfg/protobuf.cfg
+++ b/cfg/protobuf.cfg
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <def format="2">
+  <define name="PROTOBUF_PRAGMA_INIT_SEG" value=""/>
   <define name="PROTOBUF_VERSION" value="9999999"/>
   <define name="PROTOBUF_MIN_PROTOC_VERSION" value="0"/>
   <define name="PROTOBUF_NAMESPACE_OPEN" value=""/>


### PR DESCRIPTION
The value of this appears to be effecting the exectuable layout, so settings its value to an empty string should be fine.

It appears when generating protobuf sources sometimes.