### PR TITLE
Revert "Fix #9157 False negative: stlOutOfBounds, cast (#7233)"

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1991,8 +1991,6 @@ bool isConstFunctionCall(const Token* ftok, const Library& library)
         return true;
     if (!Token::Match(ftok, "%name% ("))
         return false;
-    if (ftok->isStandardType())
-        return true;
     if (const Function* f = ftok->function()) {
         if (f->isAttributePure() || f->isAttributeConst())
             return true;

--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -734,8 +734,6 @@ static void compileBinOp(Token *&tok, AST_state& state, void (*f)(Token *&tok, A
     if (!state.op.empty()) {
         binop->astOperand1(state.op.top());
         state.op.pop();
-        if (binop->str() == "(" && binop->astOperand1()->isStandardType())
-            binop->isCast(true);
     }
     state.op.push(binop);
 }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -699,19 +699,13 @@ private:
                     "    if (i <= static_cast<int>(v.size())) {\n"
                     "        if (v[i]) {}\n"
                     "    }\n"
-                    "    if (i <= int(v.size())) {\n"
-                    "        if (v[i]) {}\n"
-                    "    }\n"
                     "}\n");
         ASSERT_EQUALS("test.cpp:3:warning:Either the condition 'i<=(int)v.size()' is redundant or 'i' can have the value v.size(). Expression 'v[i]' causes access out of bounds.\n"
                       "test.cpp:2:note:condition 'i<=(int)v.size()'\n"
                       "test.cpp:3:note:Access out of bounds\n"
                       "test.cpp:6:warning:Either the condition 'i<=static_cast<int>(v.size())' is redundant or 'i' can have the value v.size(). Expression 'v[i]' causes access out of bounds.\n"
                       "test.cpp:5:note:condition 'i<=static_cast<int>(v.size())'\n"
-                      "test.cpp:6:note:Access out of bounds\n"
-                      "test.cpp:9:warning:Either the condition 'i<=int(v.size())' is redundant or 'i' can have the value v.size(). Expression 'v[i]' causes access out of bounds.\n"
-                      "test.cpp:8:note:condition 'i<=int(v.size())'\n"
-                      "test.cpp:9:note:Access out of bounds\n",
+                      "test.cpp:6:note:Access out of bounds\n",
                       errout_str());
 
         check("template<class Iterator>\n"


### PR DESCRIPTION
This reverts commit 841baa302eb821f2c18ca7e8929dd3779306c07a.