### PR TITLE
fix #13881: Stack overflow in findTokensSkipDeadCodeImpl()

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2650,6 +2650,10 @@ namespace {
             return false;
         }
 
+        if (Token::simpleMatch(tok1->tokAt(-2), "> ::")) {
+            return false;
+        }
+
         if (Token::Match(tok1, "%name% (") && TokenList::isFunctionHead(tok1->next(), "{;:")) {
             if (Token::Match(tok1->previous(), "%name%") && !tok1->previous()->isControlFlowKeyword())
                 return false;

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -140,6 +140,7 @@ private:
         TEST_CASE(nullpointer101);        // #11382
         TEST_CASE(nullpointer102);
         TEST_CASE(nullpointer103);
+        TEST_CASE(nullpointer104); // #13881
         TEST_CASE(nullpointer_addressOf); // address of
         TEST_CASE(nullpointerSwitch); // #2626
         TEST_CASE(nullpointer_cast); // #4692
@@ -2917,6 +2918,15 @@ private:
               "    f(nullptr, &x);\n"
               "}\n");
         TODO_ASSERT_EQUALS("", "[test.cpp:3:10]: (warning) Possible null pointer dereference: p [nullPointer]\n", errout_str());
+    }
+
+    void nullpointer104() // #13881
+    {
+        check("using std::max;\n"
+              "void f(int i) {\n"
+              "    const size_t maxlen = i == 1 ? 8 : (std::numeric_limits<std::size_t>::max());\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void nullpointer_addressOf() { // address of

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -71,6 +71,7 @@ private:
         TEST_CASE(simplifyUsing33);
         TEST_CASE(simplifyUsing34);
         TEST_CASE(simplifyUsing35);
+        TEST_CASE(simplifyUsing36);
 
         TEST_CASE(simplifyUsing8970);
         TEST_CASE(simplifyUsing8971);
@@ -869,6 +870,14 @@ private:
         const char code[] = "using a = b;\n"
                             "using c = d;\n";
         const char expected[] = ";";
+        ASSERT_EQUALS(expected, tok(code));
+        ASSERT_EQUALS("", errout_str());
+    }
+
+    void simplifyUsing36() {
+        const char code[] = "using A::a;\n"
+                            "int c = B<int>::a;\n";
+        const char expected[] = "int c ; c = B < int > :: a ;";
         ASSERT_EQUALS(expected, tok(code));
         ASSERT_EQUALS("", errout_str());
     }


### PR DESCRIPTION
This
```
using A::a;
int x = B<T>::a;
```
would previously be simplified to
```
int x = B<T>A::a;
```
in `simplifyUsing`.