### PR TITLE
Dont use boost when its disabled USE_BOOST=Off

### DIFF
--- a/cmake/compilerDefinitions.cmake
+++ b/cmake/compilerDefinitions.cmake
@@ -37,7 +37,7 @@ if(HAVE_RULES)
     add_definitions(-DHAVE_RULES)
 endif()
 
-if(Boost_FOUND)
+if(USE_BOOST)
     add_definitions(-DHAVE_BOOST)
     if(USE_BOOST_INT128)
         add_definitions(-DHAVE_BOOST_INT128)


### PR DESCRIPTION
We are not using boost correctly as it fails when its not installed in the system path. We should be able to disable it when setting it to `Off`.