### PR TITLE
Improve performance of SuppressionsList::isSuppressed by returning as soon as a match is found

### DIFF
--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -475,16 +475,18 @@ bool SuppressionList::isSuppressed(const SuppressionList::ErrorMessage &errmsg, 
 
     // TODO: handle unmatchedPolyspaceSuppression?
     const bool unmatchedSuppression(errmsg.errorId == "unmatchedSuppression");
-    
+    bool returnValue = false;
     for (Suppression &s : mSuppressions) {
         if (!global && !s.isLocal())
             continue;
         if (unmatchedSuppression && s.errorId != errmsg.errorId)
             continue;
+        if (returnValue && s.matched)
+            continue;
         if (s.isMatch(errmsg))
-            return true;
+            returnValue = true;
     }
-    return false;
+    return returnValue;
 }
 
 bool SuppressionList::isSuppressedExplicitly(const SuppressionList::ErrorMessage &errmsg, bool global)

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -475,16 +475,16 @@ bool SuppressionList::isSuppressed(const SuppressionList::ErrorMessage &errmsg, 
 
     // TODO: handle unmatchedPolyspaceSuppression?
     const bool unmatchedSuppression(errmsg.errorId == "unmatchedSuppression");
-    bool returnValue = false;
+    
     for (Suppression &s : mSuppressions) {
         if (!global && !s.isLocal())
             continue;
         if (unmatchedSuppression && s.errorId != errmsg.errorId)
             continue;
         if (s.isMatch(errmsg))
-            returnValue = true;
+            return true;
     }
-    return returnValue;
+    return false;
 }
 
 bool SuppressionList::isSuppressedExplicitly(const SuppressionList::ErrorMessage &errmsg, bool global)


### PR DESCRIPTION
Improve performance of SuppressionsList::isSuppressed by returning as soon as a match is found.

The same is done in the other overloads of the function. By returning immediately when a match is found, heavily improve the performance of CppCheck::CppCheckLogger reportErr function in cases where a lot of errors are being suppressed.