### PR TITLE
Evaluate type traits in valueflow

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -709,7 +709,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };
-    eval["is_lvalue_reference"] = [&](std::vector<std::vector<const Token*>> args) {
+    eval["is_lvalue_reference"] = [&](const std::vector<std::vector<const Token*>>& args) {
         if (args.size() != 1)
             return ValueFlow::Value::unknown();
         if (args[0].back()->str() == "&")
@@ -718,7 +718,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };
-    eval["is_rvalue_reference"] = [&](std::vector<std::vector<const Token*>> args) {
+    eval["is_rvalue_reference"] = [&](const std::vector<std::vector<const Token*>>& args) {
         if (args.size() != 1)
             return ValueFlow::Value::unknown();
         if (args[0].back()->str() == "&&")
@@ -727,7 +727,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };
-    eval["is_reference"] = [&](std::vector<std::vector<const Token*>> args) {
+    eval["is_reference"] = [&](const std::vector<std::vector<const Token*>>& args) {
         if (args.size() != 1)
             return ValueFlow::Value::unknown();
         ValueFlow::Value isRValue = eval["is_rvalue_reference"](args);

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -705,7 +705,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
         stripCV(args[0]);
         if (args[0].size() == 1 && args[0][0]->str() == "void")
             return ValueFlow::Value(1);
-        else if (!hasUnknownType(args[0]))
+        if (!hasUnknownType(args[0]))
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };
@@ -714,7 +714,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
             return ValueFlow::Value::unknown();
         if (args[0].back()->str() == "&")
             return ValueFlow::Value(1);
-        else if (!hasUnknownType(args[0]))
+        if (!hasUnknownType(args[0]))
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };
@@ -723,7 +723,7 @@ static void valueFlowTypeTraits(TokenList& tokenlist, const Settings& settings)
             return ValueFlow::Value::unknown();
         if (args[0].back()->str() == "&&")
             return ValueFlow::Value(1);
-        else if (!hasUnknownType(args[0]))
+        if (!hasUnknownType(args[0]))
             return ValueFlow::Value(0);
         return ValueFlow::Value::unknown();
     };

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -130,8 +130,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include <iostream>
-
 static void bailoutInternal(const std::string& type,
                             const TokenList& tokenlist,
                             ErrorLogger& errorLogger,

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -534,7 +534,14 @@ private:
     }
 
 #define testKnownValueOfTok(...) testKnownValueOfTok_(__FILE__, __LINE__, __VA_ARGS__)
-    bool testKnownValueOfTok_(const char* file, int line, const char code[], const char tokstr[], int value, const Settings *s = nullptr, bool cpp = true) {
+    bool testKnownValueOfTok_(const char* file,
+                              int line,
+                              const char code[],
+                              const char tokstr[],
+                              int value,
+                              const Settings* s = nullptr,
+                              bool cpp = true)
+    {
         std::list<ValueFlow::Value> values = removeImpossible(tokenValues_(file, line, code, tokstr, s, cpp));
         return std::any_of(values.begin(), values.end(), [&](const ValueFlow::Value& v) {
             return v.isKnown() && v.isIntValue() && v.intvalue == value;
@@ -605,7 +612,8 @@ private:
         ASSERT_EQUALS(true, testValueOfX(code, 2, "\"abc\"", ValueFlow::Value::ValueType::TOK));
     }
 
-    void valueFlowTypeTraits() {
+    void valueFlowTypeTraits()
+    {
         ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<void>{};", "{", 1));
         ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<void>::value;", ":: value", 1));
         ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void_v<void>;", "::", 1));
@@ -632,53 +640,53 @@ private:
         ASSERT_EQUALS(true, testKnownValueOfTok("std::is_reference<int&&>{};", "{", 1));
 
         {
-            const char *code;
+            const char* code;
             code = "void bar();\n"
-                                "void foo() { std::is_void<decltype(bar())>::value; }";
+                   "void foo() { std::is_void<decltype(bar())>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
 
             code = "int bar();\n"
-                                "void foo() { std::is_void<decltype(bar())>::value; }";
+                   "void foo() { std::is_void<decltype(bar())>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "void bar();\n"
-                                "void foo() { std::is_void<decltype(bar)>::value; }";
+                   "void foo() { std::is_void<decltype(bar)>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_lvalue_reference<A>::value; }";
+                   "void foo() { std::is_lvalue_reference<A>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_lvalue_reference<A&>::value; }";
+                   "void foo() { std::is_lvalue_reference<A&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
 
             code = "class A;\n"
-                                "void foo() { std::is_lvalue_reference<A&&>::value; }";
+                   "void foo() { std::is_lvalue_reference<A&&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_rvalue_reference<A>::value; }";
+                   "void foo() { std::is_rvalue_reference<A>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_rvalue_reference<A&>::value; }";
+                   "void foo() { std::is_rvalue_reference<A&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_rvalue_reference<A&&>::value; }";
+                   "void foo() { std::is_rvalue_reference<A&&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
 
             code = "class A;\n"
-                                "void foo() { std::is_reference<A>::value; }";
+                   "void foo() { std::is_reference<A>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
 
             code = "class A;\n"
-                                "void foo() { std::is_reference<A&>::value; }";
+                   "void foo() { std::is_reference<A&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
 
             code = "class A;\n"
-                                "void foo() { std::is_reference<A&&>::value; }";
+                   "void foo() { std::is_reference<A&&>::value; }";
             ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
 
             code = "void foo() {\n"

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -57,6 +57,7 @@ private:
 
         TEST_CASE(valueFlowNumber);
         TEST_CASE(valueFlowString);
+        TEST_CASE(valueFlowTypeTraits);
         TEST_CASE(valueFlowPointerAlias);
         TEST_CASE(valueFlowLifetime);
         TEST_CASE(valueFlowArrayElement);
@@ -532,6 +533,14 @@ private:
         return values.size() == 1U && !values.front().isTokValue() ? values.front() : ValueFlow::Value();
     }
 
+#define testKnownValueOfTok(...) testKnownValueOfTok_(__FILE__, __LINE__, __VA_ARGS__)
+    bool testKnownValueOfTok_(const char* file, int line, const char code[], const char tokstr[], int value, const Settings *s = nullptr, bool cpp = true) {
+        std::list<ValueFlow::Value> values = removeImpossible(tokenValues_(file, line, code, tokstr, s, cpp));
+        return std::any_of(values.begin(), values.end(), [&](const ValueFlow::Value& v) {
+            return v.isKnown() && v.isIntValue() && v.intvalue == value;
+        });
+    }
+
     static std::list<ValueFlow::Value> removeSymbolicTok(std::list<ValueFlow::Value> values)
     {
         values.remove_if([](const ValueFlow::Value& v) {
@@ -594,6 +603,135 @@ private:
                 "\n"
                 "void test() { dostuff(\"abc\"); }";
         ASSERT_EQUALS(true, testValueOfX(code, 2, "\"abc\"", ValueFlow::Value::ValueType::TOK));
+    }
+
+    void valueFlowTypeTraits() {
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<void>{};", "{", 1));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<void>::value;", ":: value", 1));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void_v<void>;", "::", 1));
+
+        // is_void
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<int>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<void*>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<const void>{};", "{", 1));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_void<volatile void>{};", "{", 1));
+
+        // is_lvalue_reference
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_lvalue_reference<int>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_lvalue_reference<int&>{};", "{", 1));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_lvalue_reference<int&&>{};", "{", 0));
+
+        // is_rvalue_reference
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_rvalue_reference<int>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_rvalue_reference<int&>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_rvalue_reference<int&&>{};", "{", 1));
+
+        // is_reference
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_reference<int>{};", "{", 0));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_reference<int&>{};", "{", 1));
+        ASSERT_EQUALS(true, testKnownValueOfTok("std::is_reference<int&&>{};", "{", 1));
+
+        {
+            const char *code;
+            code = "void bar();\n"
+                                "void foo() { std::is_void<decltype(bar())>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "int bar();\n"
+                                "void foo() { std::is_void<decltype(bar())>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void bar();\n"
+                                "void foo() { std::is_void<decltype(bar)>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_lvalue_reference<A>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_lvalue_reference<A&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "class A;\n"
+                                "void foo() { std::is_lvalue_reference<A&&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_rvalue_reference<A>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_rvalue_reference<A&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_rvalue_reference<A&&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "class A;\n"
+                                "void foo() { std::is_reference<A>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "class A;\n"
+                                "void foo() { std::is_reference<A&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "class A;\n"
+                                "void foo() { std::is_reference<A&&>::value; }";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "void foo() {\n"
+                   "    int bar;\n"
+                   "    std::is_void<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int bar) {\n"
+                   "    std::is_lvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int& bar) {\n"
+                   "    std::is_lvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "void foo(int&& bar) {\n"
+                   "    std::is_lvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int bar) {\n"
+                   "    std::is_rvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int& bar) {\n"
+                   "    std::is_rvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int&& bar) {\n"
+                   "    std::is_rvalue_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "void foo(int bar) {\n"
+                   "    std::is_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 0));
+
+            code = "void foo(int& bar) {\n"
+                   "    std::is_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+
+            code = "void foo(int&& bar) {\n"
+                   "    std::is_reference<decltype(bar)>::value;\n"
+                   "}\n";
+            ASSERT_EQUALS(true, testKnownValueOfTok(code, ":: value", 1));
+        }
     }
 
     void valueFlowPointerAlias() {


### PR DESCRIPTION
Right now it just evaluates `is_void`, `is_lvalue_reference`, and `is_rvalue_reference`. More work needed to handle library types in the type traits