### PR TITLE
Added custom timeout to ci

### DIFF
--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    #timeout-minutes: 19 # max + 3*std of the last 7K runs
+    timeout-minutes: 19 # max + 3*std of the last 7K runs
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -30,6 +30,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    timeout: 19 # max + 3*std of the last 7K runs
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout-minutes: 19 # max + 3*std of the last 7K runs
+    #timeout-minutes: 19 # max + 3*std of the last 7K runs
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI-mingw.yml
+++ b/.github/workflows/CI-mingw.yml
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    timeout: 19 # max + 3*std of the last 7K runs
+    timeout-minutes: 19 # max + 3*std of the last 7K runs
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Change Summary
Added custom timeout for `build_mingw` job of the `CI-mingw` workflow based on historical data.

### More details
Over the last 7456 successful runs, the `build_mingw` job has a maximum runtime of 13 minutes (mean=4, std=2).

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/danmar/cppcheck/actions/runs/14355314540/job/40243296664) job run, that failed after 6 hours. More stuck jobs have been observed over the last six months, the first one on 2025-01-01 and the last one one on 2025-04-09, while more recent occurences are also possible because our dataset has a cutoff date around late May. With the proposed changes, a total of **45 hours would have been saved** over the last six months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail with a timeout at 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 19 minutes` where `max` and `std` (standard deviation) are derived from the history of 7456 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch