### PR TITLE
gnu.cfg: Add support for some built-in functions to check overflow

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -169,6 +169,322 @@
       <not-uninit/>
     </arg>
   </function>
+  <!-- https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html -->
+  <!-- bool __builtin_add_overflow (type1 a, type2 b, type3 *res) -->
+  <function name="__builtin_add_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_sadd_overflow (int a, int b, int *res) -->
+  <function name="__builtin_sadd_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_saddl_overflow (long int a, long int b, long int *res) -->
+  <function name="__builtin_saddl_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_saddll_overflow (long long int a, long long int b, long long int *res) -->
+  <function name="__builtin_saddll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_uadd_overflow (unsigned int a, unsigned int b, unsigned int *res) -->
+  <function name="__builtin_uadd_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_uaddl_overflow (unsigned long int a, unsigned long int b, unsigned long int *res) -->
+  <function name="__builtin_uaddl_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_uaddll_overflow (unsigned long long int a, unsigned long long int b, unsigned long long int *res) -->
+  <function name="__builtin_uaddll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_sub_overflow (type1 a, type2 b, type3 *res) -->
+  <function name="__builtin_sub_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_ssub_overflow (int a, int b, int *res) -->
+  <function name="__builtin_ssub_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_ssubl_overflow (long int a, long int b, long int *res) -->
+  <function name="__builtin_ssubl_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_ssubll_overflow (long long int a, long long int b, long long int *res) -->
+  <function name="__builtin_ssubll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_usub_overflow (unsigned int a, unsigned int b, unsigned int *res) -->
+  <function name="__builtin_usub_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_usubl_overflow (unsigned long int a, unsigned long int b, unsigned long int *res) -->
+  <function name="__builtin_usubl_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_usubll_overflow (unsigned long long int a, unsigned long long int b, unsigned long long int *res) -->
+  <function name="__builtin_usubll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_mul_overflow (type1 a, type2 b, type3 *res) -->
+  <function name="__builtin_mul_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_smul_overflow (int a, int b, int *res) -->
+  <function name="__builtin_smul_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_smull_overflow (long int a, long int b, long int *res) -->
+  <function name="__builtin_smull_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_smulll_overflow (long long int a, long long int b, long long int *res) -->
+  <function name="__builtin_smulll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_umul_overflow (unsigned int a, unsigned int b, unsigned int *res) -->
+  <function name="__builtin_umul_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_umull_overflow (unsigned long int a, unsigned long int b, unsigned long int *res) -->
+  <function name="__builtin_umull_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
+  <!-- bool __builtin_umulll_overflow (unsigned long long int a, unsigned long long int b, unsigned long long int *res) -->
+  <function name="__builtin_umulll_overflow">
+    <noreturn>false</noreturn>
+    <returnValue type="bool"/>
+    <leak-ignore/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="2" direction="in">
+      <not-uninit/>
+    </arg>
+    <arg nr="3" direction="out" indirect="1">
+      <not-null/>
+    </arg>
+  </function>
     <!-- https://man7.org/linux/man-pages/man3/getenv.3.html -->
     <!-- char * secure_getenv(const char *name); -->
   <function name="secure_getenv">

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -12,6 +12,7 @@
 #define _GNU_SOURCE
 
 #include <string.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -155,6 +156,132 @@ int nullPointer_getopt_long_only(int argc, char* const* argv, const char* optstr
     // cppcheck-suppress nullPointer
     (void) getopt_long_only(argc, argv, optstring, NULL, longindex);
     return getopt_long_only(argc, argv, optstring, longopts, longindex);
