### PR TITLE
Fixup #14021 (Add file mode specifier to PathMatch)

### DIFF
--- a/cli/filelister.cpp
+++ b/cli/filelister.cpp
@@ -129,7 +129,7 @@ static std::string addFiles2(std::list<FileWithDetails>&files, const std::string
             } else {
                 // Directory
                 if (recursive) {
-                    if (!ignored.match(fname)) {
+                    if (!ignored.match(fname, PathMatch::Filemode::directory)) {
                         std::list<FileWithDetails> filesSorted;
 
                         std::string err = addFiles2(filesSorted, fname, extra, recursive, ignored);
@@ -241,7 +241,7 @@ static std::string addFiles2(std::list<FileWithDetails> &files,
 #endif
         if (path_is_directory) {
             if (recursive) {
-                if (!ignored.match(new_path)) {
+                if (!ignored.match(new_path, PathMatch::Filemode::directory)) {
                     std::string err = addFiles2(files, new_path, extra, recursive, ignored, debug);
                     if (!err.empty()) {
                         return err;

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -401,7 +401,7 @@ SuppressionList::Suppression::Result SuppressionList::Suppression::isSuppressed(
             if (!thisAndNextLine || lineNumber + 1 != errmsg.lineNumber)
                 return Result::None;
         }
-        if (!fileName.empty() && fileName != errmsg.getFileName() && !PathMatch::match(fileName, errmsg.getFileName()))
+        if (!fileName.empty() && !PathMatch::match(fileName, errmsg.getFileName()))
             return Result::None;
         if (hash > 0 && hash != errmsg.hash)
             return Result::Checked;


### PR DESCRIPTION
This is an addendum to #7645 that adds the ability to specify directory-only matching in PathMatch patterns with a trailing slash. I originally didn't add this because I wanted to keep PathMatch purely syntactic, and this feature seemed like it would require filesystem calls in the PathMatch code.

This PR solves that problem by lifting the responsibility of file mode checking to the caller, thus keeping PathMatch purely syntactic while still supporting directory-only matching.

Previously `/test/foo/` would match `/test/foo` even if `foo` is a regular file. With this change the caller can specify the file mode of the file named by the provided path, and `/test/foo` will only match when the file mode is directory.

The semantics of patterns that do not have a trailing slash is unchanged, e.g. `/test/foo` still matches `/test/foo/` and `/test/foo/bar.cpp`, regardless of the file mode.

Also adds some more tests.