### PR TITLE
2.18.0 crashes on Windows

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -778,7 +778,7 @@ std::vector<ValueType> getParentValueTypes(const Token* tok, const Settings& set
                     assert(argn < scope->varlist.size());
                     auto it = std::next(scope->varlist.cbegin(), argn);
                     if (it->valueType())
-                        return {*it->valueType()};
+                        return {*(it->valueType())};
                 }
             }
         }


### PR DESCRIPTION
(I'm working through impediments with issue tracking access, creating here for sharing information).

The 2.18.0 release crashes when running on some internal project code. When running in Debug, the assert at https://github.com/danmar/cppcheck/blob/2.18.0/lib/astutils.cpp#L778 is hit. When running in Release, it continues past and gets an invalid access.

I've so far distilled it down to the following reproducer.

```cpp
struct Thing
{
  int thing;
  // Uncommenting this unneeded padding variable avoids crash.
  //int other;
};

template<typename T>
class Wrapper
{
public:
  Wrapper(){}

  Wrapper(int val1, int* val2)
  {
    mItem = new T(val1, val2);
  }

private:
  T mItem;
};

class ThingWrapper
{

  Wrapper<Thing*> mThing;

  //int foo = 5;
  //Wrapper<Thing*> mThing{4, &foo};
};
```