### PR TITLE
fix #13854: memleak might show misleading location

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -6801,6 +6801,7 @@ Token *Tokenizer::simplifyAddBracesPair(Token *tok, bool commandWithCondition)
         }
         tokEnd->insertToken("}");
         Token * tokCloseBrace = tokEnd->next();
+        tokCloseBrace->column(tokEnd->column());
 
         Token::createMutualLinks(tokOpenBrace, tokCloseBrace);
         tokBracesEnd = tokCloseBrace;
@@ -6835,6 +6836,7 @@ Token *Tokenizer::simplifyAddBracesPair(Token *tok, bool commandWithCondition)
 
         tokEnd->insertToken("}");
         Token * tokCloseBrace=tokEnd->next();
+        tokCloseBrace->column(tokEnd->column());
 
         Token::createMutualLinks(tokOpenBrace,tokCloseBrace);
         tokBracesEnd=tokCloseBrace;

--- a/test/testleakautovar.cpp
+++ b/test/testleakautovar.cpp
@@ -2230,8 +2230,8 @@ private:
               "        void * p2 = malloc(2);\n"
               "    return;\n"
               "}");
-        ASSERT_EQUALS("[test.c:3:0]: (error) Memory leak: p1 [memleak]\n"
-                      "[test.c:5:0]: (error) Memory leak: p2 [memleak]\n", errout_str());
+        ASSERT_EQUALS("[test.c:3:30]: (error) Memory leak: p1 [memleak]\n"
+                      "[test.c:5:30]: (error) Memory leak: p2 [memleak]\n", errout_str());
 
         check("void f() {\n"
               "    if (x > 0)\n"
@@ -2239,8 +2239,8 @@ private:
               "    else\n"
               "        void * p2 = malloc(2);\n"
               "}");
-        ASSERT_EQUALS("[test.c:3:0]: (error) Memory leak: p1 [memleak]\n"
-                      "[test.c:5:0]: (error) Memory leak: p2 [memleak]\n", errout_str());
+        ASSERT_EQUALS("[test.c:3:30]: (error) Memory leak: p1 [memleak]\n"
+                      "[test.c:5:30]: (error) Memory leak: p2 [memleak]\n", errout_str());
     }
 
     void ifelse21() {


### PR DESCRIPTION
This sets the column of added braces to the column of the token before it, so we can point to the last token of the scope.
```
Checking tickets/13854.c ...
tickets/13854.c:3:30: error: Memory leak: p1 [memleak]
        void * p1 = malloc(5);
                             ^
```