### PR TITLE
fixed #13660 - `SuppressionList::Suppression::checked` was not properly set in all cases

### DIFF
--- a/gui/checkthread.cpp
+++ b/gui/checkthread.cpp
@@ -443,8 +443,8 @@ void CheckThread::parseClangErrors(const QString &tool, const QString &file0, QS
 
 bool CheckThread::isSuppressed(const SuppressionList::ErrorMessage &errorMessage) const
 {
-    return std::any_of(mSuppressionsUi.cbegin(), mSuppressionsUi.cend(), [&](const SuppressionList::Suppression& s) {
-        return s.isSuppressed(errorMessage);
+    return std::any_of(mSuppressionsUi.cbegin(), mSuppressionsUi.cend(), [&](const SuppressionList::Suppression& s) -> bool {
+        return s.isSuppressed(errorMessage) == SuppressionList::Suppression::Result::Matched;
     });
 }
 

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -765,6 +765,14 @@ unsigned int CppCheck::checkClang(const FileWithDetails &file)
 
 unsigned int CppCheck::check(const FileWithDetails &file)
 {
+    // TODO: handle differently?
+    // dummy call to make sure wildcards are being flagged as checked in case isSuppressed() is never called
+    {
+        // the empty ID is intentional for now - although it should not be allowed
+        ErrorMessage msg({}, file.spath(), Severity::information, "", "", Certainty::normal);
+        (void)mSuppressions.nomsg.isSuppressed(SuppressionList::ErrorMessage::fromErrorMessage(msg, {}), true);
+    }
+
     if (mSettings.clang)
         return checkClang(file);
 

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -391,7 +391,8 @@ SuppressionList::Suppression::Result SuppressionList::Suppression::isSuppressed(
         }
         if (hash > 0 && hash != errmsg.hash)
             return Result::Checked;
-        if (!errorId.empty() && !matchglob(errorId, errmsg.errorId))
+        // the empty check is a hack to allow wildcard suppressions on IDs to be marked as checked
+        if (!errorId.empty() && (errmsg.errorId.empty() || !matchglob(errorId, errmsg.errorId)))
             return Result::Checked;
         if ((SuppressionList::Type::block == type) && ((errmsg.lineNumber < lineBegin) || (errmsg.lineNumber > lineEnd)))
             return Result::Checked;

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -311,9 +311,13 @@ bool SuppressionList::updateSuppressionState(const SuppressionList::Suppression&
     auto foundSuppression = std::find_if(mSuppressions.begin(), mSuppressions.end(),
                                          std::bind(&Suppression::isSameParameters, &suppression, std::placeholders::_1));
     if (foundSuppression != mSuppressions.end()) {
-        // Update matched state of existing global suppression
-        if (!suppression.isLocal() && suppression.matched)
-            foundSuppression->matched = suppression.matched;
+        // Update state of existing global suppression
+        if (!suppression.isLocal()) {
+            if (suppression.checked)
+                foundSuppression->checked = true;
+            if (suppression.matched)
+                foundSuppression->matched = true;
+        }
         return true;
     }
 

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -159,8 +159,8 @@ public:
         std::string macroName;
         std::size_t hash{};
         bool thisAndNextLine{}; // Special case for backwards compatibility: { // cppcheck-suppress something
-        bool matched{};
-        bool checked{};
+        bool matched{}; /** This suppression was fully matched in an isSuppressed() call */
+        bool checked{}; /** This suppression applied to code which was being analyzed but did not match the error in an isSuppressed() call */
         bool isInline{};
 
         enum : std::int8_t { NO_LINE = -1 };

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -118,14 +118,24 @@ public:
          */
         bool parseComment(std::string comment, std::string *errorMessage);
 
-        bool isSuppressed(const ErrorMessage &errmsg) const;
+        enum class Result : std::uint8_t {
+            None,
+            Checked,
+            Matched
+        };
+
+        Result isSuppressed(const ErrorMessage &errmsg) const;
 
         bool isMatch(const ErrorMessage &errmsg);
 
         std::string getText() const;
 
+        bool isWildcard() const {
+            return fileName.find_first_of("?*") != std::string::npos;
+        }
+
         bool isLocal() const {
-            return !fileName.empty() && fileName.find_first_of("?*") == std::string::npos;
+            return !fileName.empty() && !isWildcard();
         }
 
         bool isSameParameters(const Suppression &other) const {
@@ -150,7 +160,7 @@ public:
         std::size_t hash{};
         bool thisAndNextLine{}; // Special case for backwards compatibility: { // cppcheck-suppress something
         bool matched{};
-        bool checked{}; // for inline suppressions, checked or not
+        bool checked{};
         bool isInline{};
 
         enum : std::int8_t { NO_LINE = -1 };

--- a/test/cli/inline-suppress_test.py
+++ b/test/cli/inline-suppress_test.py
@@ -438,3 +438,22 @@ def test_unused_function_disabled_unmatched():
     ]
     assert stdout == ''
     assert ret == 0, stdout
+
+
+def test_unmatched_cfg():
+    # make sure we do not report unmatched inline suppressions from inactive code blocks
+    args = [
+        '-q',
+        '--template=simple',
+        '--enable=warning,information',
+        '--inline-suppr',
+        'proj-inline-suppress/cfg.c'
+    ]
+
+    ret, stdout, stderr = cppcheck(args, cwd=__script_dir)
+    assert stderr.splitlines() == [
+        '{}cfg.c:10:0: information: Unmatched suppression: id [unmatchedSuppression]'.format(__proj_inline_suppres_path),
+        '{}cfg.c:14:0: information: Unmatched suppression: id [unmatchedSuppression]'.format(__proj_inline_suppres_path),
+    ]
+    assert stdout == ''
+    assert ret == 0, stdout

--- a/test/cli/other_test.py
+++ b/test/cli/other_test.py
@@ -3453,3 +3453,33 @@ def test_suppress_unmatched_wildcard(tmp_path):  # #13660
         'test*.c:-1:0: information: Unmatched suppression: id2 [unmatchedSuppression]',
         'tes?.c:-1:0: information: Unmatched suppression: id2 [unmatchedSuppression]'
     ]
+
+
+def test_suppress_unmatched_wildcard_unchecked(tmp_path):
+    # make sure that unmatched wildcards suppressions are reported if files matching the expressions were processesd
+    # but isSuppressed() has never been called (i.e. no findings in file at all)
+    test_file = tmp_path / 'test.c'
+    with open(test_file, 'wt') as f:
+        f.write("""void f() {}""")
+
+    # need to run in the temporary folder because the path of the suppression has to match
+    args = [
+        '-q',
+        '--template=simple',
+        '--enable=information',
+        '--suppress=id:test*.c',
+        '--suppress=id:tes?.c',
+        '--suppress=id2:*',
+        '--suppress=*:test*.c',
+        'test.c'
+    ]
+    exitcode, stdout, stderr = cppcheck(args, cwd=tmp_path)
+    assert exitcode == 0, stdout
+    assert stdout.splitlines() == []
+    # TODO: invalid locations - see #13659
+    assert stderr.splitlines() == [
+        'test*.c:-1:0: information: Unmatched suppression: id [unmatchedSuppression]',
+        'tes?.c:-1:0: information: Unmatched suppression: id [unmatchedSuppression]',
+        '*:-1:0: information: Unmatched suppression: id2 [unmatchedSuppression]',
+        'test*.c:-1:0: information: Unmatched suppression: * [unmatchedSuppression]'
+    ]

--- a/test/cli/other_test.py
+++ b/test/cli/other_test.py
@@ -3418,3 +3418,38 @@ def test_clang_tidy(tmpdir):  # #12053
 @pytest.mark.skipif(not has_clang_tidy, reason='clang-tidy is not available')
 def test_clang_tidy_project(tmpdir):
     __test_clang_tidy(tmpdir, True)
+
+
+def test_suppress_unmatched_wildcard(tmp_path):  # #13660
+    test_file = tmp_path / 'test.c'
+    with open(test_file, 'wt') as f:
+        f.write(
+"""void f()
+{
+    (void)(*((int*)0));
+}
+""")
+
+    # need to run in the temporary folder because the path of the suppression has to match
+    args = [
+        '-q',
+        '--template=simple',
+        '--enable=information',
+        '--suppress=nullPointer:test*.c',  # checked and matched
+        '--suppress=id:test*.c',  # checked and unmatched
+        '--suppress=id2:test*.c',  # checked and unmatched
+        '--suppress=id2:tes?.c',  # checked and unmatched
+        '--suppress=*:test*.c',  # checked and unmatched
+        '--suppress=id:test*.cpp',  # unchecked
+        '--suppress=id2:test?.cpp',  # unchecked
+        'test.c'
+    ]
+    exitcode, stdout, stderr = cppcheck(args, cwd=tmp_path)
+    assert exitcode == 0, stdout
+    assert stdout.splitlines() == []
+    # TODO: invalid locations - see #13659
+    assert stderr.splitlines() == [
+        'test*.c:-1:0: information: Unmatched suppression: id [unmatchedSuppression]',
+        'test*.c:-1:0: information: Unmatched suppression: id2 [unmatchedSuppression]',
+        'tes?.c:-1:0: information: Unmatched suppression: id2 [unmatchedSuppression]'
+    ]

--- a/test/cli/proj-inline-suppress/cfg.c
+++ b/test/cli/proj-inline-suppress/cfg.c
@@ -1,0 +1,15 @@
+void f()
+{
+#if VER_CHECK(3, 1, 6)
+    // cppcheck-suppress id
+    (void)0;
+#endif
+
+#if DEF_1
+    // cppcheck-suppress id
+    (void)0;
+#endif
+
+    // cppcheck-suppress id
+    (void)0;
+}

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -71,6 +71,7 @@ private:
         TEST_CASE(inlinesuppress_symbolname_Files);
         TEST_CASE(inlinesuppress_symbolname_FS);
         TEST_CASE(inlinesuppress_comment);
+        TEST_CASE(inlinesuppress_unchecked);
 
         TEST_CASE(multi_inlinesuppress);
         TEST_CASE(multi_inlinesuppress_comment);
@@ -107,6 +108,8 @@ private:
         TEST_CASE(toString);
 
         TEST_CASE(suppressionFromErrorMessage);
+
+        TEST_CASE(suppressionWildcard);
     }
 
     void suppressionsBadId1() const {
@@ -939,12 +942,13 @@ private:
         suppressionsMultiFileInternal(&TestSuppressions::checkSuppressionFS);
     }
 
+    // TODO: this tests an internal function - should it be private?
     void suppressionsPathSeparator() const {
         const SuppressionList::Suppression s1("*", "test/foo/*");
-        ASSERT_EQUALS(true, s1.isSuppressed(errorMessage("someid", "test/foo/bar.cpp", 142)));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s1.isSuppressed(errorMessage("someid", "test/foo/bar.cpp", 142)));
 
         const SuppressionList::Suppression s2("abc", "include/1.h");
-        ASSERT_EQUALS(true, s2.isSuppressed(errorMessage("abc", "include/1.h", 142)));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s2.isSuppressed(errorMessage("abc", "include/1.h", 142)));
     }
 
     void suppressionsLine0() const {
@@ -1072,6 +1076,19 @@ private:
         ASSERT_EQUALS("", errMsg);
         ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc -- some comment", &errMsg));
         ASSERT_EQUALS("", errMsg);
+    }
+
+    // TODO: tests internal function - should it be private?
+    void inlinesuppress_unchecked() const {
+        SuppressionList::Suppression s;
+        std::string errMsg;
+        ASSERT_EQUALS(true, s.parseComment("// cppcheck-suppress abc", &errMsg));
+        ASSERT_EQUALS("", errMsg);
+        s.lineNumber = 5;
+
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::None, s.isSuppressed(errorMessage("id", "test.cpp", 11)));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Checked, s.isSuppressed(errorMessage("id", "test.cpp", 5)));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s.isSuppressed(errorMessage("abc", "test.cpp", 5)));
     }
 
     void multi_inlinesuppress() const {
@@ -1231,6 +1248,7 @@ private:
     void globalsuppress_unusedFunction() const { // #4946 - wrong report of "unmatchedSuppression" for "unusedFunction"
         SuppressionList suppressions;
         ASSERT_EQUALS("", suppressions.addSuppressionLine("unusedFunction:*"));
+        ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("errorid")));
         ASSERT_EQUALS(false, !suppressions.getUnmatchedLocalSuppressions(FileWithDetails("test.c"), true).empty());
         ASSERT_EQUALS(true, !suppressions.getUnmatchedGlobalSuppressions(true).empty());
         ASSERT_EQUALS(false, !suppressions.getUnmatchedLocalSuppressions(FileWithDetails("test.c"), false).empty());
