### PR TITLE
ValueFlow: don't reset the struct size if there is a unknown member + empty structs have a size of 1

### DIFF
--- a/lib/checkclass.cpp
+++ b/lib/checkclass.cpp
@@ -3397,7 +3397,9 @@ void CheckClass::checkReturnByReference()
                 const bool isView = isContainer && var->valueType()->container->view;
                 bool warn = isContainer && !isView;
                 if (!warn && !isView) {
-                    const std::size_t size = ValueFlow::getSizeOf(*var->valueType(), *mSettings);
+                    const std::size_t size = ValueFlow::getSizeOf(*var->valueType(),
+                                                                  *mSettings,
+                                                                  ValueFlow::Accuracy::LowerBound);
                     if (size > 2 * mSettings->platform.sizeof_pointer)
                         warn = true;
                 }

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -324,10 +324,10 @@ static bool checkTypeCombination(ValueType src, ValueType tgt, const Settings& s
 
     const std::size_t sizeSrc = ValueFlow::getSizeOf(src,
                                                      settings,
-                                                     ValueFlow::Accuracy::ExcactOrZero);
+                                                     ValueFlow::Accuracy::ExactOrZero);
     const std::size_t sizeTgt = ValueFlow::getSizeOf(tgt,
                                                      settings,
-                                                     ValueFlow::Accuracy::ExcactOrZero);
+                                                     ValueFlow::Accuracy::ExactOrZero);
     if (!(sizeSrc > 0 && sizeTgt > 0 && sizeSrc < sizeTgt))
         return false;
 

--- a/lib/checktype.cpp
+++ b/lib/checktype.cpp
@@ -322,8 +322,12 @@ static bool checkTypeCombination(ValueType src, ValueType tgt, const Settings& s
     src.reference = Reference::None;
     tgt.reference = Reference::None;
 
-    const std::size_t sizeSrc = ValueFlow::getSizeOf(src, settings);
-    const std::size_t sizeTgt = ValueFlow::getSizeOf(tgt, settings);
+    const std::size_t sizeSrc = ValueFlow::getSizeOf(src,
+                                                     settings,
+                                                     ValueFlow::Accuracy::ExcactOrZero);
+    const std::size_t sizeTgt = ValueFlow::getSizeOf(tgt,
+                                                     settings,
+                                                     ValueFlow::Accuracy::ExcactOrZero);
     if (!(sizeSrc > 0 && sizeTgt > 0 && sizeSrc < sizeTgt))
         return false;
 

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -941,7 +941,7 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
                         const char *argattr = argnode->Attribute("arg");
                         if (!argattr)
                             return Error(ErrorCode::MISSING_ATTRIBUTE, "arg");
-                        if (strlen(argattr) != 1 || argattr[0]<'0' || argattr[0]>'9')
+                        if (strlen(argattr) != 1 || argattr[0]<'0' || argattr[0]> '9')
                             return Error(ErrorCode::BAD_ATTRIBUTE_VALUE, argattr);
 
                         ac.minsizes.reserve(type == ArgumentChecks::MinSize::Type::MUL ? 2 : 1);
@@ -950,7 +950,7 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
                             const char *arg2attr = argnode->Attribute("arg2");
                             if (!arg2attr)
                                 return Error(ErrorCode::MISSING_ATTRIBUTE, "arg2");
-                            if (strlen(arg2attr) != 1 || arg2attr[0]<'0' || arg2attr[0]>'9')
+                            if (strlen(arg2attr) != 1 || arg2attr[0]<'0' || arg2attr[0]> '9')
                                 return Error(ErrorCode::BAD_ATTRIBUTE_VALUE, arg2attr);
                             ac.minsizes.back().arg2 = arg2attr[0] - '0';
                         }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -784,7 +784,7 @@ nonneg int Token::getStrSize(const Token *tok, const Settings &settings)
     if (tok->valueType()) {
         ValueType vt(*tok->valueType());
         vt.pointer = 0;
-        sizeofType = ValueFlow::getSizeOf(vt, settings);
+        sizeofType = ValueFlow::getSizeOf(vt, settings, ValueFlow::Accuracy::ExcactOrZero);
     }
     return getStrArraySize(tok) * sizeofType;
 }

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -784,7 +784,7 @@ nonneg int Token::getStrSize(const Token *tok, const Settings &settings)
     if (tok->valueType()) {
         ValueType vt(*tok->valueType());
         vt.pointer = 0;
-        sizeofType = ValueFlow::getSizeOf(vt, settings, ValueFlow::Accuracy::ExcactOrZero);
+        sizeofType = ValueFlow::getSizeOf(vt, settings, ValueFlow::Accuracy::ExactOrZero);
     }
     return getStrArraySize(tok) * sizeofType;
 }

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -454,7 +454,7 @@ static Result accumulateStructMembers(const Scope* scope, F f, ValueFlow::Accura
             else
                 total = f(total, *vt, dim);
         }
