### PR TITLE
Fix #14654 Bad configuration for BOOST_AUTO_TEST_CASE

### DIFF
--- a/cfg/boost.cfg
+++ b/cfg/boost.cfg
@@ -83,12 +83,12 @@
   <define name="BOOST_MATH_INT_TABLE_TYPE" value=""/>
   <define name="BOOST_MATH_INT_VALUE_SUFFIX" value=""/>
   <!-- Tell cppcheck to interpret BOOST_AUTO_TEST_CASE as a function definition -->
-  <define name="BOOST_AUTO_TEST_CASE(...)" value="void BOOST_AUTO_TEST_CASE_run(__VA_ARGS__)"/>
+  <define name="BOOST_AUTO_TEST_CASE(test_name)" value="void BOOST_AUTO_TEST_CASE_run ## test_name ()"/>
   <define name="BOOST_AUTO_TEST_CASE_TEMPLATE(test_name, type_name, TL)" value="template&lt;typename type_name&gt;void test_name()"/>
-  <define name="BOOST_FIXTURE_TEST_CASE(name, fixture, ...)" value="struct name : fixture { void test_method(); }; void name::test_method()" />
+  <define name="BOOST_FIXTURE_TEST_CASE(name, fixture)" value="struct name : fixture { void test_method(); }; void name::test_method()" />
   <define name="BOOST_FIXTURE_TEST_CASE_TEMPLATE(test_name, type_name, TL, F)" value="template&lt;typename type_name&gt; struct test_name : public F { void test_method(); }; template&lt;typename type_name&gt; void test_name&lt;type_name&gt;::test_method()" />
-  <define name="BOOST_DATA_TEST_CASE(...)" value="void BOOST_DATA_TEST_CASE_run(__VA_ARGS__)"/>
-  <define name="BOOST_DATA_TEST_CASE_F(...)" value="void BOOST_DATA_TEST_CASE_F_run(__VA_ARGS__)"/>
+  <define name="BOOST_DATA_TEST_CASE(test_name)" value="void BOOST_DATA_TEST_CASE_run ## test_name ()"/>
+  <define name="BOOST_DATA_TEST_CASE_F(test_name)" value="void BOOST_DATA_TEST_CASE_F_run ## test_name ()"/>
   <define name="BOOST_PYTHON_MODULE(str)" value="void BOOST_PYTHON_MODULE_definition(str)"/>
   <define name="BOOST_SCOPED_ENUM_DECLARE_BEGIN(x)" value=""/>
   <define name="BOOST_SCOPED_ENUM_DECLARE_END(x)" value=""/>


### PR DESCRIPTION
We have this test using BOOST_AUTO_TEST_CASE, but it doesn't check what the macro actually expands to:
https://github.com/danmar/cppcheck/blob/9d1b35b82505fda733638a6dd08ef9fe3fbd63eb/test/cfg/boost.cpp#L184

None of the macros are variadic, see e.g. here: https://www.boost.org/doc/libs/latest/libs/test/doc/html/boost_test/tests_organization/test_cases/test_organization_nullary.html