### PR TITLE
ProgramMemory: avoid duplicated lookups / removed `at()`

### DIFF
--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -109,7 +109,8 @@ struct CPPCHECKLIB ProgramMemory {
     explicit ProgramMemory(Map values) : mValues(new Map(std::move(values))) {}
 
     void setValue(const Token* expr, const ValueFlow::Value& value);
-    const ValueFlow::Value* getValue(nonneg int exprid, bool impossible) const;
+    const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;
+    ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false);
 
     bool getIntValue(nonneg int exprid, MathLib::bigint& result, bool impossible = false) const;
     void setIntValue(const Token* expr, MathLib::bigint value, bool impossible = false);
@@ -122,9 +123,6 @@ struct CPPCHECKLIB ProgramMemory {
 
     bool getTokValue(nonneg int exprid, const Token*& result, bool impossible = false) const;
     bool hasValue(nonneg int exprid, bool impossible = true) const;
-
-    const ValueFlow::Value& at(nonneg int exprid, bool impossible = true) const;
-    ValueFlow::Value& at(nonneg int exprid, bool impossible = true);
 
     void erase_if(const std::function<bool(const ExprIdToken&)>& pred);
 

--- a/lib/programmemory.h
+++ b/lib/programmemory.h
@@ -109,22 +109,22 @@ struct CPPCHECKLIB ProgramMemory {
     explicit ProgramMemory(Map values) : mValues(new Map(std::move(values))) {}
 
     void setValue(const Token* expr, const ValueFlow::Value& value);
-    const ValueFlow::Value* getValue(nonneg int exprid, bool impossible = false) const;
+    const ValueFlow::Value* getValue(nonneg int exprid, bool impossible) const;
 
-    bool getIntValue(nonneg int exprid, MathLib::bigint& result) const;
+    bool getIntValue(nonneg int exprid, MathLib::bigint& result, bool impossible = false) const;
     void setIntValue(const Token* expr, MathLib::bigint value, bool impossible = false);
 
-    bool getContainerSizeValue(nonneg int exprid, MathLib::bigint& result) const;
-    bool getContainerEmptyValue(nonneg int exprid, MathLib::bigint& result) const;
+    bool getContainerSizeValue(nonneg int exprid, MathLib::bigint& result, bool impossible = false) const;
+    bool getContainerEmptyValue(nonneg int exprid, MathLib::bigint& result, bool impossible = false) const;
     void setContainerSizeValue(const Token* expr, MathLib::bigint value, bool isEqual = true);
 
     void setUnknown(const Token* expr);
 
-    bool getTokValue(nonneg int exprid, const Token*& result) const;
-    bool hasValue(nonneg int exprid) const;
+    bool getTokValue(nonneg int exprid, const Token*& result, bool impossible = false) const;
+    bool hasValue(nonneg int exprid, bool impossible = true) const;
 
-    const ValueFlow::Value& at(nonneg int exprid) const;
-    ValueFlow::Value& at(nonneg int exprid);
+    const ValueFlow::Value& at(nonneg int exprid, bool impossible = true) const;
+    ValueFlow::Value& at(nonneg int exprid, bool impossible = true);
 
     void erase_if(const std::function<bool(const ExprIdToken&)>& pred);
 

--- a/lib/vf_analyzers.cpp
+++ b/lib/vf_analyzers.cpp
@@ -716,7 +716,8 @@ private:
                 return {value->intvalue == 0};
             ProgramMemory pm = pms.get(tok, ctx, getProgramState());
             MathLib::bigint out = 0;
-            if (pm.getContainerEmptyValue(tok->exprId(), out))
+            // TODO: do we really went to return an impossible value?
+            if (pm.getContainerEmptyValue(tok->exprId(), out, true))
                 return {static_cast<int>(out)};
             return {};
         }

--- a/test/testprogrammemory.cpp
+++ b/test/testprogrammemory.cpp
@@ -35,7 +35,6 @@ private:
         TEST_CASE(copyOnWrite);
         TEST_CASE(hasValue);
         TEST_CASE(getValue);
-        TEST_CASE(at);
     }
 
     void copyOnWrite() const {
@@ -45,11 +44,11 @@ private:
         tok->exprId(id);
 
         ProgramMemory pm;
-        const ValueFlow::Value* v = pm.getValue(id, false);
+        const ValueFlow::Value* v = utils::as_const(pm).getValue(id, false);
         ASSERT(!v);
         pm.setValue(tok, ValueFlow::Value{41});
 
-        v = pm.getValue(id, false);
+        v = utils::as_const(pm).getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
 
@@ -57,7 +56,7 @@ private:
         ProgramMemory pm2 = pm;
 
         // make sure the value was copied
-        v = pm2.getValue(id, false);
+        v = utils::as_const(pm2).getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
 
@@ -71,17 +70,17 @@ private:
         pm3.setValue(tok, ValueFlow::Value{43});
 
         // make sure the value was set
-        v = pm2.getValue(id, false);
+        v = utils::as_const(pm2).getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(42, v->intvalue);
 
         // make sure the value was set
-        v = pm3.getValue(id, false);
+        v = utils::as_const(pm3).getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(43, v->intvalue);
 
         // make sure the original value remains unchanged
-        v = pm.getValue(id, false);
+        v = utils::as_const(pm).getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
     }
@@ -93,13 +92,7 @@ private:
 
     void getValue() const {
         ProgramMemory pm;
-        ASSERT(!pm.getValue(123, false));
-    }
-
-    void at() const {
-        ProgramMemory pm;
-        ASSERT_THROW_EQUALS(pm.at(123), std::out_of_range, "ProgramMemory::at");
-        ASSERT_THROW_EQUALS(utils::as_const(pm).at(123), std::out_of_range, "ProgramMemory::at");
+        ASSERT(!utils::as_const(pm).getValue(123, false));
     }
 };
 

--- a/test/testprogrammemory.cpp
+++ b/test/testprogrammemory.cpp
@@ -45,11 +45,11 @@ private:
         tok->exprId(id);
 
         ProgramMemory pm;
-        const ValueFlow::Value* v = pm.getValue(id);
+        const ValueFlow::Value* v = pm.getValue(id, false);
         ASSERT(!v);
         pm.setValue(tok, ValueFlow::Value{41});
 
-        v = pm.getValue(id);
+        v = pm.getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
 
@@ -57,7 +57,7 @@ private:
         ProgramMemory pm2 = pm;
 
         // make sure the value was copied
-        v = pm2.getValue(id);
+        v = pm2.getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
 
@@ -71,17 +71,17 @@ private:
         pm3.setValue(tok, ValueFlow::Value{43});
 
         // make sure the value was set
-        v = pm2.getValue(id);
+        v = pm2.getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(42, v->intvalue);
 
         // make sure the value was set
-        v = pm3.getValue(id);
+        v = pm3.getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(43, v->intvalue);
 
         // make sure the original value remains unchanged
-        v = pm.getValue(id);
+        v = pm.getValue(id, false);
         ASSERT(v);
         ASSERT_EQUALS(41, v->intvalue);
     }
@@ -93,7 +93,7 @@ private:
 
     void getValue() const {
         ProgramMemory pm;
-        ASSERT(!pm.getValue(123));
+        ASSERT(!pm.getValue(123, false));
     }
 
     void at() const {


### PR DESCRIPTION
all `at()` calls were proceeded by `hasValue()` so we can just directly fetch the value instead.