### PR TITLE
Add library attribute for no-failure allocators

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -27,6 +27,9 @@
             </element>
             <element name="alloc">
               <optional>
+                <attribute name="no-fail"><ref name="DATA-BOOL"/></attribute>
+              </optional>
+              <optional>
                 <attribute name="init"><ref name="DATA-BOOL"/></attribute>
               </optional>
               <optional>
@@ -38,6 +41,9 @@
               <ref name="DATA-EXTNAME"/>
             </element>
             <element name="realloc">
+              <optional>
+                <attribute name="no-fail"><ref name="DATA-BOOL"/></attribute>
+              </optional>
               <optional>
                 <attribute name="init"><ref name="DATA-BOOL"/></attribute>
               </optional>
@@ -70,6 +76,9 @@
             </element>
             <element name="alloc">
               <optional>
+                <attribute name="no-fail"><ref name="DATA-BOOL"/></attribute>
+              </optional>
+              <optional>
                 <attribute name="init"><ref name="DATA-BOOL"/></attribute>
               </optional>
               <optional>
@@ -78,6 +87,9 @@
               <ref name="DATA-EXTNAME"/>
             </element>
             <element name="realloc">
+              <optional>
+                <attribute name="no-fail"><ref name="DATA-BOOL"/></attribute>
+              </optional>
               <optional>
                 <attribute name="init"><ref name="DATA-BOOL"/></attribute>
               </optional>

--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -206,689 +206,689 @@
   <define name="g_slist_next(slist)" value="((slist) ? (((GSList *)(slist))-&gt;next) : NULL)"/>
   <define name="g_strstrip(string)" value="g_strchomp (g_strchug (string))"/>
   <memory>
-    <alloc init="true">g_thread_new</alloc>
-    <alloc init="true">g_thread_try_new</alloc>
+    <alloc init="true" no-fail="true">g_thread_new</alloc>
+    <alloc init="true" no-fail="false">g_thread_try_new</alloc>
     <use>g_thread_ref</use>
     <dealloc>g_thread_unref</dealloc>
     <dealloc>g_thread_join</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_variant_iter_copy</alloc>
-    <alloc init="true">g_variant_iter_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_iter_copy</alloc>
+    <alloc init="true" no-fail="true">g_variant_iter_new</alloc>
     <dealloc>g_variant_iter_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_source_new</alloc>
-    <alloc init="true">g_idle_source_new</alloc>
-    <alloc init="true">g_timeout_source_new</alloc>
-    <alloc init="true">g_timeout_source_new_seconds</alloc>
-    <alloc init="true">g_child_watch_source_new</alloc>
-    <alloc init="true">g_cancellable_source_new</alloc>
-    <alloc init="true">g_io_create_watch</alloc>
+    <alloc init="true" no-fail="true">g_source_new</alloc>
+    <alloc init="true" no-fail="true">g_idle_source_new</alloc>
+    <alloc init="true" no-fail="true">g_timeout_source_new</alloc>
+    <alloc init="true" no-fail="true">g_timeout_source_new_seconds</alloc>
+    <alloc init="true" no-fail="true">g_child_watch_source_new</alloc>
+    <alloc init="true" no-fail="true">g_cancellable_source_new</alloc>
+    <alloc init="true" no-fail="true">g_io_create_watch</alloc>
     <use>g_source_ref</use>
     <dealloc>g_source_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_date_time_new</alloc>
-    <alloc init="true">g_date_time_new_now</alloc>
-    <alloc init="true">g_date_time_new_now_local</alloc>
-    <alloc init="true">g_date_time_new_now_utc</alloc>
-    <alloc init="true">g_date_time_new_from_unix_local</alloc>
-    <alloc init="true">g_date_time_new_from_unix_utc</alloc>
-    <alloc init="true">g_date_time_new_from_timeval_local</alloc>
-    <alloc init="true">g_date_time_new_from_timeval_utc</alloc>
-    <alloc init="true">g_date_time_new_local</alloc>
-    <alloc init="true">g_date_time_new_utc</alloc>
-    <alloc init="true">g_date_time_add</alloc>
-    <alloc init="true">g_date_time_add_years</alloc>
-    <alloc init="true">g_date_time_add_months</alloc>
-    <alloc init="true">g_date_time_add_weeks</alloc>
-    <alloc init="true">g_date_time_add_days</alloc>
-    <alloc init="true">g_date_time_add_hours</alloc>
-    <alloc init="true">g_date_time_add_minutes</alloc>
-    <alloc init="true">g_date_time_add_seconds</alloc>
-    <alloc init="true">g_date_time_add_full</alloc>
-    <alloc init="true">g_date_time_to_timezone</alloc>
-    <alloc init="true">g_date_time_to_local</alloc>
-    <alloc init="true">g_date_time_to_utc</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_now</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_now_local</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_now_utc</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_from_unix_local</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_from_unix_utc</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_from_timeval_local</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_from_timeval_utc</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_local</alloc>
+    <alloc init="true" no-fail="true">g_date_time_new_utc</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_years</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_months</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_weeks</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_days</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_hours</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_minutes</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_seconds</alloc>
+    <alloc init="true" no-fail="true">g_date_time_add_full</alloc>
+    <alloc init="true" no-fail="true">g_date_time_to_timezone</alloc>
+    <alloc init="true" no-fail="true">g_date_time_to_local</alloc>
+    <alloc init="true" no-fail="true">g_date_time_to_utc</alloc>
     <use>g_date_time_ref</use>
     <dealloc>g_date_time_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_dir_open</alloc>
+    <alloc init="true" no-fail="false">g_dir_open</alloc>
     <alloc init="true">g_dir_rewind</alloc>
     <dealloc>g_dir_close</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_timer_new</alloc>
+    <alloc init="true" no-fail="true">g_timer_new</alloc>
     <dealloc>g_timer_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_file_attribute_info_list_new</alloc>
-    <alloc init="true">g_file_attribute_info_list_dup</alloc>
+    <alloc init="true" no-fail="true">g_file_attribute_info_list_new</alloc>
+    <alloc init="true" no-fail="true">g_file_attribute_info_list_dup</alloc>
     <use>g_file_attribute_info_list_ref</use>
     <dealloc>g_file_attribute_info_list_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_slist_alloc</alloc>
-    <alloc init="true">g_slist_copy</alloc>
-    <alloc init="true">g_slist_copy_deep</alloc>
+    <alloc init="true" no-fail="true">g_slist_alloc</alloc>
+    <alloc init="true" no-fail="true">g_slist_copy</alloc>
+    <alloc init="true" no-fail="true">g_slist_copy_deep</alloc>
     <dealloc>g_slist_free</dealloc>
     <dealloc>g_slist_free_1</dealloc>
     <dealloc>g_slist_free_full</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_variant_new</alloc>
-    <alloc init="true">g_variant_new_va</alloc>
-    <alloc init="true">g_variant_new_boolean</alloc>
-    <alloc init="true">g_variant_new_byte</alloc>
-    <alloc init="true">g_variant_new_int16</alloc>
-    <alloc init="true">g_variant_new_uint16</alloc>
-    <alloc init="true">g_variant_new_int32</alloc>
-    <alloc init="true">g_variant_new_uint32</alloc>
-    <alloc init="true">g_variant_new_int64</alloc>
-    <alloc init="true">g_variant_new_uint64</alloc>
-    <alloc init="true">g_variant_new_handle</alloc>
-    <alloc init="true">g_variant_new_double</alloc>
-    <alloc init="true">g_variant_new_string</alloc>
-    <alloc init="true">g_variant_new_take_string</alloc>
-    <alloc init="true">g_variant_new_printf</alloc>
-    <alloc init="true">g_variant_new_signature</alloc>
-    <alloc init="true">g_variant_new_object_path</alloc>
-    <alloc init="true">g_variant_new_variant</alloc>
-    <alloc init="true">g_variant_new_objv</alloc>
-    <alloc init="true">g_variant_new_strv</alloc>
-    <alloc init="true">g_variant_new_bytestring</alloc>
-    <alloc init="true">g_variant_new_bytestring_array</alloc>
-    <alloc init="true">g_variant_new_maybe</alloc>
-    <alloc init="true">g_variant_new_array</alloc>
-    <alloc init="true">g_variant_new_tuple</alloc>
-    <alloc init="true">g_variant_new_dict_entry</alloc>
-    <alloc init="true">g_variant_new_fixed_array</alloc>
-    <alloc init="true">g_variant_new_from_data</alloc>
-    <alloc init="true">g_variant_new_from_bytes</alloc>
-    <alloc init="true">g_variant_builder_end</alloc>
-    <alloc init="true">g_variant_new_parsed_va</alloc>
-    <alloc init="true">g_variant_new_parsed</alloc>
-    <alloc init="true">g_variant_byteswap</alloc>
-    <alloc init="true">g_variant_get_child_value</alloc>
-    <alloc init="true">g_variant_get_normal_form</alloc>
-    <alloc init="true">g_variant_parse</alloc>
+    <alloc init="true" no-fail="true">g_variant_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_va</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_boolean</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_byte</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_int16</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_uint16</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_int32</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_uint32</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_int64</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_uint64</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_handle</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_double</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_string</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_take_string</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_printf</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_signature</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_object_path</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_variant</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_objv</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_strv</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_bytestring</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_bytestring_array</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_maybe</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_array</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_tuple</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_dict_entry</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_fixed_array</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_from_data</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_from_bytes</alloc>
+    <alloc init="true" no-fail="true">g_variant_builder_end</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_parsed_va</alloc>
+    <alloc init="true" no-fail="true">g_variant_new_parsed</alloc>
+    <alloc init="true" no-fail="true">g_variant_byteswap</alloc>
+    <alloc init="true" no-fail="true">g_variant_get_child_value</alloc>
+    <alloc init="true" no-fail="true">g_variant_get_normal_form</alloc>
+    <alloc init="true" no-fail="true">g_variant_parse</alloc>
     <use>g_variant_ref</use>
     <use>g_variant_take_ref</use>
     <use>g_variant_ref_sink</use>
     <dealloc>g_variant_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_variant_iter_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_iter_new</alloc>
     <dealloc>g_variant_iter_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_variant_type_new</alloc>
