### PR TITLE
avoid `-Wuseless-cast` GCC warnings in Qt mocs

### DIFF
--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -75,6 +75,9 @@ CheckOptions:
             # caused by Qt generated moc code starting with 6.9.0 - see https://bugreports.qt.io/browse/QTBUG-135638
             target_compile_options_safe(cppcheck-gui -Wno-ctad-maybe-unsupported)
         endif()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # caused by mocs
+        target_compile_options_safe(cppcheck-gui -Wno-useless-cast)
     endif()
     if(QT_VERSION VERSION_GREATER_EQUAL "6.9.2")
         # QBrush fails to compile before 6.9.0 - see https://bugreports.qt.io/browse/QTBUG-134038

--- a/gui/test/resultstree/CMakeLists.txt
+++ b/gui/test/resultstree/CMakeLists.txt
@@ -43,8 +43,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # caused by Qt generated moc code starting with 6.9.0 - see https://bugreports.qt.io/browse/QTBUG-135638
         target_compile_options_safe(test-resultstree -Wno-ctad-maybe-unsupported)
     endif()
-    # caused by mocks
+    # caused by mocs
     target_compile_options_safe(test-resultstree -Wno-missing-noreturn)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # caused by mocs
+    target_compile_options_safe(test-resultstree -Wno-useless-cast)
 endif()
 
 if (REGISTER_GUI_TESTS)


### PR DESCRIPTION
example:
```
/home/runner/work/cppcheck/cppcheck/cmake.output.tinyxml2/gui/test/resultstree/__/__/moc_threadhandler.cpp: In static member function ‘static void ThreadHandler::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)’:
/home/runner/work/cppcheck/cppcheck/cmake.output.tinyxml2/gui/test/resultstree/__/__/moc_threadhandler.cpp:100:51: error: useless cast to type ‘using _t = void (class ThreadHandler::*)()’ {aka ‘void (class ThreadHandler::*)()’} [-Werror=useless-cast]
  100 |             if (*reinterpret_cast<_t *>(_a[1]) == static_cast<_t>(&ThreadHandler::done)) {
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```