### PR TITLE
Fix ErrorMessage parsing of XML Symbol Names

### DIFF
--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -206,7 +206,9 @@ ErrorMessage::ErrorMessage(const tinyxml2::XMLElement * const errmsg)
             const int line = strline ? strToInt<int>(strline) : 0;
             const int column = strcolumn ? strToInt<int>(strcolumn) : 0;
             callStack.emplace_front(file, info, line, column);
-        } else if (std::strcmp(name,"symbol")==0) {
+        } else if (std::strcmp(name,"symbol") == 0) {
+            if (!mSymbolNames.empty())
+                mSymbolNames += '\n';
             mSymbolNames += e->GetText();
         }
     }


### PR DESCRIPTION
XML-cached errors containing multiple symbol names are not stored correctly in the internal string data member with newline delimiters. This results in the symbol names becoming concatenated. In turn, suppressing them does not work when those cached files from the build directory are used instead of full analysis.