### PR TITLE
 Fix #14876 Nullptr dereference in usingMatch()

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -2720,6 +2720,9 @@ namespace {
             return false;
         }
 
+        if (!tok->tokAt(-1))
+            return false;
+
         // skip other using with this name
         if (tok1->strAt(-1) == "using") {
             // fixme: this is wrong

--- a/test/testsimplifyusing.cpp
+++ b/test/testsimplifyusing.cpp
@@ -77,6 +77,7 @@ private:
         TEST_CASE(simplifyUsing37);
         TEST_CASE(simplifyUsing38);
         TEST_CASE(simplifyUsing39);
+        TEST_CASE(simplifyUsing40);
 
         TEST_CASE(simplifyUsing8970);
         TEST_CASE(simplifyUsing8971);
@@ -937,6 +938,13 @@ private:
         ASSERT_EQUALS("", errout_str());
         ASSERT_EQUALS(expected, tok(code, dinit(TokOptions, $.cppstd = Standards::CPP03)));
         ASSERT_EQUALS("", errout_str());
+    }
+
+    void simplifyUsing40() {
+        const char code[] = "uint8_t f();\n" // #14876
+                            "using ::std::uint8_t;";
+        const char expected[] = "uint8_t f ( ) ;";
+        ASSERT_EQUALS(expected, tok(code));
     }
 
     void simplifyUsing8970() {


### PR DESCRIPTION
Root cause is here: https://github.com/cppcheck-opensource/cppcheck/blob/86f4c91741690386cd5917ccd8120624d9473ad5/lib/tokenize.cpp#L3108