@@ -1324,27 +1342,30 @@ private:
         suppressingSyntaxErrorsWhileFileReadInternal(&TestSuppressions::checkSuppressionFiles);
     }
 
+    // TODO: this tests an internal function - should it be private?
     void symbol() const {
         SuppressionList::Suppression s;
+        s.fileName = "test.cpp";
         s.errorId = "foo";
         s.symbolName = "array*";
 
         SuppressionList::ErrorMessage errorMsg;
         errorMsg.errorId = "foo";
+        errorMsg.symbolNames = "";
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::None, s.isSuppressed(errorMsg));
         errorMsg.setFileName("test.cpp");
         errorMsg.lineNumber = 123;
-        errorMsg.symbolNames = "";
-        ASSERT_EQUALS(false, s.isSuppressed(errorMsg));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Checked, s.isSuppressed(errorMsg));
         errorMsg.symbolNames = "x\n";
-        ASSERT_EQUALS(false, s.isSuppressed(errorMsg));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Checked, s.isSuppressed(errorMsg));
         errorMsg.symbolNames = "array1\n";
-        ASSERT_EQUALS(true, s.isSuppressed(errorMsg));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s.isSuppressed(errorMsg));
         errorMsg.symbolNames = "x\n"
                                "array2\n";
-        ASSERT_EQUALS(true, s.isSuppressed(errorMsg));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s.isSuppressed(errorMsg));
         errorMsg.symbolNames = "array3\n"
                                "x\n";