-    <alloc init="true">g_variant_type_copy</alloc>
-    <alloc init="true">g_variant_type_new_array</alloc>
-    <alloc init="true">g_variant_type_new_dict_entry</alloc>
-    <alloc init="true">g_variant_type_new_maybe</alloc>
-    <alloc init="true">g_variant_type_new_tuple</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_copy</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_new_array</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_new_dict_entry</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_new_maybe</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_new_tuple</alloc>
     <dealloc>g_variant_type_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_allocator_new</alloc>
+    <alloc init="true" no-fail="true">g_allocator_new</alloc>
     <dealloc>g_allocator_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_bookmark_file_new</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_new</alloc>
     <dealloc>g_bookmark_file_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_srv_target_new</alloc>
+    <alloc init="true" no-fail="true">g_srv_target_new</alloc>
     <dealloc>g_srv_target_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_string_chunk_new</alloc>
+    <alloc init="true" no-fail="true">g_string_chunk_new</alloc>
     <dealloc>g_string_chunk_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_test_log_buffer_new</alloc>
+    <alloc init="true" no-fail="true">g_test_log_buffer_new</alloc>
     <dealloc>g_test_log_buffer_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_value_array_new</alloc>
+    <alloc init="true" no-fail="true">g_value_array_new</alloc>
     <dealloc>g_value_array_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_cache_new</alloc>
+    <alloc init="true" no-fail="true">g_cache_new</alloc>
     <dealloc>g_cache_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_cclosure_new</alloc>
-    <alloc init="true">g_cclosure_new_swap</alloc>
-    <alloc init="true">g_cclosure_new_object</alloc>
-    <alloc init="true">g_cclosure_new_object_swap</alloc>
-    <alloc init="true">g_closure_new_object</alloc>
-    <alloc init="true">g_closure_new_simple</alloc>
+    <alloc init="true" no-fail="true">g_cclosure_new</alloc>
+    <alloc init="true" no-fail="true">g_cclosure_new_swap</alloc>
+    <alloc init="true" no-fail="true">g_cclosure_new_object</alloc>
+    <alloc init="true" no-fail="true">g_cclosure_new_object_swap</alloc>
+    <alloc init="true" no-fail="true">g_closure_new_object</alloc>
+    <alloc init="true" no-fail="true">g_closure_new_simple</alloc>
     <use>g_closure_ref</use>
     <dealloc>g_closure_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_array_new</alloc>
-    <alloc init="true">g_array_sized_new</alloc>
+    <alloc init="true" no-fail="true">g_array_new</alloc>
+    <alloc init="true" no-fail="true">g_array_sized_new</alloc>
     <use>g_array_ref</use>
     <dealloc>g_array_free</dealloc>
     <dealloc>g_array_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_async_queue_new</alloc>
-    <alloc init="true">g_async_queue_new_full</alloc>
+    <alloc init="true" no-fail="true">g_async_queue_new</alloc>
+    <alloc init="true" no-fail="true">g_async_queue_new_full</alloc>
     <use>g_async_queue_ref</use>
     <dealloc>g_async_queue_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_byte_array_new</alloc>
-    <alloc init="true">g_byte_array_sized_new</alloc>
-    <alloc init="true">g_byte_array_new_take</alloc>
-    <alloc init="true">g_byte_array_sized_new</alloc>
-    <alloc init="true">g_bytes_unref_to_array</alloc>
+    <alloc init="true" no-fail="true">g_byte_array_new</alloc>
+    <alloc init="true" no-fail="true">g_byte_array_sized_new</alloc>
+    <alloc init="true" no-fail="true">g_byte_array_new_take</alloc>
+    <alloc init="true" no-fail="true">g_byte_array_sized_new</alloc>
+    <alloc init="true" no-fail="true">g_bytes_unref_to_array</alloc>
     <use>g_byte_array_ref</use>
     <dealloc>g_byte_array_free</dealloc>
     <dealloc>g_byte_array_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_checksum_new</alloc>
-    <alloc init="true">g_checksum_copy</alloc>
+    <alloc init="true" no-fail="true">g_checksum_new</alloc>
+    <alloc init="true" no-fail="true">g_checksum_copy</alloc>
     <dealloc>g_checksum_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_main_loop_new</alloc>
-    <alloc init="true">g_main_new</alloc>
+    <alloc init="true" no-fail="true">g_main_loop_new</alloc>
+    <alloc init="true" no-fail="true">g_main_new</alloc>
     <use>g_main_loop_ref</use>
     <dealloc>g_main_loop_unref</dealloc>
     <dealloc>g_main_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_main_context_new</alloc>
+    <alloc init="true" no-fail="true">g_main_context_new</alloc>
     <use>g_main_context_ref</use>
     <dealloc>g_main_context_unref</dealloc>
     <dealloc>g_main_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_thread_pool_new</alloc>
+    <alloc init="true" no-fail="true">g_thread_pool_new</alloc>
     <dealloc>g_thread_pool_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_error_copy</alloc>
-    <alloc init="true">g_error_new_valist</alloc>
-    <alloc init="true">g_error_new_literal</alloc>
-    <alloc init="true">g_error_new</alloc>
+    <alloc init="true" no-fail="true">g_error_copy</alloc>
+    <alloc init="true" no-fail="true">g_error_new_valist</alloc>
+    <alloc init="true" no-fail="true">g_error_new_literal</alloc>
+    <alloc init="true" no-fail="true">g_error_new</alloc>
     <dealloc>g_error_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_string_new</alloc>
-    <alloc init="true">g_string_new_len</alloc>
-    <alloc init="true">g_string_sized_new</alloc>
-    <alloc init="true">g_variant_print_string</alloc>
+    <alloc init="true" no-fail="true">g_string_new</alloc>
+    <alloc init="true" no-fail="true">g_string_new_len</alloc>
+    <alloc init="true" no-fail="true">g_string_sized_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_print_string</alloc>
     <dealloc>g_string_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_ptr_array_new</alloc>
-    <alloc init="true">g_ptr_array_new_full</alloc>
-    <alloc init="true">g_ptr_array_new_with_free_func</alloc>
+    <alloc init="true" no-fail="true">g_ptr_array_new</alloc>
+    <alloc init="true" no-fail="true">g_ptr_array_new_full</alloc>
+    <alloc init="true" no-fail="true">g_ptr_array_new_with_free_func</alloc>
     <use>g_ptr_array_ref</use>
     <dealloc>g_ptr_array_free</dealloc>
     <dealloc>g_ptr_array_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_pattern_spec_new</alloc>
+    <alloc init="true" no-fail="true">g_pattern_spec_new</alloc>
     <dealloc>g_pattern_spec_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_key_file_new</alloc>
+    <alloc init="true" no-fail="true">g_key_file_new</alloc>
     <use>g_key_file_ref</use>
     <dealloc>g_key_file_free</dealloc>
     <dealloc>g_key_file_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_io_module_scope_new</alloc>
+    <alloc init="true" no-fail="true">g_io_module_scope_new</alloc>
     <dealloc>g_io_module_scope_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_ascii_strdown</alloc>
