### PR TITLE
tests: increase coverage for commaSeparatedReturn (negative case) [#13869]

### DIFF
--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -11152,9 +11152,8 @@ private:
     {
         check(
             "int f(){\n"
-            "  int a = 0, b = 1;\n"
-            "  a = (a, b);      // comma in assignment, not in return\n"
-            "  return a;        // plain return\n"
+            "  int a = 0;\n"
+            "  return a;\n"
             "}\n",
             true, false, false
             );

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -231,6 +231,7 @@ private:
         TEST_CASE(checkCastIntToCharAndBack); // ticket #160
 
         TEST_CASE(checkCommaSeparatedReturn);
+        TEST_CASE(commaSeparatedReturn_no_fp);
         TEST_CASE(checkPassByReference);
 
         TEST_CASE(checkComparisonFunctionIsAlwaysTrueOrFalse);
@@ -11145,6 +11146,18 @@ private:
               "        { \"3\" }\n"
               "    };\n"
               "}", true, false, false);
+        ASSERT_EQUALS("", errout_str());
+    }
+    void commaSeparatedReturn_no_fp()
+    {
+        check(
+            "int f(){\n"
+            "  int a = 0, b = 1;\n"
+            "  a = (a, b);      // comma in assignment, not in return\n"
+            "  return a;        // plain return\n"
+            "}\n",
+            true, false, false
+            );
         ASSERT_EQUALS("", errout_str());
     }
 

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -176,7 +176,6 @@ private:
 
         TEST_CASE(checkKnownEmptyContainer);
         TEST_CASE(checkMutexes);
-        TEST_CASE(commaSeparatedReturn_no_fp);
     }
 
     struct CheckOptions
@@ -7202,17 +7201,6 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout_str());
     }
-     void commaSeparatedReturn_no_fp()
-{
-    check(
-        "int g(){\n"
-        "    int a = 0, b = 1;\n"
-        "    a = (a, b);      // comma operator in an assignment, not in return\n"
-        "    return a;        // plain return, should not trigger\n"
-        "}\n"
-    );
-    ASSERT_EQUALS("", errout_str());
-}
 };
 
 REGISTER_TEST(TestStl)

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -984,25 +984,24 @@ private:
                     "    return sv[sv.size()] == '\\0';\n"
                     "}\n");
         ASSERT_EQUALS("[test.cpp:2:12]: error: Out of bounds access of sv, index 'sv.size()' is out of bounds. [containerOutOfBoundsIndexExpression]\n", errout_str());
+
         check("void f(){\n"
-      "    std::vector<double> v = {0.0, 0.1};\n"
-      "    (void)v[0];\n"
-      "}\n");
-ASSERT_EQUALS("", errout_str());
+              "    std::vector<double> v = {0.0, 0.1};\n"
+              "    (void)v[0];\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
 
-
-check("void f(){\n"
-      "    std::array<int,2> a = {1,2};\n"
-      "    (void)a[1];\n"
-      "}\n");
-ASSERT_EQUALS("", errout_str());
-
-
-check("void f(){\n"
-      "    std::vector<int> v;\n"
-      "    v.push_back(42);\n"
-      "    (void)v[0];\n"
-      "}\n");
+         check("void f(){\n"
+            "    std::array<int,2> a = {1,2};\n"
+            "    (void)a[1];\n"
+            "}\n");
+        ASSERT_EQUALS("", errout_str());
+ 
+         check("void f(){\n"
+            "    std::vector<int> v;\n"
+            "    v.push_back(42);\n"
+            "    (void)v[0];\n"
+            "}\n");
 ASSERT_EQUALS("", errout_str());
 
     }

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -176,8 +176,7 @@ private:
 
         TEST_CASE(checkKnownEmptyContainer);
         TEST_CASE(checkMutexes);
-        
-
+        TEST_CASE(commaSeparatedReturn_no_fp);
     }
 
     struct CheckOptions
@@ -984,26 +983,6 @@ private:
                     "    return sv[sv.size()] == '\\0';\n"
                     "}\n");
         ASSERT_EQUALS("[test.cpp:2:12]: error: Out of bounds access of sv, index 'sv.size()' is out of bounds. [containerOutOfBoundsIndexExpression]\n", errout_str());
-
-        check("void f(){\n"
-              "    std::vector<double> v = {0.0, 0.1};\n"
-              "    (void)v[0];\n"
-              "}\n");
-        ASSERT_EQUALS("", errout_str());
-
-         check("void f(){\n"
-            "    std::array<int,2> a = {1,2};\n"
-            "    (void)a[1];\n"
-            "}\n");
-        ASSERT_EQUALS("", errout_str());
- 
-         check("void f(){\n"
-            "    std::vector<int> v;\n"
-            "    v.push_back(42);\n"
-            "    (void)v[0];\n"
-            "}\n");
-ASSERT_EQUALS("", errout_str());
-
     }
     void outOfBoundsIterator() {
         check("int f() {\n"
@@ -7223,7 +7202,17 @@ ASSERT_EQUALS("", errout_str());
               "}\n");
         ASSERT_EQUALS("", errout_str());
     }
