### PR TITLE
Fix #14628: MISRA: avoid false positives for true/false after #14607

### DIFF
--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2460,27 +2460,38 @@ class MisraChecker:
                 if essential_type.split(' ')[0] in ('unsigned', 'signed'):
                     return essential_type.split(' ')[0]
             return None
+    
         for tok in cfg.tokenlist:
-            if tok.isAssignmentOp:
-                lhs = getEssentialType(tok.astOperand1)
-                rhs = getEssentialType(tok.astOperand2)
-                #print(lhs)
-                #print(rhs)
-                if lhs is None or rhs is None:
+            if not tok.isAssignmentOp:
+                continue
+    
+            lhs = getEssentialType(tok.astOperand1)
+            rhs = getEssentialType(tok.astOperand2)
+            if lhs is None or rhs is None:
+                continue
+    
+            find_std = cfg.standards.c if cfg.standards and cfg.standards.c else self.stdversion
+    
+            rhs_tok = tok.astOperand2
+            rhs_macro_name = rhs_tok.macroName if rhs_tok else None
+            rhs_spelling = rhs_macro_name if rhs_macro_name in ('true', 'false') else rhs_tok.str
+    
+            rhs_is_source_bool_literal = rhs_spelling in ('true', 'false')
+            rhs_is_source_int_literal_0_1 = rhs_spelling in ('0', '1')
+    
+            if lhs == 'bool':
+                if rhs_is_source_bool_literal:
                     continue
-                lhs_category = get_category(lhs)
-                rhs_category = get_category(rhs)
-                if lhs_category and rhs_category and lhs_category != rhs_category and rhs_category not in ('signed','unsigned'):
-                    self.reportError(tok, 10, 3)
-                find_std = cfg.standards.c if cfg.standards and cfg.standards.c else self.stdversion
-                allow_bool_literal_0_1 = (
-                    find_std == "c89" and
-                    lhs == "bool" and
-                    tok.astOperand2 and
-                    tok.astOperand2.str in ('0', '1')
-                )
-                if bitsOfEssentialType(lhs) < bitsOfEssentialType(rhs) and not allow_bool_literal_0_1:
-                    self.reportError(tok, 10, 3)
+                if find_std == 'c89' and rhs_is_source_int_literal_0_1:
+                    continue
+    
+            lhs_category = get_category(lhs)
+            rhs_category = get_category(rhs)
+            if lhs_category and rhs_category and lhs_category != rhs_category and rhs_category not in ('signed', 'unsigned'):
+                self.reportError(tok, 10, 3)
+    
+            if bitsOfEssentialType(lhs) < bitsOfEssentialType(rhs):
+                self.reportError(tok, 10, 3)
 
     def misra_10_4(self, data):
         op = {'+', '-', '*', '/', '%', '&', '|', '^', '+=', '-=', ':'}

--- a/addons/misra.py
+++ b/addons/misra.py
@@ -2460,36 +2460,36 @@ class MisraChecker:
                 if essential_type.split(' ')[0] in ('unsigned', 'signed'):
                     return essential_type.split(' ')[0]
             return None
-    
+
         for tok in cfg.tokenlist:
             if not tok.isAssignmentOp:
                 continue
-    
+
             lhs = getEssentialType(tok.astOperand1)
             rhs = getEssentialType(tok.astOperand2)
             if lhs is None or rhs is None:
                 continue
-    
+
             find_std = cfg.standards.c if cfg.standards and cfg.standards.c else self.stdversion
-    
+
             rhs_tok = tok.astOperand2
             rhs_macro_name = rhs_tok.macroName if rhs_tok else None
             rhs_spelling = rhs_macro_name if rhs_macro_name in ('true', 'false') else rhs_tok.str
-    
+
             rhs_is_source_bool_literal = rhs_spelling in ('true', 'false')
             rhs_is_source_int_literal_0_1 = rhs_spelling in ('0', '1')
-    
+
             if lhs == 'bool':
                 if rhs_is_source_bool_literal:
                     continue
                 if find_std == 'c89' and rhs_is_source_int_literal_0_1:
                     continue
-    
+
             lhs_category = get_category(lhs)
             rhs_category = get_category(rhs)
             if lhs_category and rhs_category and lhs_category != rhs_category and rhs_category not in ('signed', 'unsigned'):
                 self.reportError(tok, 10, 3)
-    
+
             if bitsOfEssentialType(lhs) < bitsOfEssentialType(rhs):
                 self.reportError(tok, 10, 3)
 

--- a/addons/test/misra/misra-test-c11.c
+++ b/addons/test/misra/misra-test-c11.c
@@ -29,6 +29,8 @@ static void misra_10_3_c11(void) {
     bool b = false;
     bool b0 = 0; // 10.3
     bool b1 = 1; // 10.3
+    bool bf = false; // no-warning
+    bool bt = true; // no-warning
     b = 0; // 10.3
     b = 1; // 10.3
     b = false; // no-warning


### PR DESCRIPTION
This [#14628](https://trac.cppcheck.net/ticket/14628) is a follow-up to [#14607](https://trac.cppcheck.net/ticket/14607).

After #14607, MISRA rule `10.3` report false positives for assignments written with `true`/`false` in C99 and later.

The issue is that in C, `<stdbool.h>` often expands:
- `true` -> `1`
- `false` -> `0`

So checking only the processed RHS token text is not enough to distinguish:
- source `true`/`false`
- source `0`/`1`

This change uses the RHS token macro origin (`macroName`) to preserve that distinction.

Behavior after this change:
- source `true`/`false`: allowed
- source `0`/`1`:
  - allowed in `c89`
  - reported as MISRA `10.3` in `c99`/`c11`/`c17`/`c18`/`c23`

Changes:
- update `addons/misra.py` rule `10.3` to distinguish boolean macro spelling from integer literals
- extend C11 MISRA tests to cover `true`/`false` initialization and assignment cases


Downstream reproduction:
- verified against commaai/panda using `CPPCHECK_DIR=/Users/devanshvarshney/cppcheck`
- false positives on `bool <- true/false` disappeared
- remaining `10.3` reports are actual source `0/1` assignments


Related Context:
- Earlier PR: #8340 
- Downstream issue: commaai/panda#2105