-    <alloc init="true">g_ascii_strup</alloc>
-    <alloc init="true">g_base64_decode</alloc>
-    <alloc init="true">g_base64_encode</alloc>
-    <alloc init="true">g_bookmark_file_get_description</alloc>
-    <alloc init="true">g_bookmark_file_get_mime_type</alloc>
-    <alloc init="true">g_bookmark_file_get_title</alloc>
-    <alloc init="true">g_bookmark_file_to_data</alloc>
-    <alloc init="true">g_build_filename</alloc>
-    <alloc init="true">g_build_filenamev</alloc>
-    <alloc init="true">g_build_path</alloc>
-    <alloc init="true">g_build_pathv</alloc>
-    <alloc init="true">g_bytes_unref_to_data</alloc>
-    <alloc init="true">g_compute_checksum_for_bytes</alloc>
-    <alloc init="true">g_compute_checksum_for_data</alloc>
-    <alloc init="true">g_compute_checksum_for_string</alloc>
-    <alloc init="true">g_compute_hmac_for_data</alloc>
-    <alloc init="true">g_compute_hmac_for_string</alloc>
-    <alloc init="true">g_convert</alloc>
-    <alloc init="true">g_convert_with_fallback</alloc>
-    <alloc init="true">g_convert_with_iconv</alloc>
-    <alloc init="true">g_credentials_to_string</alloc>
-    <alloc init="true">g_date_time_format</alloc>
-    <alloc init="true">g_filename_display_basename</alloc>
-    <alloc init="true">g_filename_display_name</alloc>
-    <alloc init="true">g_filename_from_uri</alloc>
-    <alloc init="true">g_filename_to_uri</alloc>
-    <alloc init="true">g_get_codeset</alloc>
-    <alloc init="true">g_get_current_dir</alloc>
-    <alloc init="true">g_get_locale_variants</alloc>
-    <alloc init="true">g_key_file_get_start_group</alloc>
-    <alloc init="true">g_key_file_to_data</alloc>
-    <alloc buffer-size="malloc">g_malloc</alloc>
-    <realloc buffer-size="malloc:2">g_realloc</realloc>
-    <alloc init="true" buffer-size="malloc">g_malloc0</alloc>
-    <alloc init="true" buffer-size="calloc">g_malloc0_n</alloc>
-    <alloc buffer-size="calloc">g_malloc_n</alloc>
-    <realloc buffer-size="calloc:2,3">g_realloc_n</realloc>
-    <alloc init="true">g_memdup</alloc>
-    <alloc init="true">g_path_get_basename</alloc>
-    <alloc init="true">g_path_get_dirname</alloc>
-    <alloc>g_slice_alloc</alloc>
-    <alloc init="true">g_slice_alloc0</alloc>
-    <alloc init="true">g_slice_copy</alloc>
-    <alloc init="true">g_strcompress</alloc>
-    <alloc init="true">g_strconcat</alloc>
-    <alloc init="true" buffer-size="strdup">g_strdup</alloc>
-    <alloc init="true">g_strdup_printf</alloc>
-    <alloc init="true">g_strdup_vprintf</alloc>
-    <alloc init="true">g_strescape</alloc>
-    <alloc init="true">g_strjoin</alloc>
-    <alloc init="true">g_strjoinv</alloc>
-    <alloc init="true">g_strndup</alloc>
-    <alloc init="true">g_strnfill</alloc>
-    <alloc init="true">g_time_val_to_iso8601</alloc>
-    <alloc buffer-size="malloc">g_try_malloc</alloc>
-    <realloc buffer-size="malloc:2">g_try_realloc</realloc>
-    <alloc init="true" buffer-size="malloc">g_try_malloc0</alloc>
-    <alloc init="true" buffer-size="calloc">g_try_malloc0_n</alloc>
-    <alloc buffer-size="calloc">g_try_malloc_n</alloc>
-    <realloc buffer-size="calloc:2,3">g_try_realloc_n</realloc>
-    <alloc init="true">g_ucs4_to_utf16</alloc>
-    <alloc init="true">g_ucs4_to_utf8</alloc>
-    <alloc init="true">g_unicode_canonical_decomposition</alloc>
-    <alloc init="true">g_utf16_to_ucs4</alloc>
-    <alloc init="true">g_utf16_to_utf8</alloc>
-    <alloc init="true">g_utf8_casefold</alloc>
-    <alloc init="true">g_utf8_collate_key</alloc>
-    <alloc init="true">g_utf8_collate_key_for_filename</alloc>
-    <alloc init="true">g_utf8_normalize</alloc>
-    <alloc init="true">g_utf8_strdown</alloc>
-    <alloc init="true">g_utf8_strreverse</alloc>
-    <alloc init="true">g_utf8_strup</alloc>
-    <alloc init="true">g_utf8_substring</alloc>
-    <alloc init="true">g_utf8_to_ucs4</alloc>
-    <alloc init="true">g_utf8_to_ucs4_fast</alloc>
-    <alloc init="true">g_utf8_to_ucs4_fast</alloc>
-    <alloc init="true">g_utf8_to_utf16</alloc>
-    <alloc init="true">g_key_file_get_locale_string</alloc>
-    <alloc init="true">g_key_file_get_value</alloc>
-    <alloc init="true">g_key_file_get_string</alloc>
-    <alloc init="true">g_key_file_get_boolean_list</alloc>
-    <alloc init="true">g_key_file_get_integer_list</alloc>
-    <alloc init="true">g_key_file_get_double_list</alloc>
-    <alloc init="true">g_key_file_get_comment</alloc>
-    <alloc init="true">g_dbus_proxy_get_name_owner</alloc>
-    <alloc init="true">g_file_info_get_attribute_as_string</alloc>
-    <alloc init="true">g_file_attribute_matcher_to_string</alloc>
-    <alloc init="true">g_app_launch_context_get_environment</alloc>
-    <alloc init="true">g_app_launch_context_get_startup_notify_id</alloc>
-    <alloc init="true">g_filename_completer_get_completion_suffix</alloc>
-    <alloc init="true">g_inet_address_mask_to_string</alloc>
-    <alloc init="true">g_variant_dup_string</alloc>
-    <alloc init="true">g_variant_dup_bytestring</alloc>
-    <alloc init="true">g_variant_get_objv</alloc>
-    <alloc init="true">g_variant_get_strv</alloc>
-    <alloc init="true">g_variant_print</alloc>
-    <alloc init="true">g_datalist_id_dup_data</alloc>
-    <alloc init="true">g_dir_make_tmp</alloc>
-    <alloc init="true">g_filename_from_utf8</alloc>
-    <alloc init="true">g_filename_to_utf8</alloc>
-    <alloc init="true">g_file_read_link</alloc>
-    <alloc init="true">g_find_program_in_path</alloc>
-    <alloc init="true">g_format_size</alloc>
-    <alloc init="true">g_format_size_for_display</alloc>
-    <alloc init="true">g_format_size_full</alloc>
-    <alloc init="true">g_hostname_to_ascii</alloc>
-    <alloc init="true">g_hostname_to_unicode</alloc>
-    <alloc init="true">g_locale_from_utf8</alloc>
-    <alloc init="true">g_locale_to_utf8</alloc>
-    <alloc init="true">g_markup_escape_text</alloc>
-    <alloc init="true">g_markup_printf_escaped</alloc>
-    <alloc init="true">g_markup_vprintf_escaped</alloc>
-    <alloc init="true">g_match_info_expand_references</alloc>
-    <alloc init="true">g_match_info_fetch</alloc>
-    <alloc init="true">g_match_info_fetch_named</alloc>
-    <alloc init="true">g_option_context_get_help</alloc>
-    <alloc init="true">g_regex_escape_nul</alloc>
-    <alloc init="true">g_regex_escape_string</alloc>
-    <alloc init="true">g_regex_replace</alloc>
-    <alloc init="true">g_regex_replace_eval</alloc>
-    <alloc init="true">g_regex_replace_literal</alloc>
-    <alloc init="true">g_shell_quote</alloc>
-    <alloc init="true">g_shell_unquote</alloc>
-    <alloc init="true">g_uri_escape_string</alloc>
-    <alloc init="true">g_uri_parse_scheme</alloc>
-    <alloc init="true">g_uri_unescape_segment</alloc>
-    <alloc init="true">g_uri_unescape_string</alloc>
-    <alloc init="true">g_variant_type_dup_string</alloc>
-    <alloc init="true">g_value_dup_string</alloc>
+    <alloc init="true" no-fail="true">g_ascii_strdown</alloc>
+    <alloc init="true" no-fail="true">g_ascii_strup</alloc>
+    <alloc init="true" no-fail="true">g_base64_decode</alloc>
+    <alloc init="true" no-fail="true">g_base64_encode</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_description</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_mime_type</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_title</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_to_data</alloc>
+    <alloc init="true" no-fail="true">g_build_filename</alloc>
+    <alloc init="true" no-fail="true">g_build_filenamev</alloc>
+    <alloc init="true" no-fail="true">g_build_path</alloc>
+    <alloc init="true" no-fail="true">g_build_pathv</alloc>
+    <alloc init="true" no-fail="true">g_bytes_unref_to_data</alloc>
+    <alloc init="true" no-fail="true">g_compute_checksum_for_bytes</alloc>
+    <alloc init="true" no-fail="true">g_compute_checksum_for_data</alloc>
+    <alloc init="true" no-fail="true">g_compute_checksum_for_string</alloc>
+    <alloc init="true" no-fail="true">g_compute_hmac_for_data</alloc>
+    <alloc init="true" no-fail="true">g_compute_hmac_for_string</alloc>
+    <alloc init="true" no-fail="true">g_convert</alloc>
+    <alloc init="true" no-fail="true">g_convert_with_fallback</alloc>
+    <alloc init="true" no-fail="true">g_convert_with_iconv</alloc>
+    <alloc init="true" no-fail="true">g_credentials_to_string</alloc>
+    <alloc init="true" no-fail="true">g_date_time_format</alloc>
+    <alloc init="true" no-fail="true">g_filename_display_basename</alloc>
+    <alloc init="true" no-fail="true">g_filename_display_name</alloc>
+    <alloc init="true" no-fail="true">g_filename_from_uri</alloc>
+    <alloc init="true" no-fail="true">g_filename_to_uri</alloc>
+    <alloc init="true" no-fail="true">g_get_codeset</alloc>
+    <alloc init="true" no-fail="true">g_get_current_dir</alloc>
+    <alloc init="true" no-fail="true">g_get_locale_variants</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_start_group</alloc>
+    <alloc init="true" no-fail="true">g_key_file_to_data</alloc>
+    <alloc buffer-size="malloc" no-fail="true">g_malloc</alloc>
+    <realloc buffer-size="malloc:2" no-fail="true">g_realloc</realloc>
+    <alloc init="true" buffer-size="malloc" no-fail="true">g_malloc0</alloc>
+    <alloc init="true" buffer-size="calloc" no-fail="true">g_malloc0_n</alloc>
+    <alloc buffer-size="calloc" no-fail="true">g_malloc_n</alloc>
+    <realloc buffer-size="calloc:2,3" no-fail="true">g_realloc_n</realloc>
+    <alloc init="true" no-fail="true">g_memdup</alloc>
+    <alloc init="true" no-fail="true">g_path_get_basename</alloc>
+    <alloc init="true" no-fail="true">g_path_get_dirname</alloc>
+    <alloc no-fail="true">g_slice_alloc</alloc>
+    <alloc init="true" no-fail="true">g_slice_alloc0</alloc>
+    <alloc init="true" no-fail="true">g_slice_copy</alloc>
+    <alloc init="true" no-fail="true">g_strcompress</alloc>
+    <alloc init="true" no-fail="true">g_strconcat</alloc>
+    <alloc init="true" buffer-size="strdup" no-fail="true">g_strdup</alloc>
+    <alloc init="true" no-fail="true">g_strdup_printf</alloc>
+    <alloc init="true" no-fail="true">g_strdup_vprintf</alloc>
+    <alloc init="true" no-fail="true">g_strescape</alloc>
+    <alloc init="true" no-fail="true">g_strjoin</alloc>
+    <alloc init="true" no-fail="true">g_strjoinv</alloc>
+    <alloc init="true" no-fail="true">g_strndup</alloc>
+    <alloc init="true" no-fail="true">g_strnfill</alloc>
+    <alloc init="true" no-fail="true">g_time_val_to_iso8601</alloc>
+    <alloc buffer-size="malloc" no-fail="false">g_try_malloc</alloc>
+    <realloc buffer-size="malloc:2" no-fail="false">g_try_realloc</realloc>
+    <alloc init="true" buffer-size="malloc" no-fail="false">g_try_malloc0</alloc>
+    <alloc init="true" buffer-size="calloc" no-fail="false">g_try_malloc0_n</alloc>
+    <alloc buffer-size="calloc" no-fail="false">g_try_malloc_n</alloc>
+    <realloc buffer-size="calloc:2,3" no-fail="false">g_try_realloc_n</realloc>
+    <alloc init="true" no-fail="true">g_ucs4_to_utf16</alloc>
+    <alloc init="true" no-fail="true">g_ucs4_to_utf8</alloc>
+    <alloc init="true" no-fail="true">g_unicode_canonical_decomposition</alloc>
+    <alloc init="true" no-fail="true">g_utf16_to_ucs4</alloc>
+    <alloc init="true" no-fail="true">g_utf16_to_utf8</alloc>
+    <alloc init="true" no-fail="true">g_utf8_casefold</alloc>
+    <alloc init="true" no-fail="true">g_utf8_collate_key</alloc>
+    <alloc init="true" no-fail="true">g_utf8_collate_key_for_filename</alloc>
+    <alloc init="true" no-fail="true">g_utf8_normalize</alloc>
+    <alloc init="true" no-fail="true">g_utf8_strdown</alloc>
+    <alloc init="true" no-fail="true">g_utf8_strreverse</alloc>
+    <alloc init="true" no-fail="true">g_utf8_strup</alloc>
+    <alloc init="true" no-fail="true">g_utf8_substring</alloc>
+    <alloc init="true" no-fail="true">g_utf8_to_ucs4</alloc>
+    <alloc init="true" no-fail="true">g_utf8_to_ucs4_fast</alloc>
+    <alloc init="true" no-fail="true">g_utf8_to_ucs4_fast</alloc>
+    <alloc init="true" no-fail="true">g_utf8_to_utf16</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_locale_string</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_value</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_string</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_boolean_list</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_integer_list</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_double_list</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_comment</alloc>
+    <alloc init="true" no-fail="true">g_dbus_proxy_get_name_owner</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_attribute_as_string</alloc>
+    <alloc init="true" no-fail="true">g_file_attribute_matcher_to_string</alloc>
+    <alloc init="true" no-fail="true">g_app_launch_context_get_environment</alloc>
+    <alloc init="true" no-fail="true">g_app_launch_context_get_startup_notify_id</alloc>
+    <alloc init="true" no-fail="true">g_filename_completer_get_completion_suffix</alloc>
+    <alloc init="true" no-fail="true">g_inet_address_mask_to_string</alloc>
+    <alloc init="true" no-fail="true">g_variant_dup_string</alloc>
+    <alloc init="true" no-fail="true">g_variant_dup_bytestring</alloc>
+    <alloc init="true" no-fail="true">g_variant_get_objv</alloc>
+    <alloc init="true" no-fail="true">g_variant_get_strv</alloc>
+    <alloc init="true" no-fail="true">g_variant_print</alloc>
+    <alloc init="true" no-fail="true">g_datalist_id_dup_data</alloc>
+    <alloc init="true" no-fail="true">g_dir_make_tmp</alloc>
+    <alloc init="true" no-fail="true">g_filename_from_utf8</alloc>
+    <alloc init="true" no-fail="true">g_filename_to_utf8</alloc>
+    <alloc init="true" no-fail="true">g_file_read_link</alloc>
+    <alloc init="true" no-fail="true">g_find_program_in_path</alloc>
+    <alloc init="true" no-fail="true">g_format_size</alloc>
+    <alloc init="true" no-fail="true">g_format_size_for_display</alloc>
+    <alloc init="true" no-fail="true">g_format_size_full</alloc>
+    <alloc init="true" no-fail="true">g_hostname_to_ascii</alloc>
+    <alloc init="true" no-fail="true">g_hostname_to_unicode</alloc>
+    <alloc init="true" no-fail="true">g_locale_from_utf8</alloc>
+    <alloc init="true" no-fail="true">g_locale_to_utf8</alloc>
+    <alloc init="true" no-fail="true">g_markup_escape_text</alloc>
+    <alloc init="true" no-fail="true">g_markup_printf_escaped</alloc>
+    <alloc init="true" no-fail="true">g_markup_vprintf_escaped</alloc>
+    <alloc init="true" no-fail="true">g_match_info_expand_references</alloc>
+    <alloc init="true" no-fail="true">g_match_info_fetch</alloc>
+    <alloc init="true" no-fail="true">g_match_info_fetch_named</alloc>
+    <alloc init="true" no-fail="true">g_option_context_get_help</alloc>
+    <alloc init="true" no-fail="true">g_regex_escape_nul</alloc>
+    <alloc init="true" no-fail="true">g_regex_escape_string</alloc>
+    <alloc init="true" no-fail="true">g_regex_replace</alloc>
+    <alloc init="true" no-fail="true">g_regex_replace_eval</alloc>
+    <alloc init="true" no-fail="true">g_regex_replace_literal</alloc>
+    <alloc init="true" no-fail="true">g_shell_quote</alloc>
+    <alloc init="true" no-fail="true">g_shell_unquote</alloc>
+    <alloc init="true" no-fail="true">g_uri_escape_string</alloc>
+    <alloc init="true" no-fail="true">g_uri_parse_scheme</alloc>
+    <alloc init="true" no-fail="true">g_uri_unescape_segment</alloc>
+    <alloc init="true" no-fail="true">g_uri_unescape_string</alloc>
+    <alloc init="true" no-fail="true">g_variant_type_dup_string</alloc>
+    <alloc init="true" no-fail="true">g_value_dup_string</alloc>
     <use>g_register_data</use>
     <dealloc>g_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_hash_table_new_full</alloc>