-        if (accuracy == ValueFlow::Accuracy::ExcactOrZero && total == 0)
+        if (accuracy == ValueFlow::Accuracy::ExactOrZero && total == 0)
             return {0, false};
     }
     return {total, true};
@@ -538,7 +538,7 @@ size_t ValueFlow::getSizeOf(const ValueType &vt, const Settings &settings, Accur
             size_t n = ValueFlow::getSizeOf(vt2, settings,accuracy, ++maxRecursion);
             size_t a = getAlignOf(vt2, settings, accuracy);
             if (n == 0 || a == 0)
-                return accuracy == Accuracy::ExcactOrZero ? 0 : total;
+                return accuracy == Accuracy::ExactOrZero ? 0 : total;
             n *= dim;
             size_t padding = (a - (total % a)) % a;
             return vt.typeScope->type == ScopeType::eUnion ? std::max(total, n) : total + padding + n;
@@ -552,12 +552,12 @@ size_t ValueFlow::getSizeOf(const ValueType &vt, const Settings &settings, Accur
                 return v;
             });
         }
-        if (accuracy == Accuracy::ExcactOrZero && total == 0 && !result.success)
+        if (accuracy == Accuracy::ExactOrZero && total == 0 && !result.success)
             return 0;
         total = std::max(size_t{1}, total);
         size_t align = getAlignOf(vt, settings, accuracy);
         if (align == 0)
-            return accuracy == Accuracy::ExcactOrZero ? 0 : total;
+            return accuracy == Accuracy::ExactOrZero ? 0 : total;
         total += (align - (total % align)) % align;
         return total;
     }
