### PR TITLE
Fix  #13816 FN uninitMemberVar with union (regression)

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -172,17 +172,6 @@ void CheckClass::constructors()
         if (!printWarnings)
             continue;
 
-        // #3196 => bailout if there are nested unions
-        // TODO: handle union variables better
-        // {
-        //     const bool bailout = std::any_of(scope->nestedList.cbegin(), scope->nestedList.cend(), [](const Scope* nestedScope) {
-        //         return nestedScope->type == ScopeType::eUnion;
-        //     });
-        //     if (bailout)
-        //         continue;
-        // }
-
-
         std::vector<Usage> usageList = createUsageList(scope);
 
         for (const Function &func : scope->functionList) {
@@ -310,22 +299,20 @@ void CheckClass::constructors()
                     // If constructor is not in scope then we maybe using a constructor from a different template specialization
                     if (!precedes(scope->bodyStart, func.tokenDef))
                         continue;
-                    const Scope *varType = var.typeScope();
-                     {
-                        const bool derived = scope != var.scope();
-                        if (func.type == FunctionType::eConstructor &&
-                            func.nestedIn && (func.nestedIn->numConstructors - func.nestedIn->numCopyOrMoveConstructors) > 1 &&
-                            func.argCount() == 0 && func.functionScope &&
-                            func.arg && func.arg->link()->next() == func.functionScope->bodyStart &&
-                            func.functionScope->bodyStart->link() == func.functionScope->bodyStart->next()) {
-                            // don't warn about user defined default constructor when there are other constructors
-                            if (printInconclusive)
-                                uninitVarError(func.token, func.access == AccessControl::Private, func.type, var.scope()->className, var.name(), derived, true);
-                        } else if (missingCopy)
-                            missingMemberCopyError(func.token, func.type, var.scope()->className, var.name());
-                        else
-                            uninitVarError(func.token, func.access == AccessControl::Private, func.type, var.scope()->className, var.name(), derived, false);
-                    }
+
+                    const bool derived = scope != var.scope();
+                    if (func.type == FunctionType::eConstructor &&
+                        func.nestedIn && (func.nestedIn->numConstructors - func.nestedIn->numCopyOrMoveConstructors) > 1 &&
+                        func.argCount() == 0 && func.functionScope &&
+                        func.arg && func.arg->link()->next() == func.functionScope->bodyStart &&
+                        func.functionScope->bodyStart->link() == func.functionScope->bodyStart->next()) {
+                        // don't warn about user defined default constructor when there are other constructors
+                        if (printInconclusive)
+                            uninitVarError(func.token, func.access == AccessControl::Private, func.type, var.scope()->className, var.name(), derived, true);
+                    } else if (missingCopy)
+                        missingMemberCopyError(func.token, func.type, var.scope()->className, var.name());
+                    else
+                        uninitVarError(func.token, func.access == AccessControl::Private, func.type, var.scope()->className, var.name(), derived, false);
                 }
             }
         }

--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -174,13 +174,13 @@ void CheckClass::constructors()
 
         // #3196 => bailout if there are nested unions
         // TODO: handle union variables better
-        {
-            const bool bailout = std::any_of(scope->nestedList.cbegin(), scope->nestedList.cend(), [](const Scope* nestedScope) {
-                return nestedScope->type == ScopeType::eUnion;
-            });
-            if (bailout)
-                continue;
-        }
+        // {
+        //     const bool bailout = std::any_of(scope->nestedList.cbegin(), scope->nestedList.cend(), [](const Scope* nestedScope) {
+        //         return nestedScope->type == ScopeType::eUnion;
+        //     });
+        //     if (bailout)
+        //         continue;
+        // }
 
 
         std::vector<Usage> usageList = createUsageList(scope);
@@ -311,7 +311,7 @@ void CheckClass::constructors()
                     if (!precedes(scope->bodyStart, func.tokenDef))
                         continue;
                     const Scope *varType = var.typeScope();
-                    if (!varType || varType->type != ScopeType::eUnion) {
+                     {
                         const bool derived = scope != var.scope();
                         if (func.type == FunctionType::eConstructor &&
                             func.nestedIn && (func.nestedIn->numConstructors - func.nestedIn->numCopyOrMoveConstructors) > 1 &&

--- a/test/testconstructors.cpp
+++ b/test/testconstructors.cpp
@@ -1302,7 +1302,7 @@ private:
               "    {\n"
               "    }\n"
               "};");
-        TODO_ASSERT_EQUALS("[test.cpp:9]: (warning) Member variable 'Fred::U' is not initialized in the constructor.\n", "", errout_str());
+        ASSERT_EQUALS("[test.cpp:9]: (warning) Member variable 'Fred::U' is not initialized in the constructor.\n", errout_str());
     }
 
 
@@ -3428,9 +3428,6 @@ private:
     }
 
     void uninitVarUnion2() {
-        // If the "data_type" is 0 it means union member "data" is invalid.
-        // So it's ok to not initialize "data".
-        // related forum: http://sourceforge.net/apps/phpbb/cppcheck/viewtopic.php?f=3&p=1806
         check("union Data { int id; int *ptr; };\n"
               "\n"
               "class Fred {\n"
@@ -3441,7 +3438,7 @@ private:
               "    Fred() : data_type(0)\n"
               "    { }\n"
               "};");
-        ASSERT_EQUALS("", errout_str());
+        ASSERT_EQUALS("[test.cpp:8]: (warning) Member variable 'Fred::data' is not initialized in the constructor.\n", errout_str());
     }
 
     void uninitMissingFuncDef() {


### PR DESCRIPTION
Re `uninitVarUnion2()`: I don't see why there should be a bailout like that for unions, or any other members. 