-    <alloc init="true">g_hash_table_new</alloc>
+    <alloc init="true" no-fail="true">g_hash_table_new_full</alloc>
+    <alloc init="true" no-fail="true">g_hash_table_new</alloc>
     <use>g_hash_table_ref</use>
     <dealloc>g_hash_table_destroy</dealloc>
     <dealloc>g_hash_table_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_io_channel_unix_new</alloc>
-    <alloc init="true">g_io_channel_win32_new_fd</alloc>
-    <alloc init="true">g_io_channel_win32_new_socket</alloc>
-    <alloc init="true">g_io_channel_win32_new_messages</alloc>
-    <alloc init="true">g_io_channel_new_file</alloc>
+    <alloc init="true" no-fail="true">g_io_channel_unix_new</alloc>
+    <alloc init="true" no-fail="true">g_io_channel_win32_new_fd</alloc>
+    <alloc init="true" no-fail="true">g_io_channel_win32_new_socket</alloc>
+    <alloc init="true" no-fail="true">g_io_channel_win32_new_messages</alloc>
+    <alloc init="true" no-fail="true">g_io_channel_new_file</alloc>
     <use>g_io_channel_ref</use>
     <dealloc>g_io_channel_close</dealloc>
     <dealloc>g_io_channel_shutdown</dealloc>
     <dealloc>g_io_channel_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_emblemed_icon_get_emblems</alloc>