@@ -4148,10 +4148,10 @@ static std::list<ValueFlow::Value> truncateValues(std::list<ValueFlow::Value> va
     if (!dst || !dst->isIntegral())
         return values;
 
-    const size_t sz = ValueFlow::getSizeOf(*dst, settings, ValueFlow::Accuracy::ExcactOrZero);
+    const size_t sz = ValueFlow::getSizeOf(*dst, settings, ValueFlow::Accuracy::ExactOrZero);
 
     if (src) {
-        const size_t osz = ValueFlow::getSizeOf(*src, settings, ValueFlow::Accuracy::ExcactOrZero);
+        const size_t osz = ValueFlow::getSizeOf(*src, settings, ValueFlow::Accuracy::ExactOrZero);
         if (osz >= sz && dst->sign == ValueType::Sign::SIGNED && src->sign == ValueType::Sign::UNSIGNED) {
             values.remove_if([&](const ValueFlow::Value& value) {
                 if (!value.isIntValue())

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -424,9 +424,16 @@ void ValueFlow::combineValueProperties(const ValueFlow::Value &value1, const Val
         result.path = value1.path;
 }
 
+namespace {
+    struct Result
+    {
+        size_t total;
+        bool success;
+    };
+}
 
 template<class F>
-static size_t accumulateStructMembers(const Scope* scope, F f)
+static Result accumulateStructMembers(const Scope* scope, F f, ValueFlow::Accuracy accuracy)
 {
     size_t total = 0;
     std::set<const Scope*> anonScopes;
@@ -435,7 +442,7 @@ static size_t accumulateStructMembers(const Scope* scope, F f)
             continue;
         if (const ValueType* vt = var.valueType()) {
             if (vt->type == ValueType::Type::RECORD && vt->typeScope == scope)
-                return 0;
+                return {0, false};
             const MathLib::bigint dim = std::accumulate(var.dimensions().cbegin(), var.dimensions().cend(), 1LL, [](MathLib::bigint i1, const Dimension& dim) {
                 return i1 * dim.num;
             });
@@ -447,10 +454,10 @@ static size_t accumulateStructMembers(const Scope* scope, F f)
             else
                 total = f(total, *vt, dim);
         }
-        if (total == 0)
-            return 0;
+        if (accuracy == ValueFlow::Accuracy::ExcactOrZero && total == 0)
+            return {0, false};
     }
-    return total;
+    return {total, true};
 }
 
 static size_t bitCeil(size_t x)
@@ -467,37 +474,38 @@ static size_t bitCeil(size_t x)
     return x + 1;
 }
 
-static size_t getAlignOf(const ValueType& vt, const Settings& settings, int maxRecursion = 0)
+static size_t getAlignOf(const ValueType& vt, const Settings& settings, ValueFlow::Accuracy accuracy, int maxRecursion = 0)
 {
     if (maxRecursion == settings.vfOptions.maxAlignOfRecursion) {
         // TODO: add bailout message
         return 0;
     }
     if (vt.pointer || vt.reference != Reference::None || vt.isPrimitive()) {
-        auto align = ValueFlow::getSizeOf(vt, settings);
+        auto align = ValueFlow::getSizeOf(vt, settings, accuracy);
         return align == 0 ? 0 : bitCeil(align);
     }
     if (vt.type == ValueType::Type::RECORD && vt.typeScope) {
         auto accHelper = [&](size_t max, const ValueType& vt2, size_t /*dim*/) {
-            size_t a = getAlignOf(vt2, settings, ++maxRecursion);
+            size_t a = getAlignOf(vt2, settings, accuracy, ++maxRecursion);
             return std::max(max, a);
         };
-        size_t total = 0;
+        Result result = accumulateStructMembers(vt.typeScope, accHelper, accuracy);
+        size_t total = result.total;
         if (const Type* dt = vt.typeScope->definedType) {
             total = std::accumulate(dt->derivedFrom.begin(), dt->derivedFrom.end(), total, [&](size_t v, const Type::BaseInfo& bi) {
                 if (bi.type && bi.type->classScope)
-                    v += accumulateStructMembers(bi.type->classScope, accHelper);
+                    v += accumulateStructMembers(bi.type->classScope, accHelper, accuracy).total;
                 return v;
             });
         }
-        return total + accumulateStructMembers(vt.typeScope, accHelper);
+        return result.success ? std::max<size_t>(1, total) : total;
     }
     if (vt.type == ValueType::Type::CONTAINER)
         return settings.platform.sizeof_pointer; // Just guess
     return 0;
 }
 
-size_t ValueFlow::getSizeOf(const ValueType &vt, const Settings &settings, int maxRecursion)
+size_t ValueFlow::getSizeOf(const ValueType &vt, const Settings &settings, Accuracy accuracy, int maxRecursion)
 {
     if (maxRecursion == settings.vfOptions.maxSizeOfRecursion) {
         // TODO: add bailout message
@@ -527,27 +535,29 @@ size_t ValueFlow::getSizeOf(const ValueType &vt, const Settings &settings, int m
         return 3 * settings.platform.sizeof_pointer; // Just guess
     if (vt.type == ValueType::Type::RECORD && vt.typeScope) {
         auto accHelper = [&](size_t total, const ValueType& vt2, size_t dim) -> size_t {
-            size_t n = ValueFlow::getSizeOf(vt2, settings, ++maxRecursion);
-            size_t a = getAlignOf(vt2, settings);
+            size_t n = ValueFlow::getSizeOf(vt2, settings,accuracy, ++maxRecursion);
+            size_t a = getAlignOf(vt2, settings, accuracy);
             if (n == 0 || a == 0)
-                return 0;
+                return accuracy == Accuracy::ExcactOrZero ? 0 : total;
             n *= dim;
             size_t padding = (a - (total % a)) % a;
             return vt.typeScope->type == ScopeType::eUnion ? std::max(total, n) : total + padding + n;
         };
-        size_t total = accumulateStructMembers(vt.typeScope, accHelper);
+        Result result = accumulateStructMembers(vt.typeScope, accHelper, accuracy);
+        size_t total = result.total;
         if (const Type* dt = vt.typeScope->definedType) {
             total = std::accumulate(dt->derivedFrom.begin(), dt->derivedFrom.end(), total, [&](size_t v, const Type::BaseInfo& bi) {
                 if (bi.type && bi.type->classScope)
-                    v += accumulateStructMembers(bi.type->classScope, accHelper);
+                    v += accumulateStructMembers(bi.type->classScope, accHelper, accuracy).total;
                 return v;
             });
         }
-        if (total == 0)
+        if (accuracy == Accuracy::ExcactOrZero && total == 0 && !result.success)
             return 0;
-        size_t align = getAlignOf(vt, settings);
+        total = std::max(size_t{1}, total);
+        size_t align = getAlignOf(vt, settings, accuracy);
         if (align == 0)
-            return 0;
+            return accuracy == Accuracy::ExcactOrZero ? 0 : total;
         total += (align - (total % align)) % align;
         return total;
     }
@@ -3614,8 +3624,8 @@ static bool isTruncated(const ValueType* src, const ValueType* dst, const Settin
     if (src->smartPointer && dst->smartPointer)
         return false;
     if ((src->isIntegral() && dst->isIntegral()) || (src->isFloat() && dst->isFloat())) {
-        const size_t srcSize = ValueFlow::getSizeOf(*src, settings);
-        const size_t dstSize = ValueFlow::getSizeOf(*dst, settings);
+        const size_t srcSize = ValueFlow::getSizeOf(*src, settings, ValueFlow::Accuracy::LowerBound);
+        const size_t dstSize = ValueFlow::getSizeOf(*dst, settings, ValueFlow::Accuracy::LowerBound);
         if (srcSize > dstSize)
             return true;
         if (srcSize == dstSize && src->sign != dst->sign)
@@ -4138,10 +4148,10 @@ static std::list<ValueFlow::Value> truncateValues(std::list<ValueFlow::Value> va
     if (!dst || !dst->isIntegral())
         return values;
 
-    const size_t sz = ValueFlow::getSizeOf(*dst, settings);
+    const size_t sz = ValueFlow::getSizeOf(*dst, settings, ValueFlow::Accuracy::ExcactOrZero);
 
     if (src) {
-        const size_t osz = ValueFlow::getSizeOf(*src, settings);
+        const size_t osz = ValueFlow::getSizeOf(*src, settings, ValueFlow::Accuracy::ExcactOrZero);
         if (osz >= sz && dst->sign == ValueType::Sign::SIGNED && src->sign == ValueType::Sign::UNSIGNED) {
             values.remove_if([&](const ValueFlow::Value& value) {
                 if (!value.isIntValue())

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -60,7 +60,15 @@ namespace ValueFlow {
 
     std::string eitherTheConditionIsRedundant(const Token *condition);
 
-    size_t getSizeOf(const ValueType &vt, const Settings &settings, int maxRecursion = 0);
+    enum class Accuracy : std::uint8_t {
+        ExcactOrZero,
+        LowerBound,
+    };
+
+    size_t getSizeOf(const ValueType &vt,
+                     const Settings &settings,
+                     Accuracy accuracy,
+                     int maxRecursion = 0);
 
     const Value* findValue(const std::list<Value>& values,
                            const Settings& settings,

--- a/lib/valueflow.h
+++ b/lib/valueflow.h
@@ -61,7 +61,7 @@ namespace ValueFlow {
     std::string eitherTheConditionIsRedundant(const Token *condition);
 
     enum class Accuracy : std::uint8_t {
-        ExcactOrZero,
+        ExactOrZero,
         LowerBound,
     };
 

--- a/lib/vf_analyzers.cpp
+++ b/lib/vf_analyzers.cpp
@@ -353,7 +353,7 @@ struct ValueFlowAnalyzer : Analyzer {
             if (dst) {
                 const size_t sz = ValueFlow::getSizeOf(*dst,
                                                        settings,
-                                                       ValueFlow::Accuracy::ExcactOrZero);
+                                                       ValueFlow::Accuracy::ExactOrZero);
                 if (sz > 0 && sz < sizeof(MathLib::biguint)) {
                     MathLib::bigint newvalue = ValueFlow::truncateIntValue(value->intvalue, sz, dst->sign);
 

--- a/lib/vf_analyzers.cpp
+++ b/lib/vf_analyzers.cpp
@@ -351,7 +351,9 @@ struct ValueFlowAnalyzer : Analyzer {
             /* Truncate value */
             const ValueType *dst = tok->valueType();
             if (dst) {
-                const size_t sz = ValueFlow::getSizeOf(*dst, settings);
+                const size_t sz = ValueFlow::getSizeOf(*dst,
+                                                       settings,
+                                                       ValueFlow::Accuracy::ExcactOrZero);
                 if (sz > 0 && sz < sizeof(MathLib::biguint)) {
                     MathLib::bigint newvalue = ValueFlow::truncateIntValue(value->intvalue, sz, dst->sign);
 

--- a/lib/vf_common.cpp
+++ b/lib/vf_common.cpp
@@ -114,7 +114,7 @@ namespace ValueFlow
     {
         const ValueType &valueType = ValueType::parseDecl(typeTok, settings);
 
-        return getSizeOf(valueType, settings);
+        return getSizeOf(valueType, settings, ValueFlow::Accuracy::ExcactOrZero);
     }
 
     // Handle various constants..
@@ -124,7 +124,9 @@ namespace ValueFlow
             try {
                 MathLib::bigint signedValue = MathLib::toBigNumber(tok);
                 const ValueType* vt = tok->valueType();
-                if (vt && vt->sign == ValueType::UNSIGNED && signedValue < 0 && getSizeOf(*vt, settings) < sizeof(MathLib::bigint)) {
+                if (vt && vt->sign == ValueType::UNSIGNED && signedValue < 0
+                    && getSizeOf(*vt, settings, ValueFlow::Accuracy::ExcactOrZero)
+                    < sizeof(MathLib::bigint)) {
                     MathLib::bigint minValue{}, maxValue{};
                     if (getMinMaxValues(tok->valueType(), settings.platform, minValue, maxValue))
                         signedValue += maxValue + 1;
@@ -158,7 +160,9 @@ namespace ValueFlow
                 (tok->next()->astOperand2()->valueType()->pointer == 0 || // <- TODO this is a bailout, abort when there are array->pointer conversions
                  (tok->next()->astOperand2()->variable() && !tok->next()->astOperand2()->variable()->isArray())) &&
                 !tok->next()->astOperand2()->valueType()->isEnum()) { // <- TODO this is a bailout, handle enum with non-int types
-                const size_t sz = getSizeOf(*tok->next()->astOperand2()->valueType(), settings);
+                const size_t sz = getSizeOf(*tok->next()->astOperand2()->valueType(),
+                                            settings,
+                                            ValueFlow::Accuracy::ExcactOrZero);
                 if (sz) {
                     Value value(sz);
                     value.setKnown();
@@ -177,7 +181,8 @@ namespace ValueFlow
             }
             if (Token::simpleMatch(tok, "sizeof ( *")) {
                 const ValueType *vt = tok->tokAt(2)->valueType();
-                const size_t sz = vt ? getSizeOf(*vt, settings) : 0;
+                const size_t sz = vt ? getSizeOf(*vt, settings, ValueFlow::Accuracy::ExcactOrZero)
+                                     : 0;
                 if (sz > 0) {
                     Value value(sz);
                     if (!tok2->isTemplateArg() && settings.platform.type != Platform::Type::Unspecified)
@@ -238,7 +243,9 @@ namespace ValueFlow
                         if (var->type()->classScope && var->type()->classScope->enumType)
                             size = getSizeOfType(var->type()->classScope->enumType, settings);
                     } else if (var->valueType()) {
-                        size = getSizeOf(*var->valueType(), settings);
+                        size = getSizeOf(*var->valueType(),
+                                         settings,
+                                         ValueFlow::Accuracy::ExcactOrZero);
                     } else if (!var->type()) {
                         size = getSizeOfType(var->typeStartToken(), settings);
                     }
@@ -287,7 +294,7 @@ namespace ValueFlow
                 }
             } else if (!tok2->type()) {
                 const ValueType& vt = ValueType::parseDecl(tok2, settings);
-                size_t sz = getSizeOf(vt, settings);
+                size_t sz = getSizeOf(vt, settings, ValueFlow::Accuracy::ExcactOrZero);
                 const Token* brac = tok2->astParent();
                 while (Token::simpleMatch(brac, "[")) {
                     const Token* num = brac->astOperand2();

--- a/lib/vf_common.cpp
+++ b/lib/vf_common.cpp
@@ -114,7 +114,7 @@ namespace ValueFlow
     {
         const ValueType &valueType = ValueType::parseDecl(typeTok, settings);
 
-        return getSizeOf(valueType, settings, ValueFlow::Accuracy::ExcactOrZero);
+        return getSizeOf(valueType, settings, ValueFlow::Accuracy::ExactOrZero);
     }
 
     // Handle various constants..
@@ -125,7 +125,7 @@ namespace ValueFlow
                 MathLib::bigint signedValue = MathLib::toBigNumber(tok);
                 const ValueType* vt = tok->valueType();
                 if (vt && vt->sign == ValueType::UNSIGNED && signedValue < 0
-                    && getSizeOf(*vt, settings, ValueFlow::Accuracy::ExcactOrZero)
+                    && getSizeOf(*vt, settings, ValueFlow::Accuracy::ExactOrZero)
                     < sizeof(MathLib::bigint)) {
                     MathLib::bigint minValue{}, maxValue{};
                     if (getMinMaxValues(tok->valueType(), settings.platform, minValue, maxValue))
@@ -162,7 +162,7 @@ namespace ValueFlow
                 !tok->next()->astOperand2()->valueType()->isEnum()) { // <- TODO this is a bailout, handle enum with non-int types
                 const size_t sz = getSizeOf(*tok->next()->astOperand2()->valueType(),
                                             settings,
-                                            ValueFlow::Accuracy::ExcactOrZero);
+                                            ValueFlow::Accuracy::ExactOrZero);
                 if (sz) {
                     Value value(sz);
                     value.setKnown();
@@ -181,7 +181,7 @@ namespace ValueFlow
             }
             if (Token::simpleMatch(tok, "sizeof ( *")) {
                 const ValueType *vt = tok->tokAt(2)->valueType();
-                const size_t sz = vt ? getSizeOf(*vt, settings, ValueFlow::Accuracy::ExcactOrZero)
+                const size_t sz = vt ? getSizeOf(*vt, settings, ValueFlow::Accuracy::ExactOrZero)
                                      : 0;
                 if (sz > 0) {
                     Value value(sz);
@@ -245,7 +245,7 @@ namespace ValueFlow
                     } else if (var->valueType()) {
                         size = getSizeOf(*var->valueType(),
                                          settings,
-                                         ValueFlow::Accuracy::ExcactOrZero);
+                                         ValueFlow::Accuracy::ExactOrZero);
                     } else if (!var->type()) {
                         size = getSizeOfType(var->typeStartToken(), settings);
                     }
@@ -294,7 +294,7 @@ namespace ValueFlow
                 }
             } else if (!tok2->type()) {
                 const ValueType& vt = ValueType::parseDecl(tok2, settings);
-                size_t sz = getSizeOf(vt, settings, ValueFlow::Accuracy::ExcactOrZero);
+                size_t sz = getSizeOf(vt, settings, ValueFlow::Accuracy::ExactOrZero);
                 const Token* brac = tok2->astParent();
                 while (Token::simpleMatch(brac, "[")) {
                     const Token* num = brac->astOperand2();

--- a/lib/vf_settokenvalue.cpp
+++ b/lib/vf_settokenvalue.cpp
@@ -83,8 +83,8 @@ namespace ValueFlow
         // If the sign is the same there is no truncation
         if (vt1->sign == vt2->sign)
             return value;
-        const size_t n1 = getSizeOf(*vt1, settings);
-        const size_t n2 = getSizeOf(*vt2, settings);
+        const size_t n1 = getSizeOf(*vt1, settings, ValueFlow::Accuracy::ExcactOrZero);
+        const size_t n2 = getSizeOf(*vt2, settings, ValueFlow::Accuracy::ExcactOrZero);
         ValueType::Sign sign = ValueType::Sign::UNSIGNED;
         if (n1 < n2)
             sign = vt2->sign;
@@ -224,8 +224,9 @@ namespace ValueFlow
                        SourceLocation loc)
     {
         // Skip setting values that are too big since its ambiguous
-        if (!value.isImpossible() && value.isIntValue() && value.intvalue < 0 && astIsUnsigned(tok) &&
-            getSizeOf(*tok->valueType(), settings) >= sizeof(MathLib::bigint))
+        if (!value.isImpossible() && value.isIntValue() && value.intvalue < 0 && astIsUnsigned(tok)
+            && getSizeOf(*tok->valueType(), settings, ValueFlow::Accuracy::LowerBound)
+            >= sizeof(MathLib::bigint))
             return;
 
         if (!value.isImpossible() && value.isIntValue())
@@ -376,9 +377,10 @@ namespace ValueFlow
                 Token::simpleMatch(parent->astOperand1(), "dynamic_cast"))
                 return;
             const ValueType &valueType = ValueType::parseDecl(castType, settings);
-            if (value.isImpossible() && value.isIntValue() && value.intvalue < 0 && astIsUnsigned(tok) &&
-                valueType.sign == ValueType::SIGNED && tok->valueType() &&
-                getSizeOf(*tok->valueType(), settings) >= getSizeOf(valueType, settings))
+            if (value.isImpossible() && value.isIntValue() && value.intvalue < 0
+                && astIsUnsigned(tok) && valueType.sign == ValueType::SIGNED && tok->valueType()
+                && getSizeOf(*tok->valueType(), settings, ValueFlow::Accuracy::ExcactOrZero)
+                >= getSizeOf(valueType, settings, ValueFlow::Accuracy::ExcactOrZero))
                 return;
             setTokenValueCast(parent, valueType, value, settings);
         }
@@ -641,7 +643,9 @@ namespace ValueFlow
                     if (v.isIntValue() || v.isSymbolicValue()) {
                         const ValueType *dst = tok->valueType();
                         if (dst) {
-                            const size_t sz = ValueFlow::getSizeOf(*dst, settings);
+                            const size_t sz = ValueFlow::getSizeOf(*dst,
+                                                                   settings,
+                                                                   ValueFlow::Accuracy::ExcactOrZero);
                             MathLib::bigint newvalue = ValueFlow::truncateIntValue(v.intvalue + 1, sz, dst->sign);
                             if (v.bound != ValueFlow::Value::Bound::Point) {
                                 if (newvalue < v.intvalue) {
@@ -671,7 +675,9 @@ namespace ValueFlow
                     if (v.isIntValue() || v.isSymbolicValue()) {
                         const ValueType *dst = tok->valueType();
                         if (dst) {
-                            const size_t sz = ValueFlow::getSizeOf(*dst, settings);
+                            const size_t sz = ValueFlow::getSizeOf(*dst,
+                                                                   settings,
+                                                                   ValueFlow::Accuracy::ExcactOrZero);
                             MathLib::bigint newvalue = ValueFlow::truncateIntValue(v.intvalue - 1, sz, dst->sign);
                             if (v.bound != ValueFlow::Value::Bound::Point) {
                                 if (newvalue > v.intvalue) {

--- a/lib/vf_settokenvalue.cpp
+++ b/lib/vf_settokenvalue.cpp
@@ -83,8 +83,8 @@ namespace ValueFlow
         // If the sign is the same there is no truncation
         if (vt1->sign == vt2->sign)
             return value;
-        const size_t n1 = getSizeOf(*vt1, settings, ValueFlow::Accuracy::ExcactOrZero);
-        const size_t n2 = getSizeOf(*vt2, settings, ValueFlow::Accuracy::ExcactOrZero);
+        const size_t n1 = getSizeOf(*vt1, settings, ValueFlow::Accuracy::ExactOrZero);
+        const size_t n2 = getSizeOf(*vt2, settings, ValueFlow::Accuracy::ExactOrZero);
         ValueType::Sign sign = ValueType::Sign::UNSIGNED;
         if (n1 < n2)
             sign = vt2->sign;
@@ -379,8 +379,8 @@ namespace ValueFlow
             const ValueType &valueType = ValueType::parseDecl(castType, settings);
             if (value.isImpossible() && value.isIntValue() && value.intvalue < 0
                 && astIsUnsigned(tok) && valueType.sign == ValueType::SIGNED && tok->valueType()
-                && getSizeOf(*tok->valueType(), settings, ValueFlow::Accuracy::ExcactOrZero)
-                >= getSizeOf(valueType, settings, ValueFlow::Accuracy::ExcactOrZero))
+                && getSizeOf(*tok->valueType(), settings, ValueFlow::Accuracy::ExactOrZero)
+                >= getSizeOf(valueType, settings, ValueFlow::Accuracy::ExactOrZero))
                 return;
             setTokenValueCast(parent, valueType, value, settings);
         }
@@ -645,7 +645,7 @@ namespace ValueFlow
                         if (dst) {
                             const size_t sz = ValueFlow::getSizeOf(*dst,
                                                                    settings,
-                                                                   ValueFlow::Accuracy::ExcactOrZero);
+                                                                   ValueFlow::Accuracy::ExactOrZero);
                             MathLib::bigint newvalue = ValueFlow::truncateIntValue(v.intvalue + 1, sz, dst->sign);
                             if (v.bound != ValueFlow::Value::Bound::Point) {
                                 if (newvalue < v.intvalue) {
@@ -677,7 +677,7 @@ namespace ValueFlow
                         if (dst) {
                             const size_t sz = ValueFlow::getSizeOf(*dst,
                                                                    settings,
-                                                                   ValueFlow::Accuracy::ExcactOrZero);
+                                                                   ValueFlow::Accuracy::ExactOrZero);
                             MathLib::bigint newvalue = ValueFlow::truncateIntValue(v.intvalue - 1, sz, dst->sign);
                             if (v.bound != ValueFlow::Value::Bound::Point) {
                                 if (newvalue > v.intvalue) {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -13037,6 +13037,18 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:3:15]: (performance) Range variable 's' should be declared as const reference. [iterateByValue]\n",
                       errout_str());
+        check("void f() {\n" // #13696
+              "    struct T {\n"
+              "        std::string name;\n"
+              "        UnknownClass member;\n"
+              "    };\n"
+              "\n"
+              "    const std::set<T> ss;\n"
+              "    for (auto s : ss)\n"
+              "        (void)s.name;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:8:15]: (performance) Range variable 's' should be declared as const reference. [iterateByValue]\n",
+                      errout_str());
     }
 
     void knownConditionFloating()

--- a/test/testvalueflow.cpp
+++ b/test/testvalueflow.cpp
@@ -1653,6 +1653,27 @@ private:
         ASSERT_EQUALS(1U, values.size());
         ASSERT_EQUALS(12, values.back().intvalue);
 
+        code = "struct X { A a; int b; A c; };\n"
+               "void f() {\n"
+               "    x = sizeof(X);\n"
+               "}";
+        values = tokenValues(code, "( X )");
+        ASSERT_EQUALS(1U, values.size());
+        ASSERT_EQUALS(-1, values.back().intvalue);
+
+        code = "struct X {};\n"
+               "struct SubX : X {};\n"
+               "void f() {\n"
+               "    x = sizeof(X);\n"
+               "    subx = sizeof(SubX);\n"
+               "}";
+        values = tokenValues(code, "( X )");
+        ASSERT_EQUALS(1U, values.size());
+        ASSERT_EQUALS(1, values.back().intvalue);
+        values = tokenValues(code, "( SubX )");
+        ASSERT_EQUALS(1U, values.size());
+        ASSERT_EQUALS(1, values.back().intvalue);
+
         code = "struct T;\n"
                "struct S { T& r; };\n"
                "struct T { S s{ *this }; };\n"


### PR DESCRIPTION
Fixes https://trac.cppcheck.net/ticket/13696 + https://github.com/danmar/cppcheck/pull/6257#issuecomment-2923965239 
One could argue that the size of a member of an unknown type should be 1 instead of 0 because the member will be at least 1 byte large (if not empty and annotated with `[[no_unique_address]]`)