### PR TITLE
Fix #13846 FP invalidFunctionArgBool with Qt SLOT() macro

### DIFF
--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -406,7 +406,6 @@
     <arg nr="3">
       <not-null/>
       <not-uninit/>
-      <not-bool/>
     </arg>
     <arg nr="4" default="0">
       <not-uninit/>

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -406,10 +406,10 @@
     <arg nr="3">
       <not-null/>
       <not-uninit/>
+      <not-bool/>
     </arg>
     <arg nr="4" default="0">
       <not-uninit/>
-      <not-bool/>
     </arg>
     <arg nr="5" default="0">
       <not-uninit/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -33,6 +33,7 @@
 #include <QRegion>
 #include <QTransform>
 #include <QDir>
+#include <QTimer>
 
 // TODO: this is actually available via Core5Compat but I could not get it to work with pkg-config
 #if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
@@ -892,3 +893,12 @@ int qdateIsValid()
     Q_ASSERT(qd.isValid()); // Should not warn here with assertWithSideEffect
     return qd.month(); 
 }
+
+struct S_QTimer_connect : QObject { // #13846
+    S_QTimer_connect() {
+        QObject::connect(&timer, SIGNAL(timeout()), this, SLOT(update()));
+    }
+    QTimer timer;
+private slots:
+    bool update();
+};

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -896,6 +896,7 @@ int qdateIsValid()
 
 struct S_QTimer_connect : QObject { // #13846
     S_QTimer_connect() {
+        // cppcheck-suppress checkLibraryFunction - timeout() is a signal from QTimer
         QObject::connect(&timer, SIGNAL(timeout()), this, SLOT(update()));
     }
     QTimer timer;


### PR DESCRIPTION
`<not-bool/>` causes a warning when passing `false`, which is rejected by a modern compiler anyway.