### PR TITLE
Fix #13628 FP: accessMoved with ternary

### DIFF
--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3296,8 +3296,16 @@ static void valueFlowAfterMove(const TokenList& tokenlist, const SymbolDatabase&
                         ternaryColon = ternaryColon->astParent();
                     if (Token::simpleMatch(ternaryColon, ":")) {
                         endOfFunctionCall = ternaryColon->astOperand2();
-                        if (Token::simpleMatch(endOfFunctionCall, "("))
+                        if (Token::simpleMatch(endOfFunctionCall, "(")) {
                             endOfFunctionCall = endOfFunctionCall->link();
+                        } else {
+                            Token* next = nextAfterAstRightmostLeaf(endOfFunctionCall);
+                            if (next)
+                                endOfFunctionCall = next;
+                            else
+                                endOfFunctionCall = endOfFunctionCall->next();
+
+                        }
                     }
                 }
                 ValueFlow::Value value;

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -3296,16 +3296,11 @@ static void valueFlowAfterMove(const TokenList& tokenlist, const SymbolDatabase&
                         ternaryColon = ternaryColon->astParent();
                     if (Token::simpleMatch(ternaryColon, ":")) {
                         endOfFunctionCall = ternaryColon->astOperand2();
-                        if (Token::simpleMatch(endOfFunctionCall, "(")) {
-                            endOfFunctionCall = endOfFunctionCall->link();
-                        } else {
-                            Token* next = nextAfterAstRightmostLeaf(endOfFunctionCall);
-                            if (next)
-                                endOfFunctionCall = next;
-                            else
-                                endOfFunctionCall = endOfFunctionCall->next();
-
-                        }
+                        Token* next = nextAfterAstRightmostLeaf(endOfFunctionCall);
+                        if (next)
+                            endOfFunctionCall = next;
+                        else
+                            endOfFunctionCall = endOfFunctionCall->next();
                     }
                 }
                 ValueFlow::Value value;

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -12861,6 +12861,18 @@ private:
               "    h(b ? h(gA(5, std::move(s))) : h(gB(7, std::move(s))));\n"
               "}\n");
         ASSERT_EQUALS("", errout_str());
+
+        check("int cb(std::string);\n" // #13628
+              "void f(bool b, std::string s1) {\n"
+              "    std::string s2 = b ? cb(std::move(s1)) : s1;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
+
+        check("int cb(std::string);\n"
+              "void f(bool b, std::string s1) {\n"
+              "    std::string s2 = b ? cb(std::move(s1)) : s1 + s1;\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void movePointerAlias()


### PR DESCRIPTION
When std::move(x) is only in the true branch of a ternary operator, endOfFunctionCall was left pointing at the first token of the false branch, causing valueFlowForward to tag it as always-moved and report a spurious warning on the ? token.

Fix by advancing past the entire false-branch subtree using nextAfterAstRightmostLeaf before starting propagation.