### PR TITLE
fixed #12325 - cancel workflows if a newer commit is pushed on the same branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,9 +15,9 @@ on:
 permissions:
   contents: read
 
-# concurrency:
-#   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-#   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # this will cancel only PRs
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # this will cancel only PRs
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,8 +16,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # this will cancel only PRs
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,9 +15,9 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }} # this will cancel only PRs
+# concurrency:
+#   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#   cancel-in-progress: ${{ github.event_name == 'pull_request' }} # this will cancel only PRs
 
 jobs:
   analyze:


### PR DESCRIPTION
### Change Summary
Currently, if a push to `branchA` triggers the CodeQL workflow, and shortly after a subsequent push on the *same* `branchA` triggers the CodeQL workflow, both runs will run. With these changes, the first run will be cancelled, thus saving compute resources (see below for quantity) without sacrificing functionality, since the second run will contain the changes from the first push as well.

The introduced syntax comes from the official [documentation](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow).

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in Github Actions workflows.

Based on our offline analysis, cancelling CodeQL runs triggered by a now-obsolete commit (because a new commit has triggered the CodeQL workflow again), could have saved ~49.9 CPU hours since the beginning of the project.

For example, the commit [70b1f](https://github.com/danmar/cppcheck/commit/70b1f665d973cfdbe493b21c4b3f9ecc2118fe28) triggered [this](https://github.com/danmar/cppcheck/actions/runs/9465323661) workflow run, and one minute later the commit [ea2c3](https://github.com/danmar/cppcheck/commit/ea2c39012ed09cd4297e42ab38a19d93475b1358), that happened on top of the first commit, triggered [this](https://github.com/danmar/cppcheck/actions/runs/9465332736) workflow. Both workflows ran till the end, spending ~12 CPU minutes each. With the proposed changes, the first run would be cancelled, hence saving ~11 CPU minutes and clearing the queue for other workflows.

Kindly let us know (here or in the email below) if you would like more details on our offline evaluation, if you want to reject the proposed changes for other reasons, or if you have any question whatsoever.

Best regards,
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch