### PR TITLE
fix #12642 - GUI: statistics is not correct

### DIFF
--- a/gui/checkstatistics.cpp
+++ b/gui/checkstatistics.cpp
@@ -33,7 +33,7 @@ static void addItem(QMap<QString,unsigned> &m, const QString &key)
     if (m.contains(key))
         m[key]++;
     else
-        m[key] = 0;
+        m[key] = 1;
 }
 
 void CheckStatistics::addItem(const QString &tool, ShowTypes::ShowType type)


### PR DESCRIPTION
I checked the latest version, as my testing this problem only happens when there is only one item reported for each category such as error, warning or information, etc.