### PR TITLE
avoid `-Wuseless-cast` GCC warnings with TinyXML-2

### DIFF
--- a/externals/tinyxml2/CMakeLists.txt
+++ b/externals/tinyxml2/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 # TODO: needs to be fixed upstream
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_compile_options(tinyxml2_objs PRIVATE -Wno-suggest-attribute=format)
+    target_compile_options(tinyxml2_objs PRIVATE -Wno-useless-cast)
 endif()
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options_safe(tinyxml2_objs -Wno-implicit-fallthrough)

--- a/lib/xml.h
+++ b/lib/xml.h
@@ -25,6 +25,7 @@
 #if defined(__GNUC__) && (__GNUC__ >= 14)
 SUPPRESS_WARNING_GCC_PUSH("-Wsuggest-attribute=returns_nonnull")
 #endif
+SUPPRESS_WARNING_GCC_PUSH("-Wuseless-cast")
 SUPPRESS_WARNING_CLANG_PUSH("-Wzero-as-null-pointer-constant")
 SUPPRESS_WARNING_CLANG_PUSH("-Wsuggest-destructor-override")
 SUPPRESS_WARNING_CLANG_PUSH("-Winconsistent-missing-destructor-override")
@@ -34,6 +35,7 @@ SUPPRESS_WARNING_CLANG_PUSH("-Winconsistent-missing-destructor-override")
 SUPPRESS_WARNING_CLANG_POP
 SUPPRESS_WARNING_CLANG_POP
 SUPPRESS_WARNING_CLANG_POP
+SUPPRESS_WARNING_GCC_POP
 #if defined(__GNUC__) && (__GNUC__ >= 14)
 SUPPRESS_WARNING_GCC_POP
 #endif


### PR DESCRIPTION
```
In file included from /home/user/cppcheck/externals/tinyxml2/tinyxml2.cpp:24:
/home/user/cppcheck/externals/tinyxml2/tinyxml2.h:442:26: warning: useless cast to type ‘size_t’ {aka ‘long unsigned int’} [-Wuseless-cast]
  442 |         char    itemData[static_cast<size_t>(ITEM_SIZE)];
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```