### PR TITLE
Feat: add checker for detecting uncontrolled format string

### DIFF
--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -43,8 +43,6 @@
 #include <utility>
 #include <vector>
 
-#include <iostream>
-
 //---------------------------------------------------------------------------
 
 // Register CheckIO..

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -1714,7 +1714,9 @@ bool CheckIO::ArgumentInfo::isLibraryType(const Settings &settings) const
 }
 
 void CheckIO::nonConstantFormatStringError(const Token* tok) {
-    reportError(tok, Severity::error, "nonConstantString", "format string must be a string literal", CWE134, Certainty::normal);
+    if (mSettings->severity.isEnabled(Severity::warning)) {
+        reportError(tok, Severity::warning, "nonConstantString", "format string must be a string literal", CWE134, Certainty::normal);
+    }
 }
 
 void CheckIO::wrongPrintfScanfArgumentsError(const Token* tok,

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -67,6 +67,9 @@ private:
     /** @brief %Checks type and number of arguments given to functions like printf or scanf*/
     void checkWrongPrintfScanfArguments();
 
+    bool findFormat(nonneg int arg, const Token *firstArg,
+                    const Token *&formatStringTok, const Token *&formatArgTok);
+
     class ArgumentInfo {
     public:
         ArgumentInfo(const Token *arg, const Settings &settings, bool _isCPP);
@@ -108,6 +111,7 @@ private:
     void seekOnAppendedFileError(const Token *tok);
     void incompatibleFileOpenError(const Token *tok, const std::string &filename);
     void invalidScanfError(const Token *tok);
+    void nonConstantFormatStringError(const Token *tok);
     void wrongPrintfScanfArgumentsError(const Token* tok,
                                         const std::string &functionName,
                                         nonneg int numFormat,


### PR DESCRIPTION
Trying to add a new checker to find uncontrolled format string, which can be used to do stack smashing.

Test example:
```C++
int main(int argc, const char* argv[]) {
    const char* fmt = argv[1];
    printf(fmt);
    printf(argv[1]);
    return 0;
}
```

Expect report:
```cmd
iot_repos/format_string/a.c:36:12: error: format string must be a string literal [nonConstantString]
    printf(fmt);
           ^
iot_repos/format_string/a.c:38:12: error: format string must be a string literal [nonConstantString]
    printf(argv[1]);
           ^
```