### PR TITLE
Fix #13852 (GUI does not finish analysis properly)

### DIFF
--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -38,8 +38,7 @@
 
 ThreadHandler::ThreadHandler(QObject *parent) :
     QObject(parent)
-{
-}
+{}
 
 ThreadHandler::~ThreadHandler()
 {

--- a/gui/threadhandler.cpp
+++ b/gui/threadhandler.cpp
@@ -39,7 +39,6 @@
 ThreadHandler::ThreadHandler(QObject *parent) :
     QObject(parent)
 {
-    setThreadCount(1);
 }
 
 ThreadHandler::~ThreadHandler()
@@ -54,7 +53,7 @@ void ThreadHandler::clearFiles()
     mAnalyseWholeProgram = false;
     mCtuInfo.clear();
     mAddonsAndTools.clear();
-    mSuppressions.clear();
+    mSuppressionsUI.clear();
 }
 
 void ThreadHandler::setFiles(const QStringList &files)
@@ -83,6 +82,14 @@ void ThreadHandler::setCheckFiles(const QStringList& files)
     }
 }
 
+void ThreadHandler::setupCheckThread(CheckThread &thread) const
+{
+    thread.setAddonsAndTools(mCheckAddonsAndTools);
+    thread.setSuppressions(mSuppressionsUI);
+    thread.setClangIncludePaths(mClangIncludePaths);
+    thread.setSettings(mCheckSettings, mCheckSuppressions);
+}
+
 void ThreadHandler::check(const Settings &settings, const std::shared_ptr<Suppressions>& supprs)
 {
     if (mResults.getFileCount() == 0 || mRunningThreadCount > 0 || settings.jobs == 0) {
@@ -91,25 +98,25 @@ void ThreadHandler::check(const Settings &settings, const std::shared_ptr<Suppre
         return;
     }
 
-    setThreadCount(settings.jobs);
+    mCheckSettings = settings;
+    mCheckSuppressions = supprs;
+
+    createThreads(mCheckSettings.jobs);
 
     mRunningThreadCount = mThreads.size();
     mRunningThreadCount = std::min(mResults.getFileCount(), mRunningThreadCount);
 
-    QStringList addonsAndTools = mAddonsAndTools;
-    for (const std::string& addon: settings.addons) {
+    mCheckAddonsAndTools = mAddonsAndTools;
+    for (const std::string& addon: mCheckSettings.addons) {
         QString s = QString::fromStdString(addon);
-        if (!addonsAndTools.contains(s))
-            addonsAndTools << s;
+        if (!mCheckAddonsAndTools.contains(s))
+            mCheckAddonsAndTools << s;
     }
 
     mCtuInfo.clear();
 
     for (int i = 0; i < mRunningThreadCount; i++) {
-        mThreads[i]->setAddonsAndTools(addonsAndTools);
-        mThreads[i]->setSuppressions(mSuppressions);
-        mThreads[i]->setClangIncludePaths(mClangIncludePaths);
-        mThreads[i]->setSettings(settings, supprs);
+        setupCheckThread(*mThreads[i]);
         mThreads[i]->start();
     }
 
@@ -123,14 +130,12 @@ void ThreadHandler::check(const Settings &settings, const std::shared_ptr<Suppre
 
 bool ThreadHandler::isChecking() const
 {
-    return mRunningThreadCount > 0;
+    return mRunningThreadCount > 0 || mAnalyseWholeProgram;
 }
 
-void ThreadHandler::setThreadCount(const int count)
+void ThreadHandler::createThreads(const int count)
 {
-    if (mRunningThreadCount > 0 ||
-        count == mThreads.size() ||
-        count <= 0) {
+    if (mRunningThreadCount > 0 || count <= 0) {
         return;
     }
 
@@ -140,9 +145,9 @@ void ThreadHandler::setThreadCount(const int count)
     for (int i = mThreads.size(); i < count; i++) {
         mThreads << new CheckThread(mResults);
         connect(mThreads.last(), &CheckThread::done,
-                this, &ThreadHandler::threadDone);
+                this, &ThreadHandler::threadDone, Qt::QueuedConnection);
         connect(mThreads.last(), &CheckThread::fileChecked,
-                &mResults, &ThreadResult::fileChecked);
+                &mResults, &ThreadResult::fileChecked, Qt::QueuedConnection);
     }
 }
 
@@ -151,7 +156,7 @@ void ThreadHandler::removeThreads()
 {
     for (CheckThread* thread : mThreads) {
         if (thread->isRunning()) {
-            thread->terminate();
+            thread->stop();
             thread->wait();
         }
         disconnect(thread, &CheckThread::done,
@@ -162,19 +167,22 @@ void ThreadHandler::removeThreads()
     }
 
     mThreads.clear();
-    mAnalyseWholeProgram = false;
 }
 
 void ThreadHandler::threadDone()
 {
-    if (mRunningThreadCount == 1 && mAnalyseWholeProgram) {
+    mRunningThreadCount--;
+
+    if (mRunningThreadCount == 0 && mAnalyseWholeProgram) {
+        createThreads(1);
+        mRunningThreadCount = 1;
+        setupCheckThread(*mThreads[0]);
         mThreads[0]->analyseWholeProgram(mLastFiles, mCtuInfo);
         mAnalyseWholeProgram = false;
         mCtuInfo.clear();
         return;
     }
 
-    mRunningThreadCount--;
     if (mRunningThreadCount == 0) {
         emit done();
 
@@ -185,6 +193,9 @@ void ThreadHandler::threadDone()
             mLastCheckTime = mCheckStartTime;
             mCheckStartTime = QDateTime();
         }
+
+        mCheckAddonsAndTools.clear();
+        mCheckSuppressions.reset();
     }
 }
 
@@ -215,7 +226,7 @@ void ThreadHandler::initialize(const ResultsView *view)
 
 void ThreadHandler::loadSettings(const QSettings &settings)
 {
-    setThreadCount(settings.value(SETTINGS_CHECK_THREADS, 1).toInt());
+    createThreads(settings.value(SETTINGS_CHECK_THREADS, 1).toInt());
 }
 
 void ThreadHandler::saveSettings(QSettings &settings) const

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -20,6 +20,7 @@
 #ifndef THREADHANDLER_H
 #define THREADHANDLER_H
 
+#include "settings.h"
 #include "suppressions.h"
 #include "threadresult.h"
 
@@ -37,7 +38,6 @@
 class ResultsView;
 class CheckThread;
 class QSettings;
-class Settings;
 class ImportProject;
 class ErrorItem;
 
@@ -56,17 +56,11 @@ public:
     ~ThreadHandler() override;
 
     /**
-     * @brief Set the number of threads to use
-     * @param count The number of threads to use
-     */
-    void setThreadCount(int count);
-
-    /**
      * @brief Initialize the threads (connect all signals to resultsview's slots)
      *
      * @param view View to show error results
      */
-    void initialize(const ResultsView *view);
+    virtual void initialize(const ResultsView *view);
 
     /**
      * @brief Load settings
@@ -85,7 +79,7 @@ public:
     }
 
     void setSuppressions(const QList<SuppressionList::Suppression> &s) {
-        mSuppressions = s;
+        mSuppressionsUI = s;
     }
 
     void setClangIncludePaths(const QStringList &s) {
@@ -236,10 +230,22 @@ protected:
     int mScanDuration{};
 
     /**
+     * @brief Create checker threads
+     * @param count The number of threads to spawn
+     */
+    void createThreads(int count);
+
+    /**
      * @brief Function to delete all threads
      *
      */
     void removeThreads();
+
+    /*
+     * @brief Apply check settings to a checker thread
+     * @param thread The thread to setup
+     */
+    void setupCheckThread(CheckThread &thread) const;
 
     /**
      * @brief Thread results are stored here
@@ -259,12 +265,24 @@ protected:
      */
     int mRunningThreadCount{};
 
+    /**
+     * @brief A whole program check is queued by check()
+     */
     bool mAnalyseWholeProgram{};
     std::string mCtuInfo;
 
     QStringList mAddonsAndTools;
-    QList<SuppressionList::Suppression> mSuppressions;
+    QList<SuppressionList::Suppression> mSuppressionsUI;
     QStringList mClangIncludePaths;
+
+    /// @{
+    /**
+     * @brief Settings specific to the current analysis
+     */
+    QStringList mCheckAddonsAndTools;
+    Settings mCheckSettings;
+    std::shared_ptr<Suppressions> mCheckSuppressions;
+    /// @}
 private:
 
     /**

--- a/gui/threadhandler.h
+++ b/gui/threadhandler.h
@@ -60,7 +60,7 @@ public:
      *
      * @param view View to show error results
      */
-    virtual void initialize(const ResultsView *view);
+    void initialize(const ResultsView *view);
 
     /**
      * @brief Load settings


### PR DESCRIPTION
Create new `QThread`s for each check, as well as for whole-program analysis, instead of restarting finished threads which is undefined behavior (see https://doc.qt.io/qt-6/qthread.html#create). Fixes Trac #13852.