### PR TITLE
Fix unused filename parameter TODO in reportProgress

### DIFF
--- a/cli/cmdlineparser.cpp
+++ b/cli/cmdlineparser.cpp
@@ -136,7 +136,7 @@ namespace {
             (void) metric;
         }
 
-        void reportProgress(const std::string & /*filename*/, const char /*stage*/[], const std::size_t /*value*/) override
+        void reportProgress(const char /*stage*/[], const std::size_t /*value*/) override
         {}
     };
 }

--- a/cli/cppcheckexecutor.cpp
+++ b/cli/cppcheckexecutor.cpp
@@ -323,7 +323,7 @@ namespace {
         /** xml output of errors */
         void reportErr(const ErrorMessage &msg) override;
 
-        void reportProgress(const std::string &filename, const char stage[], std::size_t value) override;
+        void reportProgress(const char stage[], std::size_t value) override;
 
         /**
          * Reference to current settings; set while check() is running for reportError().
@@ -618,11 +618,8 @@ void StdLogger::reportOut(const std::string &outmsg, Color c)
         std::cout << c << ansiToOEM(outmsg, true) << Color::Reset << std::endl;
 }
 
-// TODO: remove filename parameter?
-void StdLogger::reportProgress(const std::string &filename, const char stage[], const std::size_t value)
+void StdLogger::reportProgress(const char stage[], const std::size_t value)
 {
-    (void)filename;
-
     if (!mLatestProgressOutputTime)
         return;
 

--- a/democlient/democlient.cpp
+++ b/democlient/democlient.cpp
@@ -83,9 +83,7 @@ public:
     }
     void reportMetric(const std::string & /*metric*/) override {}
 
-    void reportProgress(const std::string& /*filename*/,
-                        const char /*stage*/[],
-                        const std::size_t /*value*/) override {
+    void reportProgress(const char /*stage*/[], const std::size_t /*value*/) override {
         if (std::time(nullptr) >= stoptime) {
             std::cout << "Time to analyse the code exceeded 2 seconds. Terminating.\n\n";
             Settings::terminate();

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -263,9 +263,9 @@ private:
         mErrorLogger.reportMetric(metric);
     }
 
-    void reportProgress(const std::string &filename, const char stage[], const std::size_t value) override
+    void reportProgress(const char stage[], const std::size_t value) override
     {
-        mErrorLogger.reportProgress(filename, stage, value);
+        mErrorLogger.reportProgress(stage, value);
     }
 
     ErrorLogger &mErrorLogger;

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -249,12 +249,10 @@ public:
 
     /**
      * Report progress to client
-     * @param filename main file that is checked
      * @param stage for example preprocess / tokenize / simplify / check
      * @param value progress value (0-100)
      */
-    virtual void reportProgress(const std::string &filename, const char stage[], const std::size_t value) {
-        (void)filename;
+    virtual void reportProgress(const char stage[], const std::size_t value) {
         (void)stage;
         (void)value;
     }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -202,9 +202,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
     for (const Token *tok = mTokenizer.tokens(); tok; tok = tok ? tok->next() : nullptr) {
         // #5593 suggested to add here:
         if (doProgress)
-            mErrorLogger.reportProgress(mTokenizer.list.getSourceFilePath(),
-                                        "SymbolDatabase",
-                                        tok->progressValue());
+            mErrorLogger.reportProgress("SymbolDatabase", tok->progressValue());
         // Locate next class
         if ((tok->isCpp() && tok->isKeyword() &&
              ((Token::Match(tok, "class|struct|union|namespace ::| %name% final| {|:|::|<") &&

--- a/lib/templatesimplifier.cpp
+++ b/lib/templatesimplifier.cpp
@@ -3218,7 +3218,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
 
         Token * const tok2 = instantiation.token();
         if ((mSettings.reportProgress != -1) && !mTokenList.getFiles().empty())
-            mErrorLogger.reportProgress(mTokenList.getFiles()[0], "TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
+            mErrorLogger.reportProgress("TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {
@@ -3294,7 +3294,7 @@ bool TemplateSimplifier::simplifyTemplateInstantiations(
     if (!instantiated && specialized) {
         auto * tok2 = const_cast<Token *>(templateDeclaration.nameToken());
         if ((mSettings.reportProgress != -1) && !mTokenList.getFiles().empty())
-            mErrorLogger.reportProgress(mTokenList.getFiles()[0], "TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
+            mErrorLogger.reportProgress("TemplateSimplifier::simplifyTemplateInstantiations()", tok2->progressValue());
 
         if (maxtime > 0 && std::time(nullptr) > maxtime) {
             if (mSettings.debugwarnings) {

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -1137,7 +1137,7 @@ void Tokenizer::simplifyTypedefCpp()
 
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         if (doProgress)
-            mErrorLogger.reportProgress(list.getFiles()[0], "Tokenize (typedef)", tok->progressValue());
+            mErrorLogger.reportProgress("Tokenize (typedef)", tok->progressValue());
 
         if (Settings::terminated())
             return;
@@ -2884,7 +2884,7 @@ bool Tokenizer::simplifyUsing()
 
     for (Token *tok = list.front(); tok; tok = tok->next()) {
         if (doProgress)
-            mErrorLogger.reportProgress(list.getFiles()[0], "Tokenize (using)", tok->progressValue());
+            mErrorLogger.reportProgress("Tokenize (using)", tok->progressValue());
 
         if (Settings::terminated())
             return substitute;

--- a/oss-fuzz/main.cpp
+++ b/oss-fuzz/main.cpp
@@ -40,9 +40,7 @@ class DummyErrorLogger : public ErrorLogger {
 public:
     void reportOut(const std::string& /*outmsg*/, Color /*c*/) override {}
     void reportErr(const ErrorMessage& /*msg*/) override {}
-    void reportProgress(const std::string& /*filename*/,
-                        const char /*stage*/[],
-                        const std::size_t /*value*/) override {}
+    void reportProgress(const char /*stage*/[], const std::size_t /*value*/) override {}
     void reportMetric(const std::string & /*metric*/) override {}
 };
 


### PR DESCRIPTION
Deleting the filename parameter in reportProgress, since it is not used anywhere.