### PR TITLE
refs #13788 - CI-unixish-docker.yml: removed `ubuntu:24.10`

### DIFF
--- a/.github/workflows/CI-unixish-docker.yml
+++ b/.github/workflows/CI-unixish-docker.yml
@@ -20,12 +20,10 @@ jobs:
 
     strategy:
       matrix:
-        image: ["ubuntu:24.04", "ubuntu:24.10"]
+        image: ["ubuntu:24.04"]
         include:
           - build_gui: false
           - image: "ubuntu:24.04"
-            build_gui: true
-          - image: "ubuntu:24.10"
             build_gui: true
       fail-fast: false # Prefer quick result
 
@@ -84,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        image: ["ubuntu:24.04", "ubuntu:24.10"]
+        image: ["ubuntu:24.04"]
       fail-fast: false # Prefer quick result
 
     runs-on: ubuntu-22.04


### PR DESCRIPTION
the update repo currently isn't working and it also went EOL in July 2025