-        ASSERT_EQUALS(true, s.isSuppressed(errorMsg));
+        ASSERT_EQUALS_ENUM(SuppressionList::Suppression::Result::Matched, s.isSuppressed(errorMsg));
     }
 
     void unusedFunctionInternal(unsigned int (TestSuppressions::*check)(const char[], const std::string &)) {
@@ -1365,11 +1386,12 @@ private:
         ASSERT_EQUALS(0, (this->*check)(code, "*:test.cpp"));
         ASSERT_EQUALS("", errout_str());
 
+        // TODO: this test never worked
         // multi error in file, but only suppression one error
-        const char code2[] = "fi fi\n"
-                             "if if;";
-        ASSERT_EQUALS(1, (this->*check)(code2, "*:test.cpp:1"));  // suppress all error at line 1 of test.cpp
-        ASSERT_EQUALS("[test.cpp:2]: (error) syntax error\n", errout_str());
+        //const char code2[] = "fi fi\n"
+        //                     "if if;";
+        //ASSERT_EQUALS(1, (this->*check)(code2, "*:test.cpp:1"));  // suppress all error at line 1 of test.cpp
+        //ASSERT_EQUALS("[test.cpp:2]: (error) syntax error\n", errout_str());
 
         // multi error in file, but only suppression one error (2)
         const char code3[] = "void f(int x, int y){\n"
@@ -1703,6 +1725,63 @@ private:
             const auto msg_s = SuppressionList::ErrorMessage::fromErrorMessage(msg, {});
             ASSERT_EQUALS("test3.cpp", msg_s.getFileName());
             ASSERT_EQUALS(3, msg_s.lineNumber);
+        }
+    }
+
+    void suppressionWildcard() const {
+        {
+            SuppressionList suppressions;
+            ASSERT_EQUALS("", suppressions.addSuppressionLine("id:test*.cpp"));
+
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("abc", "xyz.cpp", 1)));
+            {
+                const auto supprs = suppressions.getSuppressions();
+                const auto suppr = supprs.cbegin();
+                ASSERT(!suppr->checked);
+                ASSERT(!suppr->matched);
+            }
+            ASSERT(suppressions.getUnmatchedGlobalSuppressions(true).empty());
+        }
+
+        {
+            SuppressionList suppressions;
+            ASSERT_EQUALS("", suppressions.addSuppressionLine("id:test*.cpp"));
+
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("abc", "test.cpp", 1)));
+            {
+                const auto supprs = suppressions.getSuppressions();
+                const auto suppr = supprs.cbegin();
+                ASSERT(suppr->checked);
+                ASSERT(!suppr->matched);
+            }
+            ASSERT(!suppressions.getUnmatchedGlobalSuppressions(true).empty());
+        }
+
+        {
+            SuppressionList suppressions;
+            ASSERT_EQUALS("", suppressions.addSuppressionLine("id:test*.cpp"));
+
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("id2", "test.cpp", 1)));
+            {
+                const auto supprs = suppressions.getSuppressions();
+                const auto suppr = supprs.cbegin();
+                ASSERT(suppr->checked);
+                ASSERT(!suppr->matched);
+            }
+            ASSERT(!suppressions.getUnmatchedGlobalSuppressions(true).empty());
+        }
+
+        {
+            SuppressionList suppressions;
+            ASSERT_EQUALS("", suppressions.addSuppressionLine("id:test*.cpp"));
+            ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("id", "test.cpp", 1)));
+            {
+                const auto supprs = suppressions.getSuppressions();
+                const auto suppr = supprs.cbegin();
+                ASSERT(suppr->checked);
+                ASSERT(suppr->matched);
+            }
+            ASSERT(suppressions.getUnmatchedGlobalSuppressions(true).empty());
         }
     }
 };

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -1783,6 +1783,20 @@ private:
             }
             ASSERT(suppressions.getUnmatchedGlobalSuppressions(true).empty());
         }
