### PR TITLE
Fix #14885 Shift by negative value in TemplateSimplifier::simplifyNumericalCalculations()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -367,6 +367,7 @@ Samuel Degrande
 Samuel Poláček
 Sandeep Dutta
 Savvas Etairidis
+Sayed Kaif
 Scott Ehlert
 Scott Furry
 Seafarix Ltd.

--- a/lib/mathlib.cpp
+++ b/lib/mathlib.cpp
@@ -266,7 +266,7 @@ MathLib::value MathLib::value::shiftLeft(const MathLib::value &v) const
     if (!isInt() || !v.isInt())
         throw InternalError(nullptr, "Shift operand is not integer");
     MathLib::value ret(*this);
-    if (v.mIntValue >= MathLib::bigint_bits) {
+    if (v.mIntValue < 0 || v.mIntValue >= MathLib::bigint_bits || ret.mIntValue < 0) {
         return ret;
     }
     ret.mIntValue <<= v.mIntValue;
@@ -278,7 +278,7 @@ MathLib::value MathLib::value::shiftRight(const MathLib::value &v) const
     if (!isInt() || !v.isInt())
         throw InternalError(nullptr, "Shift operand is not integer");
     MathLib::value ret(*this);
-    if (v.mIntValue >= MathLib::bigint_bits) {
+    if (v.mIntValue < 0 || v.mIntValue >= MathLib::bigint_bits) {
         return ret;
     }
     ret.mIntValue >>= v.mIntValue;

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -64,6 +64,7 @@ private:
         TEST_CASE(tan);
         TEST_CASE(abs);
         TEST_CASE(toString);
+        TEST_CASE(valueShift);
     }
 
     void isGreater() const {
@@ -1510,6 +1511,20 @@ private:
 
         ASSERT_EQUALS("2.22507385851e-308", MathLib::toString(std::numeric_limits<double>::min()));
         ASSERT_EQUALS("1.79769313486e+308", MathLib::toString(std::numeric_limits<double>::max()));
+    }
+
+    void valueShift() const {
+        // ordinary shifts
+        ASSERT_EQUALS("16", (MathLib::value("1") << MathLib::value("4")).str());
+        ASSERT_EQUALS("64", (MathLib::value("256") >> MathLib::value("2")).str());
+
+        // a large hex literal is not negative as a string but parses to a negative
+        // bigint; shifting it must not be performed (left shift of a negative value
+        // and shifting by a negative count are both undefined). the operand is
+        // returned unchanged, as already done for counts >= bigint_bits.
+        ASSERT_EQUALS("9223372036854775808U", (MathLib::value("0x8000000000000000") << MathLib::value("1")).str());
+        ASSERT_EQUALS("1", (MathLib::value("1") << MathLib::value("0x8000000000000000")).str());
+        ASSERT_EQUALS("1", (MathLib::value("1") >> MathLib::value("0x8000000000000000")).str());
     }
 };
 

--- a/test/testmathlib.cpp
+++ b/test/testmathlib.cpp
@@ -64,7 +64,6 @@ private:
         TEST_CASE(tan);
         TEST_CASE(abs);
         TEST_CASE(toString);
-        TEST_CASE(valueShift);
     }
 
     void isGreater() const {
@@ -1511,20 +1510,6 @@ private:
 
         ASSERT_EQUALS("2.22507385851e-308", MathLib::toString(std::numeric_limits<double>::min()));
         ASSERT_EQUALS("1.79769313486e+308", MathLib::toString(std::numeric_limits<double>::max()));
-    }
-
-    void valueShift() const {
-        // ordinary shifts
-        ASSERT_EQUALS("16", (MathLib::value("1") << MathLib::value("4")).str());
-        ASSERT_EQUALS("64", (MathLib::value("256") >> MathLib::value("2")).str());
-
-        // a large hex literal is not negative as a string but parses to a negative
-        // bigint; shifting it must not be performed (left shift of a negative value
-        // and shifting by a negative count are both undefined). the operand is
-        // returned unchanged, as already done for counts >= bigint_bits.
-        ASSERT_EQUALS("9223372036854775808U", (MathLib::value("0x8000000000000000") << MathLib::value("1")).str());
-        ASSERT_EQUALS("1", (MathLib::value("1") << MathLib::value("0x8000000000000000")).str());
-        ASSERT_EQUALS("1", (MathLib::value("1") >> MathLib::value("0x8000000000000000")).str());
     }
 };
 

--- a/test/testsimplifytemplate.cpp
+++ b/test/testsimplifytemplate.cpp
@@ -320,6 +320,8 @@ private:
 
         TEST_CASE(templateArgPreserveType); // #13882 - type of template argument
 
+        TEST_CASE(template_shift_negative); // shift folding with a negative operand
+
         TEST_CASE(dumpTemplateArgFrom);
     }
 
@@ -6713,6 +6715,21 @@ private:
                       "Test<64> test ; "
                       "class Test<64> { uint32_t i ; i = ( uint32_t ) 64 ; } ;",
                       tok(code));
+    }
+
+    void template_shift_negative() {
+        // a large hex literal is not negative as a string but parses to a negative
+        // bigint, so folding the shift in simplifyNumericCalculations would left-shift
+        // a negative value / shift by a negative count, both UB. the operand must be
+        // returned unchanged. parentheses are needed so the numeric folding is reached.
+        const char code[] = "template <long long> struct S { };\n"
+                            "S<(0x8000000000000000 << 1)> s1;\n"
+                            "S<(1 << 0x8000000000000000)> s2;\n"
+                            "S<(1 >> 0x8000000000000000)> s3;";
+        const char expected[] = "struct S<9223372036854775808U> ; struct S<1> ; "
+                                "S<9223372036854775808U> s1 ; S<1> s2 ; S<1> s3 ; "
+                                "struct S<9223372036854775808U> { } ; struct S<1> { } ;";
+        ASSERT_EQUALS(expected, tok(code));
     }
 
     void dumpTemplateArgFrom() {


### PR DESCRIPTION
the value shift operators only reject a count >= bigint_bits, so MathLib::value::shiftLeft still left-shifts a negative value and both shiftLeft and shiftRight still shift by a negative count, which is undefined behaviour. it is reachable when folding a template argument like 0x8000000000000000 << 1 in simplifyNumericCalculations, since MathLib::isNegative only checks for a leading minus while a large hex literal parses to a negative bigint and the guard there lets it through. mirror the negative-operand check calculate.h already uses and return the operand unchanged, as is already done for oversized counts. ubsan flags the left shift at mathlib.cpp:272 on that input.