### PR TITLE
use number of processors provided by system instead of `auto` for `pytest-xdist` in CI

### DIFF
--- a/.github/workflows/CI-unixish.yml
+++ b/.github/workflows/CI-unixish.yml
@@ -269,7 +269,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-13]
         include:
-          - xdist_n: auto
+          - xdist_n: $(nproc)
           # FIXME: test_color_tty fails with xdist
           - os: macos-13
             xdist_n: '1'
@@ -453,7 +453,7 @@ jobs:
           ../../cppcheck --dump naming_test.cpp 
           python3 ../naming.py --var='[a-z].*' --function='[a-z].*' naming_test.cpp.dump
 
-      # TODO: run with "-n auto" when misra_test.py can be run in parallel
+      # TODO: run with "-n $(nproc)" when misra_test.py can be run in parallel
       - name: test addons (Python)
         if: matrix.os != 'ubuntu-22.04'
         run: |
@@ -461,7 +461,7 @@ jobs:
         env:
           PYTHONPATH: ./addons
 
-      # TODO: run with "-n auto" when misra_test.py can be run in parallel
+      # TODO: run with "-n $(nproc)" when misra_test.py can be run in parallel
       # we cannot specify -Werror since xml/etree/ElementTree.py in Python 3.10 contains an unclosed file
       - name: test addons (Python)
         if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -183,12 +183,12 @@ jobs:
       - name: Run test/cli
         if: matrix.config == 'release'
         run: |
-          python -m pytest -Werror --strict-markers -vv -n auto test/cli || exit /b !errorlevel!
+          python -m pytest -Werror --strict-markers -vv -n %NUMBER_OF_PROCESSORS% test/cli || exit /b !errorlevel!
 
       - name: Run test/cli (-j2)
         if: matrix.config == 'release'
         run: |
-          python -m pytest -Werror --strict-markers -vv -n auto test/cli || exit /b !errorlevel!
+          python -m pytest -Werror --strict-markers -vv -n %NUMBER_OF_PROCESSORS% test/cli || exit /b !errorlevel!
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
@@ -196,14 +196,14 @@ jobs:
       - name: Run test/cli (--clang)
         if: false # matrix.config == 'release'
         run: |
-          python -m pytest -Werror --strict-markers -vv -n auto test/cli || exit /b !errorlevel!
+          python -m pytest -Werror --strict-markers -vv -n %NUMBER_OF_PROCESSORS% test/cli || exit /b !errorlevel!
         env:
           TEST_CPPCHECK_INJECT_CLANG: clang
 
       - name: Run test/cli (--cppcheck-build-dir)
         if: matrix.config == 'release'
         run: |
-          python -m pytest -Werror --strict-markers -vv -n auto test/cli || exit /b !errorlevel!
+          python -m pytest -Werror --strict-markers -vv -n %NUMBER_OF_PROCESSORS% test/cli || exit /b !errorlevel!
         env:
           TEST_CPPCHECK_INJECT_BUILDDIR: injected
 
@@ -249,7 +249,7 @@ jobs:
           ..\..\cppcheck --dump naming_test.cpp || exit /b !errorlevel!
           python3 ..\naming.py --var='[a-z].*' --function='[a-z].*' naming_test.cpp.dump || exit /b !errorlevel!
 
-      # TODO: run with "-n auto" when misra_test.py can be run in parallel
+      # TODO: run with "-n %NUMBER_OF_PROCESSORS%" when misra_test.py can be run in parallel
       - name: test addons (Python)
         if: matrix.config == 'release'
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -104,12 +104,12 @@ jobs:
       - name: Run test/cli
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(proc) test/cli
 
       - name: Run test/cli (-j2)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(proc) test/cli
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
@@ -117,14 +117,14 @@ jobs:
         if: false
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(proc) test/cli
         env:
           TEST_CPPCHECK_INJECT_CLANG: clang
 
       - name: Run test/cli (--cppcheck-build-dir)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(proc) test/cli
         env:
           TEST_CPPCHECK_INJECT_BUILDDIR: injected
 

--- a/.github/workflows/scriptcheck.yml
+++ b/.github/workflows/scriptcheck.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           python tools/test_matchcompiler.py
 
-      # TODO: run with "-n auto" when misra_test.py can be run in parallel
+      # TODO: run with "-n $(nproc)" when misra_test.py can be run in parallel
       # we cannot specify -Werror since xml/etree/ElementTree.py in Python 3.9/3.10 contains an unclosed file
       - name: test addons
         if: matrix.python-version == '3.9' || matrix.python-version == '3.10'
@@ -145,7 +145,7 @@ jobs:
         env:
           PYTHONPATH: ./addons
 
-      # TODO: run with "-n auto" when misra_test.py can be run in parallel
+      # TODO: run with "-n $(nproc)" when misra_test.py can be run in parallel
       - name: test addons
         if: matrix.python-version != '3.9' && matrix.python-version != '3.10'
         run: |

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -104,14 +104,14 @@ jobs:
       - name: Run test/cli
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_EXECUTOR: thread
 
       - name: Run test/cli (-j2)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
@@ -119,14 +119,14 @@ jobs:
         if: false
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_CLANG: clang
 
       - name: Run test/cli (--cppcheck-build-dir)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_BUILDDIR: injected
 

--- a/.github/workflows/ubsan.yml
+++ b/.github/workflows/ubsan.yml
@@ -104,12 +104,12 @@ jobs:
       - name: Run test/cli
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
 
       - name: Run test/cli (-j2)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_J: 2
 
@@ -117,14 +117,14 @@ jobs:
         if: false
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_CLANG: clang
 
       - name: Run test/cli (--cppcheck-build-dir)
         run: |
           pwd=$(pwd)
-          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n auto test/cli
+          TEST_CPPCHECK_EXE_LOOKUP_PATH="$pwd/cmake.output" python3 -m pytest -Werror --strict-markers -vv -n $(nproc) test/cli
         env:
           TEST_CPPCHECK_INJECT_BUILDDIR: injected
 


### PR DESCRIPTION
we have mostly 4 threads available per runner but using `-n auto` is only using 2