### PR TITLE
Disable the use of getloadavg, my_fpe, feenableexcept and -rdynamic in AIX

### DIFF
--- a/cli/processexecutor.cpp
+++ b/cli/processexecutor.cpp
@@ -276,7 +276,7 @@ bool ProcessExecutor::handleRead(int rpipe, unsigned int &result, const std::str
 
 bool ProcessExecutor::checkLoadAverage(size_t nchildren)
 {
-#if defined(__QNX__) || defined(__HAIKU__)  // getloadavg() is unsupported on Qnx, Haiku.
+#if defined(__QNX__) || defined(__HAIKU__)  || defined(_AIX)// getloadavg() is unsupported on Qnx, Haiku, AIX.
     (void)nchildren;
     return true;
 #else

--- a/test/signal/CMakeLists.txt
+++ b/test/signal/CMakeLists.txt
@@ -8,7 +8,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     target_compile_options_safe(test-signalhandler -Wno-missing-declarations)
     target_compile_options_safe(test-signalhandler -Wno-missing-prototypes)
     # required for backtrace() to produce function names
-    target_link_options(test-signalhandler PRIVATE -rdynamic)
+    if(CMAKE_SYSTEM_NAME MATCHES AIX)
+        target_link_options(test-signalhandler PRIVATE)
+    else()
+        target_link_options(test-signalhandler PRIVATE -rdynamic)
+    endif()
 endif()
 
 add_executable(test-stacktrace
@@ -20,5 +24,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
     target_compile_options_safe(test-stacktrace -Wno-missing-declarations)
     target_compile_options_safe(test-stacktrace -Wno-missing-prototypes)
     # required for backtrace() to produce function names
-    target_link_options(test-stacktrace PRIVATE -rdynamic)
+    if(CMAKE_SYSTEM_NAME MATCHES AIX)
+        target_link_options(test-signalhandler PRIVATE)
+    else()
+        target_link_options(test-stacktrace PRIVATE -rdynamic)
+    endif()
 endif()

--- a/test/signal/test-signalhandler.cpp
+++ b/test/signal/test-signalhandler.cpp
@@ -54,7 +54,7 @@
     ++*static_cast<int*>(nullptr); // NOLINT(clang-analyzer-core.NullDereference)
 }
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(_AIX)
 /*static*/ int my_fpe() // NOLINT(misc-use-internal-linkage)
 {
     if (feenableexcept(FE_ALL_EXCEPT) == -1)
@@ -80,7 +80,7 @@ int main(int argc, const char * const argv[])
         my_abort();
     else if (strcmp(argv[1], "segv") == 0)
         my_segv();
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(_AIX)
     else if (strcmp(argv[1], "fpe") == 0)
         return my_fpe();
 #endif


### PR DESCRIPTION
In AIX, getloadavg, feenableexcept and my_fpe are not available. In addition, -rdynamic flag is not supported. This results in compilation errors in AIX and this patch fixes it. 
For more information please refer the discussion : https://sourceforge.net/p/cppcheck/discussion/development/thread/f7bad36f1f/