### PR TITLE
Teach qt.cfg about qml integration macros

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5448,6 +5448,9 @@
   <define name="QML_UNAVAILABLE" value=""/>
   <define name="QML_UNCREATABLE(reason)" value=""/>
   <define name="QML_VALUE_TYPE(name)" value=""/>
+  <!-- https://doc.qt.io/qt-6/qqml-h-qtqml-proxy.html -->
+  <define name="QML_DECLARE_TYPE" value=""/>
+  <define name="QML_DECLARE_TYPEINFO(Type, Flags)" value=""/>
   <!-- https://doc.qt.io/qt-5/qstring.html#QStringLiteral -->
   <define name="QStringLiteral(str)" value="QString::fromUtf8(str, sizeof(str) - 1)"/>
   <define name="QByteArrayLiteral(str)" value="QByteArray(str)"/>

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5427,6 +5427,27 @@
   <define name="Q_LOGGING_CATEGORY(name,...)" value=""/>
   <define name="QT_FORWARD_DECLARE_CLASS(name)" value="class name;"/>
   <define name="QT_FORWARD_DECLARE_STRUCT(name)" value="struct name;"/>
+  <!-- https://doc.qt.io/qt-6/qqmlintegration-h-qtqml-proxy.html -->
+  <define name="QML_ADDED_IN_VERSION(MAJOR, MINOR)" value=""/>
+  <define name="QML_ANONYMOUS" value=""/>
+  <define name="QML_ATTACHED(ATTACHED_TYPE)" value=""/>
+  <define name="QML_CONSTRUCTIBLE_VALUE" value=""/>
+  <define name="QML_ELEMENT" value=""/>
+  <define name="QML_EXTENDED(EXTENDED_TYPE)" value=""/>
+  <define name="QML_EXTENDED_NAMESPACE(EXTENSION_NAMESPACE)" value=""/>
+  <define name="QML_EXTRA_VERSION(MAJOR, MINOR)" value=""/>
+  <define name="QML_FOREIGN(FOREIGN_TYPE)" value=""/>
+  <define name="QML_FOREIGN_NAMESPACE(FOREIGN_NAMESPACE)" value=""/>
+  <define name="QML_IMPLEMENTS_INTERFACES(interfaces)" value=""/>
+  <define name="QML_INTERFACE" value=""/>
+  <define name="QML_NAMED_ELEMENT(name)" value=""/>
+  <define name="QML_REMOVED_IN_VERSION(MAJOR, MINOR)" value=""/>
+  <define name="QML_SEQUENTIAL_CONTAINER(VALUE_TYPE)" value=""/>
+  <define name="QML_SINGLETON" value=""/>
+  <define name="QML_STRUCTURED_VALUE" value=""/>
+  <define name="QML_UNAVAILABLE" value=""/>
+  <define name="QML_UNCREATABLE(reason)" value=""/>
+  <define name="QML_VALUE_TYPE(name)" value=""/>
   <!-- https://doc.qt.io/qt-5/qstring.html#QStringLiteral -->
   <define name="QStringLiteral(str)" value="QString::fromUtf8(str, sizeof(str) - 1)"/>
   <define name="QByteArrayLiteral(str)" value="QByteArray(str)"/>


### PR DESCRIPTION
Docs at:
https://doc.qt.io/qt-6/qqmlintegration-h-qtqml-proxy.html

All macros are more or less defined to a series of Q_CLASS_INFO and a bit of extra magic mostly for the QML engine at runtime, so nothing important to expand to