+}
+
+bool nullPointer_builtin_add_overflow(char a, char b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_add_overflow(a, b, (char *)0);
+}
+
+bool nullPointer_builtin_sadd_overflow(int a, int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_sadd_overflow(a, b, (int *)0);
+}
+
+bool nullPointer_builtin_saddl_overflow(long int a, long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_saddl_overflow(a, b, (long int *)0);
+}
+
+bool nullPointer_builtin_saddll_overflow(long long int a, long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_saddll_overflow(a, b, (long long int *)0);
+}
+
+bool nullPointer_builtin_uadd_overflow(unsigned int a, unsigned int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_uadd_overflow(a, b, (unsigned int *)0);
+}
+
+bool nullPointer_builtin_uaddl_overflow(unsigned long int a, unsigned long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_uaddl_overflow(a, b, (unsigned long int *)0);
+}
+
+bool nullPointer_builtin_uaddll_overflow(unsigned long long int a, unsigned long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_uaddll_overflow(a, b, (unsigned long long int *)0);
+}
+
+bool nullPointer_builtin_sub_overflow(char a, char b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_sub_overflow(a, b, (char *)0);
+}
+
+bool nullPointer_builtin_ssub_overflow(int a, int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_ssub_overflow(a, b, (int *)0);
+}
+
+bool nullPointer_builtin_ssubl_overflow(long int a, long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_ssubl_overflow(a, b, (long int *)0);
+}
+
+bool nullPointer_builtin_ssubll_overflow(long long int a, long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_ssubll_overflow(a, b, (long long int *)0);
+}
+
+bool nullPointer_builtin_usub_overflow(unsigned int a, unsigned int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_usub_overflow(a, b, (unsigned int *)0);
+}
+
+bool nullPointer_builtin_usubl_overflow(unsigned long int a, unsigned long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_usubl_overflow(a, b, (unsigned long int *)0);
+}
+
+bool nullPointer_builtin_usubll_overflow(unsigned long long int a, unsigned long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_usubll_overflow(a, b, (unsigned long long int *)0);
+}
+
+bool nullPointer_builtin_mul_overflow(char a, char b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_mul_overflow(a, b, (char *)0);
+}
+
+bool nullPointer_builtin_smul_overflow(int a, int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_smul_overflow(a, b, (int *)0);
+}
+
+bool nullPointer_builtin_smull_overflow(long int a, long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_smull_overflow(a, b, (long int *)0);
+}
+
+bool nullPointer_builtin_smulll_overflow(long long int a, long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_smulll_overflow(a, b, (long long int *)0);
+}
+
+bool nullPointer_builtin_umul_overflow(unsigned int a, unsigned int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_umul_overflow(a, b, (unsigned int *)0);
+}
+
+bool nullPointer_builtin_umull_overflow(unsigned long int a, unsigned long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_umull_overflow(a, b, (unsigned long int *)0);
+}
+
+bool nullPointer_builtin_umulll_overflow(unsigned long long int a, unsigned long long int b)
+{
+    // cppcheck-suppress nullPointer
+    return __builtin_umulll_overflow(a, b, (unsigned long long int *)0);
 }
 
 #if !defined(__APPLE__)
@@ -459,6 +586,216 @@ void uninitvar__builtin_memset(void)
     size_t n;
     // cppcheck-suppress uninitvar
     (void)__builtin_memset(s,c,n);
+}
+
+void uninitvar__builtin_add_overflow(void)
+{
+    char a;
+    char b;
+    char c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_add_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_sadd_overflow(void)
+{
+    int a;
+    int b;
+    int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_sadd_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_saddl_overflow(void)
+{
+    long int a;
+    long int b;
+    long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_saddl_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_saddll_overflow(void)
+{
+    long long int a;
+    long long int b;
+    long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_saddll_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_uadd_overflow(void)
+{
+    unsigned int a;
+    unsigned int b;
+    unsigned int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_uadd_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_uaddl_overflow(void)
+{
+    unsigned long int a;
+    unsigned long int b;
+    unsigned long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_uaddl_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_uaddll_overflow(void)
+{
+    unsigned long long int a;
+    unsigned long long int b;
+    unsigned long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_uaddll_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_sub_overflow(void)
+{
+    char a;
+    char b;
+    char c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_sub_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_ssub_overflow(void)
+{
+    int a;
+    int b;
+    int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_ssub_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_ssubl_overflow(void)
+{
+    long int a;
+    long int b;
+    long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_ssubl_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_ssubll_overflow(void)
+{
+    long long int a;
+    long long int b;
+    long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_ssubll_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_usub_overflow(void)
+{
+    unsigned int a;
+    unsigned int b;
+    unsigned int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_usub_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_usubl_overflow(void)
+{
+    unsigned long int a;
+    unsigned long int b;
+    unsigned long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_usubl_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_usubll_overflow(void)
+{
+    unsigned long long int a;
+    unsigned long long int b;
+    unsigned long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_usubll_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_mul_overflow(void)
+{
+    char a;
+    char b;
+    char c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_mul_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_smul_overflow(void)
+{
+    int a;
+    int b;
+    int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_smul_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_smull_overflow(void)
+{
+    long int a;
+    long int b;
+    long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_smull_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_smulll_overflow(void)
+{
+    long long int a;
+    long long int b;
+    long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_smulll_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_umul_overflow(void)
+{
+    unsigned int a;
+    unsigned int b;
+    unsigned int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_umul_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_umull_overflow(void)
+{
+    unsigned long int a;
+    unsigned long int b;
+    unsigned long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_umull_overflow(a, b, &c);
+}
+
+void uninitvar__builtin_umulll_overflow(void)
+{
+    unsigned long long int a;
+    unsigned long long int b;
+    unsigned long long int c;
+
+    // cppcheck-suppress uninitvar
+    (void)__builtin_umulll_overflow(a, b, &c);
 }
 
 void bufferAccessOutOfBounds__builtin_memset(void)


### PR DESCRIPTION
Reference: https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html