### PR TITLE
Partial fix for #10452 FN knownConditionTrueFalse with bool and float

### DIFF
--- a/gui/statsdialog.cpp
+++ b/gui/statsdialog.cpp
@@ -113,6 +113,7 @@ void StatsDialog::setProject(const ProjectFile* projectFile)
         if (!statsFile.isEmpty()) {
             QChartView *chartView = createChart(statsFile, "cppcheck");
             mUI->mTabHistory->layout()->addWidget(chartView);
+            // cppcheck-suppress knownConditionTrueFalse - TODO in getClangAnalyzer()
             if (projectFile->getClangAnalyzer()) {
                 chartView = createChart(statsFile, CLANG_ANALYZER);
                 mUI->mTabHistory->layout()->addWidget(chartView);

--- a/lib/checkcondition.cpp
+++ b/lib/checkcondition.cpp
@@ -1524,11 +1524,6 @@ void CheckCondition::alwaysTrueFalse()
             }
             if (!tok->hasKnownIntValue())
                 continue;
-            if (Token::Match(tok->previous(), "%name% (") && tok->previous()->function()) {
-                const Function* f = tok->previous()->function();
-                if (f->functionScope && Token::Match(f->functionScope->bodyStart, "{ return true|false ;"))
-                    continue;
-            }
             const Token* condition = nullptr;
             {
                 // is this a condition..

--- a/test/testcondition.cpp
+++ b/test/testcondition.cpp
@@ -4846,6 +4846,15 @@ private:
               "}\n");
         ASSERT_EQUALS("[test.cpp:6:9] -> [test.cpp:9:9]: (warning) Identical condition 'a', second condition is always false [identicalConditionAfterEarlyExit]\n",
                       errout_str());
+
+        check("bool b() { return false; }\n" // #10452
+              "void f() {\n"
+              "    if (b()) {}\n"
+              "    if (!b()) {}\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3:10]: (style) Condition 'b()' is always false [knownConditionTrueFalse]\n"
+                      "[test.cpp:4:9]: (style) Condition '!b()' is always true [knownConditionTrueFalse]\n",
+                      errout_str());
     }
 
     void alwaysTrueSymbolic()


### PR DESCRIPTION
The bailout was added in https://github.com/danmar/cppcheck/commit/bc3f5554a48a55ecfb8eeb14450f5a45b869bc95 but seems unrelated to that change. Also, we would still warn for e.g. `!b()` or `b() == false`.