### PR TITLE
Fix #13800 FN identicalInnerCondition with comma operator

### DIFF
--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -732,6 +732,8 @@ void CheckCondition::multiCondition2()
 
                     // Condition..
                     const Token *cond2 = tok->str() == "if" ? condStartToken->astOperand2() : condStartToken->astOperand1();
+                    if (Token::simpleMatch(cond2, ","))
+                        cond2 = cond2->astOperand2();
                     const bool isReturnVar = (tok->str() == "return" && (!Token::Match(cond2, "%cop%") || (cond2 && cond2->isUnaryOp("!"))));
 
                     ErrorPath errorPath;

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -2817,6 +2817,14 @@ private:
                "    }\n"
                "}");
         ASSERT_EQUALS("", errout_str());
+
+        check("void g(int);\n" // #13800
+              "void f(int i) {\n"
+              "    if (i) {\n"
+              "        if (g(0), i) {}\n"
+              "    }\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:4]: (warning) Identical inner 'if' condition is always true.\n", errout_str());
     }
 
     void identicalConditionAfterEarlyExit() {


### PR DESCRIPTION
There won't be a warning if the conditions are swapped due to a `nonConstFunctionCall` bailout, even if `cond1` is adjusted.