-    <alloc init="true">g_list_alloc</alloc>
-    <alloc init="true">g_list_copy</alloc>
-    <alloc init="true">g_list_copy_deep</alloc>
-    <alloc init="true">g_app_info_get_all</alloc>
-    <alloc init="true">g_app_info_get_all_for_type</alloc>
-    <alloc init="true">g_app_info_get_fallback_for_type</alloc>
-    <alloc init="true">g_app_info_get_recommended_for_type</alloc>
-    <alloc init="true">g_io_modules_load_all_in_directory</alloc>
-    <alloc init="true">g_io_modules_load_all_in_directory_with_scope</alloc>
-    <alloc init="true">g_hash_table_get_keys</alloc>
-    <alloc init="true">g_hash_table_get_values</alloc>
+    <alloc init="true" no-fail="true">g_emblemed_icon_get_emblems</alloc>
+    <alloc init="true" no-fail="true">g_list_alloc</alloc>
+    <alloc init="true" no-fail="true">g_list_copy</alloc>
+    <alloc init="true" no-fail="true">g_list_copy_deep</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_all</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_all_for_type</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_fallback_for_type</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_recommended_for_type</alloc>
+    <alloc init="true" no-fail="true">g_io_modules_load_all_in_directory</alloc>
+    <alloc init="true" no-fail="true">g_io_modules_load_all_in_directory_with_scope</alloc>
+    <alloc init="true" no-fail="true">g_hash_table_get_keys</alloc>
+    <alloc init="true" no-fail="true">g_hash_table_get_values</alloc>
     <dealloc>g_list_free</dealloc>
     <dealloc>g_list_free_1</dealloc>
     <dealloc>g_list_free_full</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_regex_new</alloc>
+    <alloc init="true" no-fail="true">g_regex_new</alloc>
     <use>g_regex_ref</use>
     <dealloc>g_regex_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_node_new</alloc>
-    <alloc init="true">g_node_copy</alloc>
-    <alloc init="true">g_node_copy_deep</alloc>
+    <alloc init="true" no-fail="true">g_node_new</alloc>
+    <alloc init="true" no-fail="true">g_node_copy</alloc>
+    <alloc init="true" no-fail="true">g_node_copy_deep</alloc>
     <dealloc>g_node_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_time_zone_new</alloc>
-    <alloc init="true">g_time_zone_new_local</alloc>
-    <alloc init="true">g_time_zone_new_utc</alloc>
+    <alloc init="true" no-fail="true">g_time_zone_new</alloc>
+    <alloc init="true" no-fail="true">g_time_zone_new_local</alloc>
+    <alloc init="true" no-fail="true">g_time_zone_new_utc</alloc>
     <use>g_time_zone_ref</use>
     <dealloc>g_time_zone_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_markup_parse_context_new</alloc>
+    <alloc init="true" no-fail="true">g_markup_parse_context_new</alloc>
     <dealloc>g_markup_parse_context_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_mapped_file_new</alloc>
-    <alloc init="true">g_mapped_file_new_from_fd</alloc>
+    <alloc init="true" no-fail="true">g_mapped_file_new</alloc>
+    <alloc init="true" no-fail="true">g_mapped_file_new_from_fd</alloc>
     <use>g_mapped_file_ref</use>
     <dealloc>g_mapped_file_free</dealloc>
     <dealloc>g_mapped_file_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_mutex_new</alloc>
+    <alloc init="true" no-fail="true">g_mutex_new</alloc>
     <dealloc>g_mutex_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_mem_chunk_new</alloc>
+    <alloc init="true" no-fail="true">g_mem_chunk_new</alloc>
     <dealloc>g_mem_chunk_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_option_group_new</alloc>
+    <alloc init="true" no-fail="true">g_option_group_new</alloc>
     <dealloc>g_option_group_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_option_context_new</alloc>
+    <alloc init="true" no-fail="true">g_option_context_new</alloc>
     <dealloc>g_option_context_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_rand_new</alloc>
-    <alloc init="true">g_rand_copy</alloc>
-    <alloc init="true">g_rand_new_with_seed</alloc>
-    <alloc init="true">g_rand_new_with_seed_array</alloc>
+    <alloc init="true" no-fail="true">g_rand_new</alloc>
+    <alloc init="true" no-fail="true">g_rand_copy</alloc>
+    <alloc init="true" no-fail="true">g_rand_new_with_seed</alloc>
+    <alloc init="true" no-fail="true">g_rand_new_with_seed_array</alloc>
     <dealloc>g_rand_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_queue_new</alloc>
-    <alloc init="true">g_queue_copy</alloc>
+    <alloc init="true" no-fail="true">g_queue_new</alloc>
+    <alloc init="true" no-fail="true">g_queue_copy</alloc>
     <dealloc>g_queue_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_slice_new</alloc>
+    <alloc init="true" no-fail="true">g_slice_new</alloc>
     <dealloc>g_slice_free</dealloc>
     <dealloc>g_slice_free1</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_sequence_new</alloc>
+    <alloc init="true" no-fail="true">g_sequence_new</alloc>
     <dealloc>g_sequence_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_completion_new</alloc>
+    <alloc init="true" no-fail="true">g_completion_new</alloc>
     <dealloc>g_completion_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_chunk_new</alloc>
+    <alloc init="true" no-fail="true">g_chunk_new</alloc>
     <dealloc>g_chunk_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_bytes_new</alloc>
-    <alloc init="true">g_bytes_new_take</alloc>
-    <alloc init="true">g_bytes_new_static</alloc>
-    <alloc init="true">g_bytes_new_with_free_func</alloc>
-    <alloc init="true">g_bytes_new_from_bytes</alloc>
-    <alloc init="true">g_byte_array_free_to_bytes</alloc>
-    <alloc init="true">g_memory_output_stream_steal_as_bytes</alloc>
-    <alloc init="true">g_variant_get_data_as_bytes</alloc>
-    <alloc init="true">g_mapped_file_get_bytes</alloc>
+    <alloc init="true" no-fail="true">g_bytes_new</alloc>
+    <alloc init="true" no-fail="true">g_bytes_new_take</alloc>
+    <alloc init="true" no-fail="true">g_bytes_new_static</alloc>
+    <alloc init="true" no-fail="true">g_bytes_new_with_free_func</alloc>
+    <alloc init="true" no-fail="true">g_bytes_new_from_bytes</alloc>
+    <alloc init="true" no-fail="true">g_byte_array_free_to_bytes</alloc>
+    <alloc init="true" no-fail="true">g_memory_output_stream_steal_as_bytes</alloc>
+    <alloc init="true" no-fail="true">g_variant_get_data_as_bytes</alloc>
+    <alloc init="true" no-fail="true">g_mapped_file_get_bytes</alloc>
     <use>g_bytes_ref</use>
     <dealloc>g_bytes_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_bookmark_file_get_uris</alloc>
