### PR TITLE
templatesimplifier.cpp: fixed `clang-analyzer-alpha.core.Conversion` warning in `getTemplateInstantiations()`

### DIFF
--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -821,7 +821,7 @@ void TemplateSimplifier::getTemplateInstantiations()
                 // Don't ignore user specialization but don't consider it an instantiation.
                 // Instantiations in return type, function parameters, and executable code
                 // are not ignored.
-                const unsigned int pos = getTemplateNamePosition(tok);
+                const int pos = getTemplateNamePosition(tok);
                 if (pos > 0)
                     skip = tok->tokAt(pos);
             } else {


### PR DESCRIPTION
```
/home/runner/work/cppcheck/cppcheck/lib/templatesimplifier.cpp:824:42: error: Loss of sign in implicit conversion [clang-analyzer-alpha.core.Conversion,-warnings-as-errors]
  824 |                 const unsigned int pos = getTemplateNamePosition(tok);
      |                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```