### PR TITLE
Fix #14743 (New check: ftell() result is unspecified when file is opened in mode "t")

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.gcno
 *.gch
 *.o
+*.a
 *.pyc
 /cppcheck
 /cppcheck.exe

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -438,6 +438,12 @@ void CheckIOImpl::seekOnAppendedFileError(const Token *tok)
                 "seekOnAppendedFile", "Repositioning operation performed on a file opened in append mode has no effect.", CWE398, Certainty::normal);
 }
 
+void CheckIOImpl::ftellFileError(const Token *tok)
+{
+    reportError(tok, Severity::portability,
+                "ftellTextModeFile", "ftell() result is unspecified when file is opened in mode \"t\"", CWE474, Certainty::normal);
+}
+
 void CheckIOImpl::incompatibleFileOpenError(const Token *tok, const std::string &filename)
 {
     reportError(tok, Severity::warning,

--- a/lib/checkio.cpp
+++ b/lib/checkio.cpp
@@ -48,6 +48,7 @@
 // CVE ID used:
 static const CWE CWE119(119U);  // Improper Restriction of Operations within the Bounds of a Memory Buffer
 static const CWE CWE398(398U);  // Indicator of Poor Code Quality
+static const CWE CWE474(474U);  // Use of Function with Inconsistent Implementations
 static const CWE CWE664(664U);  // Improper Control of a Resource Through its Lifetime
 static const CWE CWE685(685U);  // Function Call With Incorrect Number of Arguments
 static const CWE CWE686(686U);  // Function Call With Incorrect Argument Type
@@ -111,6 +112,8 @@ namespace {
         nonneg int op_indent{};
         enum class AppendMode : std::uint8_t { UNKNOWN_AM, APPEND, APPEND_EX };
         AppendMode append_mode = AppendMode::UNKNOWN_AM;
+        enum class ReadMode : std::uint8_t { READ_TEXT, READ_BIN };
+        ReadMode read_mode = ReadMode::READ_BIN;
         std::string filename;
         explicit Filepointer(OpenMode mode_ = OpenMode::UNKNOWN_OM)
             : mode(mode_) {}
@@ -183,6 +186,7 @@ void CheckIOImpl::checkFileUsage()
                 }
             } else if (Token::Match(tok, "%name% (") && tok->previous() && (!tok->previous()->isName() || Token::Match(tok->previous(), "return|throw"))) {
                 std::string mode;
+                bool isftell = false;
                 const Token* fileTok = nullptr;
                 const Token* fileNameTok = nullptr;
                 Filepointer::Operation operation = Filepointer::Operation::NONE;
@@ -266,6 +270,9 @@ void CheckIOImpl::checkFileUsage()
                     fileTok = tok->tokAt(2);
                     if ((tok->str() == "ungetc" || tok->str() == "ungetwc") && fileTok)
                         fileTok = fileTok->nextArgument();
+                    else if (tok->str() == "ftell") {
+                        isftell = true;
+                    }
                     operation = Filepointer::Operation::UNIMPORTANT;
                 } else if (!Token::Match(tok, "if|for|while|catch|switch") && !mSettings.library.isFunctionConst(tok->str(), true)) {
                     const Token* const end2 = tok->linkAt(1);
@@ -321,10 +328,15 @@ void CheckIOImpl::checkFileUsage()
                             f.append_mode = Filepointer::AppendMode::APPEND_EX;
                         else
                             f.append_mode = Filepointer::AppendMode::APPEND;
+                    }
+                    else if (mode.find('r') != std::string::npos &&
+                             mode.find('t') != std::string::npos) {
+                        f.read_mode = Filepointer::ReadMode::READ_TEXT;
                     } else
                         f.append_mode = Filepointer::AppendMode::UNKNOWN_AM;
                     f.mode_indent = indent;
                     break;
+
                 case Filepointer::Operation::POSITIONING:
                     if (f.mode == OpenMode::CLOSED)
                         useClosedFileError(tok);
@@ -357,6 +369,8 @@ void CheckIOImpl::checkFileUsage()
                 case Filepointer::Operation::UNIMPORTANT:
                     if (f.mode == OpenMode::CLOSED)
                         useClosedFileError(tok);
+                    if (isftell && f.read_mode == Filepointer::ReadMode::READ_TEXT && printPortability)
+                        ftellFileError(tok);
                     break;
                 case Filepointer::Operation::UNKNOWN_OP:
                     f.mode = OpenMode::UNKNOWN_OM;

--- a/lib/checkio.h
+++ b/lib/checkio.h
@@ -128,6 +128,7 @@ public:
     void useClosedFileError(const Token *tok);
     void fcloseInLoopConditionError(const Token *tok, const std::string &varname);
     void seekOnAppendedFileError(const Token *tok);
+    void ftellFileError(const Token *tok);
     void incompatibleFileOpenError(const Token *tok, const std::string &filename);
     void invalidScanfError(const Token *tok);
     void wrongfeofUsage(const Token *tok);

--- a/man/checkers/ftellTextModeFile.md
+++ b/man/checkers/ftellTextModeFile.md
@@ -1,0 +1,56 @@
+# ftellModeTextFile 
+
+**Message**: ftell() result is unspecified when file is opened in mode "t".<br/>
+**Category**: Portability<br/>
+**Severity**: Style<br/>
+**Language**: C/C++
+
+## Description
+
+This checker detects the use of ftell() on a file open in text (or translate) mode. The text mode is not consistent
+ in between Linux and Windows system and may cause ftell() to return the wrong offset inside a text file.
+
+This warning helps improve code quality by:
+- Making the intent clear that the use of ftell() in "t" mode may cause portability problem.
+
+## Motivation
+
+This checker improves portability accross system.
+
+## How to fix
+
+According to C11, the file must be opened in binary mode 'b' to prevent this problem.
+
+Before:
+```cpp
+     FILE *f = fopen("Example.txt", "rt");
+     if (f)
+     {
+        int position;
+        struct stat st;
+
+        // Wrong way to get the file size
+        fseek(f, 0, SEEK_END);
+        printf( "File size %d\n, ftell(f));
+        fclose(f);
+     }
+
+```
+
+After:
+```cpp
+
+     FILE *f = fopen("Example.txt", "rb");
+     if (f)
+     {
+        fseek(f, 0, SEEK_END);
+        printf( "Offset %d\n", ftell(f);
+        fclose(f);
+     }
+
+```
+
+## Notes
+
+See https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=msvc-170
+

--- a/man/checkers/ftellTextModeFile.md
+++ b/man/checkers/ftellTextModeFile.md
@@ -1,4 +1,4 @@
-# ftellModeTextFile 
+# ftellModeTextFile
 
 **Message**: ftell() result is unspecified when file is opened in mode "t".<br/>
 **Category**: Portability<br/>
@@ -9,6 +9,10 @@
 
 This checker detects the use of ftell() on a file open in text (or translate) mode. The text mode is not consistent
  in between Linux and Windows system and may cause ftell() to return the wrong offset inside a text file.
+
+See section 7.21.9.4p2 of the C11 standard regarding the ftell function states for a text stream:
+
+- For a text stream, its file position indicator contains unspecified information, usable by the fseek function for returning the file position indicator for the stream to its position at the time of the ftell call; the difference between two such return values is not necessarily a meaningful measure of the number of characters written or read.
 
 This warning helps improve code quality by:
 - Making the intent clear that the use of ftell() in "t" mode may cause portability problem.
@@ -26,12 +30,8 @@ Before:
      FILE *f = fopen("Example.txt", "rt");
      if (f)
      {
-        int position;
-        struct stat st;
-
-        // Wrong way to get the file size
         fseek(f, 0, SEEK_END);
-        printf( "File size %d\n, ftell(f));
+        printf( "File size %d\n", ftell(f));
         fclose(f);
      }
 
@@ -44,7 +44,7 @@ After:
      if (f)
      {
         fseek(f, 0, SEEK_END);
-        printf( "Offset %d\n", ftell(f);
+        printf( "File size %d\n", ftell(f));
         fclose(f);
      }
 

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -6,6 +6,7 @@ Major bug fixes & crashes:
 
 New checks:
 - Warn when feof() is used as a while loop condition (wrongfeofUsage).
+- ftell() result is unspecified when file is opened in mode "t".
 
 C/C++ support:
 -

--- a/test/testio.cpp
+++ b/test/testio.cpp
@@ -44,6 +44,7 @@ private:
         TEST_CASE(fileIOwithoutPositioning);
         TEST_CASE(seekOnAppendedFile);
         TEST_CASE(fflushOnInputStream);
+        TEST_CASE(ftellCompatibility);
         TEST_CASE(incompatibleFileOpen);
         TEST_CASE(testWrongfeofUsage); // #958
 
@@ -727,6 +728,22 @@ private:
               "}");
         ASSERT_EQUALS("", errout_str()); // #6566
     }
+
+    void ftellCompatibility() {
+
+        check("void foo() {\n"
+              "     FILE *f = fopen(\"\", \"rt\");\n"
+              "     if (f)\n"
+              "     {\n"
+              "         extern long position;\n"
+              "         fseek(f, 0, SEEK_END);\n"
+              "         position = ftell(f);\n"
+              "         fclose(f);\n"
+              "     }\n"
+              "}\n", dinit(CheckOptions, $.portability = true));
+        ASSERT_EQUALS("[test.cpp:7:21]: (portability) ftell() result is unspecified when file is opened in mode \"t\" [ftellTextModeFile]\n", errout_str());
+    }
+
 
     void fflushOnInputStream() {
         check("void foo()\n"


### PR DESCRIPTION
Some legacy tools stopped suddenly working after 20+ years.

https://stackoverflow.com/questions/79762122/ftell-no-more-returning-the-correct-offset-on-a-text-file-with-windows-11-ente

Trac ticket: https://trac.cppcheck.net/ticket/14743#ticket


