### PR TITLE
path.cpp: fixed `-Wuseless-cast` GCC warning with C++17

### DIFF
--- a/lib/path.cpp
+++ b/lib/path.cpp
@@ -242,8 +242,15 @@ static bool hasEmacsCppMarker(const char* path)
         return false;
     std::string buf(128, '\0');
     {
+#if __cplusplus >= 201703L
+        // C++17 provides an overload with non-const data()
+        #define CONST_CAST(x) (x)
+#else
+        #define CONST_CAST(x) const_cast<char*>(x)
+#endif
         // TODO: read the whole first line only
-        const char * const res = fgets(const_cast<char*>(buf.data()), buf.size(), fp);
+        const char * const res = fgets(CONST_CAST(buf.data()), buf.size(), fp);
+#undef CONST_CAST
         fclose(fp);
         fp = nullptr;
         if (!res)


### PR DESCRIPTION
building with the GUI enabled will implicitly switch the standard to C++17.

```
/home/runner/work/cppcheck/cppcheck/lib/path.cpp: In function ‘bool hasEmacsCppMarker(const char*)’:
/home/runner/work/cppcheck/cppcheck/lib/path.cpp:246:40: error: useless cast to type ‘char*’ [-Werror=useless-cast]
  246 |         const char * const res = fgets(const_cast<char*>(buf.data()), buf.size(), fp);
      |
```