### PR TITLE
test-signalhandler.cpp: fixed `-Wunused-macros` warning on macOS

### DIFF
--- a/test/signal/test-signalhandler.cpp
+++ b/test/signal/test-signalhandler.cpp
@@ -16,8 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#if !defined(__APPLE__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE // required to have feenableexcept()
+#endif
 #endif
 
 #include "config.h"

--- a/test/signal/test-signalhandler.py
+++ b/test/signal/test-signalhandler.py
@@ -39,7 +39,7 @@ def test_assert():
     if sys.platform == "darwin":
         assert stderr.startswith("Assertion failed: (false), function my_assert, file test-signalhandler.cpp, line "), stderr
     else:
-        assert stderr.endswith("test-signalhandler.cpp:41: void my_assert(): Assertion `false' failed.\n"), stderr
+        assert stderr.endswith("test-signalhandler.cpp:43: void my_assert(): Assertion `false' failed.\n"), stderr
     lines = stdout.splitlines()
     assert lines[0] == 'Internal error: cppcheck received signal SIGABRT - abort or assertion'
     # no stacktrace of macOS


### PR DESCRIPTION
```
/Users/runner/work/cppcheck/cppcheck/test/signal/test-signalhandler.cpp:20:9: error: macro is not used [-Werror,-Wunused-macros]
   20 | #define _GNU_SOURCE // required to have feenableexcept()
      |         ^
```