### PR TITLE
fix #12135: internalAstError with function pointer typedef

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -468,7 +468,7 @@ const Token *Tokenizer::processFunc(const Token *tok2, bool inOperator) const
                 while (Token::Match(tok2, "%name% ::"))
                     tok2 = tok2->tokAt(2);
 
-                if (Token::Match(tok2, "const"))
+                if (Token::simpleMatch(tok2, "const"))
                     tok2 = tok2->next();
 
                 if (!tok2)

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -468,6 +468,9 @@ const Token *Tokenizer::processFunc(const Token *tok2, bool inOperator) const
                 while (Token::Match(tok2, "%name% ::"))
                     tok2 = tok2->tokAt(2);
 
+                if (Token::Match(tok2, "const"))
+                    tok2 = tok2->next();
+
                 if (!tok2)
                     return nullptr;
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -8457,6 +8457,7 @@ private:
                             "    if (fp_t const fp = s.g<fp_t>()) {}\n"
                             "}\n";
         ASSERT_NO_THROW(tokenizeAndStringify(code));
+        ASSERT_EQUALS("void ( * const f ) ( ) ;", tokenizeAndStringify("typedef void (*fp_t)(); fp_t const f;"));
     }
 };
 

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -473,6 +473,7 @@ private:
         TEST_CASE(preincrementInLambda); // #13312
 
         TEST_CASE(atomicCast); // #12605
+        TEST_CASE(constFunctionPtrTypedef); // #12135
     }
 
 #define tokenizeAndStringify(...) tokenizeAndStringify_(__FILE__, __LINE__, __VA_ARGS__)
@@ -8442,6 +8443,20 @@ private:
                             "    return atomic_fetch_add((_Atomic(unsigned int) *)ptr, v) + v;\n"
                             "}\n";
         ASSERT_NO_THROW(tokenizeAndStringify(code, settingsDefault, false));
+    }
+
+    void constFunctionPtrTypedef() { // #12135
+        const char code[] = "struct S {\n"
+                            "    template<typename T> T g() {\n"
+                            "        return T();\n"
+                            "    }\n"
+                            "};\n"
+                            "void f() {\n"
+                            "    S s;\n"
+                            "    typedef void (*fp_t)();\n"
+                            "    if (fp_t const fp = s.g<fp_t>()) {}\n"
+                            "}\n";
+        ASSERT_NO_THROW(tokenizeAndStringify(code));
     }
 };
 


### PR DESCRIPTION
`fp_t const fp` was previously simplified to `void (*const) () fp`, now it's `void (*const fp) ()`.