### PR TITLE
gtk.cfg: Add pure annotations for more GLib functions

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -2251,6 +2251,7 @@
   </function>
   <!-- GList * g_list_find (GList *list, gconstpointer data); -->
   <function name="g_list_find">
+    <pure/>
     <leak-ignore/>
     <noreturn>false</noreturn>
     <returnValue type="GList"/>
@@ -5218,6 +5219,7 @@
   <!-- gboolean g_str_has_prefix (const gchar* str, const gchar* prefix); -->
   <!-- gboolean g_str_has_suffix (const gchar* str, const gchar* prefix); -->
   <function name="g_str_has_prefix,g_str_has_suffix">
+    <pure/>
     <leak-ignore/>
     <noreturn>false</noreturn>
     <returnValue type="gboolean"/>
@@ -6586,6 +6588,7 @@
   </function>
   <!-- gboolean g_error_matches(const GError *error, GQuark domain, gint code); -->
   <function name="g_error_matches">
+    <pure/>
     <noreturn>false</noreturn>
     <returnValue type="gboolean"/>
     <use-retval/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -59,6 +59,8 @@ void validCode(int argInt, GHashTableIter * hash_table_iter, GHashTable * hash_t
     g_string_free(pGStr1, TRUE);
 
     gchar * pGchar1 = g_strconcat("a", "b", NULL);
+    g_assert_true(g_str_has_prefix(pGchar1, "a"));
+    g_assert_true(g_str_has_suffix(pGchar1, "b"));
     printf("%s", pGchar1);
     g_free(pGchar1);
 
@@ -406,6 +408,7 @@ void g_error_new_test()
     g_error_new(1, -2, "a %d", 1);
 
     const GError * pNew2 = g_error_new(1, -2, "a %d", 1);
+    g_assert_true(g_error_matches(pNew2, 1, -2));
     printf("%p", pNew2);
     // cppcheck-suppress memleak
 }
@@ -528,6 +531,16 @@ void g_variant_test() {
 
     // leak from pGvariant1
     // cppcheck-suppress memleak
+}
+
+void g_list_test() {
+    GList *list1 = NULL;
+    gchar *c = "c";
+
+    list1 = g_list_append(list1, c);
+    g_assert_true(g_list_find(list1, c) != NULL);
+
+    g_list_free(list1);
 }
 
 void g_queue_test() {


### PR DESCRIPTION
This fixes assertWithSideEffect false positives for the following functions:

g_error_matches
g_list_find
g_str_has_prefix
g_str_has_suffix