### PR TITLE
disabled `-Wpoison-system-directories` AppleClang warnings until version 15

### DIFF
--- a/cmake/compileroptions.cmake
+++ b/cmake/compileroptions.cmake
@@ -100,6 +100,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-gdwarf-4)
     endif()
 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+        add_compile_options(-Wno-poison-system-directories)
+    endif()
+
     if(USE_LIBCXX)
         add_compile_options(-stdlib=libc++)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")


### PR DESCRIPTION
```
error: include location '/usr/local/include' is unsafe for cross-compilation [-Werror,-Wpoison-system-directories]                               ^
```