### PR TITLE
cppcheckexecutor.cpp: avoid `-Wcast-qual` warnings on macOS

### DIFF
--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -733,6 +733,9 @@ int CppCheckExecutor::executeCommand(std::string exe, std::vector<std::string> a
 
 #ifdef _WIN32
     const int res = _pclose(p);
+#elif defined(__APPLE__) && defined(__MACH__)
+    // the W* macros cast to int* on macOS
+    int res = pclose(p);
 #else
     const int res = pclose(p);
 #endif


### PR DESCRIPTION
```
/Users/runner/work/cppcheck/cppcheck/cli/cppcheckexecutor.cpp:746:9: error: cast from 'const int *' to 'int *' drops const qualifier [-Werror,-Wcast-qual]
  746 |     if (WIFEXITED(res)) {
      |         ^
[  2%] Building CXX object lib/CMakeFiles/cppcheck-core.dir/symboldatabase.cpp.o
/Applications/Xcode_16.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/usr/include/sys/wait.h:152:26: note: expanded from macro 'WIFEXITED'
  152 | #define WIFEXITED(x)    (_WSTATUS(x) == 0)
      |                          ^
/Applications/Xcode_16.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/usr/include/sys/wait.h:136:26: note: expanded from macro '_WSTATUS'
  136 | #define _WSTATUS(x)     (_W_INT(x) & 0177)
      |                          ^
/Applications/Xcode_16.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/usr/include/sys/wait.h:131:34: note: expanded from macro '_W_INT'
  131 | #define _W_INT(w)       (*(int *)&(w))  /* convert union wait to int */
      |                                  ^
```