### PR TITLE
donate_cpu_lib.py: reverted back to overriding `CXXFLAGS` for now [skip ci]

### DIFF
--- a/tools/donate_cpu_lib.py
+++ b/tools/donate_cpu_lib.py
@@ -16,7 +16,7 @@ import copy
 # Version scheme (MAJOR.MINOR.PATCH) should orientate on "Semantic Versioning" https://semver.org/
 # Every change in this script should result in increasing the version number accordingly (exceptions may be cosmetic
 # changes)
-CLIENT_VERSION = "1.3.68"
+CLIENT_VERSION = "1.3.69"
 
 # Timeout for analysis with Cppcheck in seconds
 CPPCHECK_TIMEOUT = 30 * 60
@@ -217,7 +217,8 @@ def compile_cppcheck(cppcheck_path):
             # TODO: processes still exhaust all threads of the system
             subprocess.check_call([__make_cmd, '-t:cli', os.path.join(cppcheck_path, 'cppcheck.sln'), '/property:Configuration=Release;Platform=x64'], cwd=cppcheck_path, env=build_env)
         else:
-            build_cmd = [__make_cmd, __jobs, 'MATCHCOMPILER=yes', 'CXXOPTS=-O2 -g -w']
+            # TODO: use CXXOPTS instead
+            build_cmd = [__make_cmd, __jobs, 'MATCHCOMPILER=yes', 'CXXFLAGS=-O2 -g -w']
             build_env = os.environ
             if __make_cmd == 'mingw32-make':
                 # TODO: MinGW will always link even if no changes are present


### PR DESCRIPTION
using `CXXOPTS` leaves the `_GLIBCXX_DEBUG` usage in "debug" Makefiles intact