### PR TITLE
removed usage of default parameters from `Token::insertToken*()`

### DIFF
--- a/lib/token.cpp
+++ b/lib/token.cpp
@@ -1061,7 +1061,7 @@ void Token::function(const Function *f)
         tokType(eName);
 }
 
-Token* Token::insertToken(const std::string& tokenStr, const std::string& originalNameStr, const std::string& macroNameStr, bool prepend)
+Token* Token::insertToken(const std::string& tokenStr, bool prepend)
 {
     Token *newToken;
     if (mStr.empty())
@@ -1069,10 +1069,6 @@ Token* Token::insertToken(const std::string& tokenStr, const std::string& origin
     else
         newToken = new Token(mList, mTokensFrontBack);
     newToken->str(tokenStr);
-    if (!originalNameStr.empty())
-        newToken->originalName(originalNameStr);
-    if (!macroNameStr.empty())
-        newToken->setMacroName(macroNameStr);
 
     if (newToken != this) {
         newToken->mImpl->mLineNumber = mImpl->mLineNumber;
@@ -1195,6 +1191,22 @@ Token* Token::insertToken(const std::string& tokenStr, const std::string& origin
             }
         }
     }
+    return newToken;
+}
+
+Token* Token::insertToken(const std::string& tokenStr, const std::string& originalNameStr, bool prepend)
+{
+    Token* const newToken = insertToken(tokenStr, prepend);
+    if (!originalNameStr.empty())
+        newToken->originalName(originalNameStr);
+    return newToken;
+}
+
+Token* Token::insertToken(const std::string& tokenStr, const std::string& originalNameStr, const std::string& macroNameStr, bool prepend)
+{
+    Token* const newToken = insertToken(tokenStr, originalNameStr, prepend);
+    if (!macroNameStr.empty())
+        newToken->setMacroName(macroNameStr);
     return newToken;
 }
 

--- a/lib/token.h
+++ b/lib/token.h
@@ -963,15 +963,42 @@ public:
      * Insert new token after this token. This function will handle
      * relations between next and previous token also.
      * @param tokenStr String for the new token.
-     * @param originalNameStr String used for Token::originalName().
-     * the first one on the tokens list.
      */
-    RET_NONNULL Token* insertToken(const std::string& tokenStr, const std::string& originalNameStr = emptyString, const std::string& macroNameStr = emptyString)
+    RET_NONNULL Token* insertToken(const std::string& tokenStr)
+    {
+        return insertToken(tokenStr, false);
+    }
+    /**
+     * Insert new token after this token. This function will handle
+     * relations between next and previous token also.
+     * @param tokenStr String for the new token.
+     * @param originalNameStr String used for Token::originalName().
+     */
+    RET_NONNULL Token* insertToken(const std::string& tokenStr, const std::string& originalNameStr)
+    {
+        return insertToken(tokenStr, originalNameStr, false);
+    }
+    /**
+     * Insert new token after this token. This function will handle
+     * relations between next and previous token also.
+     * @param tokenStr String for the new token.
+     * @param originalNameStr String used for Token::originalName().
+     * @param macroNameStr String used for Token::getMacroName().
+     */
+    RET_NONNULL Token* insertToken(const std::string& tokenStr, const std::string& originalNameStr, const std::string& macroNameStr)
     {
         return insertToken(tokenStr, originalNameStr, macroNameStr, false);
     }
 
-    RET_NONNULL Token* insertTokenBefore(const std::string& tokenStr, const std::string& originalNameStr = emptyString, const std::string& macroNameStr = emptyString)
+    RET_NONNULL Token* insertTokenBefore(const std::string& tokenStr)
+    {
+        return insertToken(tokenStr, true);
+    }
+    RET_NONNULL Token* insertTokenBefore(const std::string& tokenStr, const std::string& originalNameStr)
+    {
+        return insertToken(tokenStr, originalNameStr, true);
+    }
+    RET_NONNULL Token* insertTokenBefore(const std::string& tokenStr, const std::string& originalNameStr, const std::string& macroNameStr)
     {
         return insertToken(tokenStr, originalNameStr, macroNameStr, true);
     }
@@ -1404,6 +1431,8 @@ private:
      */
     static const char *chrInFirstWord(const char *str, char c);
 
+    RET_NONNULL Token* insertToken(const std::string& tokenStr, bool prepend);
+    RET_NONNULL Token* insertToken(const std::string& tokenStr, const std::string& originalNameStr, bool prepend);
     RET_NONNULL Token* insertToken(const std::string& tokenStr, const std::string& originalNameStr, const std::string& macroNameStr, bool prepend);
 
     std::string mStr;


### PR DESCRIPTION
this avoids the unnecessary creation of `std::string` objects