### PR TITLE
Fix #14487: FP duplicateBranch with empty macro

### DIFF
--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -2677,7 +2677,7 @@ void CheckOther::checkDuplicateBranch()
                 const std::string branch2 = tokElse->stringifyList(scope.bodyEnd->linkAt(2));
 
                 // check for duplicates
-                if (branch1 == branch2) {
+                if (branch1 == branch2 && branch1 != ";") {
                     duplicateBranchError(scope.classDef, scope.bodyEnd->next(), ErrorPath{});
                     continue;
                 }

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -7304,6 +7304,15 @@ private:
               "    }\n"
               "}");
         ASSERT_EQUALS("", errout_str());
+
+        check("void f(int i) {\n"
+              "  if (1 == i) {\n"
+              "    ;\n"
+              "  } else {\n"
+              "    ;\n"
+              "  }\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void duplicateBranch6() {


### PR DESCRIPTION
My reasoning here is that a single semicolon most likely is a result of an empty macro expansion. I can't think of a case where one would put a single semicolon where it would make sense to warn.