-    <alloc init="true">g_bookmark_file_get_groups</alloc>
-    <alloc init="true">g_bookmark_file_get_applications</alloc>
-    <alloc init="true">g_key_file_get_groups</alloc>
-    <alloc init="true">g_key_file_get_keys</alloc>
-    <alloc init="true">g_strdupv</alloc>
-    <alloc init="true">g_strsplit</alloc>
-    <alloc init="true">g_strsplit_set</alloc>
-    <alloc init="true">g_uri_list_extract_uris</alloc>
-    <alloc init="true">g_key_file_get_string_list</alloc>
-    <alloc init="true">g_key_file_get_locale_string_list</alloc>
-    <alloc init="true">g_file_info_list_attributes</alloc>
-    <alloc init="true">g_file_info_get_attribute_stringv</alloc>
-    <alloc init="true">g_app_launch_context_get_environment</alloc>
-    <alloc init="true">g_filename_completer_get_completions</alloc>
-    <alloc init="true">g_io_module_query</alloc>
-    <alloc init="true">g_variant_dup_objv</alloc>
-    <alloc init="true">g_variant_dup_bytestring_array</alloc>
-    <alloc init="true">g_environ_setenv</alloc>
-    <alloc init="true">g_environ_unsetenv</alloc>
-    <alloc init="true">g_get_environ</alloc>
-    <alloc init="true">g_listenv</alloc>
-    <alloc init="true">g_match_info_fetch_all</alloc>
-    <alloc init="true">g_regex_split</alloc>
-    <alloc init="true">g_regex_split_full</alloc>
-    <alloc init="true">g_regex_split_simple</alloc>
-    <alloc init="true">g_regex_split_simple</alloc>
-    <alloc init="true">g_variant_dup_strv</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_uris</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_groups</alloc>
+    <alloc init="true" no-fail="true">g_bookmark_file_get_applications</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_groups</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_keys</alloc>
+    <alloc init="true" no-fail="true">g_strdupv</alloc>
+    <alloc init="true" no-fail="true">g_strsplit</alloc>
+    <alloc init="true" no-fail="true">g_strsplit_set</alloc>
+    <alloc init="true" no-fail="true">g_uri_list_extract_uris</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_string_list</alloc>
+    <alloc init="true" no-fail="true">g_key_file_get_locale_string_list</alloc>
+    <alloc init="true" no-fail="true">g_file_info_list_attributes</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_attribute_stringv</alloc>
+    <alloc init="true" no-fail="true">g_app_launch_context_get_environment</alloc>
+    <alloc init="true" no-fail="true">g_filename_completer_get_completions</alloc>
+    <alloc init="true" no-fail="true">g_io_module_query</alloc>
+    <alloc init="true" no-fail="true">g_variant_dup_objv</alloc>
+    <alloc init="true" no-fail="true">g_variant_dup_bytestring_array</alloc>
+    <alloc init="true" no-fail="true">g_environ_setenv</alloc>
+    <alloc init="true" no-fail="true">g_environ_unsetenv</alloc>
+    <alloc init="true" no-fail="true">g_get_environ</alloc>
+    <alloc init="true" no-fail="true">g_listenv</alloc>
+    <alloc init="true" no-fail="true">g_match_info_fetch_all</alloc>
+    <alloc init="true" no-fail="true">g_regex_split</alloc>
+    <alloc init="true" no-fail="true">g_regex_split_full</alloc>
+    <alloc init="true" no-fail="true">g_regex_split_simple</alloc>
+    <alloc init="true" no-fail="true">g_regex_split_simple</alloc>
+    <alloc init="true" no-fail="true">g_variant_dup_strv</alloc>
     <dealloc>g_strfreev</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_hmac_new</alloc>
-    <alloc init="true">g_hmac_copy</alloc>
+    <alloc init="true" no-fail="true">g_hmac_new</alloc>
+    <alloc init="true" no-fail="true">g_hmac_copy</alloc>
     <use>g_hmac_ref</use>
     <dealloc>g_hmac_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_hook_alloc</alloc>
+    <alloc init="true" no-fail="true">g_hook_alloc</alloc>
     <use>g_hook_ref</use>
     <dealloc>g_hook_unref</dealloc>
     <dealloc>g_hook_destroy</dealloc>
     <dealloc>g_hook_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_date_new</alloc>
-    <alloc init="true">g_date_new_dmy</alloc>
-    <alloc init="true">g_date_new_julian</alloc>
+    <alloc init="true" no-fail="true">g_date_new</alloc>
+    <alloc init="true" no-fail="true">g_date_new_dmy</alloc>
+    <alloc init="true" no-fail="true">g_date_new_julian</alloc>
     <dealloc>g_date_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_variant_builder_new</alloc>
+    <alloc init="true" no-fail="true">g_variant_builder_new</alloc>
     <use>g_variant_builder_ref</use>
     <dealloc>g_variant_builder_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_cond_new</alloc>
+    <alloc init="true" no-fail="true">g_cond_new</alloc>
     <dealloc>g_cond_free</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_app_launch_context_new</alloc>
