### PR TITLE
checkstl.cpp: small `LoopAnalyzer` cleanup

### DIFF
--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2869,11 +2869,11 @@ namespace {
     struct LoopAnalyzer {
         const Token* bodyTok = nullptr;
         const Token* loopVar = nullptr;
-        const Settings* settings = nullptr;
+        const Settings& settings;
         std::set<nonneg int> varsChanged;
 
-        explicit LoopAnalyzer(const Token* tok, const Settings* psettings)
-            : bodyTok(tok->linkAt(1)->next()), settings(psettings)
+        explicit LoopAnalyzer(const Token* tok, const Settings& settings)
+            : bodyTok(tok->linkAt(1)->next()), settings(settings)
         {
             const Token* splitTok = tok->next()->astOperand2();
             if (Token::simpleMatch(splitTok, ":") && splitTok->previous()->varId() != 0) {
@@ -2894,11 +2894,11 @@ namespace {
             int n = 1 + (astIsPointer(tok) ? 1 : 0);
             for (int i = 0; i < n; i++) {
                 bool inconclusive = false;
-                if (isVariableChangedByFunctionCall(tok, i, *settings, &inconclusive))
+                if (isVariableChangedByFunctionCall(tok, i, settings, &inconclusive))
                     return true;
                 if (inconclusive)
                     return true;
-                if (isVariableChanged(tok, i, *settings))
+                if (isVariableChanged(tok, i, settings))
                     return true;
             }
             return false;
@@ -3044,7 +3044,7 @@ void CheckStlImpl::useStlAlgorithm()
                 continue;
             if (!Token::simpleMatch(tok->linkAt(1), ") {"))
                 continue;
-            LoopAnalyzer a{tok, &mSettings};
+            LoopAnalyzer a{tok, mSettings};
             std::string algoName = a.findAlgo();
             if (!algoName.empty()) {
                 useStlAlgorithmError(tok, algoName);

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2886,10 +2886,6 @@ namespace {
             }
         }
     private:
-        bool isLoopVarChanged() const {
-            return mVarsChanged.count(mLoopVar->varId()) > 0;
-        }
-
         bool isModified(const Token* tok) const
         {
             if (tok->variable() && tok->variable()->isConst())
@@ -2942,8 +2938,7 @@ namespace {
         {
             if (!valid())
                 return "";
-            bool loopVarChanged = isLoopVarChanged();
-            if (!loopVarChanged && mVarsChanged.empty()) {
+            if (mVarsChanged.empty()) {
                 if (hasGotoOrBreak())
                     return "";
                 bool alwaysTrue = true;

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2867,11 +2867,13 @@ static bool isTernaryAssignment(const Token* assignTok, nonneg int loopVarId, no
 
 namespace {
     struct LoopAnalyzer {
-        const Token* bodyTok = nullptr;
-        const Token* loopVar = nullptr;
+    private:
+        const Token* bodyTok;
+        const Token* loopVar{};
         const Settings& settings;
         std::set<nonneg int> varsChanged;
 
+    public:
         explicit LoopAnalyzer(const Token* tok, const Settings& settings)
             : bodyTok(tok->linkAt(1)->next()), settings(settings)
         {
@@ -2883,6 +2885,7 @@ namespace {
                 findChangedVariables();
             }
         }
+    private:
         bool isLoopVarChanged() const {
             return varsChanged.count(loopVar->varId()) > 0;
         }
@@ -2934,6 +2937,7 @@ namespace {
             return bodyTok && loopVar;
         }
 
+    public:
         std::string findAlgo() const
         {
             if (!valid())
@@ -2965,7 +2969,7 @@ namespace {
             }
             return "";
         }
-
+    private:
         bool isLocalVar(const Variable* var) const
         {
             if (!var)
@@ -2978,7 +2982,6 @@ namespace {
             return scope && scope->isNestedIn(bodyTok->scope());
         }
 
-    private:
         void findChangedVariables()
         {
             std::set<nonneg int> vars;

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2938,31 +2938,30 @@ namespace {
         {
             if (!valid())
                 return "";
-            if (mVarsChanged.empty()) {
-                if (hasGotoOrBreak())
-                    return "";
-                bool alwaysTrue = true;
-                bool alwaysFalse = true;
-                auto hasReturn = [](const Token* tok) {
-                    return Token::simpleMatch(tok, "return");
-                };
-                findTokens(hasReturn, [&](const Token* tok) {
-                    const Token* returnTok = tok->astOperand1();
-                    if (!returnTok || !returnTok->hasKnownIntValue() || !astIsBool(returnTok)) {
-                        alwaysTrue = false;
-                        alwaysFalse = false;
-                        return;
-                    }
-                    (returnTok->getKnownIntValue() ? alwaysTrue : alwaysFalse) &= true;
-                    (returnTok->getKnownIntValue() ? alwaysFalse : alwaysTrue) &= false;
-                });
-                if (alwaysTrue == alwaysFalse)
-                    return "";
-                if (alwaysTrue)
-                    return "std::any_of";
-                return "std::all_of or std::none_of";
-            }
-            return "";
+            if (!mVarsChanged.empty())
+                return "";
+            if (hasGotoOrBreak())
+                return "";
+            bool alwaysTrue = true;
+            bool alwaysFalse = true;
+            const auto hasReturn = [](const Token* tok) {
+                return Token::simpleMatch(tok, "return");
+            };
+            findTokens(hasReturn, [&](const Token* tok) {
+                const Token* returnTok = tok->astOperand1();
+                if (!returnTok || !returnTok->hasKnownIntValue() || !astIsBool(returnTok)) {
+                    alwaysTrue = false;
+                    alwaysFalse = false;
+                    return;
+                }
+                (returnTok->getKnownIntValue() ? alwaysTrue : alwaysFalse) &= true;
+                (returnTok->getKnownIntValue() ? alwaysFalse : alwaysTrue) &= false;
+            });
+            if (alwaysTrue == alwaysFalse)
+                return "";
+            if (alwaysTrue)
+                return "std::any_of";
+            return "std::all_of or std::none_of";
         }
     private:
         bool isLocalVar(const Variable* var) const

--- a/lib/checkstl.cpp
+++ b/lib/checkstl.cpp
@@ -2868,18 +2868,18 @@ static bool isTernaryAssignment(const Token* assignTok, nonneg int loopVarId, no
 namespace {
     struct LoopAnalyzer {
     private:
-        const Token* bodyTok;
-        const Token* loopVar{};
-        const Settings& settings;
-        std::set<nonneg int> varsChanged;
+        const Token* mBodyTok;
+        const Token* mLoopVar{};
+        const Settings& mSettings;
+        std::set<nonneg int> mVarsChanged;
 
     public:
         explicit LoopAnalyzer(const Token* tok, const Settings& settings)
-            : bodyTok(tok->linkAt(1)->next()), settings(settings)
+            : mBodyTok(tok->linkAt(1)->next()), mSettings(settings)
         {
             const Token* splitTok = tok->next()->astOperand2();
             if (Token::simpleMatch(splitTok, ":") && splitTok->previous()->varId() != 0) {
-                loopVar = splitTok->previous();
+                mLoopVar = splitTok->previous();
             }
             if (valid()) {
                 findChangedVariables();
@@ -2887,7 +2887,7 @@ namespace {
         }
     private:
         bool isLoopVarChanged() const {
-            return varsChanged.count(loopVar->varId()) > 0;
+            return mVarsChanged.count(mLoopVar->varId()) > 0;
         }
 
         bool isModified(const Token* tok) const
@@ -2897,11 +2897,11 @@ namespace {
             int n = 1 + (astIsPointer(tok) ? 1 : 0);
             for (int i = 0; i < n; i++) {
                 bool inconclusive = false;
-                if (isVariableChangedByFunctionCall(tok, i, settings, &inconclusive))
+                if (isVariableChangedByFunctionCall(tok, i, mSettings, &inconclusive))
                     return true;
                 if (inconclusive)
                     return true;
-                if (isVariableChanged(tok, i, settings))
+                if (isVariableChanged(tok, i, mSettings))
                     return true;
             }
             return false;
@@ -2910,7 +2910,7 @@ namespace {
         template<class Predicate, class F>
         void findTokens(Predicate pred, F f) const
         {
-            for (const Token* tok = bodyTok; precedes(tok, bodyTok->link()); tok = tok->next()) {
+            for (const Token* tok = mBodyTok; precedes(tok, mBodyTok->link()); tok = tok->next()) {
                 if (pred(tok))
                     f(tok);
             }
@@ -2919,7 +2919,7 @@ namespace {
         template<class Predicate>
         const Token* findToken(Predicate pred) const
         {
-            for (const Token* tok = bodyTok; precedes(tok, bodyTok->link()); tok = tok->next()) {
+            for (const Token* tok = mBodyTok; precedes(tok, mBodyTok->link()); tok = tok->next()) {
                 if (pred(tok))
                     return tok;
             }
@@ -2934,7 +2934,7 @@ namespace {
         }
 
         bool valid() const {
-            return bodyTok && loopVar;
+            return mBodyTok && mLoopVar;
         }
 
     public:
@@ -2943,7 +2943,7 @@ namespace {
             if (!valid())
                 return "";
             bool loopVarChanged = isLoopVarChanged();
-            if (!loopVarChanged && varsChanged.empty()) {
+            if (!loopVarChanged && mVarsChanged.empty()) {
                 if (hasGotoOrBreak())
                     return "";
                 bool alwaysTrue = true;
@@ -2976,16 +2976,16 @@ namespace {
                 return false;
             if (var->isPointer() || var->isReference())
                 return false;
-            if (var->declarationId() == loopVar->varId())
+            if (var->declarationId() == mLoopVar->varId())
                 return false;
             const Scope* scope = var->scope();
-            return scope && scope->isNestedIn(bodyTok->scope());
+            return scope && scope->isNestedIn(mBodyTok->scope());
         }
 
         void findChangedVariables()
         {
             std::set<nonneg int> vars;
-            for (const Token* tok = bodyTok; precedes(tok, bodyTok->link()); tok = tok->next()) {
+            for (const Token* tok = mBodyTok; precedes(tok, mBodyTok->link()); tok = tok->next()) {
                 if (tok->varId() == 0)
                     continue;
                 if (vars.count(tok->varId()) > 0)
@@ -2996,7 +2996,7 @@ namespace {
                 }
                 if (!isModified(tok))
                     continue;
-                varsChanged.insert(tok->varId());
+                mVarsChanged.insert(tok->varId());
                 vars.insert(tok->varId());
             }
         }


### PR DESCRIPTION
- pass `Settings` by reference
- cleaned up `LoopAnalyzer` access
- removed unnessary condition from `LoopAnalyzer::findAlgo()`
- small `LoopAnalyzer::findAlgo()` cleanup