### PR TITLE
ProgramMemory: avoid unnecessary insertion in `setValue()`

### DIFF
--- a/lib/programmemory.cpp
+++ b/lib/programmemory.cpp
@@ -61,7 +61,6 @@ std::size_t ExprIdToken::Hash::operator()(ExprIdToken etok) const
 void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value) {
     copyOnWrite();
 
-    (*mValues)[expr] = value;
     ValueFlow::Value subvalue = value;
     const Token* subexpr = solveExprValue(
         expr,
@@ -74,6 +73,8 @@ void ProgramMemory::setValue(const Token* expr, const ValueFlow::Value& value) {
         return {};
     },
         subvalue);
+    if (expr != subexpr)
+        (*mValues)[expr] = value;
     if (subexpr)
         (*mValues)[subexpr] = std::move(subvalue);
 }


### PR DESCRIPTION
`subexpr` might have been the same as `expr` and thus overwrote the previously added value.