### PR TITLE
Fix null deref of tok1->tokAt(-1) in usingMatch (lib/tokenize.cpp:2725)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2722,8 +2722,11 @@ namespace {
             return false;
         }
 
-        if (tok1->tokAt(-1)->tokType() == Token::eType || tok1->tokAt(-1)->tokType() == Token::eName)
-            return false;
+        {
+            const Token *prev1 = tok1->tokAt(-1);
+            if (prev1 && (prev1->tokType() == Token::eType || prev1->tokType() == Token::eName))
+                return false;
+        }
 
         if (Token::Match(tok1->tokAt(-1), "class|struct|union|enum|namespace")) {
             // fixme


### PR DESCRIPTION
## Summary

`Tokenizer::simplifyUsing` → `(anonymous namespace)::usingMatch()` at
`lib/tokenize.cpp:2725` dereferences `tok1->tokAt(-1)` without a null
check:

```cpp
if (tok1->tokAt(-1)->tokType() == Token::eType
    || tok1->tokAt(-1)->tokType() == Token::eName)
    return false;
```

`Token::tokAt(int)` may legitimately return `nullptr` (e.g. when `tok1`
sits at the very start of the token stream after earlier simplifications
and has no previous token); `->tokType()` then dereferences NULL and
crashes the worker with SIGSEGV.

All sibling branches in the same function already null-check the
previous token through `Token::Match(tok1->previous(), ...)` which
handles `nullptr` internally — this one was simply overlooked.

## Fix

Pull the previous token into a local and guard against `nullptr`;
preserves existing behaviour when the previous token does exist.

```diff
-        if (tok1->tokAt(-1)->tokType() == Token::eType || tok1->tokAt(-1)->tokType() == Token::eName)
-            return false;
+        {
+            const Token *prev1 = tok1->tokAt(-1);
+            if (prev1 && (prev1->tokType() == Token::eType || prev1->tokType() == Token::eName))
+                return false;
+        }
```

## Crash signature

In the kernel ring buffer (`dmesg` / `journalctl -k`) the failing
process leaves a stable footprint:

```
cppcheck[PID]: segfault at 50 ip <addr> error 4 in cppcheck[…]
```

`fault addr = 0x50` is the offset of `Token::mTokType` within the
`Token` class — exactly what `Token::tokType()` reads:

```cpp
// lib/token.h:391
Token::Type tokType() const {
    return mTokType;
}
```

`error 4 = USER read of non-present page`, i.e. classic NULL deref.

## Backtrace (debug build core dump)

```
#0  Token::tokType (this=0x0)               at lib/token.h:391
#1  (anonymous namespace)::usingMatch        at lib/tokenize.cpp:2725
#2  Tokenizer::simplifyUsing                 at lib/tokenize.cpp:3201
#3  Tokenizer::simplifyTokenList1            at lib/tokenize.cpp:5902
#4  Tokenizer::simplifyTokens1               at lib/tokenize.cpp:3520
#5  CppCheck::checkInternal                  at lib/cppcheck.cpp:1209
```

## Affected versions

- cppcheck 2.20.0
- main HEAD as of 2026-05-20

No relevant changes around line 2725 for the past year, so the bug
likely lives much further back.

## Reproducibility

Triggers deterministically on specific `using`-declaration patterns in
real C++ source. Parameters such as `-j N`, `--executor=…`,
`--cppcheck-build-dir` only affect visibility — under parallelism the
worker dies in a thread/child and the failure looks racy, but it's
fully input-deterministic. Switching to `-j 1` makes the crash kill
the main process with a non-zero exit code instead.

If a minimised reproducer is required I can try to bisect a small
snippet from the affected source files; happy to attach one if useful.