### PR TITLE
Add functions thread-unsafe in Ubuntu 26.04

### DIFF
--- a/addons/threadsafety.py
+++ b/addons/threadsafety.py
@@ -111,6 +111,8 @@ id_MTunsafe_full = {
     'cuserid',
     'drand48',
     'ecvt',
+    'elf_fill',
+    'elf_flagelf',
     'encrypt',
     'endfsent',
     'endgrent',


### PR DESCRIPTION
Two new? thread-unsafe functions were found in Ubuntu 26.04 "Resolute Raccoon":
Add these to addons/threadsafety.py