### PR TITLE
fix #13452: iterator for library container not always detected

### DIFF
--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -978,10 +978,10 @@ private:
         {
             const SimpleTokenizer var(*this, "std::F::iterator I;");
             ASSERT(!library.detectContainer(var.tokens()));
-            TODO_ASSERT(library.detectIterator(var.tokens()));
+            ASSERT(library.detectIterator(var.tokens()));
             bool isIterator = false;
-            TODO_ASSERT_EQUALS((intptr_t)&F, 0, (intptr_t)library.detectContainerOrIterator(var.tokens(), &isIterator));
-            TODO_ASSERT(isIterator);
+            ASSERT_EQUALS((intptr_t)&F, (intptr_t)library.detectContainerOrIterator(var.tokens(), &isIterator));
+            ASSERT(isIterator);
         }
 
         {
@@ -990,8 +990,8 @@ private:
             ASSERT(!library.detectIterator(var.tokens()));
             ASSERT(!library.detectContainerOrIterator(var.tokens()));
             bool isIterator = false;
-            TODO_ASSERT_EQUALS((intptr_t)&F, 0, (intptr_t)library.detectContainerOrIterator(var.tokens(), &isIterator, true));
-            TODO_ASSERT(isIterator);
+            ASSERT_EQUALS((intptr_t)&F, (intptr_t)library.detectContainerOrIterator(var.tokens(), &isIterator, true));
+            ASSERT(isIterator);
         }
     }
 


### PR DESCRIPTION
In reference to https://github.com/danmar/cppcheck/pull/6595.