-    <alloc init="true">g_app_info_create_from_commandline</alloc>
-    <alloc init="true">g_app_info_dup</alloc>
-    <alloc init="true">g_app_info_get_default_for_type</alloc>
-    <alloc init="true">g_app_info_get_default_for_uri_scheme</alloc>
-    <alloc init="true">g_application_new</alloc>
-    <alloc init="true">g_application_get_dbus_connection</alloc>
-    <alloc init="true">g_application_get_default</alloc>
-    <alloc init="true">g_buffered_input_stream_new</alloc>
-    <alloc init="true">g_buffered_output_stream_new</alloc>
-    <alloc init="true">g_cancellable_new</alloc>
-    <alloc init="true">g_charset_converter_new</alloc>
-    <alloc init="true">g_converter_input_stream_new</alloc>
-    <alloc init="true">g_converter_output_stream_new</alloc>
-    <alloc init="true">g_credentials_new</alloc>
-    <alloc init="true">g_data_input_stream_new</alloc>
-    <alloc init="true">g_data_output_stream_new</alloc>
-    <alloc init="true">g_dbus_auth_observer_new</alloc>
-    <alloc init="true">g_dbus_connection_new_finish</alloc>
-    <alloc init="true">g_dbus_connection_new_sync</alloc>
-    <alloc init="true">g_dbus_connection_new_for_address_finish</alloc>
-    <alloc init="true">g_dbus_connection_new_for_address_sync</alloc>
-    <alloc init="true">g_dbus_message_new</alloc>
-    <alloc init="true">g_dbus_message_new_signal</alloc>
-    <alloc init="true">g_dbus_message_new_method_call</alloc>
-    <alloc init="true">g_dbus_message_new_method_reply</alloc>
-    <alloc init="true">g_dbus_message_new_method_error</alloc>
-    <alloc init="true">g_dbus_message_new_method_error_valist</alloc>
-    <alloc init="true">g_dbus_message_new_method_error_literal</alloc>
-    <alloc init="true">g_dbus_object_manager_client_new_finish</alloc>
-    <alloc init="true">g_dbus_object_manager_client_new_sync</alloc>
-    <alloc init="true">g_dbus_object_manager_client_new_for_bus_finish</alloc>
-    <alloc init="true">g_dbus_object_manager_client_new_for_bus_sync</alloc>
-    <alloc init="true">g_dbus_object_manager_server_new</alloc>
-    <alloc init="true">g_dbus_object_manager_server_get_connection</alloc>
-    <alloc init="true">g_dbus_object_proxy_new</alloc>
-    <alloc init="true">g_dbus_object_skeleton_new</alloc>
-    <alloc init="true">g_dbus_proxy_new_finish</alloc>
-    <alloc init="true">g_dbus_proxy_new_sync</alloc>
-    <alloc init="true">g_dbus_proxy_new_for_bus_finish</alloc>
-    <alloc init="true">g_dbus_proxy_new_for_bus_sync</alloc>
-    <alloc init="true">g_emblemed_icon_new</alloc>
-    <alloc init="true">g_emblem_new</alloc>
-    <alloc init="true">g_emblem_new_with_origin</alloc>
-    <alloc init="true">g_file_icon_new</alloc>
-    <alloc init="true">g_file_icon_get_file</alloc>
-    <alloc init="true">g_file_info_new</alloc>
-    <alloc init="true">g_file_info_dup</alloc>
-    <alloc init="true">g_file_info_get_icon</alloc>
-    <alloc init="true">g_file_info_get_symbolic_icon</alloc>
-    <alloc init="true">g_file_info_get_attribute_object</alloc>
-    <alloc init="true">g_file_info_get_deletion_date</alloc>
-    <alloc init="true">g_filename_completer_new</alloc>
-    <alloc init="true">g_inet_address_mask_new</alloc>
-    <alloc init="true">g_inet_address_mask_new_from_string</alloc>
-    <alloc init="true">g_inet_address_mask_get_address</alloc>
-    <alloc init="true">g_inet_socket_address_new</alloc>
-    <alloc init="true">g_inet_socket_address_get_address</alloc>
-    <alloc init="true">g_initable_new</alloc>
-    <alloc init="true">g_initable_new_valist</alloc>
-    <alloc init="true">g_initable_newv</alloc>
-    <alloc init="true">g_io_module_new</alloc>
-    <alloc init="true">g_io_module_scope_new</alloc>
-    <alloc init="true">g_keyfile_settings_backend_new</alloc>
-    <alloc init="true">g_memory_input_stream_new</alloc>
-    <alloc init="true">g_memory_input_stream_new_from_data</alloc>
-    <alloc init="true">g_memory_input_stream_new_from_bytes</alloc>
-    <alloc init="true">g_memory_output_stream_new</alloc>
-    <alloc init="true">g_memory_output_stream_new_resizable</alloc>
-    <alloc init="true">g_memory_settings_backend_new</alloc>
-    <alloc init="true">g_null_settings_backend_new</alloc>
-    <alloc init="true">g_menu_item_new</alloc>
-    <alloc init="true">g_menu_item_new_section</alloc>
-    <alloc init="true">g_menu_item_new_submenu</alloc>
-    <alloc init="true">g_menu_item_new_from_model</alloc>
-    <alloc init="true">g_menu_new</alloc>
-    <alloc init="true">g_mount_operation_new</alloc>
-    <alloc init="true">g_network_address_new</alloc>
-    <alloc init="true">g_network_service_new</alloc>
-    <alloc init="true">g_object_new</alloc>
-    <alloc init="true">g_param_spec_pool_new</alloc>
-    <alloc init="true">g_pollable_source_new</alloc>
-    <alloc init="true">g_private_new</alloc>
-    <alloc init="true">g_proxy_address_new</alloc>
-    <alloc init="true">g_ptr_array_sized_new</alloc>
-    <alloc init="true">g_relation_new</alloc>
-    <alloc init="true">g_scanner_new</alloc>
-    <alloc init="true">g_settings_new</alloc>
-    <alloc init="true">g_signal_type_cclosure_new</alloc>
-    <alloc init="true">g_simple_action_group_new</alloc>
-    <alloc init="true">g_simple_action_new</alloc>
-    <alloc init="true">g_simple_async_result_new</alloc>
-    <alloc init="true">g_simple_permission_new</alloc>
-    <alloc init="true">g_socket_client_new</alloc>
-    <alloc init="true">g_socket_listener_new</alloc>
-    <alloc init="true">g_socket_new</alloc>
-    <alloc init="true">g_socket_service_new</alloc>
-    <alloc init="true">g_tcp_wrapper_connection_new</alloc>
-    <alloc init="true">g_test_dbus_new</alloc>
-    <alloc init="true">g_themed_icon_new</alloc>
-    <alloc init="true">g_threaded_socket_service_new</alloc>
-    <alloc init="true">g_tls_client_connection_new</alloc>
-    <alloc init="true">g_tls_file_database_new</alloc>
-    <alloc init="true">g_tls_password_new</alloc>
-    <alloc init="true">g_tls_server_connection_new</alloc>
-    <alloc init="true">g_unix_signal_source_new</alloc>
-    <alloc init="true">g_zlib_compressor_new</alloc>
-    <alloc init="true">g_zlib_decompressor_new</alloc>
+    <alloc init="true" no-fail="true">g_app_launch_context_new</alloc>
+    <alloc init="true" no-fail="true">g_app_info_create_from_commandline</alloc>
+    <alloc init="true" no-fail="true">g_app_info_dup</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_default_for_type</alloc>
+    <alloc init="true" no-fail="true">g_app_info_get_default_for_uri_scheme</alloc>
+    <alloc init="true" no-fail="true">g_application_new</alloc>
+    <alloc init="true" no-fail="true">g_application_get_dbus_connection</alloc>
+    <alloc init="true" no-fail="true">g_application_get_default</alloc>
+    <alloc init="true" no-fail="true">g_buffered_input_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_buffered_output_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_cancellable_new</alloc>
+    <alloc init="true" no-fail="true">g_charset_converter_new</alloc>
+    <alloc init="true" no-fail="true">g_converter_input_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_converter_output_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_credentials_new</alloc>
+    <alloc init="true" no-fail="true">g_data_input_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_data_output_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_auth_observer_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_connection_new_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_connection_new_sync</alloc>
+    <alloc init="true" no-fail="true">g_dbus_connection_new_for_address_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_connection_new_for_address_sync</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_signal</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_method_call</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_method_reply</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_method_error</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_method_error_valist</alloc>
+    <alloc init="true" no-fail="true">g_dbus_message_new_method_error_literal</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_client_new_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_client_new_sync</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_client_new_for_bus_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_client_new_for_bus_sync</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_server_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_manager_server_get_connection</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_proxy_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_object_skeleton_new</alloc>
+    <alloc init="true" no-fail="true">g_dbus_proxy_new_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_proxy_new_sync</alloc>
+    <alloc init="true" no-fail="true">g_dbus_proxy_new_for_bus_finish</alloc>
+    <alloc init="true" no-fail="true">g_dbus_proxy_new_for_bus_sync</alloc>
+    <alloc init="true" no-fail="true">g_emblemed_icon_new</alloc>
+    <alloc init="true" no-fail="true">g_emblem_new</alloc>
+    <alloc init="true" no-fail="true">g_emblem_new_with_origin</alloc>
+    <alloc init="true" no-fail="true">g_file_icon_new</alloc>
+    <alloc init="true" no-fail="true">g_file_icon_get_file</alloc>
+    <alloc init="true" no-fail="true">g_file_info_new</alloc>
+    <alloc init="true" no-fail="true">g_file_info_dup</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_icon</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_symbolic_icon</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_attribute_object</alloc>
+    <alloc init="true" no-fail="true">g_file_info_get_deletion_date</alloc>
+    <alloc init="true" no-fail="true">g_filename_completer_new</alloc>
+    <alloc init="true" no-fail="true">g_inet_address_mask_new</alloc>
+    <alloc init="true" no-fail="true">g_inet_address_mask_new_from_string</alloc>
+    <alloc init="true" no-fail="true">g_inet_address_mask_get_address</alloc>
+    <alloc init="true" no-fail="true">g_inet_socket_address_new</alloc>
+    <alloc init="true" no-fail="true">g_inet_socket_address_get_address</alloc>
+    <alloc init="true" no-fail="true">g_initable_new</alloc>
+    <alloc init="true" no-fail="true">g_initable_new_valist</alloc>
+    <alloc init="true" no-fail="true">g_initable_newv</alloc>
+    <alloc init="true" no-fail="true">g_io_module_new</alloc>
+    <alloc init="true" no-fail="true">g_io_module_scope_new</alloc>
+    <alloc init="true" no-fail="true">g_keyfile_settings_backend_new</alloc>
+    <alloc init="true" no-fail="true">g_memory_input_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_memory_input_stream_new_from_data</alloc>
+    <alloc init="true" no-fail="true">g_memory_input_stream_new_from_bytes</alloc>
+    <alloc init="true" no-fail="true">g_memory_output_stream_new</alloc>
+    <alloc init="true" no-fail="true">g_memory_output_stream_new_resizable</alloc>
+    <alloc init="true" no-fail="true">g_memory_settings_backend_new</alloc>
+    <alloc init="true" no-fail="true">g_null_settings_backend_new</alloc>
+    <alloc init="true" no-fail="true">g_menu_item_new</alloc>
+    <alloc init="true" no-fail="true">g_menu_item_new_section</alloc>
+    <alloc init="true" no-fail="true">g_menu_item_new_submenu</alloc>
+    <alloc init="true" no-fail="true">g_menu_item_new_from_model</alloc>
+    <alloc init="true" no-fail="true">g_menu_new</alloc>
+    <alloc init="true" no-fail="true">g_mount_operation_new</alloc>
+    <alloc init="true" no-fail="true">g_network_address_new</alloc>
+    <alloc init="true" no-fail="true">g_network_service_new</alloc>
+    <alloc init="true" no-fail="true">g_object_new</alloc>
+    <alloc init="true" no-fail="true">g_param_spec_pool_new</alloc>
+    <alloc init="true" no-fail="true">g_pollable_source_new</alloc>
+    <alloc init="true" no-fail="true">g_private_new</alloc>
+    <alloc init="true" no-fail="true">g_proxy_address_new</alloc>
+    <alloc init="true" no-fail="true">g_ptr_array_sized_new</alloc>
+    <alloc init="true" no-fail="true">g_relation_new</alloc>
+    <alloc init="true" no-fail="true">g_scanner_new</alloc>
+    <alloc init="true" no-fail="true">g_settings_new</alloc>
+    <alloc init="true" no-fail="true">g_signal_type_cclosure_new</alloc>
+    <alloc init="true" no-fail="true">g_simple_action_group_new</alloc>
+    <alloc init="true" no-fail="true">g_simple_action_new</alloc>
+    <alloc init="true" no-fail="true">g_simple_async_result_new</alloc>
+    <alloc init="true" no-fail="true">g_simple_permission_new</alloc>
+    <alloc init="true" no-fail="true">g_socket_client_new</alloc>
+    <alloc init="true" no-fail="true">g_socket_listener_new</alloc>
+    <alloc init="true" no-fail="true">g_socket_new</alloc>
+    <alloc init="true" no-fail="true">g_socket_service_new</alloc>
+    <alloc init="true" no-fail="true">g_tcp_wrapper_connection_new</alloc>
+    <alloc init="true" no-fail="true">g_test_dbus_new</alloc>
+    <alloc init="true" no-fail="true">g_themed_icon_new</alloc>
+    <alloc init="true" no-fail="true">g_threaded_socket_service_new</alloc>
+    <alloc init="true" no-fail="true">g_tls_client_connection_new</alloc>
+    <alloc init="true" no-fail="true">g_tls_file_database_new</alloc>
+    <alloc init="true" no-fail="true">g_tls_password_new</alloc>
+    <alloc init="true" no-fail="true">g_tls_server_connection_new</alloc>
+    <alloc init="true" no-fail="true">g_unix_signal_source_new</alloc>
+    <alloc init="true" no-fail="true">g_zlib_compressor_new</alloc>
+    <alloc init="true" no-fail="true">g_zlib_decompressor_new</alloc>
     <use>g_object_ref</use>
     <dealloc>g_object_unref</dealloc>
     <dealloc>gtk_widget_destroy</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_tree_new</alloc>
-    <alloc init="true">g_tree_new_full</alloc>
-    <alloc init="true">g_tree_new_with_data</alloc>
+    <alloc init="true" no-fail="true">g_tree_new</alloc>
+    <alloc init="true" no-fail="true">g_tree_new_full</alloc>
+    <alloc init="true" no-fail="true">g_tree_new_with_data</alloc>
     <use>g_tree_ref</use>
     <dealloc>g_tree_unref</dealloc>
   </memory>
   <memory>
