### PR TITLE
 fix #13775: internalError with operator new

### DIFF
--- a/lib/tokenlist.cpp
+++ b/lib/tokenlist.cpp
@@ -834,6 +834,10 @@ static void compileTerm(Token *&tok, AST_state& state)
                     if (precedes(tok,end)) // typically for something like `MACRO(x, { if (c) { ... } })`, where end is the last curly, and tok is the open curly for the if
                         tok = end;
                 }
+            } else if (tok->next() == end) {
+                tok->astOperand1(state.op.top());
+                state.op.pop();
+                tok = tok->next();
             } else
                 compileBinOp(tok, state, compileExpression);
             if (tok != end)

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -456,6 +456,8 @@ private:
         TEST_CASE(simplifyIfSwitchForInit4);
         TEST_CASE(simplifyIfSwitchForInit5);
 
+        TEST_CASE(newPlacementArgsCppInit); // #13775
+
         TEST_CASE(cpp20_default_bitfield_initializer);
 
         TEST_CASE(cpp11init);
@@ -8068,6 +8070,18 @@ private:
         const Settings settings = settingsBuilder().cpp(Standards::CPP20).build();
         const char code[] = "void f() { if ([] { ; }) {} }";
         ASSERT_EQUALS("void f ( ) { if ( [ ] { ; } ) { } }", tokenizeAndStringify(code, settings));
+    }
+
+    void newPlacementArgsCppInit() { // #13775
+        const char code[] = "::new(nullptr) int {};";
+        SimpleTokenizer tokenizer(settings1, *this);
+        tokenizer.tokenize(code);
+        const Token *inttok = Token::findsimplematch(tokenizer.tokens(), "int");
+        ASSERT(inttok);
+        const Token *brace = inttok->next();
+        ASSERT(brace);
+        ASSERT_EQUALS(brace->astOperand1(), inttok);
+        ASSERT_EQUALS(brace->astOperand2(), (const Token*) nullptr);
     }
 
     void cpp20_default_bitfield_initializer() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -8081,7 +8081,7 @@ private:
         const Token *brace = inttok->next();
         ASSERT(brace);
         ASSERT_EQUALS(brace->astOperand1(), inttok);
-        ASSERT_EQUALS(brace->astOperand2(), (const Token*) nullptr);
+        ASSERT_EQUALS(brace->astOperand2(), static_cast<const Token*>(nullptr));
     }
 
     void cpp20_default_bitfield_initializer() {


### PR DESCRIPTION
Compiling an empty initializer list as a binary operator would previously take too many tokens from the operand stack.