### PR TITLE
gtk.cfg: Remove extra semicolons from g_return* macros

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -4,10 +4,10 @@
 <def format="2">
   <define name="TRUE" value="(!FALSE)"/>
   <define name="FALSE" value="(0)"/>
-  <define name="g_return_if_fail(expr)" value="do{if(!(expr)){return;}}while(0);"/>
-  <define name="g_return_val_if_fail(expr,val)" value="do{if(!(expr)){return (val);}}while(0);"/>
-  <define name="g_return_if_reached()" value="do{return;}while(0);"/>
-  <define name="g_return_val_if_reached(val)" value="do{return (val);}while(0);"/>
+  <define name="g_return_if_fail(expr)" value="do{if(!(expr)){return;}}while(0)"/>
+  <define name="g_return_val_if_fail(expr,val)" value="do{if(!(expr)){return (val);}}while(0)"/>
+  <define name="g_return_if_reached()" value="do{return;}while(0)"/>
+  <define name="g_return_val_if_reached(val)" value="do{return (val);}while(0)"/>
   <define name="G_CALLBACK(cb)" value="cb"/>
   <define name="GTK_SIGNAL_FUNC(f)" value="G_CALLBACK(f)"/>
   <define name="G_DIR_SEPARATOR_S" value="&quot;/&quot;"/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -596,3 +596,43 @@ void gtk_widget_destroy_test() {
     // cppcheck-suppress mismatchAllocDealloc
     g_object_unref(widget);
 }
+
+void g_return_if_fail_test(const char *s) {
+    // cppcheck-suppress valueFlowBailout
+    g_return_if_fail(s);
+
+    if (*s)
+        // cppcheck-suppress valueFlowBailout
+        g_return_if_fail(*s == 'a');
+    else
+        g_info("Test the else branch can be parsed");
+}
+
+int g_return_val_if_fail_test(const char *s) {
+    // cppcheck-suppress valueFlowBailout
+    g_return_val_if_fail(s, 1);
+
+    if (*s)
+        // cppcheck-suppress valueFlowBailout
+        g_return_val_if_fail(*s == 'a', 1);
+    else
+        g_info("Test the else branch can be parsed");
+
+    return 0;
+}
+
+void g_return_if_reached_test(const char *s) {
+    if (s)
+        g_return_if_reached();
+    else
+        g_info("Test the else branch can be parsed");
+}
+
+int g_return_val_if_reached_test(const char *s) {
+    if (s)
+        g_return_val_if_reached(1);
+    else
+        g_info("Test the else branch can be parsed");
+
+    return 0;
+}


### PR DESCRIPTION
The extra semicolons caused unknownMacro errors when checking code like this:

```c
if (hadj)
  g_return_if_fail (GTK_IS_ADJUSTMENT (hadj));
else
  hadj = GTK_ADJUSTMENT (...)
```

They were introduced in commit c0b530947, but they are not actually present in the upstream GLib macros.