-    <alloc init="true">g_file_attribute_matcher_new</alloc>
-    <alloc init="true">g_file_attribute_matcher_subtract</alloc>
+    <alloc init="true" no-fail="true">g_file_attribute_matcher_new</alloc>
+    <alloc init="true" no-fail="true">g_file_attribute_matcher_subtract</alloc>
     <use>g_file_attribute_matcher_ref</use>
     <dealloc>g_file_attribute_matcher_unref</dealloc>
   </memory>

--- a/gui/cppchecklibrarydata.cpp
+++ b/gui/cppchecklibrarydata.cpp
@@ -272,6 +272,7 @@ static CppcheckLibraryData::MemoryResource loadMemoryResource(QXmlStreamReader &
         if (elementName == "alloc" || elementName == "realloc") {
             CppcheckLibraryData::MemoryResource::Alloc alloc;
             alloc.isRealloc = (elementName == "realloc");
+            alloc.noFail = (xmlReader.attributes().value("no-fail").toString() == "true");
             alloc.init = (xmlReader.attributes().value("init").toString() == "true");
             if (xmlReader.attributes().hasAttribute("arg")) {
                 alloc.arg = xmlReader.attributes().value("arg").toInt();
@@ -723,6 +724,8 @@ static void writeMemoryResource(QXmlStreamWriter &xmlWriter, const CppcheckLibra
             xmlWriter.writeStartElement("alloc");
         }
         xmlWriter.writeAttribute("init", bool_to_string(alloc.init));
+        if (alloc.noFail)
+            xmlWriter.writeAttribute("no-fail", bool_to_string(alloc.noFail));
         if (alloc.arg != -1) {
             xmlWriter.writeAttribute("arg", QString("%1").arg(alloc.arg));
         }

--- a/gui/cppchecklibrarydata.h
+++ b/gui/cppchecklibrarydata.h
@@ -142,6 +142,7 @@ public:
         struct Alloc {
             bool isRealloc{};
             bool init{};
+            bool noFail{};
             int arg = -1; // -1: Has no optional "realloc-arg" attribute
             int reallocArg = -1; // -1: Has no optional "arg" attribute
             QString bufferSize;

--- a/gui/test/cppchecklibrarydata/files/memory_resource_valid.cfg
+++ b/gui/test/cppchecklibrarydata/files/memory_resource_valid.cfg
@@ -6,6 +6,7 @@
 	<realloc init="false" buffer-size="malloc:2">realloc</realloc> 
 	<alloc arg="2">UuidToString</alloc>
 	<dealloc arg="3">HeapFree</dealloc>
+	<alloc init="false" no-fail="true" buffer-size="malloc">g_malloc</alloc>
   </memory>
 
   <resource>

--- a/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
+++ b/gui/test/cppchecklibrarydata/testcppchecklibrarydata.cpp
@@ -284,7 +284,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
     // Do size and content checks against swapped data.
     QCOMPARE(libraryData.memoryresource.size(), 2);
     QCOMPARE(libraryData.memoryresource[0].type, QString("memory"));
-    QCOMPARE(libraryData.memoryresource[0].alloc.size(), 4);
+    QCOMPARE(libraryData.memoryresource[0].alloc.size(), 5);
     QCOMPARE(libraryData.memoryresource[0].dealloc.size(), 1);
     QCOMPARE(libraryData.memoryresource[0].use.size(), 0);
 
@@ -292,6 +292,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
     QCOMPARE(libraryData.memoryresource[0].alloc[0].bufferSize, QString("malloc"));
     QCOMPARE(libraryData.memoryresource[0].alloc[0].isRealloc, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[0].init, false);
+    QCOMPARE(libraryData.memoryresource[0].alloc[0].noFail, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[0].arg, -1);
     QCOMPARE(libraryData.memoryresource[0].alloc[0].reallocArg, -1);
 
@@ -299,6 +300,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
     QCOMPARE(libraryData.memoryresource[0].alloc[1].bufferSize, QString("calloc"));
     QCOMPARE(libraryData.memoryresource[0].alloc[1].isRealloc, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[1].init, true);
+    QCOMPARE(libraryData.memoryresource[0].alloc[1].noFail, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[1].arg, -1);
     QCOMPARE(libraryData.memoryresource[0].alloc[1].reallocArg, -1);
 
@@ -306,6 +308,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
     QCOMPARE(libraryData.memoryresource[0].alloc[2].bufferSize, QString("malloc:2"));
     QCOMPARE(libraryData.memoryresource[0].alloc[2].isRealloc, true);
     QCOMPARE(libraryData.memoryresource[0].alloc[2].init, false);
+    QCOMPARE(libraryData.memoryresource[0].alloc[2].noFail, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[2].arg, -1);
     QCOMPARE(libraryData.memoryresource[0].alloc[2].reallocArg, -1);
 
@@ -313,8 +316,17 @@ void TestCppcheckLibraryData::memoryResourceValid()
     QCOMPARE(libraryData.memoryresource[0].alloc[3].bufferSize.isEmpty(), true);
     QCOMPARE(libraryData.memoryresource[0].alloc[3].isRealloc, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[3].init, false);
+    QCOMPARE(libraryData.memoryresource[0].alloc[3].noFail, false);
     QCOMPARE(libraryData.memoryresource[0].alloc[3].arg, 2);
     QCOMPARE(libraryData.memoryresource[0].alloc[3].reallocArg, -1);
+
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].name, QString("g_malloc"));
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].bufferSize, QString("malloc"));
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].isRealloc, false);
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].init, false);
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].noFail, true);
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].arg, -1);
+    QCOMPARE(libraryData.memoryresource[0].alloc[4].reallocArg, -1);
 
     QCOMPARE(libraryData.memoryresource[0].dealloc[0].name, QString("HeapFree"));
     QCOMPARE(libraryData.memoryresource[0].dealloc[0].arg, 3);
@@ -328,6 +340,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
     QCOMPARE(libraryData.memoryresource[1].alloc[0].bufferSize.isEmpty(), true);
     QCOMPARE(libraryData.memoryresource[1].alloc[0].isRealloc, false);
     QCOMPARE(libraryData.memoryresource[1].alloc[0].init, true);
+    QCOMPARE(libraryData.memoryresource[1].alloc[0].noFail, false);
     QCOMPARE(libraryData.memoryresource[1].alloc[0].arg, 1);
     QCOMPARE(libraryData.memoryresource[1].alloc[0].reallocArg, -1);
 
@@ -362,6 +375,7 @@ void TestCppcheckLibraryData::memoryResourceValid()
             QCOMPARE(lhs.alloc[num].bufferSize, rhs.alloc[num].bufferSize);
             QCOMPARE(lhs.alloc[num].isRealloc, rhs.alloc[num].isRealloc);
             QCOMPARE(lhs.alloc[num].init, rhs.alloc[num].init);
+            QCOMPARE(lhs.alloc[num].noFail, rhs.alloc[num].noFail);
             QCOMPARE(lhs.alloc[num].arg, rhs.alloc[num].arg);
             QCOMPARE(lhs.alloc[num].reallocArg, rhs.alloc[num].reallocArg);
         }

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -366,6 +366,7 @@ Library::Error Library::load(const tinyxml2::XMLDocument &doc)
                     AllocFunc temp;
                     temp.groupId = allocationId;
 
+                    temp.noFail = memorynode->BoolAttribute("no-fail", false);
                     temp.initData = memorynode->BoolAttribute("init", true);
                     temp.arg = memorynode->IntAttribute("arg", -1);
 

--- a/lib/library.h
+++ b/lib/library.h
@@ -88,6 +88,7 @@ public:
         int bufferSizeArg2{};
         int reallocArg{};
         bool initData{};
+        bool noFail{};
     };
 
     /** get allocation info for function */

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -6975,7 +6975,9 @@ static void valueFlowUnknownFunctionReturn(TokenList& tokenlist, const Settings&
             continue;
 
         if (const auto* f = settings.library.getAllocFuncInfo(tok->astOperand1())) {
-            if (settings.library.returnValueType(tok->astOperand1()).find('*') != std::string::npos) {
+            if (f->noFail) {
+                // Allocation function that cannot fail
+            } else if (settings.library.returnValueType(tok->astOperand1()).find('*') != std::string::npos) {
                 // Allocation function that returns a pointer
                 ValueFlow::Value value(0);
                 value.setPossible();

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -46,12 +46,10 @@ void validCode(int argInt, GHashTableIter * hash_table_iter, GHashTable * hash_t
     g_printerr("err");
 
     GString * pGStr1 = g_string_new("test");
-    // cppcheck-suppress nullPointerOutOfMemory
     g_string_append(pGStr1, "a");
     g_string_free(pGStr1, TRUE);
 
     gchar * pGchar1 = g_strconcat("a", "b", NULL);
-    // cppcheck-suppress nullPointerOutOfMemory
     printf("%s", pGchar1);
     g_free(pGchar1);
 


### PR DESCRIPTION
For example GLib and GTK abort on most allocation failures, making the nullPointerOutOfMemory check produce lots of false positives.

To fix this, introduce a new allocator attribute "no-fail" to notify that this allocator cannot fail and that this check is thus irrelevant for it.