### PR TITLE
Fix BOOST_REQUIRE false positives

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -33,7 +33,7 @@
   <define name="BOOST_AUTO_TEST_SUITE_END()" value="}" />
   <define name="BOOST_ASSERT(condition)" value="assert(condition)"/>
   <define name="BOOST_TEST(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
-  <define name="BOOST_TEST_REQUIRE(condition, ...)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
+  <define name="BOOST_TEST_REQUIRE(condition, ...)" value='do { if (!(condition)) { throw false; }} while(0)' />
   <define name="BOOST_WARN(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
   <define name="BOOST_WARN_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); static_cast&lt;void&gt;(msg)" />
   <define name="BOOST_WARN_EQUAL(a, b)" value="static_cast&lt;void&gt;((a) == (b))" />
@@ -50,8 +50,8 @@
   <define name="BOOST_CHECK_GE(a, b)" value="static_cast&lt;void&gt;((a) &gt;= (b))" />
   <define name="BOOST_CHECK_LT(a, b)" value="static_cast&lt;void&gt;((a) &lt; (b))" />
   <define name="BOOST_CHECK_LE(a, b)" value="static_cast&lt;void&gt;((a) &lt;= (b))" />
-  <define name="BOOST_REQUIRE(condition)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition))" />
-  <define name="BOOST_REQUIRE_MESSAGE(condition, msg)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;(condition)); static_cast&lt;void&gt;(msg)" />
+  <define name="BOOST_REQUIRE(condition)" value='do { if (!(condition)) { throw false; }} while(0)' />
+  <define name="BOOST_REQUIRE_MESSAGE(condition, msg)" value='do { if (!(condition)) { throw false; }} while(0); static_cast&lt;void&gt;(msg)' />
   <define name="BOOST_REQUIRE_EQUAL(a, b)" value="static_cast&lt;void&gt;(static_cast&lt;bool&gt;((a) == (b)))" />
   <define name="BOOST_REQUIRE_NE(a, b)" value="static_cast&lt;void&gt;((a) != (b))" />
   <define name="BOOST_REQUIRE_GT(a, b)" value="static_cast&lt;void&gt;((a) &gt; (b))" />

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -170,7 +170,6 @@ void test_require()
     BOOST_REQUIRE(some_int);
     BOOST_TEST_REQUIRE(some_other_int);
     *some_int = 42;
-    // cppcheck-suppress nullPointerOutOfMemory
     *some_other_int = 42;
     std::free(some_int);
     free(some_other_int);

--- a/test/cfg/boost.cpp
+++ b/test/cfg/boost.cpp
@@ -21,6 +21,7 @@
 #include <boost/core/scoped_enum.hpp>
 #include <boost/foreach.hpp>
 
+#include <cstdlib>
 #include <set>
 #include <vector>
 
@@ -160,6 +161,19 @@ void test_BOOST_FOREACH_6(std::vector<int> data)
         data.push_back(123);
         break;
     }
+}
+
+void test_require()
+{
+    int *some_int = static_cast<int*>(std::malloc(sizeof(int)));
+    int *some_other_int = static_cast<int*>(malloc(sizeof(int)));
+    BOOST_REQUIRE(some_int);
+    BOOST_TEST_REQUIRE(some_other_int);
+    *some_int = 42;
+    // cppcheck-suppress nullPointerOutOfMemory
+    *some_other_int = 42;
+    std::free(some_int);
+    free(some_other_int);
 }
 
 BOOST_AUTO_TEST_SUITE(my_auto_test_suite)


### PR DESCRIPTION
The **BOOST_REQUIRE** macros would not exit early and in case of a possible null pointer assignment in the condition, it would not get caught in the macro definition.
This would show false positives in next usages of the condition and show a `nullPointerOutOfMemory` warning, whereas the **BOOST_REQUIE** would have thrown an exception.

Mimic **BOOST_REQUIRE** behavior in the macro.