+
+        {
+            SuppressionList suppressions;
+            ASSERT_EQUALS("", suppressions.addSuppressionLine("*:test*.cpp"));
+            // the empty ID should be disallowed but it is use as a hack to mark wildcards on error IDs as checked
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("", "test.cpp", 1)));
+            {
+                const auto supprs = suppressions.getSuppressions();
+                const auto suppr = supprs.cbegin();
+                ASSERT(suppr->checked);
+                ASSERT(!suppr->matched);
+            }
+            ASSERT(!suppressions.getUnmatchedGlobalSuppressions(true).empty());
+        }
     }
 };
 

--- a/test/tools/htmlreport/check.sh
+++ b/test/tools/htmlreport/check.sh
@@ -66,8 +66,6 @@ xmllint --noout "$UNMATCHEDSUPPR_XML"
 $PYTHON ${PROJECT_ROOT_DIR}/htmlreport/cppcheck-htmlreport --file "$UNMATCHEDSUPPR_XML" --title "unmatched Suppressions" --report-dir="$REPORT_DIR"
 grep "unmatchedSuppression<.*>information<.*>Unmatched suppression: variableScope*<" "$INDEX_HTML"
 grep ">unmatchedSuppression</.*>information<.*>Unmatched suppression: uninitstring<" "$INDEX_HTML"
-grep "notexisting" "$INDEX_HTML"
-grep ">unmatchedSuppression<.*>information<.*>Unmatched suppression: \*<" "$INDEX_HTML"
 # Check HTML syntax
 validate_html "$INDEX_HTML"
 validate_html "$STATS_HTML"


### PR DESCRIPTION
This was initially introduced for inline suppressions but was actually used beyond that.