### PR TITLE
Make isValidGlobPattern recognize `**`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -187,6 +187,7 @@ Jesse Boswell
 Jim Kuhn
 Jim Zhou
 jlguardi
+Joel Johnson
 Johan Bertrand
 Johan Samuelson
 John Marshall

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -44,7 +44,7 @@ bool isValidGlobPattern(const std::string& pattern)
     for (auto i = pattern.cbegin(); i != pattern.cend(); ++i) {
         if (*i == '*') {
             ++consecutiveAsterisks;
-            if ( consecutiveAsterisks > 2 ) {
+            if (consecutiveAsterisks > 2) {
                 return false;
             }
         } else if (*i == '?') {

--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -40,12 +40,19 @@ int caseInsensitiveStringCompare(const std::string &lhs, const std::string &rhs)
 
 bool isValidGlobPattern(const std::string& pattern)
 {
+    int consecutiveAsterisks = 0;
     for (auto i = pattern.cbegin(); i != pattern.cend(); ++i) {
-        if (*i == '*' || *i == '?') {
-            const auto j = i + 1;
-            if (j != pattern.cend() && (*j == '*' || *j == '?')) {
+        if (*i == '*') {
+            ++consecutiveAsterisks;
+            if ( consecutiveAsterisks > 2 ) {
                 return false;
             }
+        } else if (*i == '?') {
+            if (consecutiveAsterisks > 0) {
+                return false;
+            }
+        } else {
+            consecutiveAsterisks = 0;
         }
     }
     return true;

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -163,8 +163,8 @@ private:
         // Check for syntax errors in glob
         {
             SuppressionList suppressions;
-            std::istringstream s("errorid:**.cpp\n");
-            ASSERT_EQUALS("Failed to add suppression. Invalid glob pattern '**.cpp'.", suppressions.parseFile(s));
+            std::istringstream s("errorid:*?.cpp\n");
+            ASSERT_EQUALS("Failed to add suppression. Invalid glob pattern '*?.cpp'.", suppressions.parseFile(s));
         }
 
         // Check that globbing works

--- a/test/testsuppressions.cpp
+++ b/test/testsuppressions.cpp
@@ -172,7 +172,9 @@ private:
             SuppressionList suppressions;
             std::istringstream s("errorid:x*.cpp\n"
                                  "errorid:y?.cpp\n"
-                                 "errorid:test.c*");
+                                 "errorid:test.c*\n"
+                                 "errorid:dir/**\n"
+                                 "errorid:**/abc**/xyz-??*.?pp\n");
             ASSERT_EQUALS("", suppressions.parseFile(s));
             ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "xyz.cpp", 1)));
             ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "xyz.cpp.cpp", 1)));
@@ -181,6 +183,13 @@ private:
             ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("errorid", "y.cpp", 1)));
             ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "test.c", 1)));
             ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "test.cpp", 1)));
+
+            ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "dir/test.cpp", 1)));
+            ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "dir/deep/nested/test.cpp", 1)));
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("errorid", "yellow.cpp", 1)));
+            ASSERT_EQUALS(true, suppressions.isSuppressed(errorMessage("errorid", "foo/sub/abc/sub/xyz-22aaa.cpp", 1)));
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("errorid", "foo/sub/abc-xyz-22.cpp", 1)));
+            ASSERT_EQUALS(false, suppressions.isSuppressed(errorMessage("errorid", "x/abcxyz-11.cpp", 1)));
         }
 
         // Check that both a filename match and a glob match apply

--- a/test/testutils.cpp
+++ b/test/testutils.cpp
@@ -52,18 +52,32 @@ private:
         ASSERT_EQUALS(true, ::isValidGlobPattern("x*"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("*/x/*"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("x/*/z"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("**"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("**x"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("x**"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("**"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("**x"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x**"));
 
         ASSERT_EQUALS(true, ::isValidGlobPattern("?"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("?x"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("x?"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("?/x/?"));
         ASSERT_EQUALS(true, ::isValidGlobPattern("x/?/z"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("??"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("??x"));
-        ASSERT_EQUALS(false, ::isValidGlobPattern("x??"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("??"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("????"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("??x"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("x??"));
+
+        ASSERT_EQUALS(true, ::isValidGlobPattern("?*"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("?**"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("?***"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("???*"));
+        ASSERT_EQUALS(true, ::isValidGlobPattern("???**"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("???***"));
+
+        ASSERT_EQUALS(false, ::isValidGlobPattern("*?"));
+        ASSERT_EQUALS(true,  ::isValidGlobPattern("*x?"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("**?"));
+        ASSERT_EQUALS(false, ::isValidGlobPattern("***"));
+        ASSERT_EQUALS(true,  ::isValidGlobPattern("**x*"));
     }
 
     void matchglob() const {
@@ -76,11 +90,26 @@ private:
         ASSERT_EQUALS(true, ::matchglob("*", "x/y/z"));
         ASSERT_EQUALS(true, ::matchglob("*/y/z", "x/y/z"));
 
+        ASSERT_EQUALS(true, ::matchglob("**", ""));
+        ASSERT_EQUALS(true, ::matchglob("**", "abcdefg"));
+        ASSERT_EQUALS(true, ::matchglob("**", "abcde/foo/bar"));
+        ASSERT_EQUALS(false, ::matchglob("*/**", "abcde"));
+        ASSERT_EQUALS(true, ::matchglob("*/**", "abcde/foo"));
+        ASSERT_EQUALS(true, ::matchglob("*/**", "abcde/foo/bar"));
+
         ASSERT_EQUALS(false, ::matchglob("?", "xyz"));
         ASSERT_EQUALS(false, ::matchglob("x?", "xyz"));
         ASSERT_EQUALS(false, ::matchglob("?z", "xyz"));
         ASSERT_EQUALS(true, ::matchglob("?y?", "xyz"));
         ASSERT_EQUALS(true, ::matchglob("?/?/?", "x/y/z"));
+
+        ASSERT_EQUALS(true, ::matchglob("??", "xy"));
+        ASSERT_EQUALS(false, ::matchglob("??", "x"));
+        ASSERT_EQUALS(false, ::matchglob("??", "xyz"));
+
+        ASSERT_EQUALS(true, ::matchglob("????", "wxyz"));
+        ASSERT_EQUALS(false, ::matchglob("????", "xyz"));
+        ASSERT_EQUALS(false, ::matchglob("????", "vwxyz"));
     }
 
     void isStringLiteral() const {


### PR DESCRIPTION
https://github.com/danmar/cppcheck/pull/7645 added support for `**` matching path separators, but didn't update `isValidGlobPattern` for `--suppress` to enable it.

This also updates test cases and makes `isValidGlobPattern` more correct and robust overall. In particular multiple consecutive `?` for a glob is absolutely valid and frequently useful to ensure exactly or at least some number of characters.