### PR TITLE
cfg: add relative location of Cppcheck config location to search path

### DIFF
--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -224,6 +224,7 @@ Library::Error Library::load(const char exename[], const char path[], bool debug
             if (exename) {
                 std::string exepath(Path::fromNativeSeparators(Path::getPathFromFilename(Path::getCurrentExecutablePath(exename))));
                 cfgfolders.push_back(exepath + "cfg");
+                cfgfolders.push_back(exepath + "../share/Cppcheck/cfg");
                 cfgfolders.push_back(std::move(exepath));
             }
 


### PR DESCRIPTION
We are installing cppcheck on a distributed filesystem (CVMFS) in various locations.

Since the cppcheck cfg files are installed into `${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}` it would be great if we could use the fact that the `share` folder is relative to the executable, so that we can relocate cppcheck easily.

Defining `FILESDIR(_DEF)` does not work for this, since we cannot change this after compilation, and we do not know a priory where the installation will be. We compile cppcheck once and install it on many locations.

Thanks!