### PR TITLE
Makefile: disabled usage of `_GLIBCXX_DEBUG` for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ ifeq (clang++, $(findstring clang++,$(CXX)))
     CPPCHK_GLIBCXX_DEBUG=
 endif
 ifndef CXXFLAGS
-    CXXFLAGS=-pedantic -Wall -Wextra -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-sign-compare -Wno-multichar -Woverloaded-virtual $(CPPCHK_GLIBCXX_DEBUG) -g
+    CXXFLAGS=-pedantic -Wall -Wextra -Wcast-qual -Wfloat-equal -Wmissing-declarations -Wmissing-format-attribute -Wno-long-long -Wpacked -Wredundant-decls -Wundef -Wno-sign-compare -Wno-multichar -Woverloaded-virtual -g
 endif
 
 ifeq (g++, $(findstring g++,$(CXX)))

--- a/tools/dmake/dmake.cpp
+++ b/tools/dmake/dmake.cpp
@@ -725,7 +725,7 @@ int main(int argc, char **argv)
                                 "-Wno-sign-compare "
                                 "-Wno-multichar "
                                 "-Woverloaded-virtual "
-                                "$(CPPCHK_GLIBCXX_DEBUG) "
+                                //"$(CPPCHK_GLIBCXX_DEBUG) " // TODO: when using CXXOPTS this would always be set - need to handle this differently
                                 "-g");
     }
 


### PR DESCRIPTION
this was blowing some builds (including the selfcheck) in the CI.