### PR TITLE
release-windows.yml: fixed build with Visual Studio 2026 [skip ci]

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -56,7 +56,7 @@ jobs:
           cd pcre-%PCRE_VERSION% || exit /b !errorlevel!
           git apply --ignore-space-change ..\externals\pcre.patch || exit /b !errorlevel!
           cmake . -A x64 -DPCRE_BUILD_PCRECPP=OFF -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_COMPILE_WARNING_AS_ERROR=On || exit /b !errorlevel!
-          msbuild -m PCRE.sln -p:Configuration=Release -p:Platform=x64 || exit /b !errorlevel!
+          msbuild -m PCRE.slnx -p:Configuration=Release -p:Platform=x64 || exit /b !errorlevel!
           copy pcre.h ..\externals || exit /b !errorlevel!
           copy Release\pcre.lib ..\externals\pcre64.lib || exit /b !errorlevel!
 

--- a/releasenotes.txt
+++ b/releasenotes.txt
@@ -26,4 +26,5 @@ Other:
 - Make it possible to specify the regular expression engine using the `engine` element in a rule XML.
 - Added CLI option `--exitcode-suppress` to specify an error ID which should not result in a non-zero exitcode.
 - Moved source code from https://github.com/danmar/cppcheck to https://github.com/cppcheck-opensource/cppcheck
+- The official Windows binary is now built with Visual Studio 2026.
 -

--- a/win_installer/config.wxi
+++ b/win_installer/config.wxi
@@ -9,6 +9,6 @@
   <?define AddonsDir = "files\addons" ?>
   <?define QtDllDir = "files" ?>
 
-  <?define CrtMergeModule = "$(env.VCINSTALLDIR)Redist\MSVC\v143\MergeModules\Microsoft_VC143_CRT_x64.msm" ?>
+  <?define CrtMergeModule = "$(env.VCINSTALLDIR)Redist\MSVC\v145\MergeModules\Microsoft_VC145_CRT_x64.msm" ?>
   <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
 </Include>


### PR DESCRIPTION
this is caused by `vs2025` now using Visual Studio 2026