-    
+     void commaSeparatedReturn_no_fp()
+{
+    check(
+        "int g(){\n"
+        "    int a = 0, b = 1;\n"
+        "    a = (a, b);      // comma operator in an assignment, not in return\n"
+        "    return a;        // plain return, should not trigger\n"
+        "}\n"
+    );
+    ASSERT_EQUALS("", errout_str());
+}
 };
 
 REGISTER_TEST(TestStl)

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -176,6 +176,10 @@ private:
 
         TEST_CASE(checkKnownEmptyContainer);
         TEST_CASE(checkMutexes);
+        TEST_CASE(coob_initlist_vector_nonempty_no_fp_regression_20250812);
+        TEST_CASE(coob_array_initlist_nonempty_no_fp_regression_20250812);
+        TEST_CASE(coob_vector_pushback_nonempty_no_fp_regression_20250812);
+
     }
 
     struct CheckOptions
@@ -7201,6 +7205,36 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout_str());
     }
+    // Regression guards: non-empty containers must NOT trigger containerOutOfBounds (2025-08-12)
+
+
+ void coob_initlist_vector_nonempty_no_fp_regression_20250812()
+{
+    check(
+        "#include <vector>\n"
+        "void f(){ std::vector<double> v{0.0, 0.1}; (void)v[0]; }\n"
+    );
+    ASSERT_EQUALS("", errout_str());
+}
+
+ void coob_array_initlist_nonempty_no_fp_regression_20250812()
+{
+    check(
+        "#include <array>\n"
+        "void f(){ std::array<int,2> a{1,2}; (void)a[1]; }\n"
+    );
+    ASSERT_EQUALS("", errout_str());
+}
+
+      void coob_vector_pushback_nonempty_no_fp_regression_20250812()
+{
+    check(
+        "#include <vector>\n"
+        "void f(){ std::vector<int> v; v.push_back(42); (void)v[0]; }\n"
+    );
+    ASSERT_EQUALS("", errout_str());
+}
+
 };
 
 REGISTER_TEST(TestStl)

--- a/test/teststl.cpp
+++ b/test/teststl.cpp
@@ -176,9 +176,7 @@ private:
 
         TEST_CASE(checkKnownEmptyContainer);
         TEST_CASE(checkMutexes);
-        TEST_CASE(coob_initlist_vector_nonempty_no_fp_regression_20250812);
-        TEST_CASE(coob_array_initlist_nonempty_no_fp_regression_20250812);
-        TEST_CASE(coob_vector_pushback_nonempty_no_fp_regression_20250812);
+        
 
     }
 
@@ -986,6 +984,27 @@ private:
                     "    return sv[sv.size()] == '\\0';\n"
                     "}\n");
         ASSERT_EQUALS("[test.cpp:2:12]: error: Out of bounds access of sv, index 'sv.size()' is out of bounds. [containerOutOfBoundsIndexExpression]\n", errout_str());
+        check("void f(){\n"
+      "    std::vector<double> v = {0.0, 0.1};\n"
+      "    (void)v[0];\n"
+      "}\n");
+ASSERT_EQUALS("", errout_str());
+
+
+check("void f(){\n"
+      "    std::array<int,2> a = {1,2};\n"
+      "    (void)a[1];\n"
+      "}\n");
+ASSERT_EQUALS("", errout_str());
+
+
+check("void f(){\n"
+      "    std::vector<int> v;\n"
+      "    v.push_back(42);\n"
+      "    (void)v[0];\n"
+      "}\n");
+ASSERT_EQUALS("", errout_str());
+
     }
     void outOfBoundsIterator() {
         check("int f() {\n"
@@ -7205,36 +7224,7 @@ private:
               "}\n");
         ASSERT_EQUALS("", errout_str());
     }
-    // Regression guards: non-empty containers must NOT trigger containerOutOfBounds (2025-08-12)
-
-
- void coob_initlist_vector_nonempty_no_fp_regression_20250812()
-{
-    check(
-        "#include <vector>\n"
-        "void f(){ std::vector<double> v{0.0, 0.1}; (void)v[0]; }\n"
-    );
-    ASSERT_EQUALS("", errout_str());
-}
-
- void coob_array_initlist_nonempty_no_fp_regression_20250812()
-{
-    check(
-        "#include <array>\n"
-        "void f(){ std::array<int,2> a{1,2}; (void)a[1]; }\n"
-    );
-    ASSERT_EQUALS("", errout_str());
-}
-
-      void coob_vector_pushback_nonempty_no_fp_regression_20250812()
-{
-    check(
-        "#include <vector>\n"
-        "void f(){ std::vector<int> v; v.push_back(42); (void)v[0]; }\n"
-    );
-    ASSERT_EQUALS("", errout_str());
-}
-
+    
 };
 
 REGISTER_TEST(TestStl)


### PR DESCRIPTION
Adds a negative test next to existing `checkCommaSeparatedReturn` coverage:
- plain `return` with no comma operator → expect no diagnostic

Placement: `test/testother.cpp`, registered in `TestOther::run()` after `checkCommaSeparatedReturn`.
Formatting: applied with `.uncrustify.cfg`.

Earlier version accidentally triggered `constStatement`; this version avoids unrelated warnings.
All tests pass locally.