### PR TITLE
refactor(utils): improve splitString using std::string_view input

### DIFF
--- a/lib/utils.cpp
+++ b/lib/utils.cpp
@@ -183,16 +183,15 @@ std::string replaceEscapeSequences(const std::string &source) {
 }
 
 
-std::vector<std::string> splitString(const std::string& str, char sep)
+std::vector<std::string> splitString(std::string_view str, char sep)
 {
     std::vector<std::string> l;
-
-    std::string::size_type pos1 = 0;
-    std::string::size_type pos2;
+    std::string_view::size_type pos1 = 0;
+    std::string_view::size_type pos2 = std::string_view::npos;
     while (true) {
         pos2 = str.find(sep, pos1);
-        l.push_back(str.substr(pos1, pos2 - pos1));
-        if (pos2 == std::string::npos)
+        l.emplace_back(str.substr(pos1, pos2 - pos1));
+        if (pos2 == std::string_view::npos)
             break;
         pos1 = pos2 + 1;
     }

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -35,6 +35,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include<string_view>
 
 struct SelectMapKeys {
     template<class Pair>
@@ -428,7 +429,7 @@ static inline T* empty_if_null(T* p)
  * @param sep The separator
  * @return The list of separate strings (including empty ones). The whole input string if no separator found.
  */
-CPPCHECKLIB std::vector<std::string> splitString(const std::string& str, char sep);
+CPPCHECKLIB std::vector<std::string> splitString(std::string_view str, char sep);
 
 namespace utils {
     /**


### PR DESCRIPTION
Refactor the parameter type of splitString() in utils.cpp  from 'const std::string&' to 'std::string_view' to avoid unnecessary string construction when called with string literals or string-like inputs.

Changes:
- utils.h: Declaration updated to use 'std::string_view'
- utils.cpp: Parameter changed from 'const std::string&' to 'std::string_view'
- utils.cpp: Updated 'std::string::size_type' to 'std::string_view::size_type'
- utils.cpp: Replaced 'push_back' with 'emplace_back'
- utils.cpp: Initialized 'pos2' with 'std::string_view::npos' to avoid uninitialized variable warning

Note:
- clangimport.cpp contains a separate static splitString() with a different signature; it is unrelated and unchanged.
- std::string_view is used only for input; ownership remains with the caller.

Call sites reviewed:
- errorlogger.cpp: passes std::string (implicit conversion)
- suppressions.cpp: passes std::string (implicit conversion)
- cppcheck.cpp: passes substr() result (implicit conversion)

No functional change in behavior.