### PR TITLE
fixed building outdated (pre-3.5) CMake projects in CI

### DIFF
--- a/.github/workflows/CI-windows.yml
+++ b/.github/workflows/CI-windows.yml
@@ -127,9 +127,11 @@ jobs:
       - name: Install PCRE
         if: steps.cache-pcre.outputs.cache-hit != 'true'
         run: |
+          @echo on
           7z x pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
           cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
-          cmake . -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DPCRE_BUILD_PCRECPP=Off -DPCRE_BUILD_TESTS=Off -DPCRE_BUILD_PCREGREP=Off || exit /b !errorlevel!
+          git apply --ignore-space-change ..\externals\pcre.patch || exit /b !errorlevel!
+          cmake . -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DPCRE_BUILD_PCRECPP=Off -DPCRE_BUILD_TESTS=Off -DPCRE_BUILD_PCREGREP=Off -DCMAKE_POLICY_VERSION_MINIMUM=3.5 || exit /b !errorlevel!
           nmake || exit /b !errorlevel!
           copy pcre.h ..\externals || exit /b !errorlevel!
           copy pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           wget https://github.com/uncrustify/uncrustify/archive/refs/tags/uncrustify-0.72.0.tar.gz
           tar xzvf uncrustify-0.72.0.tar.gz && cd uncrustify-uncrustify-0.72.0 
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build build -- -j$(nproc) -s
           mkdir ~/uncrustify 
           cd build && cp uncrustify ~/uncrustify/

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Install PCRE
         if: steps.cache-pcre.outputs.cache-hit != 'true'
         run: |
+          @echo on
           7z x pcre-%PCRE_VERSION%.zip || exit /b !errorlevel!
           cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
-          cmake . -G "Visual Studio 17 2022" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF || exit /b !errorlevel!
+          git apply --ignore-space-change ..\externals\pcre.patch || exit /b !errorlevel!
+          cmake . -G "Visual Studio 17 2022" -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 || exit /b !errorlevel!
           msbuild -m PCRE.sln -p:Configuration=Release -p:Platform=x64 || exit /b !errorlevel!
           copy pcre.h ..\externals || exit /b !errorlevel!
           copy Release\pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: CMake (corpus / no test)
         run: |
-          cmake -S cppcheck-2.8 -B cmake.output.corpus -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=Off -DBUILD_GUI=ON -DUSE_QT6=On -DWITH_QCHART=ON -DENABLE_CHECK_INTERNAL=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On
+          cmake -S cppcheck-2.8 -B cmake.output.corpus -G "Unix Makefiles" -DHAVE_RULES=On -DBUILD_TESTS=Off -DBUILD_GUI=ON -DUSE_QT6=On -DWITH_QCHART=ON -DENABLE_CHECK_INTERNAL=On -DCMAKE_GLOBAL_AUTOGEN_TARGET=On -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Generate dependencies (corpus)
         run: |

--- a/externals/pcre.patch
+++ b/externals/pcre.patch
@@ -1,0 +1,12 @@
+diff -urN pcre/CMakeLists.txt pcre-8.45/CMakeLists.txt
+--- pcre/CMakeLists.txt	2021-11-05 13:28:16.000000000 +0100
++++ pcre-8.45/CMakeLists.txt	2025-04-02 10:18:49.636009900 +0200
+@@ -77,7 +77,7 @@
+ # CMP0026 to avoid warnings for the use of LOCATION in GET_TARGET_PROPERTY.
+ 
+ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
+-CMAKE_POLICY(SET CMP0026 OLD)
++#CMAKE_POLICY(SET CMP0026 OLD)
+ 
+ # For FindReadline.cmake. This was changed to allow setting CMAKE_MODULE_PATH
+ # on the command line.


### PR DESCRIPTION
CMake 4.0 removed support for projects targeting versions prior to 3.5.