### PR TITLE
various improvements to bisection of performance issues

### DIFF
--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -86,6 +86,8 @@ if not run_res:
 print('run_time: {}'.format(run_time))
 run_time_factor = run_time / elapsed_time
 print('run_time_factor: {}'.format(run_time_factor))
+run_time_diff = run_time - elapsed_time
+print('run_time_diff: {}'.format(run_time_diff))
 
 if run_time_factor >= MAX_RT_FACTOR:
     sys.exit(EC_BAD if not invert else EC_GOOD)  # factor exceeded

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -63,7 +63,7 @@ if not elapsed_time:
     elapsed_time = time.perf_counter() - t
     print('elapsed_time: {}'.format(elapsed_time))
     # TODO: write to stdout and redirect all all printing to stderr
-    sys.exit(round(elapsed_time + .5))  # return the time
+    sys.exit(max(round(elapsed_time - .5), 1))  # return the time
 
 t = time.perf_counter()
 run_res = run(cppcheck_path, options, elapsed_time)
@@ -73,7 +73,7 @@ if not elapsed_time:
     # TODO: handle error result
     print('elapsed_time: {}'.format(run_time))
     # TODO: write to stdout and redirect all printing to stderr
-    sys.exit(round(run_time + .5))  # return the time
+    sys.exit(max(round(run_time - .5), 1))  # return the time
 
 if run_res is None:
     sys.exit(EC_SKIP)  # error occurred

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -4,6 +4,8 @@ import sys
 
 from bisect_common import *
 
+MAX_RT_FACTOR = 1.3
+
 # TODO: detect missing file
 def run(cppcheck_path, options, elapsed_time=None):
     timeout = None
@@ -84,5 +86,8 @@ if not run_res:
 print('run_time: {}'.format(run_time))
 run_time_factor = run_time / elapsed_time
 print('run_time_factor: {}'.format(run_time_factor))
+
+if run_time_factor >= MAX_RT_FACTOR:
+    sys.exit(EC_BAD if not invert else EC_GOOD)  # factor exceeded
 
 sys.exit(EC_GOOD if not invert else EC_BAD)  # no timeout

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -82,5 +82,7 @@ if not run_res:
     sys.exit(EC_BAD if not invert else EC_GOOD)  # timeout occurred
 
 print('run_time: {}'.format(run_time))
+run_time_factor = run_time / elapsed_time
+print('run_time_factor: {}'.format(run_time_factor))
 
 sys.exit(EC_GOOD if not invert else EC_BAD)  # no timeout

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -12,9 +12,9 @@ def run(cppcheck_path, options, elapsed_time=None):
     cmd = options.split()
     cmd.insert(0, cppcheck_path)
     print('running {}'.format(cppcheck_path))
-    with subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) as p:
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL) as p:
         try:
-            p.communicate(timeout=timeout)
+            stdout, _ = p.communicate(timeout=timeout)
             if p.returncode != 0:
                 print('error')
                 return None
@@ -22,8 +22,11 @@ def run(cppcheck_path, options, elapsed_time=None):
         except subprocess.TimeoutExpired:
             print('timeout')
             p.kill()
-            p.communicate()
+            stdout, _ = p.communicate()
             return False
+        finally:
+            stdout = stdout.decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
+            print(stdout)
 
     return True
 
@@ -33,6 +36,10 @@ bisect_path = sys.argv[1]
 options = sys.argv[2]
 if '--error-exitcode=0' not in options:
     options += ' --error-exitcode=0'
+if '--showtime=file' not in options:
+    options += ' --showtime=file-total'
+if '-q' not in options:
+    options += ' -q'
 if len(sys.argv) >= 4:
     elapsed_time = float(sys.argv[3])
 else:

--- a/tools/bisect/bisect_hang.py
+++ b/tools/bisect/bisect_hang.py
@@ -11,7 +11,7 @@ def run(cppcheck_path, options, elapsed_time=None):
         timeout = elapsed_time * 2
     cmd = options.split()
     cmd.insert(0, cppcheck_path)
-    print('running {}'.format(cppcheck_path))
+    print('running (timeout: {}) {}'.format(timeout, cppcheck_path))
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL) as p:
         try:
             stdout, _ = p.communicate(timeout=timeout)


### PR DESCRIPTION
these improvements help with bisecting performance issues in long/short-running cases

- print timing information for each file
- print the timeout we are running with
- print the run time factor
- round down the elapsed time
- introduced a maximum run time factor (default: 1.3)
- print the difference in run time