### PR TITLE
removed usage of `emptyString` from error messages

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -2038,7 +2038,7 @@ void CheckClass::virtualDestructor()
     }
 
     for (const Function *func : inconclusiveErrors)
-        virtualDestructorError(func->tokenDef, func->name(), emptyString, true);
+        virtualDestructorError(func->tokenDef, func->name(), "", true);
 }
 
 void CheckClass::virtualDestructorError(const Token *tok, const std::string &Base, const std::string &Derived, bool inconclusive)

--- a/lib/checkinternal.cpp
+++ b/lib/checkinternal.cpp
@@ -126,7 +126,7 @@ void CheckInternal::checkRedundantTokCheck()
 void CheckInternal::checkRedundantTokCheckError(const Token* tok)
 {
     reportError(tok, Severity::style, "redundantTokCheck",
-                "Unnecessary check of \"" + (tok? tok->expressionString(): emptyString) + "\", match-function already checks if it is null.");
+                "Unnecessary check of \"" + (tok? tok->expressionString(): "") + "\", match-function already checks if it is null.");
 }
 
 void CheckInternal::checkTokenSimpleMatchPatterns()

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -3512,7 +3512,7 @@ void CheckOther::unusedLabelError(const Token* tok, bool inSwitch, bool hasIfdef
     if (hasIfdef)
         id += "Configuration";
 
-    std::string msg = "$symbol:" + (tok ? tok->str() : emptyString) + "\nLabel '$symbol' is not used.";
+    std::string msg = "$symbol:" + (tok ? tok->str() : "") + "\nLabel '$symbol' is not used.";
     if (hasIfdef)
         msg += " There is #if in function body so the label might be used in code that is removed by the preprocessor.";
     if (inSwitch)
@@ -4325,7 +4325,7 @@ void CheckOther::checkOverlappingWrite()
                         constexpr bool follow = true;
                         if (!isSameExpression(macro, ptr1, ptr2, *mSettings, pure, follow, &errorPath))
                             continue;
-                        overlappingWriteFunction(tok);
+                        overlappingWriteFunction(tok, tok->str());
                     }
                     continue;
                 }
@@ -4351,7 +4351,7 @@ void CheckOther::checkOverlappingWrite()
                 constexpr bool follow = true;
                 if (!isSameExpression(macro, buf1, buf2, *mSettings, pure, follow, &errorPath))
                     continue;
-                overlappingWriteFunction(tok);
+                overlappingWriteFunction(tok, tok->str());
             }
         }
     }
@@ -4362,9 +4362,8 @@ void CheckOther::overlappingWriteUnion(const Token *tok)
     reportError(tok, Severity::error, "overlappingWriteUnion", "Overlapping read/write of union is undefined behavior");
 }
 
-void CheckOther::overlappingWriteFunction(const Token *tok)
+void CheckOther::overlappingWriteFunction(const Token *tok, const std::string& funcname)
 {
-    const std::string &funcname = tok ? tok->str() : emptyString;
     reportError(tok, Severity::error, "overlappingWriteFunction", "Overlapping read/write in " + funcname + "() is undefined behavior");
 }
 
@@ -4430,7 +4429,7 @@ void CheckOther::getErrorMessages(ErrorLogger *errorLogger, const Settings *sett
     c.raceAfterInterlockedDecrementError(nullptr);
     c.invalidFreeError(nullptr, "malloc", false);
     c.overlappingWriteUnion(nullptr);
-    c.overlappingWriteFunction(nullptr);
+    c.overlappingWriteFunction(nullptr, "funcname");
 
     //performance
     c.redundantCopyError(nullptr,  "varname");

--- a/lib/checkother.h
+++ b/lib/checkother.h
@@ -190,7 +190,7 @@ private:
 
     void checkOverlappingWrite();
     void overlappingWriteUnion(const Token *tok);
-    void overlappingWriteFunction(const Token *tok);
+    void overlappingWriteFunction(const Token *tok, const std::string& funcname);
 
     // Error messages..
     void checkComparisonFunctionIsAlwaysTrueOrFalseError(const Token* tok, const std::string &functionName, const std::string &varName, bool result);

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2514,7 +2514,7 @@ void CheckStl::checkDereferenceInvalidIterator2()
                     outOfBoundsError(emptyAdvance,
                                      lValue.tokvalue->expressionString(),
                                      cValue,
-                                     advanceIndex ? advanceIndex->expressionString() : emptyString,
+                                     advanceIndex ? advanceIndex->expressionString() : "",
                                      nullptr);
                 else
                     outOfBoundsError(tok, lValue.tokvalue->expressionString(), cValue, tok->expressionString(), &value);
@@ -3148,7 +3148,7 @@ void CheckStl::knownEmptyContainer()
                 const Token* contTok = splitTok->astOperand2();
                 if (!isKnownEmptyContainer(contTok))
                     continue;
-                knownEmptyContainerError(contTok, emptyString);
+                knownEmptyContainerError(contTok, "");
             } else {
                 const std::vector<const Token *> args = getArguments(tok);
                 if (args.empty())

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -650,7 +650,7 @@ bool CheckUninitVar::checkScopeForVariable(const Token *tok, const Variable& var
                     // Assert that the tokens are '} while ('
                     if (!Token::simpleMatch(tok, "} while (")) {
                         if (printDebug)
-                            reportError(tok,Severity::debug,emptyString,"assertion failed '} while ('");
+                            reportError(tok,Severity::debug,"","assertion failed '} while ('");
                         break;
                     }
 

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -196,7 +196,7 @@ public:
         return mSymbolNames;
     }
 
-    static ErrorMessage fromInternalError(const InternalError &internalError, const TokenList *tokenList, const std::string &filename, const std::string& msg = emptyString);
+    static ErrorMessage fromInternalError(const InternalError &internalError, const TokenList *tokenList, const std::string &filename, const std::string& msg = "");
 
 private:
     static std::string fixInvalidChars(const std::string& raw);

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -878,7 +878,7 @@ void Preprocessor::reportOutput(const simplecpp::OutputList &outputList, bool sh
         case simplecpp::Output::EXPLICIT_INCLUDE_NOT_FOUND:
         case simplecpp::Output::FILE_NOT_FOUND:
         case simplecpp::Output::DUI_ERROR:
-            error(emptyString, 0, out.msg);
+            error("", 0, out.msg);
             break;
         }
     }

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -374,7 +374,7 @@ private:
 public:
 
     /** Syntax error */
-    NORETURN void syntaxError(const Token *tok, const std::string &code = emptyString) const;
+    NORETURN void syntaxError(const Token *tok, const std::string &code = "") const;
 
     /** Syntax error. Unmatched character. */
     NORETURN void unmatchedToken(const Token *tok) const;


### PR DESCRIPTION
these can be considered cold paths in the optimal case i.e. no errors