### PR TITLE
Fix #14854 (import project: Handle forced include files from compilation database projects)

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Self check (unusedFunction / no test / no gui)
         run: |
-          supprs="--suppress=unusedFunction:lib/errorlogger.h:197 --suppress=unusedFunction:lib/importproject.cpp:1666 --suppress=unusedFunction:lib/importproject.cpp:1690"
+          supprs="--suppress=unusedFunction:lib/errorlogger.h:197 --suppress=unusedFunction:lib/importproject.cpp:1671 --suppress=unusedFunction:lib/importproject.cpp:1695"
           ./cppcheck -q --template=selfcheck --error-exitcode=1 --library=cppcheck-lib -D__CPPCHECK__ -D__GNUC__ --enable=unusedFunction,information --exception-handling -rp=. --project=cmake.output.notest_nogui/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr $supprs
         env:
           DISABLE_VALUEFLOW: 1

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -825,6 +825,7 @@ unsigned int CppCheck::check(const FileSettings &fs)
     else
         tempSettings.userDefines += fs.cppcheckDefines();
     tempSettings.includePaths = fs.includePaths;
+    tempSettings.userIncludes.insert(tempSettings.userIncludes.end(), fs.forcedIncludes.cbegin(), fs.forcedIncludes.cend());
     tempSettings.userUndefs.insert(fs.undefs.cbegin(), fs.undefs.cend());
     if (fs.standard.find("++") != std::string::npos)
         tempSettings.standards.setCPP(fs.standard);

--- a/lib/filesettings.h
+++ b/lib/filesettings.h
@@ -148,6 +148,7 @@ struct CPPCHECKLIB FileSettings {
     }
     std::set<std::string> undefs;
     std::list<std::string> includePaths;
+    std::list<std::string> forcedIncludes;
     // only used by clang mode
     std::list<std::string> systemIncludePaths;
     std::string standard;

--- a/lib/importproject.cpp
+++ b/lib/importproject.cpp
@@ -149,6 +149,11 @@ void ImportProject::parseArgs(FileSettings &fs, const std::vector<std::string> &
             continue;
         }
 
+        if (!(optArg = getOptArg({ "-include", "/FI", "-FI" }, i)).empty()) {
+            fs.forcedIncludes.push_back(std::move(optArg));
+            continue;
+        }
+
         if (!(optArg = getOptArg({ "-D", "/D" }, i)).empty()) {
             defs += optArg + ";";
             continue;

--- a/test/testimportproject.cpp
+++ b/test/testimportproject.cpp
@@ -73,6 +73,7 @@ private:
         TEST_CASE(importCompileCommands13); // #13333: duplicate file entries
         TEST_CASE(importCompileCommands14); // #14156
         TEST_CASE(importCompileCommands15); // #14306
+        TEST_CASE(importCompileCommandsForcedInclude); // -include / /FI force-include
         TEST_CASE(importCompileCommandsArgumentsSection); // Handle arguments section
         TEST_CASE(importCompileCommandsNoCommandSection); // gracefully handles malformed json
         TEST_CASE(importCompileCommandsDirectoryMissing); // 'directory' field missing
@@ -434,6 +435,24 @@ private:
         const FileSettings &fs = importer.fileSettings.front();
         ASSERT_EQUALS(1, fs.includePaths.size());
         ASSERT_EQUALS("C:/Users/abcd/efg/hijk/path/123/", fs.includePaths.front());
+    }
+
+    void importCompileCommandsForcedInclude() const { // -include / /FI force-include
+        REDIRECT;
+        constexpr char json[] =
+            R"([{
+               "file": "/x/a.c",
+               "directory": "/x",
+               "command": "cc -include prefix.h /FIplatform.h -c a.c"
+            }])";
+        std::istringstream istr(json);
+        TestImporter importer;
+        ASSERT_EQUALS(true, importer.importCompileCommands(istr));
+        ASSERT_EQUALS(1, importer.fileSettings.size());
+        const FileSettings &fs = importer.fileSettings.front();
+        ASSERT_EQUALS(2, fs.forcedIncludes.size());
+        ASSERT_EQUALS("prefix.h", fs.forcedIncludes.front()); // gcc/clang -include
+        ASSERT_EQUALS("platform.h", fs.forcedIncludes.back()); // MSVC/clang-cl /FI
     }
 
     void importCompileCommandsArgumentsSection() const {


### PR DESCRIPTION
Sorry, I don't have access to the bug tracker so haven't been able to log an issue, but hoping it's simple enough

The problem is that if a project uses forced includes cppcheck does not process these when running via a compilation database which can cause errors.

I appreciate it's possible to workaround using cppchecks `--include` argument, but that means maintaining the force includes in multiple places, and can easily get out of sync with the actual project setup. There may also be file or config specific settings

This change parses those arguments from the project and respects them, with an accompanying test