### PR TITLE
Fix #13970 cfg/qt.cfg - add definition for QDate::isValid()

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -2737,6 +2737,7 @@
     <arg nr="1" direction="in" default=""/>
     <arg nr="2" direction="in" default=""/>
     <arg nr="3" direction="in" default=""/>
+    <const/>
   </function>
   <!-- int QDate::month() const -->
   <function name="QDate::month">

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -847,3 +847,10 @@ namespace {
     // cppcheck-suppress functionStatic
     void TestUnusedFunction::doStuff() {} // Should not warn here with unusedFunction
 }
+
+int qdateIsValid()
+{
+    QDate qd(1,1,2025);
+    Q_ASSERT(qd.isValid()); // Should not warn here with assertWithSideEffect
+    return qd.month(); 
+}


### PR DESCRIPTION
Add the bool isValid() signature.
bool isValid(int, int, int) is already there.