### PR TITLE
Add trap and unreachable builtins to std.cfg

### DIFF
--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -8820,6 +8820,11 @@ initializer list (7) string& replace (const_iterator i1, const_iterator i2, init
     <noreturn>true</noreturn>
     <leak-ignore/>
   </function>
+  <!-- void __builtin_trap (void) -->
+  <!-- void __builtin_unreachable (void) -->
+  <function name="__builtin_trap,__builtin_unreachable">
+    <noreturn>true</noreturn>
+  </function>
   <memory>
     <alloc init="false" buffer-size="malloc">malloc,std::malloc</alloc>
     <alloc init="true" buffer-size="calloc">calloc,std::calloc</alloc>


### PR DESCRIPTION
Taken from cfg/gnu.cfg as these are not really tied to GNU.