### PR TITLE
gtk.cfg: Add G_DEPRECATED_FOR and G_ENCODE_VERSION

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -92,6 +92,7 @@
   <define name="G_LIKELY(expr)" value="(expr)"/>
   <define name="G_UNLIKELY(expr)" value="(expr)"/>
   <define name="G_DEPRECATED" value="__attribute__((__deprecated__))"/>
+  <define name="G_DEPRECATED_FOR(f)" value="__attribute__((__deprecated__(&quot;Use '&quot; #f &quot;' instead&quot;)))"/>
   <define name="G_STMT_START" value="do"/>
   <define name="G_STMT_END" value="while (0)"/>
   <define name="_G_TYPE_CIC(ip, gt, ct)" value="((ct*) ip)"/>
@@ -126,6 +127,7 @@
   <define name="g_try_new(struct_type, n_structs)" value="_G_NEW (struct_type, n_structs, try_malloc)"/>
   <define name="g_try_new0(struct_type, n_structs)" value="_G_NEW (struct_type, n_structs, try_malloc0)"/>
   <define name="g_try_renew(struct_type, mem, n_structs)" value="_G_RENEW (struct_type, mem, n_structs, try_realloc)"/>
+  <define name="G_ENCODE_VERSION(major, minor)" value="((major) &lt;&lt; 16 | (minor) &lt;&lt; 8)"/>
   <define name="GTK_BUTTON(obj)" value="((GtkButton*)(obj))"/>
   <define name="GTK_BOX(obj)" value="((GtkBox*)(obj))"/>
   <define name="GTK_CONTAINER(obj)" value="((GtkContainer*)(obj))"/>


### PR DESCRIPTION
`G_DEPRECATED_FOR` is defined in [glib/gmacros.h](https://github.com/GNOME/glib/blob/2.89.1/glib/gmacros.h#L1313).
`G_ENCODE_VERSION` is defined in [glib/gversionmacros.h](https://github.com/GNOME/glib/blob/2.89.1/glib/gversionmacros.h.in#L49).