### PR TITLE
gtk.cfg: Fix gtk_widget_destroy definition and usage

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -1003,7 +1003,6 @@
     <alloc init="true" no-fail="true">g_zlib_decompressor_new</alloc>
     <use>g_object_ref</use>
     <dealloc>g_object_unref</dealloc>
-    <dealloc>gtk_widget_destroy</dealloc>
   </memory>
   <memory>
     <alloc init="true" no-fail="true">g_tree_new</alloc>
@@ -1018,6 +1017,11 @@
     <alloc init="true" no-fail="true">g_file_attribute_matcher_subtract</alloc>
     <use>g_file_attribute_matcher_ref</use>
     <dealloc>g_file_attribute_matcher_unref</dealloc>
+  </memory>
+  <memory>
+    <alloc init="true" no-fail="true">gtk_window_new</alloc>
+    <dealloc>gtk_widget_destroy</dealloc>
+    <dealloc>gtk_window_destroy</dealloc>
   </memory>
   <function name="g_application_get_default">
     <leak-ignore/>
@@ -9786,6 +9790,14 @@
   <function name="gtk_window_get_default_icon_name">
     <leak-ignore/>
     <noreturn>false</noreturn>
+  </function>
+  <!-- gtk3: GtkWidget * gtk_window_new(GtkWindowType type)
+       gtk4: GtkWidget * gtk_window_new() -->
+  <function name="gtk_window_new">
+    <noreturn>false</noreturn>
+    <use-retval/>
+    <returnValue type="GtkWidget *"/>
+    <arg nr="1" direction="in" default="0"/>
   </function>
   <function name="gtk_window_list_toplevels">
     <leak-ignore/>
@@ -21229,10 +21241,6 @@
     <leak-ignore/>
     <noreturn>false</noreturn>
   </function>
-  <function name="gtk_widget_destroy">
-    <leak-ignore/>
-    <noreturn>false</noreturn>
-  </function>
   <function name="gtk_widget_destroyed">
     <leak-ignore/>
     <noreturn>false</noreturn>
@@ -21888,6 +21896,13 @@
   <function name="gtk_window_deiconify">
     <leak-ignore/>
     <noreturn>false</noreturn>
+  </function>
+  <function name="gtk_window_destroy">
+    <noreturn>false</noreturn>
+    <returnValue type="void"/>
+    <arg nr="1">
+      <not-uninit/>
+    </arg>
   </function>
   <function name="gtk_window_fullscreen">
     <leak-ignore/>
@@ -23070,6 +23085,9 @@
   <define name="GTK_LEVEL_BAR_OFFSET_FULL" value="&quot;full&quot;"/>
   <define name="GTK_LEVEL_BAR_OFFSET_HIGH" value="&quot;high&quot;"/>
   <define name="GTK_LEVEL_BAR_OFFSET_LOW" value="&quot;low&quot;"/>
+  <!-- gtk/gtkwindow.h -->
+  <define name="GTK_WINDOW_TOPLEVEL" value="0"/>
+  <define name="GTK_WINDOW_POPUP" value="1"/>
   <!-- gtk/gtk.h -->
   <define name="GTK_STOCK_ZOOM_IN" value="&quot;gtk-zoom-in&quot;"/>
   <define name="GTK_STOCK_ZOOM_FIT" value="&quot;gtk-zoom-fit&quot;"/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -585,3 +585,14 @@ void g_tree_test() {
     printf("%p\n", tree2);
     // cppcheck-suppress memleak
 }
+
+void gtk_widget_destroy_test() {
+    GtkWidget *widget = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_widget_show(widget);
+    // cppcheck-suppress memleak
+
+    widget = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+    gtk_widget_show(widget);
+    // cppcheck-suppress mismatchAllocDealloc
+    g_object_unref(widget);
+}


### PR DESCRIPTION
gtk_widget_destroy is only for GtkWidget derived objects.