### PR TITLE
Fixes for sanitizer errors from SPEC CPU testing

### DIFF
--- a/lib/infer.cpp
+++ b/lib/infer.cpp
@@ -321,7 +321,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
         } else {
             if (!diff.minvalue.empty()) {
                 int adder(0);
-                if (std::numeric_limits<long long>::min() < diff.minvalue.front())
+                if (std::numeric_limits<MathLib::bigint>::min() < diff.minvalue.front())
                     adder = -1;
                 ValueFlow::Value value(diff.minvalue.front() + adder);
                 value.setImpossible();
@@ -331,7 +331,7 @@ std::vector<ValueFlow::Value> infer(const ValuePtr<InferModel>& model,
             }
             if (!diff.maxvalue.empty()) {
                 int adder(0);
-                if (std::numeric_limits<long long>::max() > diff.maxvalue.front())
+                if (std::numeric_limits<MathLib::bigint>::max() > diff.maxvalue.front())
                     adder = 1;
                 ValueFlow::Value value(diff.maxvalue.front() + adder);
                 value.setImpossible();

--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -2018,8 +2018,8 @@ static bool isAdjacent(const ValueFlow::Value& x, const ValueFlow::Value& y)
 
     // original abs() is not safe against overflows:
     // return std::abs(x.intvalue - y.intvalue) == 1;
-    return (y.intvalue != std::numeric_limits<long long>::max() && x.intvalue == y.intvalue + 1) ||
-           (y.intvalue != std::numeric_limits<long long>::min() && x.intvalue == y.intvalue - 1);
+    return (y.intvalue != std::numeric_limits<MathLib::bigint>::max() && x.intvalue == y.intvalue + 1) ||
+           (y.intvalue != std::numeric_limits<MathLib::bigint>::min() && x.intvalue == y.intvalue - 1);
 }
 
 static bool removePointValue(std::list<ValueFlow::Value>& values, std::list<ValueFlow::Value>::iterator& x)

--- a/lib/vf_common.cpp
+++ b/lib/vf_common.cpp
@@ -103,7 +103,7 @@ namespace ValueFlow
             return value;
 
         // sizeof(long long) = 8
-        value_size = std::min(sizeof(long long), value_size);
+        value_size = std::min(sizeof(MathLib::bigint), value_size);
 
         const MathLib::biguint unsignedMaxValue = std::numeric_limits<MathLib::biguint>::max() >> ((sizeof(unsignedMaxValue) - value_size) * 8);
         const MathLib::biguint signBit = 1ULL << (value_size * 8 - 1);


### PR DESCRIPTION
We're doing some sanitizer testing on the source code here at SPEC, and I was able to offer some patches to correct the overflow issues. These are corner cases so maybe the cppcheck community may not be so keen to accept these, but I figured I would share.

```
lib/infer.cpp:131:39: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long long int'
lib/infer.cpp:141:39: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long long int'
lib/infer.cpp:322:65: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long long int'
lib/vf_common.cpp:115:96: runtime error: shift exponent 18446744073709550144 is too large for 64-bit type 'long long unsigned int'
lib/vf_common.cpp:116:47: runtime error: shift exponent 1919 is too large for 64-bit type 'long long unsigned int'
lib/token.cpp:1949:20: runtime error: signed integer overflow: -9223372036854775808 - 9223372032559808511 cannot be represented in type 'long long int'
```